### PR TITLE
Account for item remove in dynamo-to-sns lambda

### DIFF
--- a/lambdas/common/tests/test_dynamo_utils.py
+++ b/lambdas/common/tests/test_dynamo_utils.py
@@ -1,0 +1,31 @@
+from utils import dynamo_utils
+
+remove_event = {'Records': [
+    {
+        'eventID': '87cf2ca0f689908d573fb3698a487bb1',
+        'eventName': 'REMOVE',
+        'eventVersion': '1.1',
+        'eventSource': 'aws:dynamodb',
+        'awsRegion': 'eu-west-1',
+        'dynamodb': {
+            'ApproximateCreationDateTime': 1505815200.0,
+            'Keys': {
+                'MiroID': {
+                    'S': 'V0000001'
+                },
+                'MiroCollection': {
+                    'S': 'Images-V'
+                }
+            },
+            'SequenceNumber': '545308300000000005226392296', 'SizeBytes': 36,
+            'StreamViewType': 'NEW_IMAGE'
+        },
+        'eventSourceARN': 'arn:aws:dynamodb:eu-west-1:760097843905:table/MiroData/stream/2017-06-01T12:51:55.680'
+    }]
+}
+
+def test_getting_new_image_where_not_available_returns_none():
+    dynamo_event = dynamo_utils.DynamoEvent(remove_event)
+
+    assert dynamo_event.simplified_new_image == None
+    assert dynamo_event.new_image == None

--- a/lambdas/common/tests/test_dynamo_utils.py
+++ b/lambdas/common/tests/test_dynamo_utils.py
@@ -24,8 +24,9 @@ remove_event = {'Records': [
     }]
 }
 
+
 def test_getting_new_image_where_not_available_returns_none():
     dynamo_event = dynamo_utils.DynamoEvent(remove_event)
 
-    assert dynamo_event.simplified_new_image == None
-    assert dynamo_event.new_image == None
+    assert dynamo_event.simplified_new_image is None
+    assert dynamo_event.new_image is None

--- a/lambdas/common/utils/dynamo_utils.py
+++ b/lambdas/common/utils/dynamo_utils.py
@@ -9,7 +9,10 @@ class DynamoEvent:
 
     @property
     def new_image(self):
-        return self.event['Records'][0]['dynamodb']['NewImage']
+        if 'NewImage' in self.event['Records'][0]['dynamodb']:
+            return self.event['Records'][0]['dynamodb']['NewImage']
+        else:
+            return None
 
     @property
     def source_arn(self):
@@ -17,11 +20,13 @@ class DynamoEvent:
 
     @property
     def simplified_new_image(self):
-        image = self.event['Records'][0]['dynamodb']['NewImage']
+        image = self.new_image
 
-        td = TypeDeserializer()
-
-        return {k: td.deserialize(v) for k, v in image.items()}
+        if image is not None:
+            td = TypeDeserializer()
+            return {k: td.deserialize(v) for k, v in image.items()}
+        else:
+            return None
 
 
 def _is_capacity_different(x, desired_capacity):

--- a/lambdas/dynamo_to_sns/src/dynamo_to_sns.py
+++ b/lambdas/dynamo_to_sns/src/dynamo_to_sns.py
@@ -13,10 +13,14 @@ from utils.sns_utils import publish_sns_message
 
 def main(event, _):
     print(f'Received event:\n{event}')
+
     dynamo_event = DynamoEvent(event)
     stream_topic_map = json.loads(os.environ["STREAM_TOPIC_MAP"])
+
     topic_arn = stream_topic_map[dynamo_event.source_arn]
+    new_image = dynamo_event.simplified_new_image
 
-    print(dynamo_event.simplified_new_image)
+    print(new_image)
 
-    publish_sns_message(topic_arn, dynamo_event.simplified_new_image)
+    if new_image is not None:
+        publish_sns_message(topic_arn, dynamo_event.simplified_new_image)

--- a/lambdas/dynamo_to_sns/src/test_dynamo_to_sns.py
+++ b/lambdas/dynamo_to_sns/src/test_dynamo_to_sns.py
@@ -6,6 +6,54 @@ import boto3
 import dynamo_to_sns
 
 
+def test_dynamo_to_sns_fails_gracefully_on_remove_event(sns_sqs):
+    sqs_client = boto3.client('sqs')
+    topic_arn, queue_url = sns_sqs
+    stream_arn = 'arn:aws:dynamodb:eu-west-1:123456789012:table/table-stream'
+
+    stream_arn_map = {
+        stream_arn: topic_arn
+    }
+
+    os.environ = {
+        "STREAM_TOPIC_MAP": json.dumps(stream_arn_map)
+    }
+
+    remove_event = {'Records': [
+        {
+            'eventID': '87cf2ca0f689908d573fb3698a487bb1',
+            'eventName': 'REMOVE',
+            'eventVersion': '1.1',
+            'eventSource': 'aws:dynamodb',
+            'awsRegion': 'eu-west-1',
+            'dynamodb': {
+                'ApproximateCreationDateTime': 1505815200.0,
+                'Keys': {
+                    'MiroID': {
+                        'S': 'V0000001'
+                    },
+                    'MiroCollection': {
+                        'S': 'Images-V'
+                    }
+                },
+                'SequenceNumber': '545308300000000005226392296', 'SizeBytes': 36,
+                'StreamViewType': 'NEW_IMAGE'
+            },
+            'eventSourceARN': stream_arn
+        }]
+    }
+
+    dynamo_to_sns.main(remove_event, None)
+
+    messages = sqs_client.receive_message(
+        QueueUrl=queue_url,
+        MaxNumberOfMessages=1
+    )
+
+    print(messages)
+
+    assert messages.get("Messages") == None
+
 def test_dynamo_to_sns(sns_sqs):
     sqs_client = boto3.client('sqs')
     topic_arn, queue_url = sns_sqs

--- a/lambdas/dynamo_to_sns/src/test_dynamo_to_sns.py
+++ b/lambdas/dynamo_to_sns/src/test_dynamo_to_sns.py
@@ -52,7 +52,8 @@ def test_dynamo_to_sns_fails_gracefully_on_remove_event(sns_sqs):
 
     print(messages)
 
-    assert messages.get("Messages") == None
+    assert messages.get("Messages") is None
+
 
 def test_dynamo_to_sns(sns_sqs):
     sqs_client = boto3.client('sqs')

--- a/lambdas/post_to_slack/src/test_post_to_slack.py
+++ b/lambdas/post_to_slack/src/test_post_to_slack.py
@@ -15,7 +15,10 @@ def _assert_field_contains(field, title, value):
 @mock.patch('post_to_slack.requests.post')
 def test_post_to_slack(mock_post):
     url = "http://blah.com"
+
     os.environ['SLACK_INCOMING_WEBHOOK'] = url
+    os.environ['BITLY_ACCESS_TOKEN'] = "foo"
+
     mock_post.return_value.ok = True
 
     alarm_name = "api-alb-target-500-errors"


### PR DESCRIPTION
### What is this PR trying to achieve?

Currently a failure in processing successfully from the dynamo event stream will result in the lambda blocking and retrying for 24 hours! See https://forums.aws.amazon.com/thread.jspa?messageID=652591

This change accounts for the case where a record is removed and does not throw an error.

### Who is this change for?

💻  and 💵 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
