### PR TITLE
Fix URLs and other tweaks in Post To Slack Lambda

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
@@ -63,7 +63,7 @@ class ElasticsearchResponseExceptionMapper @Inject()(
                   exception)
       case _ =>
         serverError(
-          "Unknown reason for error in Elasticsearch response: $reason",
+          s"Unknown reason for error in Elasticsearch response: $reason",
           exception)
     }
 

--- a/lambdas/main.tf
+++ b/lambdas/main.tf
@@ -60,6 +60,7 @@ module "post_to_slack" {
   ec2_instance_terminating_for_too_long_alarm_arn = "${data.terraform_remote_state.platform.ec2_instance_terminating_for_too_long_alarm_arn}"
   slack_webhook                                   = "${var.slack_webhook}"
   alb_server_error_alarm_arn                      = "${data.terraform_remote_state.platform.alb_server_error_alarm_arn}"
+  bitly_access_token                              = "${var.bitly_access_token}"
 
   lambda_error_alarm_arn = "${module.lambda_error_alarm.arn}"
 }

--- a/lambdas/post_to_slack/main.tf
+++ b/lambdas/post_to_slack/main.tf
@@ -9,6 +9,7 @@ module "lambda_post_to_slack" {
 
   environment_variables = {
     SLACK_INCOMING_WEBHOOK = "${var.slack_webhook}"
+    BITLY_ACCESS_TOKEN     = "${var.bitly_access_token}"
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"

--- a/lambdas/post_to_slack/src/post_to_slack.py
+++ b/lambdas/post_to_slack/src/post_to_slack.py
@@ -128,8 +128,26 @@ class Alarm:
         )
 
 
+def to_bitly(url, access_token):
+    """
+    Try to shorten a URL with bit.ly.  If it fails, just return the
+    original URL.
+    """
+    resp = requests.get(
+        'https://api-ssl.bitly.com/v3/user/link_save',
+        params={'access_token': access_token, 'longUrl': url}
+    )
+    try:
+        return resp.json()['data']['link_save']['link']
+    except KeyError:
+        return url
+
+
 def main(event, _):
     print(f'event = {event!r}')
+
+    bitly_access_token = os.environ['BITLY_ACCESS_TOKEN']
+
     alarm = Alarm(event['Records'][0]['Sns']['Message'])
 
     slack_data = {'username': 'cloudwatch-alert',
@@ -148,6 +166,10 @@ def main(event, _):
 
     cloudwatch_url = alarm.cloudwatch_url()
     if cloudwatch_url is not None:
+        cloudwatch_url = to_bitly(
+            url=cloudwatch_url,
+            access_token=bitly_access_token
+        )
         slack_data['attachments'][0]['fields'].append({
             'title': 'CloudWatch URL',
             'value': cloudwatch_url

--- a/lambdas/post_to_slack/src/post_to_slack.py
+++ b/lambdas/post_to_slack/src/post_to_slack.py
@@ -107,10 +107,10 @@ class Alarm:
             search_term = 'Traceback'
         elif self.name == 'api_romulus-alb-target-500-errors':
             group = 'platform/api_romulus'
-            search_term = 'Unhandled Exception'
+            search_term = '"HTTP 500"'
         elif self.name == 'api_remus-alb-target-500-errors':
             group = 'platform/api_remus'
-            search_term = 'Unhandled Exception'
+            search_term = '"HTTP 500"'
         else:
             return
 

--- a/lambdas/post_to_slack/variables.tf
+++ b/lambdas/post_to_slack/variables.tf
@@ -4,3 +4,4 @@ variable "terminal_failure_alarm_arn" {}
 variable "alb_server_error_alarm_arn" {}
 variable "dlq_alarm_arn" {}
 variable "ec2_instance_terminating_for_too_long_alarm_arn" {}
+variable "bitly_access_token" {}

--- a/lambdas/variables.tf
+++ b/lambdas/variables.tf
@@ -16,3 +16,7 @@ variable "dash_bucket" {
   description = "S3 bucket hosting our dashboard"
   default     = "wellcome-platform-dash"
 }
+
+variable "bitly_access_token" {
+  description = "Access token for the bit.ly API"
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

Make sure the CloudWatch URLs for API errors are still useful. Plus shorten them so they don’t take up as much space in Slack.

Fixes #930.

### Who is this change for?

Platform devs who want useful error reporting.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.