### PR TITLE
Expose INNOPAC IDs as the sierra-system-number identifier in the API

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/IdentifierSchemeModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/IdentifierSchemeModule.scala
@@ -13,4 +13,6 @@ object IdentifierSchemes {
   val calmPlaceholder = "calm-placeholder"
 
   val calmAltRefNo = "calm-altrefno"
+
+  val sierraSystemNumber = "sierra-system-number"
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -217,15 +217,45 @@ case class MiroTransformable(MiroID: String,
       ))
   }
 
+  // The ID in the Miro record is an 8-digit number with a check digit
+  // (which may be x), but the system number is 7-digits, sans checksum.
+  val innopacIDregex = """^([0-9]{7})[0-9xX]$""".r
+
+  def getIdentifiers(miroData: MiroTransformableData): List[SourceIdentifier] = {
+    val miroIDList = List(
+      SourceIdentifier(IdentifierSchemes.miroImageNumber, MiroID)
+    )
+
+    // Add the Sierra system number from the INNOPAC ID, if it's present.
+    //
+    // We add a b-prefix because everything in Miro is a bibliographic record,
+    // but there are other types in Sierra (e.g. item, holding) with matching
+    // IDs but different prefixes.
+    val sierraList: List[SourceIdentifier] = miroData.innopacID match {
+      case Some(s) => {
+        val regexMatch = innopacIDregex.unapplySeq(s)
+        regexMatch match {
+          case Some(s) => s.map { id =>
+            SourceIdentifier(IdentifierSchemes.sierraSystemNumber, s"b$id")
+          }
+          case _ => throw new RuntimeException(
+            s"Expected 8-digit INNOPAC ID or nothing, got ${miroData.innopacID}"
+          )
+        }
+      }
+      case None => List()
+    }
+
+    miroIDList ++ sierraList
+  }
+
   override def transform: Try[Work] = Try {
 
     val miroData = MiroTransformableData.create(data)
     val (title, description) = getTitleAndDescription(miroData)
-    val identifiers =
-      List(SourceIdentifier(IdentifierSchemes.miroImageNumber, MiroID))
 
     Work(
-      identifiers = identifiers,
+      identifiers = getIdentifiers(miroData),
       title = title,
       description = description,
       createdDate = getCreatedDate(miroData),

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -217,10 +217,6 @@ case class MiroTransformable(MiroID: String,
       ))
   }
 
-  // The ID in the Miro record is an 8-digit number with a check digit
-  // (which may be x), but the system number is 7-digits, sans checksum.
-  val innopacIDregex = """^([0-9]{7})[0-9xX]$""".r
-
   def getIdentifiers(miroData: MiroTransformableData): List[SourceIdentifier] = {
     val miroIDList = List(
       SourceIdentifier(IdentifierSchemes.miroImageNumber, MiroID)
@@ -233,7 +229,10 @@ case class MiroTransformable(MiroID: String,
     // IDs but different prefixes.
     val sierraList: List[SourceIdentifier] = miroData.innopacID match {
       case Some(s) => {
-        val regexMatch = innopacIDregex.unapplySeq(s)
+
+        // The ID in the Miro record is an 8-digit number with a check digit
+        // (which may be x), but the system number is 7-digits, sans checksum.
+        val regexMatch = """^([0-9]{7})[0-9xX]$""".r.unapplySeq(s)
         regexMatch match {
           case Some(s) =>
             s.map { id =>

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -235,12 +235,14 @@ case class MiroTransformable(MiroID: String,
       case Some(s) => {
         val regexMatch = innopacIDregex.unapplySeq(s)
         regexMatch match {
-          case Some(s) => s.map { id =>
-            SourceIdentifier(IdentifierSchemes.sierraSystemNumber, s"b$id")
-          }
-          case _ => throw new RuntimeException(
-            s"Expected 8-digit INNOPAC ID or nothing, got ${miroData.innopacID}"
-          )
+          case Some(s) =>
+            s.map { id =>
+              SourceIdentifier(IdentifierSchemes.sierraSystemNumber, s"b$id")
+            }
+          case _ =>
+            throw new RuntimeException(
+              s"Expected 8-digit INNOPAC ID or nothing, got ${miroData.innopacID}"
+            )
         }
       }
       case None => List()

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformableData.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformableData.scala
@@ -27,7 +27,8 @@ case class MiroTransformableData(
   @JsonProperty("image_lc_genre") lcGenre: Option[String],
   @JsonProperty("image_tech_file_size") techFileSize: Option[List[String]],
   @JsonProperty("image_use_restrictions") useRestrictions: Option[String],
-  @JsonProperty("image_supp_lettering") suppLettering: Option[String]
+  @JsonProperty("image_supp_lettering") suppLettering: Option[String],
+  @JsonProperty("image_innopac_id") innopacID: Option[String]
 )
 
 case object MiroTransformableData extends MiroTransformChecks {

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -210,6 +210,12 @@ class MiroTransformableTest
     )
   }
 
+  it("should reject records with an invalid INNOPAC ID") {
+    assertTransformWorkFails(buildJSONForWork(
+      """"image_innopac_id": "this is neither numeric nor the right length""""
+    ))
+  }
+
   it("should have an empty list if no image_creator field is present") {
     val work = transformWork(data = s""""image_title": "A guide to giraffes"""")
     work.creators shouldBe List[Agent]()

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -206,7 +206,7 @@ class MiroTransformableTest
     )
     work.identifiers shouldBe List(
       SourceIdentifier(IdentifierSchemes.miroImageNumber, miroID),
-      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, sierraNumber)
+      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, s"b${sierraNumber}")
     )
   }
 

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -193,6 +193,23 @@ class MiroTransformableTest
     work.identifiers shouldBe List(SourceIdentifier(IdentifierSchemes.miroImageNumber, MiroID))
   }
 
+  it("should pass through the INNOPAC ID, if present") {
+    val sierraNumber = "1161183"
+    val innopacID = s"${sierraNumber}2"
+    val miroID = "V0000832_test"
+    val work = transformWork(
+      data = s"""
+        "image_title": "A bouncing bundle of bison",
+        "image_innopac_id": "$innopacID"
+      """,
+      MiroID = miroID
+    )
+    work.identifiers shouldBe List(
+      SourceIdentifier(IdentifierSchemes.miroImageNumber, miroID),
+      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, sierraNumber)
+    )
+  }
+
   it("should have an empty list if no image_creator field is present") {
     val work = transformWork(data = s""""image_title": "A guide to giraffes"""")
     work.creators shouldBe List[Agent]()


### PR DESCRIPTION
### What is this PR trying to achieve?

Add Sierra b-numbers to the API results.

Related: #887

### Who is this change for?

The Experience team, so they can link to catalogue records on the Collection site.

### Have the following been considered/are they needed?

- [ ] Reviewed by @jtweed
- [ ] Updated the Swagger documentation – do we need Swagger changes for extra identifiers blocks? I don’t think so, but I might have forgotten
- [ ] Deployed new versions