### PR TITLE
Wrap Miro Image JSON with collection to pass through pipeline

### DIFF
--- a/miro_preprocessor/miro_image_to_dynamo/src/test_miro_image_to_dynamo.py
+++ b/miro_preprocessor/miro_image_to_dynamo/src/test_miro_image_to_dynamo.py
@@ -95,7 +95,8 @@ def test_should_insert_the_json_into_dynamo(miro_table, s3_miro_data_bucket):
     s3_client.put_object(
         Bucket=bucket_name,
         ACL='private',
-        Body=b'baba',Key="fullsize/A0000000/A0000002.jpg")
+        Body=b'baba',
+        Key="fullsize/A0000000/A0000002.jpg")
     table = miro_table
 
     miro_id = "A0000002"

--- a/miro_preprocessor/xml_to_json_converter/src/run.py
+++ b/miro_preprocessor/xml_to_json_converter/src/run.py
@@ -29,11 +29,13 @@ import docopt
 
 from utils import generate_images
 
+
 def _wrap_image_data(collection, image_data):
     return {
         "collection": collection,
         "image_data": image_data
     }
+
 
 def main(bucket, src_key, dst_key, js_path="json"):
     image_data = generate_images(bucket=bucket, key=src_key)

--- a/miro_preprocessor/xml_to_json_converter/src/run.py
+++ b/miro_preprocessor/xml_to_json_converter/src/run.py
@@ -29,9 +29,16 @@ import docopt
 
 from utils import generate_images
 
+def _wrap_image_data(collection, image_data):
+    return {
+        "collection": collection,
+        "image_data": image_data
+    }
 
 def main(bucket, src_key, dst_key, js_path="json"):
     image_data = generate_images(bucket=bucket, key=src_key)
+
+    collection = src_key.split(".")[0]
 
     tmp_json = tempfile.mktemp()
     os.makedirs(os.path.dirname(tmp_json), exist_ok=True)
@@ -40,10 +47,18 @@ def main(bucket, src_key, dst_key, js_path="json"):
 
     with open(tmp_json, 'w') as f:
         for img in image_data:
-            img_json_dump = json.dumps(img, separators=(',', ':'), sort_keys=True)
+            img_json_dump = json.dumps(
+                _wrap_image_data(
+                    collection=collection,
+                    image_data=img
+                ),
+                separators=(',', ':'),
+                sort_keys=True
+            )
 
             image_id = img["image_no_calc"]
             json_object_key = f'{js_path}/{image_id}.json'
+
             byte_encoded_json_dump = img_json_dump.encode()
 
             s3.put_object(

--- a/miro_preprocessor/xml_to_json_converter/src/test_run.py
+++ b/miro_preprocessor/xml_to_json_converter/src/test_run.py
@@ -84,9 +84,9 @@ def test_creates_txt_with_all_images_json(s3_fixture, xml_file_contents):
     src_key = xml_file_contents["src_key"]
     dst_key = "images-AAA.txt"
 
-    expected_txt_file = b"""{"image_artwork_date_from":"01/01/2000","image_artwork_date_to":"31/12/2000","image_int_default":null,"image_no_calc":"A0000001"}
-{"image_artwork_date_from":"01/02/2000","image_artwork_date_to":"13/12/2000","image_barcode":"10000000","image_creator":["Caspar Bauhin"],"image_int_default":null,"image_no_calc":"A0000002"}
-{"image_artwork_date_from":"02/02/2000","image_artwork_date_to":"13/11/2000","image_image_desc":"Test Description of Image","image_no_calc":"A0000003"}
+    expected_txt_file = b"""{"collection":"images-AAA","image_data":{"image_artwork_date_from":"01/01/2000","image_artwork_date_to":"31/12/2000","image_int_default":null,"image_no_calc":"A0000001"}}
+{"collection":"images-AAA","image_data":{"image_artwork_date_from":"01/02/2000","image_artwork_date_to":"13/12/2000","image_barcode":"10000000","image_creator":["Caspar Bauhin"],"image_int_default":null,"image_no_calc":"A0000002"}}
+{"collection":"images-AAA","image_data":{"image_artwork_date_from":"02/02/2000","image_artwork_date_to":"13/11/2000","image_image_desc":"Test Description of Image","image_no_calc":"A0000003"}}
 """
 
     run.main(bucket, src_key, dst_key)
@@ -105,9 +105,9 @@ def test_creates_json_file_for_each_image(s3_fixture, xml_file_contents):
     src_key = xml_file_contents["src_key"]
 
     expected_json_objects = {
-        "json/A0000001.json": b'{"image_artwork_date_from":"01/01/2000","image_artwork_date_to":"31/12/2000","image_int_default":null,"image_no_calc":"A0000001"}',
-        "json/A0000003.json": b'{"image_artwork_date_from":"02/02/2000","image_artwork_date_to":"13/11/2000","image_image_desc":"Test Description of Image","image_no_calc":"A0000003"}',
-        "json/A0000002.json": b'{"image_artwork_date_from":"01/02/2000","image_artwork_date_to":"13/12/2000","image_barcode":"10000000","image_creator":["Caspar Bauhin"],"image_int_default":null,"image_no_calc":"A0000002"}'
+        "json/A0000001.json": b'{"collection":"images-AAA","image_data":{"image_artwork_date_from":"01/01/2000","image_artwork_date_to":"31/12/2000","image_int_default":null,"image_no_calc":"A0000001"}}',
+        "json/A0000003.json": b'{"collection":"images-AAA","image_data":{"image_artwork_date_from":"02/02/2000","image_artwork_date_to":"13/11/2000","image_image_desc":"Test Description of Image","image_no_calc":"A0000003"}}',
+        "json/A0000002.json": b'{"collection":"images-AAA","image_data":{"image_artwork_date_from":"01/02/2000","image_artwork_date_to":"13/12/2000","image_barcode":"10000000","image_creator":["Caspar Bauhin"],"image_int_default":null,"image_no_calc":"A0000002"}}'
     }
 
     run.main(bucket, src_key, dst_key, prefix)


### PR DESCRIPTION
### What is this PR trying to achieve?

Wrapping the Miro Image JSON to add collection id extracted from the filename.

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
