### PR TITLE
Make Loris use io1 EBS volume

### DIFF
--- a/loris/terraform/asg.tf
+++ b/loris/terraform/asg.tf
@@ -39,4 +39,6 @@ module "loris_cluster_asg_ebs" {
 
   ebs_device_name = "/dev/xvdb"
   ebs_size        = 60
+  ebs_volume_type = "io1"
+  ebs_iops        = "200"
 }

--- a/terraform/ecs_asg/ecs_asg_launch_config/main.tf
+++ b/terraform/ecs_asg/ecs_asg_launch_config/main.tf
@@ -38,7 +38,7 @@ resource "aws_launch_configuration" "spot_launch_config" {
 }
 
 resource "aws_launch_configuration" "ebs_launch_config" {
-  count = "${var.ebs_device_name == "" ? 0 : 1}"
+  count = "${var.ebs_device_name == "" || var.ebs_volume_type == "io1" ? 0 : 1}"
 
   security_groups = [
     "${aws_security_group.instance_sg.id}",
@@ -59,5 +59,31 @@ resource "aws_launch_configuration" "ebs_launch_config" {
     volume_size = "${var.ebs_size}"
     device_name = "${var.ebs_device_name}"
     volume_type = "${var.ebs_volume_type}"
+  }
+}
+
+resource "aws_launch_configuration" "ebs_io1_launch_config" {
+  count = "${var.ebs_device_name != "" && var.ebs_volume_type == "io1" ? 1 : 0}"
+
+  security_groups = [
+    "${aws_security_group.instance_sg.id}",
+  ]
+
+  key_name                    = "${var.key_name}"
+  image_id                    = "${var.image_id}"
+  instance_type               = "${var.instance_type}"
+  iam_instance_profile        = "${var.instance_profile_name}"
+  user_data                   = "${var.user_data}"
+  associate_public_ip_address = "${var.public_ip}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  ebs_block_device {
+    volume_size = "${var.ebs_size}"
+    device_name = "${var.ebs_device_name}"
+    volume_type = "${var.ebs_volume_type}"
+    iops        = "${var.ebs_iops}"
   }
 }

--- a/terraform/ecs_asg/ecs_asg_launch_config/outputs.tf
+++ b/terraform/ecs_asg/ecs_asg_launch_config/outputs.tf
@@ -1,5 +1,5 @@
 output "name" {
-  value = "${element(concat(aws_launch_configuration.spot_launch_config.*.name, aws_launch_configuration.ondemand_launch_config.*.name, aws_launch_configuration.ebs_launch_config.*.name), 0)}"
+  value = "${element(concat(aws_launch_configuration.spot_launch_config.*.name, aws_launch_configuration.ondemand_launch_config.*.name, aws_launch_configuration.ebs_launch_config.*.name, aws_launch_configuration.ebs_io1_launch_config.*.name), 0)}"
 }
 
 output "instance_sg_id" {

--- a/terraform/ecs_asg/ecs_asg_launch_config/variables.tf
+++ b/terraform/ecs_asg/ecs_asg_launch_config/variables.tf
@@ -46,3 +46,5 @@ variable "ebs_device_name" {}
 variable "ebs_size" {}
 
 variable "ebs_volume_type" {}
+
+variable "ebs_iops" {}

--- a/terraform/ecs_asg/main.tf
+++ b/terraform/ecs_asg/main.tf
@@ -30,4 +30,5 @@ module "launch_config" {
   ebs_size              = "${var.ebs_size}"
   public_ip             = "${var.public_ip}"
   ebs_volume_type       = "${var.ebs_volume_type}"
+  ebs_iops              = "${var.ebs_iops}"
 }

--- a/terraform/ecs_asg/variables.tf
+++ b/terraform/ecs_asg/variables.tf
@@ -87,3 +87,7 @@ variable "ebs_size" {
 variable "ebs_volume_type" {
   default = "standard"
 }
+
+variable "ebs_iops" {
+  default = ""
+}


### PR DESCRIPTION
### What is this PR trying to achieve?
Make Loris use the IO optimized volume instead of the standard magnetic one to see if it makes it faster
### Who is this change for?
Devs & users
### Have the following been considered/are they needed?

- [x] Run `terraform apply`.
