### PR TITLE
Add new public bucket for miro-images

### DIFF
--- a/shared_infra/outputs.tf
+++ b/shared_infra/outputs.tf
@@ -110,12 +110,21 @@ output "bucket_miro_images_sync_id" {
   value = "${aws_s3_bucket.miro-images-sync.id}"
 }
 
+# This should be removed when they are superseded by bucket_wellcomecollectio_miro_images_public_* below
 output "bucket_miro_images_public_arn" {
   value = "${aws_s3_bucket.miro_images_public.arn}"
 }
 
 output "bucket_miro_images_public_id" {
   value = "${aws_s3_bucket.miro_images_public.id}"
+}
+
+output "bucket_wellcomecollectio_miro_images_public_arn" {
+  value = "${aws_s3_bucket.wellcomecollection-miro-images-public.arn}"
+}
+
+output "bucket_wellcomecollectio_miro_images_public_id" {
+  value = "${aws_s3_bucket.wellcomecollection-miro-images-public.id}"
 }
 
 output "table_miro_data_arn" {

--- a/shared_infra/s3.tf
+++ b/shared_infra/s3.tf
@@ -23,6 +23,7 @@ resource "aws_s3_bucket" "miro-images-sync" {
   }
 }
 
+# This bucket needs to be removed when we transition to using wellcomecollection-miro-images-public
 resource "aws_s3_bucket" "miro_images_public" {
   bucket = "miro-images-public"
   acl    = "public-read"
@@ -64,6 +65,11 @@ resource "aws_s3_bucket" "mets-ingest" {
   lifecycle {
     prevent_destroy = true
   }
+}
+
+resource "aws_s3_bucket" "wellcomecollection-miro-images-public" {
+  bucket = "wellcomecollection-miro-images-public"
+  acl    = "public-read"
 }
 
 resource "aws_s3_bucket" "alb-logs" {


### PR DESCRIPTION
### What is this PR trying to achieve?

New miro images processed end up in a new bucket with a name prefixed `wellcomecollection-` in order that we move to that naming scheme and can sandbox changes caused by the new pre-processor pipeline.

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
