### PR TITLE
Bump the Loris version to pick up the TemplateHTTPResolver fixes

### DIFF
--- a/loris/Dockerfile
+++ b/loris/Dockerfile
@@ -7,8 +7,8 @@ RUN apt-get install -y python python-pip python-setuptools python-dev \
 
 RUN pip install awscli
 
-ENV LORIS_COMMIT 18f0ed38b544e84227d26c0b69815115493d38fa
-ENV LORIS_GITHUB_USER alexwlchan
+ENV LORIS_COMMIT df047b41f83465643e8137f48865116d5083795f
+ENV LORIS_GITHUB_USER loris-imageserver
 
 COPY install_loris.sh /install_loris.sh
 RUN /install_loris.sh


### PR DESCRIPTION
### What is this PR trying to achieve?

Resolves #786. We pick up the Loris fix in https://github.com/loris-imageserver/loris/pull/355.

### Who is this change for?

Folks who want less spurious 500s from Loris, and more 404s!

### Have the following been considered/are they needed?

- [ ] Deployed new versions