### PR TITLE
Do not crash if the innopac_id is empty

### DIFF
--- a/miro_preprocessor/image_sorter/src/sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/sorter_logic.py
@@ -145,7 +145,8 @@ class Rules:
             self.is_copyright_cleared and \
             self.is_cleared and \
             (not self.has_use_restrictions) and \
-            (not self.use_restrictions_are_none)
+            (not self.use_restrictions_are_none) and \
+            (self._get("image_innopac_id") is None or self.is_innopac_id_8_digits)
 
     @property
     def is_cold_store(self):

--- a/miro_preprocessor/image_sorter/src/sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/sorter_logic.py
@@ -85,7 +85,7 @@ class Rules:
 
     @property
     def is_innopac_id_8_digits(self):
-        return self._search(r"[0-9]{7}[0-9xX]{1}", "image_innopac_id") is not None
+        return self._get("image_innopac_id") is not None and self._search(r"[0-9]{7}[0-9xX]{1}", "image_innopac_id") is not None
 
     @property
     def is_title_blank(self):

--- a/miro_preprocessor/image_sorter/src/sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/sorter_logic.py
@@ -57,7 +57,10 @@ class Rules:
         return self._normalise_string(self.collection) == self._normalise_string(f"images-{collection_name}")
 
     def _search(self, regex, key):
-        return re.search(regex, self._get_normalised(key))
+        if self._get_normalised(key) is None:
+            return None
+        else:
+            return re.search(regex, self._get_normalised(key))
 
     def _is_blank(self, key):
         return self._get_normalised(key) is None
@@ -85,7 +88,7 @@ class Rules:
 
     @property
     def is_innopac_id_8_digits(self):
-        return self._get("image_innopac_id") is not None and self._search(r"[0-9]{7}[0-9xX]{1}", "image_innopac_id") is not None
+        return self._search(r"[0-9]{7}[0-9xX]{1}", "image_innopac_id") is not None
 
     @property
     def is_title_blank(self):

--- a/miro_preprocessor/image_sorter/src/test_sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/test_sorter_logic.py
@@ -115,9 +115,9 @@ def test_is_digital_library(collection, image_data):
 
 
 @pytest.mark.parametrize('collection, image_data', [
-    collection_image_data(collection='images-M', image_use_restrictions="CC-BY-NC-ND", image_innopac_id="blahbluh"),
-    collection_image_data(collection='images-L', image_use_restrictions="CC-BY-NC-ND", image_innopac_id="blahbluh"),
-    collection_image_data(collection='images-V', image_use_restrictions="CC-BY-NC-ND", image_innopac_id="blahbluh"),
+    collection_image_data(collection='images-M', image_use_restrictions="CC-BY-NC-ND", image_innopac_id=None),
+    collection_image_data(collection='images-L', image_use_restrictions="CC-BY-NC-ND", image_innopac_id=None),
+    collection_image_data(collection='images-V', image_use_restrictions="CC-BY-NC-ND", image_innopac_id=None),
 ])
 def test_is_catalogue_api(collection, image_data):
     """These examples all end up in the Digital Library."""
@@ -131,6 +131,9 @@ def test_is_catalogue_api(collection, image_data):
                           image_cleared=None),
     collection_image_data(collection='images-L', image_use_restrictions="CC-BY-NC-ND", image_innopac_id=None,
                           image_cleared=None),
+    collection_image_data(collection='images-M', image_use_restrictions="CC-BY-NC-ND", image_innopac_id="blahbluh"),
+    collection_image_data(collection='images-L', image_use_restrictions="CC-BY-NC-ND", image_innopac_id="blahbluh"),
+    collection_image_data(collection='images-V', image_use_restrictions="CC-BY-NC-ND", image_innopac_id="blahbluh"),
 ])
 def test_is_no_decision(collection, image_data):
     """These examples all end up in the Digital Library."""

--- a/miro_preprocessor/image_sorter/src/test_sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/test_sorter_logic.py
@@ -129,6 +129,8 @@ def test_is_catalogue_api(collection, image_data):
                           image_cleared="N"),
     collection_image_data(collection='images-L', image_use_restrictions="CC-BY-NC-ND", image_innopac_id="blahbluh",
                           image_cleared=None),
+    collection_image_data(collection='images-L', image_use_restrictions="CC-BY-NC-ND", image_innopac_id=None,
+                          image_cleared=None),
 ])
 def test_is_no_decision(collection, image_data):
     """These examples all end up in the Digital Library."""


### PR DESCRIPTION
### What is this PR trying to achieve?
Make image_sorter lambda not crash if innopac_id is empty
### Who is this change for?
Devs
