### PR TITLE
Tweak the Gatling to CloudWatch Lambda

### DIFF
--- a/lambdas/gatling_to_cloudwatch/main.tf
+++ b/lambdas/gatling_to_cloudwatch/main.tf
@@ -4,6 +4,7 @@ module "lambda_gatling_to_cloudwatch" {
 
   name        = "gatling_to_cloudwatch"
   description = "Record gatling results as CloudWatch metrics"
+  timeout     = 5
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
 }

--- a/lambdas/gatling_to_cloudwatch/src/gatling_to_cloudwatch.py
+++ b/lambdas/gatling_to_cloudwatch/src/gatling_to_cloudwatch.py
@@ -45,11 +45,12 @@ def send_assertions_to_cloudwatch(client, event):
         [_generate_metric(a, timestamp) for a in assertions]
     )
 
-    _send_metric(
+    resp = _send_metric(
         client=client,
         namespace=namespace,
         metric_data=metric_data
     )
+    print(f'resp = {resp}')
 
 
 def main(event, _):


### PR DESCRIPTION
### What is this PR trying to achieve?

Addressing the alarm we got this morning:

* Increase the timeout to 5s. We’ve hit the timeout twice before, and there’s no harm in doing so.
* Make it slightly easier to spot when we’ve hit the timeout (we won’t see the `resp = { ... }` line)

### Who is this change for?

Platform devs.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.