### PR TITLE
Replace deprecated lock_table with dynamodb_table

### DIFF
--- a/lambdas/terraform.tf
+++ b/lambdas/terraform.tf
@@ -2,10 +2,10 @@ terraform {
   required_version = ">= 0.9"
 
   backend "s3" {
-    bucket     = "platform-infra"
-    key        = "platform-lambda.tfstate"
-    lock_table = "terraform-locktable"
-    region     = "eu-west-1"
+    bucket       = "platform-infra"
+    key          = "platform-lambda.tfstate"
+    dynamo_table = "terraform-locktable"
+    region       = "eu-west-1"
   }
 }
 

--- a/miro_preprocessor/terraform.tf
+++ b/miro_preprocessor/terraform.tf
@@ -2,10 +2,10 @@ terraform {
   required_version = ">= 0.9"
 
   backend "s3" {
-    bucket     = "platform-infra"
-    key        = "platform-miro_preprocessor.tfstate"
-    lock_table = "terraform-locktable"
-    region     = "eu-west-1"
+    bucket       = "platform-infra"
+    key          = "platform-miro_preprocessor.tfstate"
+    dynamo_table = "terraform-locktable"
+    region       = "eu-west-1"
   }
 }
 

--- a/shared_infra/terraform.tf
+++ b/shared_infra/terraform.tf
@@ -2,9 +2,9 @@ terraform {
   required_version = ">= 0.9"
 
   backend "s3" {
-    bucket     = "platform-infra"
-    key        = "platform.tfstate"
-    lock_table = "terraform-locktable"
-    region     = "eu-west-1"
+    bucket       = "platform-infra"
+    key          = "platform.tfstate"
+    dynamo_table = "terraform-locktable"
+    region       = "eu-west-1"
   }
 }


### PR DESCRIPTION
This reflects a deprecation in Terraform 0.9.7 ([changelog](https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#097-june-7-2017)), and gets rid of the annoying deprecation message I was seeing.