### PR TITLE
Add Lambda to run ECS task from SNS trigger

### DIFF
--- a/lambdas/common/tests/test_ecs_utils.py
+++ b/lambdas/common/tests/test_ecs_utils.py
@@ -150,6 +150,7 @@ def test_describe_service_throws_EcsThrottleException():
     with pytest.raises(ecs_utils.EcsThrottleException):
         ecs_utils.describe_service(mock_ecs_client, 'foo/bar', 'bat/baz')
 
+
 @mock_ec2
 @mock_ecs
 def test_run_task():

--- a/lambdas/common/tests/test_ecs_utils.py
+++ b/lambdas/common/tests/test_ecs_utils.py
@@ -1,8 +1,10 @@
-import boto3
+import json
 
+import boto3
 from botocore.exceptions import ClientError
 from mock import Mock
-from moto import mock_ecs
+from moto import mock_ecs, mock_ec2
+from moto.ec2 import utils as moto_ec2_utils
 import pytest
 
 from utils import ecs_utils
@@ -147,3 +149,50 @@ def test_describe_service_throws_EcsThrottleException():
 
     with pytest.raises(ecs_utils.EcsThrottleException):
         ecs_utils.describe_service(mock_ecs_client, 'foo/bar', 'bat/baz')
+
+@mock_ec2
+@mock_ecs
+def test_run_task():
+    ecs_client = boto3.client('ecs')
+    ec2 = boto3.resource('ec2', region_name='us-east-1')
+
+    cluster_response = ecs_client.create_cluster(clusterName=cluster_name)
+    cluster_arn = cluster_response['cluster']['clusterArn']
+
+    test_instance = ec2.create_instances(
+        ImageId="ami-1234abcd",
+        MinCount=1,
+        MaxCount=1,
+    )[0]
+
+    instance_id_document = json.dumps(
+        moto_ec2_utils.generate_instance_identity_document(test_instance)
+    )
+
+    ecs_client.register_container_instance(
+        cluster=cluster_name,
+        instanceIdentityDocument=instance_id_document
+    )
+
+    task_definition_response = ecs_client.register_task_definition(
+        family='my_family',
+        containerDefinitions=[]
+    )
+    task_definition_arn = (
+        task_definition_response['taskDefinition']['taskDefinitionArn']
+    )
+
+    started_by = "started_by"
+
+    response = ecs_utils.run_task(
+        ecs_client,
+        cluster_name,
+        task_definition_arn,
+        started_by)
+
+    assert len(response["failures"]) == 0
+    assert len(response["tasks"]) == 1
+
+    assert response["tasks"][0]["taskDefinitionArn"] == task_definition_arn
+    assert response["tasks"][0]["clusterArn"] == cluster_arn
+    assert response["tasks"][0]["startedBy"] == started_by

--- a/lambdas/common/tests/test_sns_utils.py
+++ b/lambdas/common/tests/test_sns_utils.py
@@ -61,5 +61,3 @@ def test_extract_json_message():
     extracted_object = sns_utils.extract_json_message(example_event)
 
     assert example_object == extracted_object
-
-

--- a/lambdas/common/tests/test_sns_utils.py
+++ b/lambdas/common/tests/test_sns_utils.py
@@ -37,3 +37,29 @@ def test_publish_sns_message(sns_sqs):
     actual_decoded_message = json.loads(inner_message)
 
     assert actual_decoded_message == expected_decoded_message
+
+
+def test_extract_json_message():
+    example_object = {
+        "foo": "bar",
+        "baz": ["bat", 0, 0.1, {"boo": "beep"}]
+    }
+
+    example_object_json = json.dumps(example_object)
+
+    example_event = {
+        "Records": [
+            {
+                "Sns": {
+                    "Message": example_object_json
+                }
+
+            }
+        ]
+    }
+
+    extracted_object = sns_utils.extract_json_message(example_event)
+
+    assert example_object == extracted_object
+
+

--- a/lambdas/common/utils/ecs_utils.py
+++ b/lambdas/common/utils/ecs_utils.py
@@ -157,3 +157,32 @@ def describe_service(ecs_client, cluster_arn, service_arn):
         cluster=_name_from_arn(cluster_arn),
         services=[_name_from_arn(service_arn)]
     )['services'][0]
