### PR TITLE
Return JSON error responses for 404 errors in the API

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -11,6 +11,7 @@ import scala.collection.JavaConverters._
 import uk.ac.wellcome.models.Error
 import uk.ac.wellcome.platform.api.ApiSwagger
 import uk.ac.wellcome.platform.api.models.{
+  DisplayError,
   DisplayResultList,
   DisplayWork,
   WorksIncludes
@@ -129,7 +130,8 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
               description = s"Work not found for identifier ${request.id}"
             )
             response.notFound.json(
-              ResultResponse(context = contextUri, result = DisplayError(result))
+              ResultResponse(context = contextUri,
+                             result = DisplayError(result))
             )
           }
         }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -8,6 +8,7 @@ import com.twitter.inject.annotations.Flag
 import io.swagger.models.parameters.QueryParameter
 import io.swagger.models.properties.StringProperty
 import scala.collection.JavaConverters._
+import uk.ac.wellcome.models.Error
 import uk.ac.wellcome.platform.api.ApiSwagger
 import uk.ac.wellcome.platform.api.models.{
   DisplayResultList,
@@ -114,7 +115,6 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
         .parameter(includesSwaggerParam)
     // Deliberately undocumented: the index flag.  See above.
     } { request: SingleWorkRequest =>
-      // val includes = WorksIncludes(request.includes)
       worksService
         .findWorkById(request.id,
                       request.includes.getOrElse(WorksIncludes()),
@@ -123,7 +123,15 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
           case Some(result) =>
             response.ok.json(
               ResultResponse(context = contextUri, result = result))
-          case None => response.notFound
+          case None => {
+            val result = Error(
+              variant = "http-404",
+              description = s"Work not found for identifier ${request.id}"
+            )
+            response.notFound.json(
+              ResultResponse(context = contextUri, result = DisplayError(result))
+            )
+          }
         }
     }
 

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayError.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayError.scala
@@ -1,0 +1,38 @@
+package uk.ac.wellcome.platform.api.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+
+import uk.ac.wellcome.models.Error
+
+@ApiModel(
+  value = "Error"
+)
+case class DisplayError(
+  @ApiModelProperty(
+    value = "The type of error",
+    allowableValues = "http"
+  ) errorType: String,
+  @ApiModelProperty(
+    dataType = "Int",
+    value = "The HTTP response status code"
+  ) httpStatus: Option[Int] = None,
+  @ApiModelProperty(
+    value = "The title or other short name of the error"
+  ) label: String,
+  @ApiModelProperty(
+    dataType = "String",
+    value = "The specific error"
+  ) description: Option[String] = None
+) {
+  @JsonProperty("type") val ontologyType: String = "Error"
+}
+
+case object DisplayError {
+  def apply(error: Error): DisplayError = DisplayError(
+    errorType = error.errorType,
+    httpStatus = error.httpStatus,
+    label = error.label,
+    description = error.description
+  )
+}

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -339,10 +339,18 @@ class ApiWorksTest
 
   it(
     "should return a not found error when requesting a single work with a non existing id") {
+    val badId = "non-existing-id"
     server.httpGet(
-      path = s"/$apiPrefix/works/non-existing-id",
+      path = s"/$apiPrefix/works/$badId",
       andExpect = Status.NotFound,
-      withJsonBody = ""
+      withJsonBody = s"""{
+        "@context": "https://localhost:8888/catalogue/v0/context.json",
+        "type": "Error",
+        "errorType": "http",
+        "httpStatus": 404,
+        "label": "Not Found",
+        "description": "Work not found for identifier $badId"
+      }"""
     )
   }
 

--- a/common/src/main/scala/uk/ac/wellcome/models/Error.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Error.scala
@@ -6,8 +6,22 @@ case class Error(
   errorType: String,
   httpStatus: Option[Int],
   label: String,
-  description: Option[String],
-  reference: Option[String]
+  description: Option[String]
 ) {
   @JsonProperty("type") val ontologyType: String = "Error"
+}
+
+case object Error {
+  def apply(variant: String, description: String): Error = {
+    variant match {
+      case "http-404" => Error(
+        errorType = "http",
+        httpStatus = Some(404),
+        label = "Not Found",
+        description = Some(description)
+      )
+      case unknownVariant =>
+        throw new Exception(s"$unknownVariant is not a valid error variant")
+    }
+  }
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/Error.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Error.scala
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 case class Error(
   errorType: String,
-  httpStatus: Option[Int],
+  httpStatus: Option[Int] = None,
   label: String,
-  description: Option[String]
+  description: Option[String] = None
 ) {
   @JsonProperty("type") val ontologyType: String = "Error"
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/Error.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Error.scala
@@ -14,12 +14,13 @@ case class Error(
 case object Error {
   def apply(variant: String, description: String): Error = {
     variant match {
-      case "http-404" => Error(
-        errorType = "http",
-        httpStatus = Some(404),
-        label = "Not Found",
-        description = Some(description)
-      )
+      case "http-404" =>
+        Error(
+          errorType = "http",
+          httpStatus = Some(404),
+          label = "Not Found",
+          description = Some(description)
+        )
       case unknownVariant =>
         throw new Exception(s"$unknownVariant is not a valid error variant")
     }

--- a/common/src/main/scala/uk/ac/wellcome/models/Error.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Error.scala
@@ -1,0 +1,13 @@
+package uk.ac.wellcome.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+case class Error(
+  errorType: String,
+  httpStatus: Option[Int],
+  label: String,
+  description: Option[String],
+  reference: Option[String]
+) {
+  @JsonProperty("type") val ontologyType: String = "Error"
+}

--- a/common/src/test/scala/uk/ac/wellcome/models/ErrorTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/ErrorTest.scala
@@ -1,0 +1,15 @@
+package uk.ac.wellcome.models
+
+import org.scalatest.{FunSpec, Matchers}
+
+class ErrorTest extends FunSpec with Matchers {
+  it("should create an HTTP 404 error response") {
+    val description = "Work not found for identifier 1234"
+    val error: Error = Error(variant = "http-404", description = description)
+
+    error.errorType shouldBe "http"
+    error.httpStatus.get shouldBe 404
+    error.label shouldBe "Not Found"
+    error.description.get shouldBe description
+  }
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

Start down the path of #213, by returning JSON 404 responses if a user asks for a non-existent work.

Related: #213

### Who is this change for?

API users who want more constructive error messages.

### Have the following been considered/are they needed?

- [ ] Reviewed by @jtweed – in particular, wording of the 404 description
- [ ] Updated the Swagger documentation
- [ ] Deployed new versions