### PR TITLE
Remove Terraform for the Imgix read-only user

### DIFF
--- a/shared_infra/iam_policy_document.tf
+++ b/shared_infra/iam_policy_document.tf
@@ -198,19 +198,6 @@ data "aws_iam_policy_document" "s3_put_gatling_reports" {
   }
 }
 
-data "aws_iam_policy_document" "s3_read_miro_images" {
-  statement {
-    actions = [
-      "s3:Get*",
-      "s3:List*",
-    ]
-
-    resources = [
-      "${aws_s3_bucket.miro_images_public.arn}",
-    ]
-  }
-}
-
 data "aws_iam_policy_document" "s3_tif_derivative" {
   statement {
     actions = [

--- a/shared_infra/iam_users.tf
+++ b/shared_infra/iam_users.tf
@@ -26,22 +26,6 @@ resource "aws_iam_user_policy" "miro_images_sync" {
   policy = "${data.aws_iam_policy_document.miro_images_sync.json}"
 }
 
-# User that provides read-only access to the Miro images bucket.
-# This is for temporary use by the Experience team in their Imgix instance
-# until we make the images available properly.
-resource "aws_iam_user" "miro_images_readonly" {
-  name = "miro_images_readonly"
-}
-
-resource "aws_iam_access_key" "miro_images_readonly" {
-  user = "${aws_iam_user.miro_images_readonly.name}"
-}
-
-resource "aws_iam_user_policy" "miro_images_readonly" {
-  user   = "${aws_iam_user.miro_images_readonly.name}"
-  policy = "${data.aws_iam_policy_document.s3_read_miro_images.json}"
-}
-
 # This user is for a third party to place METS files in an ingest bucket
 resource "aws_iam_user" "mets_ingest_read_write" {
   name = "mets_ingest_read_write"


### PR DESCRIPTION
### What is this PR trying to achieve?

Since the Experience team have removed their Imgix stack, we don’t need this user for giving read-only access to our bucket. We can delete the Terraform and the corresponding users.

### Who is this change for?

Devs who don’t want unnecessary users hanging around, and lean and mean Terraform stacks!

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.