### PR TITLE
Make sure the Error type is documented in Swagger

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -55,6 +55,9 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
         .description("Returns a paginated list of works")
         .tag("Works")
         .responseWith[DisplayResultList](200, "ResultList[Work]")
+        .responseWith[DisplayError](400, "Bad Request Error")
+        .responseWith[DisplayError](404, "Not Found Error")
+        .responseWith[DisplayError](500, "Internal Server Error")
         .queryParam[Int]("page",
                          "The page to return from the result list",
                          required = false)
@@ -113,6 +116,9 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
         .tag("Works")
         .routeParam[String]("id", "The work to return", required = true)
         .responseWith[DisplayWork](200, "Work")
+        .responseWith[DisplayError](400, "Bad Request Error")
+        .responseWith[DisplayError](404, "Not Found Error")
+        .responseWith[DisplayError](500, "Internal Server Error")
         .parameter(includesSwaggerParam)
     // Deliberately undocumented: the index flag.  See above.
     } { request: SingleWorkRequest =>

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -5,7 +5,7 @@ import com.twitter.finagle.http.{Response, Status}
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.server.FeatureTestMixin
 import org.scalatest.FunSpec
-import uk.ac.wellcome.models._
+import uk.ac.wellcome.models.Work
 
 class ApiSwaggerTest extends FunSpec with FeatureTestMixin {
 
@@ -28,6 +28,11 @@ class ApiSwaggerTest extends FunSpec with FeatureTestMixin {
     tree.at("/schemes").toString should be("[\"http\"]")
     tree.at("/info/version").toString should be("\"v99\"")
     tree.at("/basePath").toString should be("\"/test/v99\"")
+  }
+
+  it("should include the DisplayError model") {
+    val tree = readTree("/test/v99/swagger.json")
+    tree.at("/definitions/Error/type").toString should be("\"object\"")
   }
 
   def readTree(path: String): JsonNode = {


### PR DESCRIPTION
### What is this PR trying to achieve?

Ensure our documentation is complete – we tell users what sort of errors they might receive, and document the model properly.

### Who is this change for?

Users who read the documentation.

### Have the following been considered/are they needed?

- [x] Updated the Swagger documentation
- [ ] Deployed new versions