### PR TITLE
Bump the API to v1

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
@@ -41,7 +41,7 @@ class Server extends HttpServer {
   private final val apiName =
     flag(name = "api.name", default = "catalogue", help = "API name path part")
   private final val apiVersion =
-    flag(name = "api.version", default = "v0", help = "API version path part")
+    flag(name = "api.version", default = "v1", help = "API version path part")
   private final val apiPrefix = flag(
     name = "api.prefix",
     default = "/" + apiName() + "/" + apiVersion(),

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -26,7 +26,7 @@ class ApiWorksTest
       )
     )
 
-  val apiPrefix = "catalogue/v0"
+  val apiPrefix = "catalogue/v1"
 
   private val emptyJsonResult = s"""
                            |{
@@ -93,7 +93,7 @@ class ApiWorksTest
 
   private def badRequest(description: String) =
     s"""{
-      "@context": "https://localhost:8888/catalogue/v0/context.json",
+      "@context": "https://localhost:8888/$apiPrefix/context.json",
       "type": "Error",
       "errorType": "http",
       "httpStatus": 400,
@@ -873,7 +873,7 @@ class ApiWorksTest
         path = s"/$apiPrefix/works?_index=.watches",
         andExpect = Status.InternalServerError,
         withJsonBody = s"""{
-          "@context": "https://localhost:8888/catalogue/v0/context.json",
+          "@context": "https://localhost:8888/$apiPrefix/context.json",
           "type": "Error",
           "errorType": "http",
           "httpStatus": 500,

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -125,7 +125,7 @@ class ApiWorksTest
 
   private def notFound(description: String) =
     s"""{
-      "@context": "https://localhost:8888/catalogue/v0/context.json",
+      "@context": "https://localhost:8888/$apiPrefix/context.json",
       "type": "Error",
       "errorType": "http",
       "httpStatus": 404,

--- a/docker/gatling/user-files/simulations/CatalogueApiSimulation.scala
+++ b/docker/gatling/user-files/simulations/CatalogueApiSimulation.scala
@@ -16,7 +16,7 @@ class CatalogueApiSimulation extends Simulation {
     .getOrElse(defaultDuration)
 
   val httpConf = http
-    .baseURL("https://api.wellcomecollection.org/catalogue/v0")
+    .baseURL("https://api.wellcomecollection.org/catalogue/v1")
     .inferHtmlResources()
 
   val searchFeeder = csv("terms.csv").random

--- a/docker/update_api_docs/README.md
+++ b/docker/update_api_docs/README.md
@@ -15,7 +15,7 @@ The task takes three parameters:
 *   `VERSION_ID` -- the [version identifier][version] for the docs
 *   `API_SECRET` -- your API secret, as provided by [the Stoplight API][auth].
 *   `SWAGGER_URL` -- the URL of the Swagger file to use.
-    This defaults to <https://api.wellcomecollection.org/catalogue/v0/swagger.json>.
+    This defaults to <https://api.wellcomecollection.org/catalogue/v1/swagger.json>.
 
 You can invoke the task as follows:
 

--- a/docker/update_api_docs/update_api_docs.sh
+++ b/docker/update_api_docs/update_api_docs.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o nounset
 
-SWAGGER_URL="${SWAGGER_URL:-https://api.wellcomecollection.org/catalogue/v0/swagger.json}"
+SWAGGER_URL="${SWAGGER_URL:-https://api.wellcomecollection.org/catalogue/v1/swagger.json}"
 
 echo "*** Making the IMPORT request"
 curl --request PUT \

--- a/ontologies/Examples/CALM_from_hierarchy.json
+++ b/ontologies/Examples/CALM_from_hierarchy.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+  "@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
   "id": "n9gfw78",
   "type": "Work",
   "identifiers": [

--- a/ontologies/Examples/CALM_single_MS.json
+++ b/ontologies/Examples/CALM_single_MS.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+  "@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
   "id": "e39dg92",
   "type": "Work",
   "identifiers": 

--- a/ontologies/Examples/MIRO_sample_image_of_artwork_v2.json
+++ b/ontologies/Examples/MIRO_sample_image_of_artwork_v2.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+  "@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
   "id": "watu9tbc",
   "type": "Work",
   "workType": {

--- a/ontologies/Examples/editoiral-article.json
+++ b/ontologies/Examples/editoiral-article.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+  "@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
   "id": "watu9tbc",
   "type": "Work",
   "workType": {

--- a/ontologies/Examples/mosaic-story.json
+++ b/ontologies/Examples/mosaic-story.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+  "@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
   "id": "watu9tbc",
   "type": "Work",
   "workType": {

--- a/ontologies/WIP/CALM_top_of_hierarchy.json
+++ b/ontologies/WIP/CALM_top_of_hierarchy.json
@@ -1,5 +1,5 @@
 {
-	"@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+	"@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
 	"id": "25kw8v9",
 	"type": "Work",
 	"identifiers": 

--- a/ontologies/WIP/Journal_with_items.json
+++ b/ontologies/WIP/Journal_with_items.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+  "@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
   "id": "298yw4g",
   "type": "Work",
   "workType": {

--- a/ontologies/WIP/MIRO_sample_image_of_artwork.json
+++ b/ontologies/WIP/MIRO_sample_image_of_artwork.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+  "@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
   "id": "watu9tbc",
   "type": "Work",
   "identifiers": 

--- a/ontologies/WIP/MIRO_sample_image_of_digital-only_image.json
+++ b/ontologies/WIP/MIRO_sample_image_of_digital-only_image.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+  "@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
   "id": "ghdke34",
   "type": "Work",
   "identifiers": 

--- a/ontologies/WIP/Sierra_book.json
+++ b/ontologies/WIP/Sierra_book.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+  "@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
   "id": "25bbk4m",
   "type": "Work",
   "identifiers": 

--- a/ontologies/WIP/Sierra_book_b12656008.json
+++ b/ontologies/WIP/Sierra_book_b12656008.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+  "@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
   "id": "25bbk5m",
   "type": "Work",
   "identifiers": 

--- a/ontologies/WIP/Sierra_book_many_items.json
+++ b/ontologies/WIP/Sierra_book_many_items.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+  "@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
   "id": "r8wuk27",
   "type": "Work",
   "identifiers": 

--- a/ontologies/WIP/Sierra_film.json
+++ b/ontologies/WIP/Sierra_film.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+  "@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
   "id": "8rm28aw",
   "type": "Work",
   "identifiers": [

--- a/ontologies/WIP/editorial-article.json
+++ b/ontologies/WIP/editorial-article.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+  "@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
   "id": "watu9tbc",
   "type": "Work",
   "workType": {

--- a/ontologies/WIP/mosaic-story.json
+++ b/ontologies/WIP/mosaic-story.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+  "@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
   "id": "watu9tbc",
   "type": "Work",
   "workType": {

--- a/ontologies/WIP/work-with-one-holding-and-one-item.json
+++ b/ontologies/WIP/work-with-one-holding-and-one-item.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+  "@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
   "id": "298yw4g",
   "type": "Work",
   "workType": {

--- a/ontologies/WIP/work-with-single-holding.json
+++ b/ontologies/WIP/work-with-single-holding.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+  "@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
   "id": "298yw4g",
   "type": "Work",
   "workType": {

--- a/shared_infra/services.tf
+++ b/shared_infra/services.tf
@@ -175,7 +175,51 @@ module "api_romulus" {
   listener_http_arn  = "${module.api_alb.listener_http_arn}"
   infra_bucket       = "${var.infra_bucket}"
   config_key         = "config/${var.build_env}/api_romulus.ini"
+  path_pattern       = "/catalogue/v0/*"
   alb_priority       = "112"
+  host_name          = "${var.production_api == "romulus" ? var.api_host : var.api_host_stage}"
+
+  enable_alb_alarm = "${var.production_api == "romulus" ? 1 : 0}"
+
+  cpu    = 1792
+  memory = 2048
+
+  desired_count = "${var.production_api == "romulus" ? var.api_task_count : var.api_task_count_stage}"
+
+  deployment_minimum_healthy_percent = "${var.production_api == "romulus" ? "50" : "0"}"
+  deployment_maximum_percent         = "200"
+
+  config_vars = {
+    api_host    = "${var.api_host}"
+    es_host     = "${data.template_file.es_cluster_host_romulus.rendered}"
+    es_port     = "${var.es_config_romulus["port"]}"
+    es_name     = "${var.es_config_romulus["name"]}"
+    es_index    = "${var.es_config_romulus["index"]}"
+    es_doc_type = "${var.es_config_romulus["doc_type"]}"
+    es_username = "${var.es_config_romulus["username"]}"
+    es_password = "${var.es_config_romulus["password"]}"
+    es_protocol = "${var.es_config_romulus["protocol"]}"
+  }
+
+  loadbalancer_cloudwatch_id   = "${module.api_alb.cloudwatch_id}"
+  server_error_alarm_topic_arn = "${module.alb_server_error_alarm.arn}"
+  client_error_alarm_topic_arn = "${module.alb_client_error_alarm.arn}"
+}
+
+module "api_romulus_v1" {
+  source             = "../terraform/services"
+  name               = "api_romulus_v1"
+  cluster_id         = "${aws_ecs_cluster.api.id}"
+  task_role_arn      = "${module.ecs_api_iam.task_role_arn}"
+  vpc_id             = "${module.vpc_api.vpc_id}"
+  app_uri            = "${module.ecr_repository_api.repository_url}:${var.pinned_romulus_api != "" ? var.pinned_romulus_api : var.release_ids["api"]}"
+  nginx_uri          = "${module.ecr_repository_nginx_api.repository_url}:${var.pinned_romulus_api_nginx != "" ? var.pinned_romulus_api_nginx : var.release_ids["nginx_api"]}"
+  listener_https_arn = "${module.api_alb.listener_https_arn}"
+  listener_http_arn  = "${module.api_alb.listener_http_arn}"
+  infra_bucket       = "${var.infra_bucket}"
+  config_key         = "config/${var.build_env}/api_romulus.ini"
+  path_pattern       = "/catalogue/v1/*"
+  alb_priority       = "114"
   host_name          = "${var.production_api == "romulus" ? var.api_host : var.api_host_stage}"
 
   enable_alb_alarm = "${var.production_api == "romulus" ? 1 : 0}"
@@ -226,7 +270,51 @@ module "api_remus" {
   listener_http_arn  = "${module.api_alb.listener_http_arn}"
   infra_bucket       = "${var.infra_bucket}"
   config_key         = "config/${var.build_env}/api_remus.ini"
+  path_pattern       = "/catalogue/v1/*"
   alb_priority       = "111"
+  host_name          = "${var.production_api == "remus" ? var.api_host : var.api_host_stage}"
+
+  enable_alb_alarm = "${var.production_api == "remus" ? 1 : 0}"
+
+  cpu    = 1792
+  memory = 2048
+
+  desired_count = "${var.production_api == "remus" ? var.api_task_count : var.api_task_count_stage}"
+
+  deployment_minimum_healthy_percent = "${var.production_api == "remus" ? "50" : "0"}"
+  deployment_maximum_percent         = "200"
+
+  config_vars = {
+    api_host    = "${var.api_host}"
+    es_host     = "${data.template_file.es_cluster_host_remus.rendered}"
+    es_port     = "${var.es_config_remus["port"]}"
+    es_name     = "${var.es_config_remus["name"]}"
+    es_index    = "${var.es_config_remus["index"]}"
+    es_doc_type = "${var.es_config_remus["doc_type"]}"
+    es_username = "${var.es_config_remus["username"]}"
+    es_password = "${var.es_config_remus["password"]}"
+    es_protocol = "${var.es_config_remus["protocol"]}"
+  }
+
+  loadbalancer_cloudwatch_id   = "${module.api_alb.cloudwatch_id}"
+  server_error_alarm_topic_arn = "${module.alb_server_error_alarm.arn}"
+  client_error_alarm_topic_arn = "${module.alb_client_error_alarm.arn}"
+}
+
+module "api_remus_v1" {
+  source             = "../terraform/services"
+  name               = "api_remus"
+  cluster_id         = "${aws_ecs_cluster.api.id}"
+  task_role_arn      = "${module.ecs_api_iam.task_role_arn}"
+  vpc_id             = "${module.vpc_api.vpc_id}"
+  app_uri            = "${module.ecr_repository_api.repository_url}:${var.pinned_remus_api != "" ? var.pinned_remus_api : var.release_ids["api"]}"
+  nginx_uri          = "${module.ecr_repository_nginx_api.repository_url}:${var.pinned_remus_api_nginx != "" ? var.pinned_remus_api_nginx : var.release_ids["nginx_api"]}"
+  listener_https_arn = "${module.api_alb.listener_https_arn}"
+  listener_http_arn  = "${module.api_alb.listener_http_arn}"
+  infra_bucket       = "${var.infra_bucket}"
+  config_key         = "config/${var.build_env}/api_remus.ini"
+  path_pattern       = "/catalogue/v1/*"
+  alb_priority       = "113"
   host_name          = "${var.production_api == "remus" ? var.api_host : var.api_host_stage}"
 
   enable_alb_alarm = "${var.production_api == "remus" ? 1 : 0}"


### PR DESCRIPTION
### What is this PR trying to achieve?

Bump the API version from v0 to v1. We’re production-ready! Or at least, we have a shiny new version number.

The aim is that new deployments of the API should response to catalogue/v1, but we’ll continue to serve the current version on catalogue/v0, at least until we can get the Experience site migrated over.

Related: #582.

### Who is this change for?

Our quarterly goals! Also, folks who want a guarantee of stability from the API – we’re not going to make backwards-incompatible changes with v1.

### Have the following been considered/are they needed?

- [ ] Reviewed by @jtweed
- [ ] Deployed new versions
- [ ] Run `terraform apply`.