### PR TITLE
Remove BaseLicense and make License a real enum

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayLicense.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayLicense.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.api.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.BaseLicense
+import uk.ac.wellcome.models.License
 
 @ApiModel(
   value = "License",
@@ -27,7 +27,7 @@ case class DisplayLicense(
 }
 
 case object DisplayLicense {
-  def apply(license: BaseLicense): DisplayLicense = DisplayLicense(
+  def apply(license: License): DisplayLicense = DisplayLicense(
     licenseType = license.licenseType,
     label = license.label,
     url = license.url

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -64,7 +64,7 @@ class ApiWorksTest
       "license": ${license(loc.license)}
     }"""
 
-  private def license(license: BaseLicense) =
+  private def license(license: License) =
     s"""{
       "label": "${license.label}",
       "licenseType": "${license.licenseType}",
@@ -830,11 +830,7 @@ class ApiWorksTest
       thumbnail = Location(
         locationType = "thumbnail-image",
         url = Some("https://iiif.example.org/1234/default.jpg"),
-        license = License(
-          licenseType = "CC-test",
-          label = "A fictional license for testing",
-          url = "http://creativecommons.org/licenses/test/-1.0/"
-        )
+        license = License_CCBY
       )
     )
     insertIntoElasticSearch(work)
@@ -873,11 +869,7 @@ class ApiWorksTest
       title = "An otter omitted from an occasion in Oslo",
       thumbnail = Location(
         locationType = "thumbnail-image",
-        license = License(
-          licenseType = "CC-toast",
-          label = "A fictional license for toasting",
-          url = "http://creativecommons.org/licenses/toast/-slice/"
-        )
+        license = License_CCBY
       )
     )
     insertIntoElasticSearch(work)

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
@@ -112,7 +112,7 @@ trait WorksUtil {
     )
   }
 
-  def locationWith(url: Option[String], license: BaseLicense): Location = {
+  def locationWith(url: Option[String], license: License): Location = {
     Location(
       "iiif-image",
       url,

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayItemTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayItemTest.scala
@@ -10,10 +10,6 @@ class DisplayItemTest extends FunSpec with Matchers {
     val thumbnailUrl = Some("https://iiif.example.org/V0000001/default.jpg")
     val locationType = "thumbnail-image"
 
-    val licenseType = "CC-Test"
-    val licenseLabel = "A fictional license for testing"
-    val licenseUrl = "http://creativecommons.org/licenses/test/-1.0/"
-
     Location(
       locationType = locationType,
       url = thumbnailUrl,

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayItemTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayItemTest.scala
@@ -6,18 +6,6 @@ import uk.ac.wellcome.models._
 
 class DisplayItemTest extends FunSpec with Matchers {
 
-  val license: License = {
-    val licenseType = "CC-Test"
-    val label = "A fictional license for testing"
-    val url = "http://creativecommons.org/licenses/test/-1.0/"
-
-    License(
-      licenseType = licenseType,
-      label = label,
-      url = url
-    )
-  }
-
   val location: Location = {
     val thumbnailUrl = Some("https://iiif.example.org/V0000001/default.jpg")
     val locationType = "thumbnail-image"
@@ -29,7 +17,7 @@ class DisplayItemTest extends FunSpec with Matchers {
     Location(
       locationType = locationType,
       url = thumbnailUrl,
-      license = license
+      license = License_CCBY
     )
   }
 

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayLicenseTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayLicenseTest.scala
@@ -10,12 +10,7 @@ class DisplayLicenseTest extends FunSpec with Matchers {
     val label = "A fictional license for testing"
     val url = "http://creativecommons.org/licenses/test/-1.0/"
 
-    val internalLicense = License(
-      licenseType = licenseType,
-      label = label,
-      url = url
-    )
-    val displayLicense = DisplayLicense(internalLicense)
+    val displayLicense = DisplayLicense(License_CCBY)
 
     displayLicense.licenseType shouldBe licenseType
     displayLicense.label shouldBe label

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayLicenseTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayLicenseTest.scala
@@ -6,15 +6,11 @@ import uk.ac.wellcome.models._
 class DisplayLicenseTest extends FunSpec with Matchers {
 
   it("should read a License as a DisplayLicense correctly") {
-    val licenseType = "CC-Test"
-    val label = "A fictional license for testing"
-    val url = "http://creativecommons.org/licenses/test/-1.0/"
-
     val displayLicense = DisplayLicense(License_CCBY)
 
-    displayLicense.licenseType shouldBe licenseType
-    displayLicense.label shouldBe label
-    displayLicense.url shouldBe url
+    displayLicense.licenseType shouldBe License_CCBY.licenseType
+    displayLicense.label shouldBe License_CCBY.label
+    displayLicense.url shouldBe License_CCBY.url
     displayLicense.ontologyType shouldBe "License"
   }
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayLocationTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayLocationTest.scala
@@ -18,11 +18,7 @@ class DisplayLocationTest extends FunSpec with Matchers {
 
     displayLocation.locationType shouldBe locationType
     displayLocation.url shouldBe thumbnailUrl
-    displayLocation.license shouldBe DisplayLicense(
-      licenseType = License_CCBY.licenseType,
-      label = License_CCBY.label,
-      url = License_CCBY.url
-    )
+    displayLocation.license shouldBe DisplayLicense(internalLocation.license)
     displayLocation.ontologyType shouldBe "Location"
   }
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayLocationTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayLocationTest.scala
@@ -8,9 +8,6 @@ class DisplayLocationTest extends FunSpec with Matchers {
   it("should read a Location as a DisplayLocation correctly") {
     val thumbnailUrl = Some("https://iiif.example.org/V0000001/default.jpg")
     val locationType = "thumbnail-image"
-    val licenseType = "CC-Test"
-    val licenseLabel = "A fictional license for testing"
-    val licenseUrl = "http://creativecommons.org/licenses/test/-1.0/"
 
     val internalLocation = Location(
       locationType = locationType,
@@ -22,9 +19,9 @@ class DisplayLocationTest extends FunSpec with Matchers {
     displayLocation.locationType shouldBe locationType
     displayLocation.url shouldBe thumbnailUrl
     displayLocation.license shouldBe DisplayLicense(
-      licenseType = licenseType,
-      label = licenseLabel,
-      url = licenseUrl
+      licenseType = License_CCBY.licenseType,
+      label = License_CCBY.label,
+      url = License_CCBY.url
     )
     displayLocation.ontologyType shouldBe "Location"
   }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayLocationTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayLocationTest.scala
@@ -15,11 +15,7 @@ class DisplayLocationTest extends FunSpec with Matchers {
     val internalLocation = Location(
       locationType = locationType,
       url = thumbnailUrl,
-      license = License(
-        licenseType = licenseType,
-        label = licenseLabel,
-        url = licenseUrl
-      )
+      license = License_CCBY
     )
     val displayLocation = DisplayLocation(internalLocation)
 

--- a/common/src/main/scala/uk/ac/wellcome/models/License.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/License.scala
@@ -3,46 +3,39 @@ package uk.ac.wellcome.models
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 
-@JsonDeserialize(as = classOf[License])
-trait BaseLicense {
+sealed trait License {
   val licenseType: String
   val label: String
   val url: String
   @JsonProperty("type") val ontologyType: String = "License"
 }
 
-case class License(
-  val licenseType: String,
-  val label: String,
-  val url: String
-) extends BaseLicense
-
-case object License_CCBY extends BaseLicense {
+case object License_CCBY extends License {
   val licenseType = "CC-BY"
   val label = "Attribution 4.0 International (CC BY 4.0)"
   val url = "http://creativecommons.org/licenses/by/4.0/"
 }
 
-case object License_CCBYNC extends BaseLicense {
+case object License_CCBYNC extends License {
   val licenseType = "CC-BY-NC"
   val label = "Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)"
   val url = "https://creativecommons.org/licenses/by-nc/4.0/"
 }
 
-case object License_CCBYNCND extends BaseLicense {
+case object License_CCBYNCND extends License {
   val licenseType = "CC-BY-NC-ND"
   val label =
     "Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)"
   val url = "https://creativecommons.org/licenses/by-nc-nd/4.0/"
 }
 
-case object License_CC0 extends BaseLicense {
+case object License_CC0 extends License {
   val licenseType = "CC-0"
   val label = "CC0 1.0 Universal"
   val url = "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
 }
 
-case object License_PDM extends BaseLicense {
+case object License_PDM extends License {
   val licenseType = "PDM"
   val label = "Public Domain Mark"
   val url = "https://creativecommons.org/share-your-work/public-domain/pdm/"

--- a/common/src/main/scala/uk/ac/wellcome/models/License.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/License.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.models
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer, JsonNode}
+import com.fasterxml.jackson.databind.{
+  DeserializationContext,
+  JsonDeserializer,
+  JsonNode
+}
 
 @JsonDeserialize(using = classOf[LicenseDeserialiser])
 sealed trait License {
@@ -14,14 +18,16 @@ sealed trait License {
 }
 
 class LicenseDeserialiser extends JsonDeserializer[License] {
-  override def deserialize(p: JsonParser, ctxt: DeserializationContext): License = {
+
+  override def deserialize(p: JsonParser,
+                           ctxt: DeserializationContext): License = {
     val node: JsonNode = p.getCodec.readTree(p)
     val licenseType = node.get("licenseType").asText
     println(s"got licenseType: $licenseType")
     createLicense(licenseType)
   }
-  private def createLicense(
-                     licenseType: String): License = {
+
+  private def createLicense(licenseType: String): License = {
     licenseType match {
       case s: String if s == License_CCBY.licenseType => License_CCBY
       case s: String if s == License_CCBYNC.licenseType => License_CCBYNC

--- a/common/src/main/scala/uk/ac/wellcome/models/License.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/License.scala
@@ -23,7 +23,6 @@ class LicenseDeserialiser extends JsonDeserializer[License] {
                            ctxt: DeserializationContext): License = {
     val node: JsonNode = p.getCodec.readTree(p)
     val licenseType = node.get("licenseType").asText
-    println(s"got licenseType: $licenseType")
     createLicense(licenseType)
   }
 

--- a/common/src/main/scala/uk/ac/wellcome/models/License.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/License.scala
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.{
   JsonDeserializer,
   JsonNode
 }
+import com.twitter.inject.Logging
 
 @JsonDeserialize(using = classOf[LicenseDeserialiser])
 sealed trait License {
@@ -17,7 +18,7 @@ sealed trait License {
   @JsonProperty("type") val ontologyType: String = "License"
 }
 
-class LicenseDeserialiser extends JsonDeserializer[License] {
+class LicenseDeserialiser extends JsonDeserializer[License] with Logging {
 
   override def deserialize(p: JsonParser,
                            ctxt: DeserializationContext): License = {
@@ -33,6 +34,10 @@ class LicenseDeserialiser extends JsonDeserializer[License] {
       case s: String if s == License_CCBYNCND.licenseType => License_CCBYNCND
       case s: String if s == License_CC0.licenseType => License_CC0
       case s: String if s == License_PDM.licenseType => License_PDM
+      case licenseType =>
+        val errorMessage = s"$licenseType is not a valid licenseType"
+        error(errorMessage)
+        throw new Exception(errorMessage)
     }
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/License.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/License.scala
@@ -1,13 +1,35 @@
 package uk.ac.wellcome.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer, JsonNode}
 
+@JsonDeserialize(using = classOf[LicenseDeserialiser])
 sealed trait License {
   val licenseType: String
   val label: String
   val url: String
   @JsonProperty("type") val ontologyType: String = "License"
+}
+
+class LicenseDeserialiser extends JsonDeserializer[License] {
+  override def deserialize(p: JsonParser, ctxt: DeserializationContext): License = {
+    val node: JsonNode = p.getCodec.readTree(p)
+    val licenseType = node.get("licenseType").asText
+    println(s"got licenseType: $licenseType")
+    createLicense(licenseType)
+  }
+  private def createLicense(
+                     licenseType: String): License = {
+    licenseType match {
+      case s: String if s == License_CCBY.licenseType => License_CCBY
+      case s: String if s == License_CCBYNC.licenseType => License_CCBYNC
+      case s: String if s == License_CCBYNCND.licenseType => License_CCBYNCND
+      case s: String if s == License_CC0.licenseType => License_CC0
+      case s: String if s == License_PDM.licenseType => License_PDM
+    }
+  }
 }
 
 case object License_CCBY extends License {

--- a/common/src/main/scala/uk/ac/wellcome/models/Location.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Location.scala
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 case class Location(
   locationType: String,
   url: Option[String] = None,
-  license: BaseLicense
+  license: License
 ) {
   @JsonProperty("type") val ontologyType: String = "Location"
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -180,7 +180,7 @@ case class MiroTransformable(MiroID: String,
     *  TODO: Update these mappings based on the final version of Christy's
     *        document.
     */
-  private def chooseLicense(useRestrictions: String): BaseLicense =
+  private def chooseLicense(useRestrictions: String): License =
     useRestrictions match {
 
       // Certain strings map directly onto license types

--- a/common/src/test/scala/uk/ac/wellcome/models/ItemTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/ItemTest.scala
@@ -1,12 +1,13 @@
 package uk.ac.wellcome.models
 
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.test.utils.JsonTestUtil
 import uk.ac.wellcome.utils.JsonUtil
 
-class ItemTest extends FunSpec with Matchers {
+class ItemTest extends FunSpec with Matchers with JsonTestUtil {
 
   val identifiedItemJson: String =
-    """
+    s"""
       |{
       |  "canonicalId": "canonicalId",
       |  "identifiers": [
@@ -19,9 +20,9 @@ class ItemTest extends FunSpec with Matchers {
       |    {
       |      "locationType": "location",
       |      "license": {
-      |        "licenseType": "license",
-      |        "label": "label",
-      |        "url": "http://www.example.com",
+      |        "licenseType": "${License_CCBY.licenseType}",
+      |        "label": "${License_CCBY.label}",
+      |        "url": "${License_CCBY.url}",
       |        "type": "License"
       |      },
       |      "type": "Location"
@@ -29,10 +30,10 @@ class ItemTest extends FunSpec with Matchers {
       |  ],
       |  "type": "Item"
       |}
-    """.stripMargin.replaceAll("\\s", "")
+    """.stripMargin
 
   val unidentifiedItemJson: String =
-    """
+    s"""
       |{
       |  "identifiers": [
       |    {
@@ -44,9 +45,9 @@ class ItemTest extends FunSpec with Matchers {
       |    {
       |      "locationType": "location",
       |      "license": {
-      |        "licenseType": "license",
-      |        "label": "label",
-      |        "url": "http://www.example.com",
+      |        "licenseType": "${License_CCBY.licenseType}",
+      |        "label": "${License_CCBY.label}",
+      |        "url": "${License_CCBY.url}",
       |        "type": "License"
       |      },
       |      "type": "Location"
@@ -54,7 +55,7 @@ class ItemTest extends FunSpec with Matchers {
       |  ],
       |  "type": "Item"
       |}
-    """.stripMargin.replaceAll("\\s", "")
+    """.stripMargin
 
   val location = Location(
     locationType = "location",
@@ -83,7 +84,7 @@ class ItemTest extends FunSpec with Matchers {
     val result = JsonUtil.toJson(unidentifiedItem)
 
     result.isSuccess shouldBe true
-    result.get shouldBe unidentifiedItemJson
+    assertJsonStringsAreEqual(result.get, unidentifiedItemJson)
   }
 
   it("should deserialize a JSON string as a unidentified Item") {
@@ -97,7 +98,7 @@ class ItemTest extends FunSpec with Matchers {
     val result = JsonUtil.toJson(identifiedItem)
 
     result.isSuccess shouldBe true
-    result.get shouldBe identifiedItemJson
+    assertJsonStringsAreEqual(result.get, identifiedItemJson)
   }
 
   it("should deserialize a JSON string as a identified Item") {

--- a/common/src/test/scala/uk/ac/wellcome/models/ItemTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/ItemTest.scala
@@ -56,16 +56,10 @@ class ItemTest extends FunSpec with Matchers {
       |}
     """.stripMargin.replaceAll("\\s", "")
 
-  val license = License(
-    licenseType = "license",
-    label = "label",
-    url = "http://www.example.com"
-  )
-
   val location = Location(
     locationType = "location",
     url = None,
-    license = license
+    license = License_CCBY
   )
 
   val identifier = SourceIdentifier(

--- a/common/src/test/scala/uk/ac/wellcome/models/LicenseTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/LicenseTest.scala
@@ -17,16 +17,10 @@ class LicenseTest extends FunSpec with Matchers {
     assertDeserialisationSucceededForType[License]()
   }
 
-  it("should deserialise a JSON string as a BaseLicense") {
-    // Because BaseLicense is an abstract type, Jackson can't deserialise it
-    // without an annotation from us.
-    assertDeserialisationSucceededForType[License]()
-  }
-
   def assertDeserialisationSucceededForType[T <: License]()(implicit m: Manifest[T]) = {
-    val licenseType = "CC-Test"
-    val label = "A fictional license for testing"
-    val url = "http://creativecommons.org/licenses/test/-1.0/"
+    val licenseType = License_CC0.licenseType
+    val label = License_CC0.label
+    val url = License_CC0.url
 
     val jsonString = s"""
       {

--- a/common/src/test/scala/uk/ac/wellcome/models/LicenseTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/LicenseTest.scala
@@ -20,10 +20,10 @@ class LicenseTest extends FunSpec with Matchers {
   it("should deserialise a JSON string as a BaseLicense") {
     // Because BaseLicense is an abstract type, Jackson can't deserialise it
     // without an annotation from us.
-    assertDeserialisationSucceededForType[BaseLicense]()
+    assertDeserialisationSucceededForType[License]()
   }
 
-  def assertDeserialisationSucceededForType[T <: BaseLicense]()(implicit m: Manifest[T]) = {
+  def assertDeserialisationSucceededForType[T <: License]()(implicit m: Manifest[T]) = {
     val licenseType = "CC-Test"
     val label = "A fictional license for testing"
     val url = "http://creativecommons.org/licenses/test/-1.0/"

--- a/common/src/test/scala/uk/ac/wellcome/models/WorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/WorkTest.scala
@@ -1,12 +1,21 @@
 package uk.ac.wellcome.models
 
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.test.utils.JsonTestUtil
 import uk.ac.wellcome.utils.JsonUtil
 
-class WorkTest extends FunSpec with Matchers {
+class WorkTest extends FunSpec with Matchers with JsonTestUtil {
+
+  private val license_CCBYJson =
+    s"""{
+            "licenseType": "${License_CCBY.licenseType}",
+            "label": "${License_CCBY.label}",
+            "url": "${License_CCBY.url}",
+            "type": "License"
+          }"""
 
   val identifiedWorkJson: String =
-    """
+    s"""
       |{
       |  "title": "title",
       |  "identifiers": [
@@ -42,12 +51,7 @@ class WorkTest extends FunSpec with Matchers {
       |  ],
       |  "thumbnail": {
       |    "locationType": "location",
-      |    "license": {
-      |      "licenseType": "license",
-      |      "label": "label",
-      |      "url": "http://www.example.com",
-      |      "type": "License"
-      |    },
+      |    "license": $license_CCBYJson,
       |    "type": "Location"
       |  },
       |  "items": [
@@ -62,12 +66,7 @@ class WorkTest extends FunSpec with Matchers {
       |      "locations": [
       |        {
       |          "locationType": "location",
-      |          "license": {
-      |            "licenseType": "license",
-      |            "label": "label",
-      |            "url": "http://www.example.com",
-      |            "type": "License"
-      |          },
+      |          "license": $license_CCBYJson,
       |          "type": "Location"
       |        }
       |      ],
@@ -76,10 +75,10 @@ class WorkTest extends FunSpec with Matchers {
       |  ],
       |  "type": "Work"
       |}
-    """.stripMargin.replaceAll("\\s", "")
+    """.stripMargin
 
   val unidentifiedWorkJson: String =
-    """
+    s"""
       |{
       |  "title": "title",
       |  "identifiers": [
@@ -114,12 +113,7 @@ class WorkTest extends FunSpec with Matchers {
       |  ],
       |  "thumbnail": {
       |    "locationType": "location",
-      |    "license": {
-      |      "licenseType": "license",
-      |      "label": "label",
-      |      "url": "http://www.example.com",
-      |      "type": "License"
-      |    },
+      |    "license": $license_CCBYJson,
       |    "type": "Location"
       |  },
       |  "items": [
@@ -134,12 +128,7 @@ class WorkTest extends FunSpec with Matchers {
       |      "locations": [
       |        {
       |          "locationType": "location",
-      |          "license": {
-      |            "licenseType": "license",
-      |            "label": "label",
-      |            "url": "http://www.example.com",
-      |            "type": "License"
-      |          },
+      |          "license": $license_CCBYJson,
       |          "type": "Location"
       |        }
       |      ],
@@ -148,7 +137,7 @@ class WorkTest extends FunSpec with Matchers {
       |  ],
       |  "type": "Work"
       |}
-    """.stripMargin.replaceAll("\\s", "")
+    """.stripMargin
 
   val location = Location(
     locationType = "location",
@@ -198,7 +187,7 @@ class WorkTest extends FunSpec with Matchers {
     val result = JsonUtil.toJson(unidentifiedWork)
 
     result.isSuccess shouldBe true
-    result.get shouldBe unidentifiedWorkJson
+    assertJsonStringsAreEqual(result.get, unidentifiedWorkJson)
   }
 
   it("should deserialize a JSON string as a unidentified Work") {
@@ -214,7 +203,7 @@ class WorkTest extends FunSpec with Matchers {
     print(result)
 
     result.isSuccess shouldBe true
-    result.get shouldBe identifiedWorkJson
+    assertJsonStringsAreEqual(result.get, identifiedWorkJson)
   }
 
   it("should deserialize a JSON string as a identified Item") {

--- a/common/src/test/scala/uk/ac/wellcome/models/WorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/WorkTest.scala
@@ -150,16 +150,10 @@ class WorkTest extends FunSpec with Matchers {
       |}
     """.stripMargin.replaceAll("\\s", "")
 
-  val license = License(
-    licenseType = "license",
-    label = "label",
-    url = "http://www.example.com"
-  )
-
   val location = Location(
     locationType = "location",
     url = None,
-    license = license
+    license = License_CCBY
   )
 
   val identifier = SourceIdentifier(


### PR DESCRIPTION
### What is this PR trying to achieve?
Licenses should be enums, so we can only create valid license instances
### Who is this change for?
Devs
### Have the following been considered/are they needed?

- [ ] Deployed new versions
