### PR TITLE
Revamp the way we publish and deploy Lambdas

### DIFF
--- a/.travis/run_task.py
+++ b/.travis/run_task.py
@@ -52,6 +52,8 @@ def main():
         make('loris-publish')
     elif task == 'miro_preprocessor-test':
         make('miro_preprocessor-publish')
+    elif task == 'lambdas-test':
+        make('lambdas-publish')
     else:
         task = task.replace('build', 'deploy').replace('test', 'deploy')
         make(task)

--- a/.travis/run_task.py
+++ b/.travis/run_task.py
@@ -49,14 +49,18 @@ def main():
         return 0
 
     if task == 'loris-build':
-        make('loris-publish')
+        publish_task = 'loris-publish'
     elif task == 'miro_preprocessor-test':
-        make('miro_preprocessor-publish')
+        publish_task = 'miro_preprocessor-publish'
     elif task == 'lambdas-test':
-        make('lambdas-publish')
+        publish_task = 'lambdas-publish'
     else:
-        task = task.replace('build', 'deploy').replace('test', 'deploy')
-        make(task)
+        publish_task = (task
+            .replace('build', 'deploy')
+            .replace('test', 'deploy')
+        )
+
+    make(publish_task)
 
     return 0
 

--- a/.travis/run_task.py
+++ b/.travis/run_task.py
@@ -55,10 +55,8 @@ def main():
     elif task == 'lambdas-test':
         publish_task = 'lambdas-publish'
     else:
-        publish_task = (task
-            .replace('build', 'deploy')
-            .replace('test', 'deploy')
-        )
+        publish_task = task.replace('build', 'deploy')
+        publish_task = task.replace('test', 'deploy')
 
     make(publish_task)
 

--- a/.travis/should_publish.py
+++ b/.travis/should_publish.py
@@ -24,7 +24,6 @@ def should_publish(task, travis_event_type):
     if task in [
         'check-format',
         'sbt-test-common',
-        'lambdas-test',
     ]:
         print('*** Task %s does not have a publish step' % task)
         return False

--- a/builds/publish_lambda_zip.Dockerfile
+++ b/builds/publish_lambda_zip.Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine
+
+LABEL maintainer "Alex Chan <a.chan@wellcome.ac.uk>"
+LABEL description "A Docker image for publishing AWS Lambda ZIPs to S3"
+
+RUN apk update
+RUN apk add git python3
+RUN pip3 install boto3 docopt
+
+COPY publish_lambda_zip.py /publish_lambda_zip.py
+
+VOLUME /repo
+WORKDIR /repo
+
+ENTRYPOINT ["python3", "/publish_lambda_zip.py"]

--- a/builds/publish_lambda_zip.Dockerfile
+++ b/builds/publish_lambda_zip.Dockerfile
@@ -8,6 +8,7 @@ RUN apk add git python3
 RUN pip3 install boto3 docopt
 
 COPY publish_lambda_zip.py /publish_lambda_zip.py
+COPY tooling.py /tooling.py
 
 VOLUME /repo
 WORKDIR /repo

--- a/builds/publish_lambda_zip.Dockerfile
+++ b/builds/publish_lambda_zip.Dockerfile
@@ -3,8 +3,7 @@ FROM alpine
 LABEL maintainer "Alex Chan <a.chan@wellcome.ac.uk>"
 LABEL description "A Docker image for publishing AWS Lambda ZIPs to S3"
 
-RUN apk update
-RUN apk add git python3
+RUN apk update && apk add libzip-tools git python3
 RUN pip3 install boto3 docopt
 
 COPY publish_lambda_zip.py /publish_lambda_zip.py