+
+
+def run_task(
+        ecs_client,
+        cluster_name,
+        task_definition,
+        started_by,
+        container_name="app",
+        command=[]):
+    """
+    Run a given command against a named container in a task definition on a particular cluster.
+
+    Returns the response from calling run_task
+    """
+    return ecs_client.run_task(
+        cluster=cluster_name,
+        taskDefinition=task_definition,
+        overrides={
+            'containerOverrides': [
+                {
+                    'name': container_name,
+                    'command': command
+                },
+            ],
+            'taskRoleArn': 'string'
+        },
+        count=1,
+        startedBy=started_by,
+    )

--- a/lambdas/common/utils/sns_utils.py
+++ b/lambdas/common/utils/sns_utils.py
@@ -39,3 +39,11 @@ def publish_sns_message(topic_arn, message):
     )
     print(f'SNS response = {resp!r}')
     assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
+
+
+def extract_json_message(event):
+    """
+    Extracts a JSON message from an SNS event sent to a lambda
+    """
+    message = event['Records'][0]['Sns']['Message']
+    return json.loads(message)

--- a/lambdas/run_ecs_task/main.tf
+++ b/lambdas/run_ecs_task/main.tf
@@ -1,0 +1,19 @@
+# Lambda for publishing ECS service schedules to an SNS topic
+
+module "lambda_run_ecs_task" {
+  source     = "../../terraform/lambda"
+  source_dir = "${path.module}/target"
+
+  name        = "run_ecs_task"
+  description = "Run an ECS task from a message published to SNS"
+
+  alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+}
+
+module "trigger_run_ecs_task" {
+  source = "../../terraform/lambda/trigger_sns"
+
+  lambda_function_name = "${module.lambda_run_ecs_task.function_name}"
+  lambda_function_arn  = "${module.lambda_run_ecs_task.arn}"
+  sns_trigger_arn      = "${module.run_ecs_task_topic.arn}"
+}

--- a/lambdas/run_ecs_task/outputs.tf
+++ b/lambdas/run_ecs_task/outputs.tf
@@ -1,0 +1,9 @@
+output "arn" {
+  description = "ARN for the SNS topic"
+  value       = "${module.run_ecs_task_topic.arn}"
+}
+
+output "publish_policy" {
+  description = "Policy that allows publishing to the SNS topic"
+  value       = "${module.run_ecs_task_topic.publish_policy}"
+}

--- a/lambdas/run_ecs_task/src/run_ecs_task.py
+++ b/lambdas/run_ecs_task/src/run_ecs_task.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+"""
+Run an
+
+This is used to run one off ECS tasks.
+
+The script is triggered by notifications to an SNS topic, in which the
+message should be a JSON string that includes "cluster", "task_defintiion",
+"name" and "desired_count" as attributes.
+"""
+
+import boto3
+
+from utils.ecs_utils import run_task
+from utils.sns_utils import extract_json_message
+
+
+def main(event, _):
+    print(f'event = {event!r}')
+
+    message_data = extract_json_message(event)
+
+    response = run_task(
+        ecs_client=boto3.client('ecs'),
+        cluster_name=message_data['cluster_name'],
+        container_name=message_data['container_name'],
+        task_definition=message_data['task_definition'],
+        command=message_data['command'],
+        started_by=message_data['started_by']
+    )
+
+    print(f'response = {response!r}')
+    assert len(response['failures']) == 0

--- a/lambdas/run_ecs_task/topics.tf
+++ b/lambdas/run_ecs_task/topics.tf
@@ -1,0 +1,4 @@
+module "run_ecs_task_topic" {
+  source = "../terraform/sns"
+  name   = "run_ecs_task"
+}

--- a/lambdas/run_ecs_task/variables.tf
+++ b/lambdas/run_ecs_task/variables.tf
@@ -1,0 +1,1 @@
+variable "lambda_error_alarm_arn" {}


### PR DESCRIPTION
### What is this PR trying to achieve?

Add a lambda that can start ECS tasks when triggered from SNS. This constitutes part of the pipeline for running a task to convert Miro XML output to JSON.

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
