### PR TITLE
ReindexTrackerService tracks shards

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/Reindex.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Reindex.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.models
 
 case class Reindex(TableName: String,
+                   ReindexShard: String,
                    RequestedVersion: Int,
                    CurrentVersion: Int)

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/DynamoDBLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/DynamoDBLocal.scala
@@ -40,6 +40,7 @@ trait DynamoDBLocal extends BeforeAndAfterEach { this: Suite =>
   val miroDataTableName = "MiroData"
   val calmDataTableName = "CalmData"
   val reindexTableName = "ReindexTracker"
+  val reindexShard = "default"
 
   deleteTables()
   createReindexTable()
@@ -90,7 +91,10 @@ trait DynamoDBLocal extends BeforeAndAfterEach { this: Suite =>
       case Right(reindex) =>
         dynamoDbClient.deleteItem(
           reindexTableName,
-          Map("TableName" -> new AttributeValue(reindex.TableName)))
+          Map(
+            "TableName" -> new AttributeValue(reindex.TableName),
+            "ReindexShard" -> new AttributeValue(reindex.ReindexShard)
+          ))
       case a =>
         throw new Exception(
           s"Unable to clear the table $reindexTableName error $a")
@@ -252,9 +256,17 @@ trait DynamoDBLocal extends BeforeAndAfterEach { this: Suite =>
         .withKeySchema(new KeySchemaElement()
           .withAttributeName("TableName")
           .withKeyType(KeyType.HASH))
+        .withKeySchema(new KeySchemaElement()
+          .withAttributeName("ReindexShard")
+          .withKeyType(KeyType.RANGE))
         .withAttributeDefinitions(
           new AttributeDefinition()
             .withAttributeName("TableName")
+            .withAttributeType("S")
+        )
+        .withAttributeDefinitions(
+          new AttributeDefinition()
+            .withAttributeName("ReindexShard")
             .withAttributeType("S")
         )
         .withProvisionedThroughput(new ProvisionedThroughput()

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTrackerService.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTrackerService.scala
@@ -17,8 +17,9 @@ import uk.ac.wellcome.utils.GlobalExecutionContext.context
 class ReindexTrackerService @Inject()(
   dynamoDBClient: AmazonDynamoDB,
   dynamoConfigs: Map[String, DynamoConfig],
-  @Flag("reindex.target.tableName") reindexTargetTableName: String)
-    extends Logging {
+  @Flag("reindex.target.tableName") reindexTargetTableName: String,
+  @Flag("reindex.target.reindexShard") targetReindexShard: String
+ ) extends Logging {
 
   private val reindexTrackerTableConfigId = "reindex"
 
@@ -43,10 +44,10 @@ class ReindexTrackerService @Inject()(
 
   def getIndexForReindex: Future[Option[Reindex]] =
     getIndices.map {
-      case Reindex(tableName, requested, current) if requested > current => {
+      case Reindex(tableName, reindexShard, requested, current) if requested > current => {
         info(
           s"ReindexTracker found out of sync table: $tableName, ($requested > $current)")
-        Some(Reindex(tableName, requested, current))
+        Some(Reindex(tableName, reindexShard, requested, current))
       }
       case _ => {
         info(s"ReindexTracker found no out of sync tables.")
@@ -56,7 +57,9 @@ class ReindexTrackerService @Inject()(
 
   private def getIndices: Future[Reindex] = Future {
     Scanamo.exec(dynamoDBClient)(
-      reindexTable.get('TableName -> reindexTargetTableName)) match {
+      reindexTable.get(
+        'TableName -> reindexTargetTableName and 'ReindexShard -> targetReindexShard
+      )) match {
       case Some(Right(reindex)) => {
         info(s"ReindexTracker found $reindex matching $reindexTargetTableName")
         reindex

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTrackerService.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTrackerService.scala
@@ -19,7 +19,7 @@ class ReindexTrackerService @Inject()(
   dynamoConfigs: Map[String, DynamoConfig],
   @Flag("reindex.target.tableName") reindexTargetTableName: String,
   @Flag("reindex.target.reindexShard") targetReindexShard: String
- ) extends Logging {
+) extends Logging {
 
   private val reindexTrackerTableConfigId = "reindex"
 
@@ -44,7 +44,8 @@ class ReindexTrackerService @Inject()(
 
   def getIndexForReindex: Future[Option[Reindex]] =
     getIndices.map {
-      case Reindex(tableName, reindexShard, requested, current) if requested > current => {
+      case Reindex(tableName, reindexShard, requested, current)
+          if requested > current => {
         info(
           s"ReindexTracker found out of sync table: $tableName, ($requested > $current)")
         Some(Reindex(tableName, reindexShard, requested, current))

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/ReindexerFeatureTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/ReindexerFeatureTest.scala
@@ -44,7 +44,7 @@ class ReindexerFeatureTest
     })
 
     val reindexList = List(
-      Reindex(miroDataTableName, requestedVersion, currentVersion)
+      Reindex(miroDataTableName, reindexShard, requestedVersion, currentVersion)
     )
 
     itemsToPut.foreach(Scanamo.put(dynamoDbClient)(miroDataTableName))

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/ReindexerFeatureTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/ReindexerFeatureTest.scala
@@ -43,9 +43,8 @@ class ReindexerFeatureTest
       Right(item.copy(ReindexVersion = requestedVersion))
     })
 
-    val reindexList = List(
-      Reindex(miroDataTableName, reindexShard, requestedVersion, currentVersion)
-    )
+    val reindex = Reindex(miroDataTableName, reindexShard, requestedVersion, currentVersion)
+    val reindexList = List(reindex)
 
     itemsToPut.foreach(Scanamo.put(dynamoDbClient)(miroDataTableName))
     reindexList.foreach(Scanamo.put(dynamoDbClient)(reindexTableName))

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
@@ -55,7 +55,7 @@ class ReindexModuleTest
         reindexTargetService)
     maybeServer = Some(server)
 
-    val reindex = Reindex(calmDataTableName, requestedVersion, currentVersion)
+    val reindex = Reindex(calmDataTableName, reindexShard, requestedVersion, currentVersion)
     Scanamo.put(dynamoDbClient)(reindexTableName)(reindex)
 
     when(reindexTargetService.runReindex(ReindexAttempt(reindex, false, 0)))

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
@@ -68,7 +68,7 @@ class ReindexModuleTest
 
     eventually {
       Scanamo.get[Reindex](dynamoDbClient)(reindexTableName)(
-        'TableName -> "CalmData") shouldBe Some(
+        'TableName -> "CalmData" and 'ReindexShard -> reindexShard) shouldBe Some(
         Right(reindex.copy(CurrentVersion = requestedVersion)))
     }
   }

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/CalmReindexTargetServiceTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/CalmReindexTargetServiceTest.scala
@@ -48,7 +48,7 @@ class CalmReindexTargetServiceTest
     val expectedCalmTransformableList =
       outOfdateCalmTransformableList.map(_.copy(ReindexVersion = 2))
 
-    val reindex = Reindex(calmDataTableName, requestedVersion, currentVersion)
+    val reindex = Reindex(calmDataTableName, reindexShard, requestedVersion, currentVersion)
 
     calmTransformableList.foreach(
       Scanamo.put(dynamoDbClient)(calmDataTableName))

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/MiroReindexTargetServiceTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/MiroReindexTargetServiceTest.scala
@@ -62,7 +62,7 @@ class MiroReindexTargetServiceTest
 
     val miroTransformableList = inShardMiroTransformables ++ diffShardMiroTransformables
 
-    val reindex = Reindex(miroDataTableName, requestedVersion, currentVersion)
+    val reindex = Reindex(miroDataTableName, reindexShard, requestedVersion, currentVersion)
     val reindexAttempt = ReindexAttempt(reindex)
     val expectedReindexAttempt = reindexAttempt.copy(
       reindex = reindex,
@@ -123,7 +123,8 @@ class MiroReindexTargetServiceTest
 
     val miroTransformableList = outOfdateMiroTransformableList ++ inDateMiroTransferrableList
 
-    val reindex = Reindex(miroDataTableName, requestedVersion, currentVersion)
+    val reindex = Reindex(miroDataTableName, reindexShard, requestedVersion, currentVersion)
+
     val reindexAttempt = ReindexAttempt(reindex)
     val expectedReindexAttempt = reindexAttempt.copy(
       reindex = reindex,

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexServiceTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexServiceTest.scala
@@ -127,7 +127,7 @@ class ReindexServiceTest
 
     whenReady(reindexService.run) { _ =>
       Scanamo.get[Reindex](dynamoDbClient)(reindexTableName)(
-        'TableName -> "CalmData") shouldBe Some(
+        'TableName -> "CalmData" and 'ReindexShard -> reindexShard) shouldBe Some(
         Right(reindex.copy(CurrentVersion = requestedVersion)))
     }
 

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexServiceTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexServiceTest.scala
@@ -80,7 +80,7 @@ class ReindexServiceTest
     whenReady(reindexService.run) { _ =>
       Scanamo.scan[CalmTransformable](dynamoDbClient)(calmDataTableName) shouldBe expectedCalmTransformableList
       Scanamo.get[Reindex](dynamoDbClient)(reindexTableName)(
-        'TableName -> "CalmData") shouldBe Some(
+        'TableName -> "CalmData" and 'ReindexShard -> reindexShard) shouldBe Some(
         Right(reindex.copy(CurrentVersion = requestedVersion)))
     }
   }

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexServiceTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexServiceTest.scala
@@ -38,7 +38,8 @@ class ReindexServiceTest
       new ReindexTrackerService(
         dynamoDbClient,
         dynamoConfigs,
-        "CalmData"
+        "CalmData",
+        reindexShard
       ),
       new CalmReindexTargetService(
         dynamoDBClient = dynamoDbClient,
@@ -71,7 +72,7 @@ class ReindexServiceTest
     calmTransformableList.foreach(
       Scanamo.put(dynamoDbClient)(calmDataTableName))
 
-    val reindex = Reindex(calmDataTableName, requestedVersion, currentVersion)
+    val reindex = Reindex(calmDataTableName, reindexShard, requestedVersion, currentVersion)
     Scanamo.put(dynamoDbClient)(reindexTableName)(reindex)
 
     val reindexService = createReindexService
@@ -87,7 +88,7 @@ class ReindexServiceTest
   it("should retry while the target reports that there are not updated items") {
     val calmReindexTargetService = mock[CalmReindexTargetService]
 
-    val reindex = Reindex(calmDataTableName, requestedVersion, currentVersion)
+    val reindex = Reindex(calmDataTableName, reindexShard, requestedVersion, currentVersion)
     Scanamo.put(dynamoDbClient)(reindexTableName)(reindex)
 
     val calmTransformableList = List(
@@ -117,7 +118,8 @@ class ReindexServiceTest
       new ReindexTrackerService(
         dynamoDbClient,
         dynamoConfigs,
-        "CalmData"
+        "CalmData",
+        reindexShard
       ),
       calmReindexTargetService,
       new MetricsSender("reindexer-tests", mock[AmazonCloudWatch])
@@ -132,7 +134,7 @@ class ReindexServiceTest
   }
 
   it("should report successful when there is no work to do") {
-    val reindex = Reindex(calmDataTableName, currentVersion, currentVersion)
+    val reindex = Reindex(calmDataTableName, reindexShard, currentVersion, currentVersion)
     Scanamo.put(dynamoDbClient)(reindexTableName)(reindex)
 
     val reindexService = createReindexService

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTrackerServiceTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTrackerServiceTest.scala
@@ -23,10 +23,11 @@ class ReindexTrackerServiceTest
   it(
     "should return the index in need of reindexing"
   ) {
-    val expectedReindex = Reindex("CalmData", 2, 1)
+    val expectedReindex = Reindex("CalmData", "default", 2, 1)
+    val anotherReindex = Reindex("MiroData", "default", 2, 1)
     val reindexList = List(
       expectedReindex,
-      Reindex("MiroData", 1, 1)
+      anotherReindex
     )
 
     reindexList.foreach(Scanamo.put(dynamoDbClient)(reindexTableName))
@@ -34,7 +35,8 @@ class ReindexTrackerServiceTest
     val reindexTrackerService = new ReindexTrackerService(
       dynamoDbClient,
       dynamoConfigs,
-      "CalmData"
+      "CalmData",
+      reindexShard
     )
 
     val op = reindexTrackerService.getIndexForReindex

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTrackerServiceTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTrackerServiceTest.scala
@@ -21,13 +21,22 @@ class ReindexTrackerServiceTest
     "calm" -> DynamoConfig("applicationName", "streamArn", calmDataTableName))
 
   it(
-    "should return the index in need of reindexing"
+    "should return the index and shard in need of reindexing"
   ) {
-    val expectedReindex = Reindex("CalmData", "default", 2, 1)
-    val anotherReindex = Reindex("MiroData", "default", 2, 1)
+    val expectedTable = "CalmData"
+    val expectedShard = "new_shard"
+
+    val anotherTable = "MiroData"
+    val anotherShard = "another_shard"
+
+    val expectedReindex = Reindex(expectedTable, expectedShard, 2, 1)
+    val anotherReindex = Reindex(anotherTable, anotherShard, 2, 1)
+
     val reindexList = List(
       expectedReindex,
-      anotherReindex
+      Reindex(expectedTable, anotherShard, 2, 1),
+      Reindex(anotherTable, expectedShard, 2, 1),
+      Reindex(anotherTable, anotherShard, 2, 1)
     )
 
     reindexList.foreach(Scanamo.put(dynamoDbClient)(reindexTableName))
@@ -35,8 +44,8 @@ class ReindexTrackerServiceTest
     val reindexTrackerService = new ReindexTrackerService(
       dynamoDbClient,
       dynamoConfigs,
-      "CalmData",
-      reindexShard
+      expectedTable,
+      expectedShard
     )
 
     val op = reindexTrackerService.getIndexForReindex

--- a/shared_infra/dynamo.tf
+++ b/shared_infra/dynamo.tf
@@ -125,11 +125,17 @@ resource "aws_dynamodb_table" "reindex_tracker" {
   read_capacity    = 1
   write_capacity   = 1
   hash_key         = "TableName"
+  range_key        = "ReindexShard"
   stream_enabled   = true
   stream_view_type = "NEW_IMAGE"
 
   attribute {
     name = "TableName"
+    type = "S"
+  }
+
+  attribute {
+    name = "ReindexShard"
     type = "S"
   }
 


### PR DESCRIPTION
### What is this PR trying to achieve?

In order to run reindexes against particular shards the ReindexTrackerService (and its underlying table) need to keep track of the particular shard that we wish to reindex.

### Who is this change for?

Folk who want effective reindexes of individual image collections (and whatever else we choose to shard on in the future).

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.
