### PR TITLE
Whitelist the User-Agent header to be passed to origin

### DIFF
--- a/shared_infra/cloudfront.tf
+++ b/shared_infra/cloudfront.tf
@@ -27,6 +27,10 @@ resource "aws_cloudfront_distribution" "loris" {
       cookies {
         forward = "none"
       }
+
+      headers {
+        forward = "User-Agent"
+      }
     }
 
     viewer_protocol_policy = "redirect-to-https"


### PR DESCRIPTION
### What is this PR trying to achieve?

Pass the `User-Agent` header to origin (Loris) so that logs contain this info.

**Note:** The headers will have `Cloudfront-` prefixed to them when they are passed from CloudFront as per https://aws.amazon.com/blogs/aws/enhanced-cloudfront-customization/

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
