### PR TITLE
Don't expect collection to match, rather contain

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -149,7 +149,7 @@ case class MiroTransformable(MiroID: String,
   }
 
   def getCreatedDate(miroData: MiroTransformableData): Option[Period] =
-    if(collectionIsV(MiroCollection)) {
+    if (collectionIsV(MiroCollection)) {
       miroData.artworkDate.map { Period(_) }
     } else {
       None

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -19,6 +19,8 @@ case class MiroTransformable(MiroID: String,
     RangeKey("MiroCollection", MiroCollection)
   )
 
+  def collectionIsV(c: String) = c.toLowerCase.contains("images-v")
+
   /*
    * Populate the title and description.  The rules are as follows:
    *
@@ -49,6 +51,7 @@ case class MiroTransformable(MiroID: String,
    */
   private def getTitleAndDescription(
     miroData: MiroTransformableData): (String, Option[String]) = {
+
     val candidateDescription: String = miroData.description match {
       case Some(s) => {
         if (s == "--" || s == "-") miroData.academicDescription.getOrElse("")
@@ -62,7 +65,7 @@ case class MiroTransformable(MiroID: String,
       .startsWith(miroData.title.get)
 
     val useDescriptionAsTitle =
-      (titleIsTruncatedDescription && MiroCollection.contains("Images-V")) ||
+      (titleIsTruncatedDescription && collectionIsV(MiroCollection)) ||
         (miroData.title.get == "-" || miroData.title.get == "--")
 
     val title = if (useDescriptionAsTitle) {
@@ -146,9 +149,10 @@ case class MiroTransformable(MiroID: String,
   }
 
   def getCreatedDate(miroData: MiroTransformableData): Option[Period] =
-    MiroCollection match {
-      case "Images-V" => miroData.artworkDate.map { Period(_) }
-      case _ => None
+    if(collectionIsV(MiroCollection)) {
+      miroData.artworkDate.map { Period(_) }
+    } else {
+      None
     }
 
   private def buildImageApiURL(miroID: String, templateName: String): String = {

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -61,8 +61,9 @@ case class MiroTransformable(MiroID: String,
     val titleIsTruncatedDescription = candidateTitle
       .startsWith(miroData.title.get)
 
-    val useDescriptionAsTitle = (titleIsTruncatedDescription &&
-      MiroCollection == "Images-V") || (miroData.title.get == "-" || miroData.title.get == "--")
+    val useDescriptionAsTitle =
+      (titleIsTruncatedDescription && MiroCollection.contains("Images-V")) ||
+        (miroData.title.get == "-" || miroData.title.get == "--")
 
     val title = if (useDescriptionAsTitle) {
       candidateTitle


### PR DESCRIPTION
### What is this PR trying to achieve?

In the Transformer when trying to extract title information, use `contains` rather than equality to be more pessimistic about what we are sent.

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Deployed new versions.