--- a/builds/publish_lambda_zip.py
+++ b/builds/publish_lambda_zip.py
@@ -38,15 +38,14 @@ def create_zip(src, dst):
 
     Based on https://stackoverflow.com/a/14569017/1558022
     """
-    name = f'{dst}.zip'
-    with zipfile.ZipFile(name, 'w', zipfile.ZIP_DEFLATED) as zf:
+    with zipfile.ZipFile(dst, 'w', zipfile.ZIP_DEFLATED) as zf:
         abs_src = os.path.abspath(src)
         for dirname, subdirs, files in os.walk(src):
             for filename in files:
                 absname = os.path.abspath(os.path.join(dirname, filename))
                 arcname = absname[len(abs_src) + 1:]
                 zf.write(absname, arcname)
-    return name
+    return dst
 
 
 def build_lambda_local(path, name):
@@ -75,7 +74,7 @@ def build_lambda_local(path, name):
     if os.path.exists(reqs_file):
         print(f'*** Installing dependencies from requirements.txt')
         subprocess.check_call([
-            'pip', 'install', '--requirement', reqs_file, '--target', target
+            'pip3', 'install', '--requirement', reqs_file, '--target', target
         ])
     else:
         print(f'*** No requirements.txt found')
@@ -93,7 +92,7 @@ if __name__ == '__main__':
     bucket = args['--bucket']
 
     client = boto3.client('s3')
-    name = os.path.basename(key) + '.zip'
+    name = os.path.basename(key)
     filename = build_lambda_local(path=path, name=name)
 
     print(f'*** Uploading {filename} to S3')

--- a/builds/publish_lambda_zip.py
+++ b/builds/publish_lambda_zip.py
@@ -14,7 +14,6 @@ Options:
 
 """
 
-import hashlib
 import os
 import shutil
 import subprocess
@@ -51,7 +50,6 @@ def create_zip(src, dst):
                 absname = os.path.abspath(os.path.join(dirname, filename))
                 arcname = absname[len(abs_src) + 1:]
                 zf.write(absname, arcname)
-    return dst
 
 
 def build_lambda_local(path, name):
@@ -87,7 +85,10 @@ def build_lambda_local(path, name):
 
     print(f'*** Creating zip bundle for {name}')
     os.makedirs(ZIP_DIR, exist_ok=True)
-    return create_zip(target, os.path.join(ZIP_DIR, name))
+    src = target
+    dst = os.path.join(ZIP_DIR, name)
+    create_zip(src=src, dst=dst)
+    return dst
 
 
 def upload_to_s3(client, filename, bucket, key):

--- a/builds/tooling.py
+++ b/builds/tooling.py
@@ -4,6 +4,7 @@ import errno
 import os
 import shlex
 import subprocess
+import zipfile
 
 
 # Root of the Git repository
@@ -63,3 +64,18 @@ def mkdir_p(path):
             pass
         else:
             raise
+
+
+def compare_zip_files(zf1, zf2):
+    """Return True/False if ``zf1`` and ``zf2`` have the same contents.
+
+    This ignores file metadata (e.g. creation time), and just looks at
+    filenames and CRC-32 checksums.
+    """
+    with zipfile.ZipFile(zf1) as zf:
+        info1 = {f.filename: f.CRC for f in zf.infolist()}
+
+    with zipfile.ZipFile(zf2) as zf:
+        info2 = {f.filename: f.CRC for f in zf.infolist()}
+
+    return info1 == info2

--- a/builds/tooling.py
+++ b/builds/tooling.py
@@ -4,7 +4,6 @@ import errno
 import os
 import shlex
 import subprocess
-import zipfile
 
 
 # Root of the Git repository

--- a/builds/tooling.py
+++ b/builds/tooling.py
@@ -71,11 +71,12 @@ def compare_zip_files(zf1, zf2):
 
     This ignores file metadata (e.g. creation time), and just looks at
     filenames and CRC-32 checksums.
