### PR TITLE
Add the Cache-Control header to responses from Loris

### DIFF
--- a/docker/nginx/loris.nginx.conf
+++ b/docker/nginx/loris.nginx.conf
@@ -29,6 +29,8 @@ http {
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
 
+    add_header Cache-Control "max-age=31536000;";
+
     # Requests for iiif.wellcomecollection.org/image should be forwarded to our IIIF Image API, Loris
     #
     # Wellcome Collection V images are currenly hosted in an s3 bucket and


### PR DESCRIPTION
### What is this PR trying to achieve?

Add the Cache-Control header to Loris responses. Related: #972.

### Who is this change for?

Users who want *even faster* repeat searches.

### Have the following been considered/are they needed?

- [ ] Deployed new versions