### PR TITLE
Remove Terraform config for the v0 API

### DIFF
--- a/shared_infra/services.tf
+++ b/shared_infra/services.tf
@@ -163,49 +163,6 @@ data "template_file" "es_cluster_host_romulus" {
   }
 }
 
-module "api_romulus" {
-  source             = "../terraform/services"
-  name               = "api_romulus"
-  cluster_id         = "${aws_ecs_cluster.api.id}"
-  task_role_arn      = "${module.ecs_api_iam.task_role_arn}"
-  vpc_id             = "${module.vpc_api.vpc_id}"
-  app_uri            = "${module.ecr_repository_api.repository_url}:${var.pinned_romulus_api != "" ? var.pinned_romulus_api : var.release_ids["api"]}"
-  nginx_uri          = "${module.ecr_repository_nginx_api.repository_url}:${var.pinned_romulus_api_nginx != "" ? var.pinned_romulus_api_nginx : var.release_ids["nginx_api"]}"
-  listener_https_arn = "${module.api_alb.listener_https_arn}"
-  listener_http_arn  = "${module.api_alb.listener_http_arn}"
-  infra_bucket       = "${var.infra_bucket}"
-  config_key         = "config/${var.build_env}/api_romulus.ini"
-  path_pattern       = "/catalogue/v0/*"
-  alb_priority       = "112"
-  host_name          = "${var.production_api == "romulus" ? var.api_host : var.api_host_stage}"
-
-  enable_alb_alarm = "${var.production_api == "romulus" ? 1 : 0}"
-
-  cpu    = 1792
-  memory = 2048
-
-  desired_count = "${var.production_api == "romulus" ? var.api_task_count : var.api_task_count_stage}"
-
-  deployment_minimum_healthy_percent = "${var.production_api == "romulus" ? "50" : "0"}"
-  deployment_maximum_percent         = "200"
-
-  config_vars = {
-    api_host    = "${var.api_host}"
-    es_host     = "${data.template_file.es_cluster_host_romulus.rendered}"
-    es_port     = "${var.es_config_romulus["port"]}"
-    es_name     = "${var.es_config_romulus["name"]}"
-    es_index    = "${var.es_config_romulus["index"]}"
-    es_doc_type = "${var.es_config_romulus["doc_type"]}"
-    es_username = "${var.es_config_romulus["username"]}"
-    es_password = "${var.es_config_romulus["password"]}"
-    es_protocol = "${var.es_config_romulus["protocol"]}"
-  }
-
-  loadbalancer_cloudwatch_id   = "${module.api_alb.cloudwatch_id}"
-  server_error_alarm_topic_arn = "${module.alb_server_error_alarm.arn}"
-  client_error_alarm_topic_arn = "${module.alb_client_error_alarm.arn}"
-}
-
 module "api_romulus_v1" {
   source             = "../terraform/services"
   name               = "api_romulus_v1"
@@ -256,49 +213,6 @@ data "template_file" "es_cluster_host_remus" {
     name   = "${var.es_config_remus["name"]}"
     region = "${var.es_config_remus["region"]}"
   }
-}
-
-module "api_remus" {
-  source             = "../terraform/services"
-  name               = "api_remus"
-  cluster_id         = "${aws_ecs_cluster.api.id}"
-  task_role_arn      = "${module.ecs_api_iam.task_role_arn}"
-  vpc_id             = "${module.vpc_api.vpc_id}"
-  app_uri            = "${module.ecr_repository_api.repository_url}:${var.pinned_remus_api != "" ? var.pinned_remus_api : var.release_ids["api"]}"
-  nginx_uri          = "${module.ecr_repository_nginx_api.repository_url}:${var.pinned_remus_api_nginx != "" ? var.pinned_remus_api_nginx : var.release_ids["nginx_api"]}"
-  listener_https_arn = "${module.api_alb.listener_https_arn}"
-  listener_http_arn  = "${module.api_alb.listener_http_arn}"
-  infra_bucket       = "${var.infra_bucket}"
-  config_key         = "config/${var.build_env}/api_remus.ini"
-  path_pattern       = "/catalogue/v1/*"
-  alb_priority       = "111"
-  host_name          = "${var.production_api == "remus" ? var.api_host : var.api_host_stage}"
-
-  enable_alb_alarm = "${var.production_api == "remus" ? 1 : 0}"
-
-  cpu    = 1792
-  memory = 2048
-
-  desired_count = "${var.production_api == "remus" ? var.api_task_count : var.api_task_count_stage}"
-
-  deployment_minimum_healthy_percent = "${var.production_api == "remus" ? "50" : "0"}"
-  deployment_maximum_percent         = "200"
-
-  config_vars = {
-    api_host    = "${var.api_host}"
-    es_host     = "${data.template_file.es_cluster_host_remus.rendered}"
-    es_port     = "${var.es_config_remus["port"]}"
-    es_name     = "${var.es_config_remus["name"]}"
-    es_index    = "${var.es_config_remus["index"]}"
-    es_doc_type = "${var.es_config_remus["doc_type"]}"
-    es_username = "${var.es_config_remus["username"]}"
-    es_password = "${var.es_config_remus["password"]}"
-    es_protocol = "${var.es_config_remus["protocol"]}"
-  }
-
-  loadbalancer_cloudwatch_id   = "${module.api_alb.cloudwatch_id}"
-  server_error_alarm_topic_arn = "${module.alb_server_error_alarm.arn}"
-  client_error_alarm_topic_arn = "${module.alb_client_error_alarm.arn}"
 }
 
 module "api_remus_v1" {

--- a/shared_infra/variables_api.tf
+++ b/shared_infra/variables_api.tf
@@ -17,7 +17,7 @@ variable "production_api" {
 
 variable "pinned_romulus_api" {
   description = "Which version of the API image to pin romulus to, if any"
-  default     = "efa911ceb7814e3ca77f1e454f908a4a8debc970_dev"
+  default     = "06ec423fc0233ede77f7309f56f3ba598f4f49d0_dev"
 }
 
 variable "pinned_romulus_api_nginx" {

--- a/terraform/services/config/templates/api_remus.ini.template
+++ b/terraform/services/config/templates/api_remus.ini.template
@@ -1,9 +1,0 @@
--api.host=${api_host}
--es.host=${es_host}
--es.port=${es_port}
--es.name=${es_name}
--es.index=${es_index}
--es.type=${es_doc_type}
--es.username=${es_username}
--es.password=${es_password}
--es.protocol=${es_protocol}

--- a/terraform/services/config/templates/api_romulus.ini.template
+++ b/terraform/services/config/templates/api_romulus.ini.template
@@ -1,9 +1,0 @@
--api.host=${api_host}
--es.host=${es_host}
--es.port=${es_port}
--es.name=${es_name}
--es.index=${es_index}
--es.type=${es_doc_type}
--es.username=${es_username}
--es.password=${es_password}
--es.protocol=${es_protocol}


### PR DESCRIPTION
Poof! The v0 API has vanished in a puff of purple-smelling smoke!

![default-6](https://user-images.githubusercontent.com/301220/30738345-ae2174fc-9f81-11e7-9c90-1d7a7a810fa1.jpg)

(from https://wellcomecollection.org/works/s4zcab9j?query=smoke)

### Who is this change for?

Platform team, who don’t want to be running two versions of the API unnecessarily. Collection site is now using v1.

It might be nicer to send some 301 redirects, but as a v0 API whose existence wasn’t widely advertised, I really don’t think we can be bothered.

### Have the following been considered/are they needed?

- [x] Run `terraform apply`.