### PR TITLE
Return a 404 error if you look up a non-existent index

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
@@ -58,6 +58,7 @@ class ElasticsearchResponseExceptionMapper @Inject()(
 
   private def jsonToError(jsonDocument: String,
                           exception: Exception): DisplayError = {
+    val mapper = new ObjectMapper()
     val exceptionData = mapper.readTree(jsonDocument)
     val reason = exceptionData
       .get("error")
@@ -101,12 +102,11 @@ class ElasticsearchResponseExceptionMapper @Inject()(
       // a JSON response, so there's only a single-line message -- then `.head`
       // fails: "NoSuchElementException: next on empty iterator".  I think
       // this happens when the cluster doesn't reply, but I'm not sure.
-      val mapper = new ObjectMapper()
       val jsonDocument = exception.getMessage
         .split("\n")
         .tail
         .head
-      jsonToError(jsonDocument)
+      jsonToError(jsonDocument = jsonDocument, exception = exception)
     } catch {
       case e: Exception =>
         serverError(s"Error ($e) parsing Elasticsearch response", exception)

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
@@ -29,21 +29,22 @@ class ElasticsearchResponseExceptionMapper @Inject()(
     error(
       s"Sending HTTP 400 from ElasticsearchResponseExceptionMapper ($message)",
       exception)
-    DisplayError(Error(variant = s"http-400", description = Some(message)))
+    DisplayError(Error(variant = "http-400", description = Some(message)))
   }
 
   private def notFound(message: String, exception: Exception): DisplayError = {
     error(
       s"Sending HTTP 404 from ElasticsearchResponseExceptionMapper ($message)",
       exception)
-    DisplayError(Error(variant = s"http-404", description = Some(message)))
+    DisplayError(Error(variant = "http-404", description = Some(message)))
   }
 
-  private def serverError(message: String, exception: Exception): DisplayError = {
+  private def serverError(message: String,
+                          exception: Exception): DisplayError = {
     error(
       s"Sending HTTP 500 from ElasticsearchResponseExceptionMapper ($message)",
       exception)
-    DisplayError(Error(variant = s"http-500", description = None))
+    DisplayError(Error(variant = "http-500", description = None))
   }
 
   // This error is of the form:

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
@@ -37,10 +37,10 @@ class ElasticsearchResponseExceptionMapper @Inject()(
   private def userError(message: String, exception: Exception): DisplayError =
     sendError(message = message, exception = exception, status = 400)
 
-  private def notFound(message: String, exception: Exception): DisplayError = {
+  private def notFound(message: String, exception: Exception): DisplayError =
     sendError(message = message, exception = exception, status = 404)
 
-  private def serverError(message: String, exception: Exception): DisplayError = {
+  private def serverError(message: String, exception: Exception): DisplayError =
     sendError(message = message, exception = exception, status = 500)
 
   // This error is of the form:

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -123,6 +123,16 @@ class ApiWorksTest
       "totalResults": $totalResults
     """
 
+  private def notFound(description: String) =
+    s"""{
+      "@context": "https://localhost:8888/catalogue/v0/context.json",
+      "type": "Error",
+      "errorType": "http",
+      "httpStatus": 404,
+      "label": "Not Found",
+      "description": "$description"
+    }"""
+
   it("should return a list of works") {
 
     val works = createWorks(3)
@@ -353,14 +363,7 @@ class ApiWorksTest
     server.httpGet(
       path = s"/$apiPrefix/works/$badId",
       andExpect = Status.NotFound,
-      withJsonBody = s"""{
-        "@context": "https://localhost:8888/catalogue/v0/context.json",
-        "type": "Error",
-        "errorType": "http",
-        "httpStatus": 404,
-        "label": "Not Found",
-        "description": "Work not found for identifier $badId"
-      }"""
+      withJsonBody = notFound(s"Work not found for identifier $badId")
     )
   }
 

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -851,22 +851,12 @@ class ApiWorksTest
     }
   }
 
-  it("should return an Internal Server Error if you trigger an internal exception") {
-    // Strictly speaking, looking up a non-existent index should be a
-    // 400 Bad Request or maybe 404 Not Found, not a 500 error -- but this test
-    // just needs to reliably trigger an internal exception, and for now
-    // this code path will do.
+  it("should return Not Found if you look up a non-existent index") {
     eventually {
       server.httpGet(
         path = s"/$apiPrefix/works?_index=foobarbaz",
-        andExpect = Status.InternalServerError,
-        withJsonBody = s"""{
-          "@context": "https://localhost:8888/catalogue/v0/context.json",
-          "type": "Error",
-          "errorType": "http",
-          "httpStatus": 500,
-          "label": "Internal Server Error"
-        }"""
+        andExpect = Status.NotFound,
+        withJsonBody = notFound("There is no index foobarbaz")
       )
     }
   }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -868,6 +868,28 @@ class ApiWorksTest
     }
   }
 
+  it("should return an Internal Server error if you try to search a malformed index") {
+    // We need to do something that reliably triggers an internal exception
+    // in the Elasticsearch handler.
+    //
+    // Elasticsearch has a number of "private" indexes, which don't have
+    // a canonicalId field to sort on.  Trying to query one of these will
+    // trigger one such exception!
+    eventually {
+      server.httpGet(
+        path = s"/$apiPrefix/works?_index=.watches",
+        andExpect = Status.InternalServerError,
+        withJsonBody = s"""{
+          "@context": "https://localhost:8888/catalogue/v0/context.json",
+          "type": "Error",
+          "errorType": "http",
+          "httpStatus": 500,
+          "label": "Internal Server Error"
+        }"""
+      )
+    }
+  }
+
   it("should return a Bad Request error if you try to page beyond the first 10000 items") {
     val queries = List(
       "page=10000",


### PR DESCRIPTION
### What is this PR trying to achieve?

In the title. Which is really a way to stop alarms in our Slack channel for what’s a pretty benign error. Plus some tidying the internal logic of the ExceptionMapper, which is still a bit crappy but now in a different way. (A pox on the Elasticsearch SDK for not returning proper error types!)

Resolves #965.

### Who is this change for?

Me, because I’m bored of investigating those alarms.

oh also i guess users who want helpful error messages \*sigh*

### Have the following been considered/are they needed?

- [ ] Deployed new versions