### PR TITLE
Build correct collection from object src key

### DIFF
--- a/miro_preprocessor/xml_to_json_converter/src/run.py
+++ b/miro_preprocessor/xml_to_json_converter/src/run.py
@@ -37,11 +37,15 @@ def _wrap_image_data(collection, image_data):
     }
 
 
+def _build_collection_id(src_key):
+    return src_key.split(".")[0].split("/")[-1]
+
+
 def main(bucket, src_key, dst_key, js_path="json"):
     print(f"Starting to process s3://{bucket}/{src_key}.")
     image_data = generate_images(bucket=bucket, key=src_key)
 
-    collection = src_key.split(".")[0]
+    collection = _build_collection_id(src_key)
 
     tmp_json = tempfile.mktemp()
     os.makedirs(os.path.dirname(tmp_json), exist_ok=True)

--- a/miro_preprocessor/xml_to_json_converter/src/test_run.py
+++ b/miro_preprocessor/xml_to_json_converter/src/test_run.py
@@ -128,3 +128,12 @@ def test_creates_json_file_for_each_image(s3_fixture, xml_file_contents):
     actual_json_objects = {key: _get_body(key) for key in keys}
 
     assert expected_json_objects == actual_json_objects
+
+
+def test_build_collection_id():
+    src_key = "source/Images-V.xml"
+    expected_collection_id = "Images-V"
+
+    actual_collection_id = run._build_collection_id(src_key)
+
+    assert expected_collection_id == actual_collection_id


### PR DESCRIPTION
### What is this PR trying to achieve?

The `xml_to_json_convertor` ECS task wraps the image data from the Miro XML and adds a collection identifier.

It should pass along an identifier understood by later steps in the pipeline.

### Who is this change for?

Folks who want new images in the API

### Have the following been considered/are they needed?

- [ ] Deployed new versions