+
+    This requires zipcmp to be available.
     """
-    with zipfile.ZipFile(zf1) as zf:
-        info1 = {f.filename: f.CRC for f in zf.infolist()}
-
-    with zipfile.ZipFile(zf2) as zf:
-        info2 = {f.filename: f.CRC for f in zf.infolist()}
-
-    return info1 == info2
+    try:
+        subprocess.check_call(['zipcmp', '-q', zf1, zf2])
+    except subprocess.CalledProcessError:
+        return False
+    else:
+        return True

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -25,7 +25,7 @@ class IdEmbedderTests
     with PatienceConfiguration {
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(
     timeout = scaled(Span(1, Seconds)),
-    interval = scaled(Span(25, Millis))
+    interval = scaled(Span(50, Millis))
   )
 
   private val metricsSender =

--- a/lambdas/Makefile
+++ b/lambdas/Makefile
@@ -1,4 +1,6 @@
-ROOT = $(shell git rev-parse --show-toplevel)
+export ROOT = $(shell git rev-parse --show-toplevel)
+export LAMBDAS = $(ROOT)/lambdas
+export INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile
@@ -7,23 +9,26 @@ endif
 
 .docker/_lambda_deps: $(ROOT)/.docker/python3.6_ci
 	docker run \
-		-v $(ROOT)/lambdas:/data \
+		-v $(LAMBDAS):/data \
 		-e OP=install-deps \
 		python3.6_ci:latest
 
 ## Run tests for our Lambda code
 lambdas-test: $(ROOT)/.docker/python3.6_ci
 	$(ROOT)/builds/docker_run.py --aws -- \
-		-v $(ROOT)/lambdas:/data \
+		-v $(LAMBDAS):/data \
 		-e OP=test \
 		-e FIND_MATCH_PATHS='./*/target common/tests' \
 		python3.6_ci:latest
+
+lambdas-publish: $(ROOT)/.docker/publish_lambda_zip
+	$(LAMBDAS)/publish_all_lambdas.sh
 
 ## Run a plan on lambda stack
 lambdas-terraform-plan: uptodate-git $(ROOT)/.docker/terraform_ci .docker/_lambda_deps
 	$(ROOT)/builds/docker_run.py --aws -- \
 	-v $(ROOT)/terraform:/terraform \
-	-v $(ROOT)/lambdas:/data \
+	-v $(LAMBDAS):/data \
 	-e OP=plan \
 	terraform_ci:latest
 
@@ -31,7 +36,7 @@ lambdas-terraform-plan: uptodate-git $(ROOT)/.docker/terraform_ci .docker/_lambd
 lambdas-terraform-apply: $(ROOT)/.docker/terraform_ci
 	$(ROOT)/builds/docker_run.py --aws -- \
 	-v $(ROOT)/terraform:/terraform \
-	-v $(ROOT)/lambdas:/data \
+	-v $(LAMBDAS):/data \
 	-e OP=apply \
 	terraform_ci:latest
 

--- a/lambdas/Makefile
+++ b/lambdas/Makefile
@@ -41,4 +41,4 @@ lambdas-terraform-apply: $(ROOT)/.docker/terraform_ci
 	terraform_ci:latest
 
 
-.PHONY: lambdas-test lambdas-terraform--plan lambdas-terraform-apply
+.PHONY: lambdas-publish lambdas-test lambdas-terraform--plan lambdas-terraform-apply

--- a/lambdas/drain_ecs_container_instance/main.tf
+++ b/lambdas/drain_ecs_container_instance/main.tf
@@ -1,12 +1,12 @@
 module "lambda_drain_ecs_container_instance" {
-  source     = "../../terraform/lambda"
-  source_dir = "${path.module}/target"
+  source = "../../terraform/lambda"
 
   name        = "drain_ecs_container_instance"
   description = "Drain ECS container instance when the corresponding EC2 instance is being terminated"
   timeout     = 60
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_key          = "lambdas/lambdas/drain_ecs_container_instance.zip"
 }
 
 module "trigger_drain_ecs_container_instance" {

--- a/lambdas/dynamo_to_sns/main.tf
+++ b/lambdas/dynamo_to_sns/main.tf
@@ -1,6 +1,5 @@
 module "lambda_dynamo_to_sns" {
-  source     = "../../terraform/lambda"
-  source_dir = "${path.module}/target"
+  source = "../../terraform/lambda"
 
   name        = "dynamo_to_sns"
   description = "Push new images form DynamoDB updates to SNS"
@@ -15,6 +14,7 @@ module "lambda_dynamo_to_sns" {
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_key          = "lambdas/lambdas/dynamo_to_sns.zip"
 }
 
 module "trigger_dynamo_to_sns_miro" {

--- a/lambdas/ecs_ec2_instance_tagger/main.tf
+++ b/lambdas/ecs_ec2_instance_tagger/main.tf
@@ -1,8 +1,7 @@
 # Lambda for tagging EC2 instances with ECS cluster/container instance id
 
 module "lambda_ecs_ec2_instance_tagger" {
-  source     = "../../terraform/lambda"
-  source_dir = "${path.module}/target"
+  source = "../../terraform/lambda"
 
   name        = "ecs_ec2_instance_tagger"
   description = "Tag an EC2 instance with ECS cluster/container instance id"
@@ -14,6 +13,7 @@ module "lambda_ecs_ec2_instance_tagger" {
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_key          = "lambdas/lambdas/ecs_ec2_instance_tagger.zip"
 }
 
 module "trigger_ecs_ec2_instance_tagger" {

--- a/lambdas/gatling_to_cloudwatch/main.tf
+++ b/lambdas/gatling_to_cloudwatch/main.tf
@@ -1,12 +1,12 @@
 module "lambda_gatling_to_cloudwatch" {
-  source     = "../../terraform/lambda"
-  source_dir = "${path.module}/target"
+  source = "../../terraform/lambda"
 
   name        = "gatling_to_cloudwatch"
   description = "Record gatling results as CloudWatch metrics"
   timeout     = 5
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_key          = "lambdas/lambdas/gatling_to_cloudwatch.zip"
 }
 
 module "trigger_gatling_to_cloudwatch" {

--- a/lambdas/notify_old_deploys/main.tf
+++ b/lambdas/notify_old_deploys/main.tf
@@ -1,8 +1,7 @@
 # Lambda for publishing out of date deployments to SNS
 
 module "lambda_notify_old_deploys" {
-  source     = "../../terraform/lambda"
-  source_dir = "${path.module}/target"
+  source = "../../terraform/lambda"
 
   name        = "notify_old_deploys"
   description = "For publishing out of date deployments to SNS"
@@ -14,6 +13,7 @@ module "lambda_notify_old_deploys" {
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_key          = "lambdas/lambdas/notify_old_deploys.zip"
 }
 
 module "trigger_notify_old_deploys" {

--- a/lambdas/post_to_slack/main.tf
+++ b/lambdas/post_to_slack/main.tf
@@ -1,8 +1,7 @@
 # Lambda for posting on slack when an alarm is triggered
 
 module "lambda_post_to_slack" {
-  source     = "../../terraform/lambda"
-  source_dir = "${path.module}/target"
+  source = "../../terraform/lambda"
 
   name        = "post_to_slack"
   description = "Post notification to Slack when an alarm is triggered"
@@ -13,6 +12,7 @@ module "lambda_post_to_slack" {
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_key          = "lambdas/lambdas/post_to_slack.zip"
 }
 
 module "trigger_post_to_slack_dlqs_not_empty" {

--- a/lambdas/publish_all_lambdas.sh
+++ b/lambdas/publish_all_lambdas.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+set -o errexit
+set -o nounset
+
+ROOT=$(git rev-parse --show-toplevel)
+
+for f in $(find $LAMBDAS -name src -type d)
+do
+  name=$(basename $(dirname "$f"))
+  echo "Building Lambda $name"
+  $ROOT/builds/docker_run.py --aws -- \
+    --volume $ROOT:/repo \
+    publish_lambda_zip \
+    "lambdas/$name/src" --key="lambdas/$name" --bucket="$INFRA_BUCKET"
+done

--- a/lambdas/publish_all_lambdas.sh
+++ b/lambdas/publish_all_lambdas.sh
@@ -12,5 +12,5 @@ do
   $ROOT/builds/docker_run.py --aws -- \
     --volume $ROOT:/repo \
     publish_lambda_zip \
-    "lambdas/$name/src" --key="lambdas/$name" --bucket="$INFRA_BUCKET"
+    "lambdas/$name/src" --key="lambdas/lambdas/$name.zip" --bucket="$INFRA_BUCKET"
 done

--- a/lambdas/run_ecs_task/main.tf
+++ b/lambdas/run_ecs_task/main.tf
@@ -1,13 +1,13 @@
 # Lambda for publishing ECS service schedules to an SNS topic
 
 module "lambda_run_ecs_task" {
-  source     = "../../terraform/lambda"
-  source_dir = "${path.module}/target"
+  source = "../../terraform/lambda"
 
   name        = "run_ecs_task"
   description = "Run an ECS task from a message published to SNS"
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_key          = "lambdas/lambdas/run_ecs_task.zip"
 }
 
 module "trigger_run_ecs_task" {

--- a/lambdas/schedule_reindexer/main.tf
+++ b/lambdas/schedule_reindexer/main.tf
@@ -1,6 +1,5 @@
 module "lambda_schedule_reindexer" {
-  source     = "../../terraform/lambda"
-  source_dir = "${path.module}/target"
+  source = "../../terraform/lambda"
 
   name        = "schedule_reindexer"
   description = "Schedules the reindexer based on the ReindexerTracker table"
@@ -15,6 +14,7 @@ module "lambda_schedule_reindexer" {
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_key          = "lambdas/lambdas/schedule_reindexer.zip"
 }
 
 module "trigger_reindexer_lambda" {

--- a/lambdas/service_deployment_status/main.tf
+++ b/lambdas/service_deployment_status/main.tf
@@ -1,8 +1,7 @@
 # Lambda for tracking deployment status in dynamo db
 
 module "lambda_service_deployment_status" {
-  source     = "../../terraform/lambda"
-  source_dir = "${path.module}/target"
+  source = "../../terraform/lambda"
 
   name        = "service_deployment_status"
   description = "Lambda for tracking deployment status in dynamo db"
@@ -13,6 +12,7 @@ module "lambda_service_deployment_status" {
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_key          = "lambdas/lambdas/service_deployment_status.zip"
 }
 
 module "trigger_service_deployment_status" {

--- a/lambdas/service_scheduler/main.tf
+++ b/lambdas/service_scheduler/main.tf
@@ -1,11 +1,11 @@
 # Lambda for publishing ECS service schedules to an SNS topic
 
 module "lambda_service_scheduler" {
-  source     = "../../terraform/lambda"
-  source_dir = "${path.module}/target"
+  source = "../../terraform/lambda"
 
   name        = "service_scheduler"
   description = "Publish an ECS service schedule to SNS"
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_key          = "lambdas/lambdas/service_scheduler.zip"
 }

--- a/lambdas/update_dynamo_capacity/main.tf
+++ b/lambdas/update_dynamo_capacity/main.tf
@@ -2,9 +2,9 @@ module "lambda_update_dynamo_capacity" {
   source      = "../../terraform/lambda"
   name        = "update_dynamo_capacity"
   description = "Update the capacity of a DynamoDB table"
-  source_dir  = "${path.module}/target"
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_key          = "lambdas/lambdas/update_dynamo_capacity.zip"
 }
 
 module "trigger_update_dynamo_capacity" {

--- a/lambdas/update_ecs_service_size/main.tf
+++ b/lambdas/update_ecs_service_size/main.tf
@@ -4,9 +4,9 @@ module "lambda_update_ecs_service_size" {
   source      = "../../terraform/lambda"
   name        = "update_ecs_service_size"
   description = "Update the desired count of an ECS service"
-  source_dir  = "${path.module}/target"
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_key          = "lambdas/lambdas/update_ecs_service_size.zip"
 }
 
 module "trigger_update_ecs_service_size" {

--- a/lambdas/update_service_list/main.tf
+++ b/lambdas/update_service_list/main.tf
@@ -3,7 +3,6 @@ module "lambda_update_service_list" {
   name        = "update_service_list"
   description = "Publish ECS service status summary to S3"
   timeout     = 10
-  source_dir  = "${path.module}/target"
 
   environment_variables = {
     BUCKET_NAME     = "${var.bucket_dashboard_id}"
@@ -12,6 +11,7 @@ module "lambda_update_service_list" {
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_key          = "lambdas/lambdas/update_service_list.zip"
 }
 
 module "trigger_update_service_list" {

--- a/lambdas/update_task_for_config_change/main.tf
+++ b/lambdas/update_task_for_config_change/main.tf
@@ -4,9 +4,9 @@ module "lambda_update_task_for_config_change" {
   source      = "../../terraform/lambda"
   name        = "update_task_for_config_change"
   description = "Trigger a task definition change and restart on config change."
-  source_dir  = "${path.module}/target"
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_key          = "lambdas/lambdas/update_task_for_config_change.zip"
 }
 
 resource "aws_lambda_permission" "allow_lambda" {

--- a/shared.Makefile
+++ b/shared.Makefile
@@ -42,6 +42,11 @@ $(ROOT)/.docker/miro_adapter_tests:
 		--dir=miro_adapter \
 		--file=miro_adapter/miro_adapter_tests.Dockerfile
 
+$(ROOT)/.docker/publish_lambda_zip:
+	$(ROOT)/builds/build_ci_docker_image.py \
+		--project=publish_lambda_zip \
+		--dir=builds \
+		--file=builds/publish_lambda_zip.Dockerfile
 
 
 # Project utility tasks

--- a/shared_infra/iam_policy_document.tf
+++ b/shared_infra/iam_policy_document.tf
@@ -112,22 +112,23 @@ data "aws_iam_policy_document" "travis_permissions" {
 
   statement {
     actions = [
-      "ecr:GetAuthorizationToken",
-    ]
-
-    resources = [
-      "*",
-    ]
-  }
-
-  statement {
-    actions = [
       "s3:PutObject",
       "s3:GetObject",
     ]
 
     resources = [
+      "${aws_s3_bucket.infra.arn}/lambdas/*",
       "${aws_s3_bucket.infra.arn}/releases/*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "sns:ListTopic",
+    ]
+
+    resources = [
+      "*",
     ]
   }
 }

--- a/terraform/lambda/lambda_function.tf
+++ b/terraform/lambda/lambda_function.tf
@@ -1,18 +1,20 @@
-data "archive_file" "lambda_zip_file" {
-  type        = "zip"
-  source_dir  = "${var.source_dir}"
-  output_path = "${var.source_dir}/../${var.name}.zip"
+data "aws_s3_bucket_object" "package" {
+  bucket = "${var.s3_bucket}"
+  key    = "${var.s3_key}"
 }
 
 resource "aws_lambda_function" "lambda_function" {
-  description      = "${var.description}"
-  filename         = "${data.archive_file.lambda_zip_file.output_path}"
-  function_name    = "${var.name}"
-  role             = "${aws_iam_role.iam_role.arn}"
-  handler          = "${var.name}.main"
-  runtime          = "python3.6"
-  source_code_hash = "${data.archive_file.lambda_zip_file.output_base64sha256}"
-  timeout          = "${var.timeout}"
+  description   = "${var.description}"
+  function_name = "${var.name}"
+
+  s3_bucket         = "${var.s3_bucket}"
+  s3_key            = "${var.s3_key}"
+  s3_object_version = "${data.aws_s3_bucket_object.package.version_id}"
+
+  role    = "${aws_iam_role.iam_role.arn}"
+  handler = "${var.name}.main"
+  runtime = "python3.6"
+  timeout = "${var.timeout}"
 
   dead_letter_config = {
     target_arn = "${aws_sqs_queue.lambda_dlq.arn}"

--- a/terraform/lambda/variables.tf
+++ b/terraform/lambda/variables.tf
@@ -6,15 +6,11 @@ variable "description" {
   description = "Description of the Lambda function"
 }
 
-variable "source_dir" {
-  description = "Path to the directory containing the Lambda source code"
-}
-
 variable "environment_variables" {
   description = "Environment variables to pass to the Lambda"
   type        = "map"
 
-  # environment cannot be emtpy so we need to pass at least one value
+  # environment cannot be empty so we need to pass at least one value
   default = {
     EMPTY_VARIABLE = ""
   }
@@ -27,4 +23,13 @@ variable "timeout" {
 
 variable "alarm_topic_arn" {
   description = "ARN of the topic where to send notification for lambda errors"
+}
+
+variable "s3_bucket" {
+  description = "The S3 bucket containing the function's deployment package"
+  default     = "platform-infra"
+}
+
+variable "s3_key" {
+  description = "The S3 key of the function's deployment package"
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

This is a complete rethink of the way we deploy Lambdas. Rather than installing files locally, we:

* Have Travis build a ZIP “deployment package” inside a Docker container
* Upload the ZIP to S3 (but only if there are changes against the current version, and in *non-test code*)
* Use that S3 object when deploying the Lambda

Resolves #971.

Still to do is adding the Travis config, but that’s blocked on a merge of #987.

### Who is this change for?

Devs who want neater deployment procedures.

Also, me when I come to pull apart the Lambdas stack.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [x] Run `terraform apply`.