### PR TITLE
Image Sorter default to Catalogue API

### DIFF
--- a/miro_preprocessor/image_sorter/src/sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/sorter_logic.py
@@ -20,7 +20,9 @@ class Undecidable(Exception):
 
 
 def sort_image(collection, image_data):
-    # TODO: Logic goes here!
+    # For now reproduce the behaviour of the miro_adapter and send all images to the catalogue API.
+    return Decision.catalogue_api
+
     raise Undecidable(
         f'No decision for collection={collection!r}, image_data={image_data!r}'
     )

--- a/miro_preprocessor/image_sorter/src/test_sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/test_sorter_logic.py
@@ -6,7 +6,6 @@ from sorter_logic import Decision, Undecidable, sort_image
 
 
 @pytest.mark.parametrize('collection, image_data', [
-    ('Images-A', {}),
 ])
 def test_is_undecidable(collection, image_data):
     """These examples are undecidable."""


### PR DESCRIPTION
### What is this PR trying to achieve?

Default to sending images to the Catalogue API to reproduce functionality of the `miro_adapter`.

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
