### PR TITLE
Add multiple json files from miro XML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,10 +177,6 @@ sbt-deploy-transformer: sbt-build-transformer $(ROOT)/.docker/publish_service_to
 lint-ontologies: $(ROOT)/.docker/jslint_ci
 	docker run -v $$(pwd)/ontologies:/data jslint_ci:latest
 
-## Run flake8 linting over our Python code
-lint-python: $(ROOT)/.docker/python3.6_ci
-	docker run -v $$(pwd):/data -e OP=lint python3.6_ci:latest
-
 ## Check a git repo is up to date with remote master
 uptodate-git: $(ROOT)/.docker/python3.6_ci
 	docker run -v $$HOME/.ssh:/root/.ssh -v $$(pwd):/data -e OP=is-master-head python3.6_ci:latest

--- a/miro_preprocessor/xml_to_json_converter/run.py
+++ b/miro_preprocessor/xml_to_json_converter/run.py
@@ -30,19 +30,32 @@ import docopt
 from utils import generate_images
 
 
-def main(bucket, src_key, dst_key):
+def main(bucket, src_key, dst_key, js_path="json"):
     image_data = generate_images(bucket=bucket, key=src_key)
 
     tmp_json = tempfile.mktemp()
     os.makedirs(os.path.dirname(tmp_json), exist_ok=True)
+
+    s3 = boto3.client('s3')
+
     with open(tmp_json, 'w') as f:
         for img in image_data:
+            img_json_dump = json.dumps(img, separators=(',', ':'))
+
+            image_id = img["image_no_calc"]
+            json_object_key = f'{js_path}/{image_id}.json'
+            byte_encoded_json_dump = img_json_dump.encode()
+
+            s3.put_object(
+                Bucket=bucket,
+                Key=json_object_key,
+                Body=byte_encoded_json_dump
+            )
 
             # Adding the separators omits unneeded whitespace in the JSON,
             # giving us smaller files.
-            f.write(json.dumps(img, separators=(',', ':')) + '\n')
+            f.write(img_json_dump + '\n')
 
-    s3 = boto3.client('s3')
     s3.upload_file(
         Bucket=bucket,
         Key=dst_key,

--- a/miro_preprocessor/xml_to_json_converter/run.py
+++ b/miro_preprocessor/xml_to_json_converter/run.py
@@ -40,7 +40,7 @@ def main(bucket, src_key, dst_key, js_path="json"):
 
     with open(tmp_json, 'w') as f:
         for img in image_data:
-            img_json_dump = json.dumps(img, separators=(',', ':'))
+            img_json_dump = json.dumps(img, separators=(',', ':'), sort_keys=True)
 
             image_id = img["image_no_calc"]
             json_object_key = f'{js_path}/{image_id}.json'

--- a/shared.Makefile
+++ b/shared.Makefile
@@ -24,23 +24,27 @@ $(ROOT)/.docker/publish_service_to_aws:
 		--file=builds/publish_service_to_aws.Dockerfile
 
 $(ROOT)/.docker/jslint_ci:
-	./scripts/build_ci_docker_image.py --project=jslint_ci --dir=docker/jslint_ci
+	$(ROOT)/scripts/build_ci_docker_image.py --project=jslint_ci --dir=docker/jslint_ci
 
 $(ROOT)/.docker/python3.6_ci:
-	./scripts/build_ci_docker_image.py --project=python3.6_ci --dir=docker/python3.6_ci
+	$(ROOT)/scripts/build_ci_docker_image.py --project=python3.6_ci --dir=docker/python3.6_ci
 
 $(ROOT)/.docker/terraform_ci:
-	./scripts/build_ci_docker_image.py --project=terraform_ci --dir=docker/terraform_ci
+	$(ROOT)/scripts/build_ci_docker_image.py --project=terraform_ci --dir=docker/terraform_ci
 
 $(ROOT)/.docker/_build_deps:
 	pip3 install --upgrade boto3 docopt
-	mkdir -p .docker && touch .docker/_build_deps
+	mkdir -p $(ROOT)/.docker && touch $(ROOT)/.docker/_build_deps
 
 $(ROOT)/.docker/miro_adapter_tests:
-	./scripts/build_ci_docker_image.py \
+	$(ROOT)/scripts/build_ci_docker_image.py \
 		--project=miro_adapter_tests \
 		--dir=miro_adapter \
 		--file=miro_adapter/miro_adapter_tests.Dockerfile
+
+## Run flake8 linting over our Python code
+lint-python: $(ROOT)/.docker/python3.6_ci
+	docker run -v $$(pwd):/data -e OP=lint python3.6_ci:latest
 
 clean:
 	rm -rf $(ROOT)/.docker


### PR DESCRIPTION
### What is this PR trying to achieve?

Create a single JSON file for each Miro "image" processed in order to enable processing on that image via lambda in a distributed fashion.

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
