### PR TITLE
More changes to the sbt build

### DIFF
--- a/builds/build_sbt_image.py
+++ b/builds/build_sbt_image.py
@@ -4,13 +4,12 @@
 Build a Docker image for one of our sbt applications.
 
 Usage:
-  build_sbt_image.py --project=<PROJECT> [--version=<VERSION>] [--env=<BUILD_ENV>]
+  build_sbt_image.py --project=<PROJECT> [--env=<BUILD_ENV>]
   build_sbt_image.py -h | --help
 
 Options:
   -h --help                  Show this screen.
   --project=<PROJECT>        Name of the sbt project (e.g. api, transformer)
-  --version=<VERSION>        Version to use in the release ID
   --env=<BUILD_ENV>          Build environment (dev, prod, etc.)
 
 """
@@ -29,21 +28,17 @@ from tooling import (
 )
 
 
-DEFAULT_VERSION = '0.0.1'
-
-
 if __name__ == '__main__':
     args = docopt.docopt(__doc__)
 
     # Read arguments from docopt
     project = args['--project']
-    version = args['--version'] or DEFAULT_VERSION
     build_env = args['--env'] or PLATFORM_ENV
 
     print('*** Building sbt Docker image for %s' % project)
 
     # Construct the release ID and the tag
-    release_id = '%s-%s_%s' % (version, CURRENT_COMMIT, build_env)
+    release_id = '%s_%s' % (CURRENT_COMMIT, build_env)
     tag = '%s:%s' % (project, release_id)
     print('*** Image will be tagged %s' % tag)
 

--- a/builds/sbt_image_builder.Dockerfile
+++ b/builds/sbt_image_builder.Dockerfile
@@ -1,21 +1,9 @@
-FROM java:openjdk-8-jdk-alpine
+FROM pvansia/scala-sbt:0.13.13
 
 LABEL maintainer "Alex Chan <a.chan@wellcome.ac.uk>"
 LABEL description "A Docker image for building sbt-based Docker images for the Wellcome Digital Platform"
 
-# Based on https://bitbucket.org/iflavours/sbt-openjdk-8-alpine
-# but with our version of sbt.  Also, this one actually works.
-ENV SBT_VERSION 0.13.13
-ENV SBT_HOME /usr/local/sbt
-ENV PATH=${PATH}:${SBT_HOME}/bin
-ENV SBT_JAR http://dl.bintray.com/sbt/native-packages/sbt/$SBT_VERSION/sbt-$SBT_VERSION.tgz
-
 RUN apk update
-RUN apk add bash findutils tar wget
-RUN wget ${SBT_JAR} -O sbt-$SBT_VERSION.tgz
-RUN tar -xf sbt-$SBT_VERSION.tgz -C /usr/local --strip-components 1
-RUN sbt -verbose sbt-version
-
 RUN apk add docker git python3
 RUN pip3 install docopt
 


### PR DESCRIPTION
### What is this PR trying to achieve?

* Don’t include the version number in image tags, we’re not using it
* Use a builder image that has sbt installed, don’t reinstall it every time (makes things _much_ faster)

### Who is this change for?

🚤 