### PR TITLE
Fix stack references in miro_preproc stack

### DIFF
--- a/catalogue_api/terraform/locals.tf
+++ b/catalogue_api/terraform/locals.tf
@@ -10,4 +10,6 @@ locals {
   bucket_infra_id  = "${data.terraform_remote_state.shared_infra.bucket_infra_id}"
 
   bucket_alb_logs_id = "${data.terraform_remote_state.shared_infra.bucket_alb_logs_id}"
+
+  run_ecs_task_topic_arn = "${data.terraform_remote_state.shared_infra.run_ecs_task_topic_arn}"
 }

--- a/miro_preprocessor/iam_policy_document.tf
+++ b/miro_preprocessor/iam_policy_document.tf
@@ -6,7 +6,7 @@ data "aws_iam_policy_document" "s3_read_miro_data" {
     ]
 
     resources = [
-      "${data.terraform_remote_state.platform.bucket_miro_data_arn}/source",
+      "${local.bucket_miro_data_arn}/source",
     ]
   }
 }
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "s3_write_miro_data" {
     ]
 
     resources = [
-      "${data.terraform_remote_state.platform.bucket_miro_data_arn}/*",
+      "${local.bucket_miro_data_arn}/*",
     ]
   }
 }

--- a/miro_preprocessor/locals.tf
+++ b/miro_preprocessor/locals.tf
@@ -1,0 +1,19 @@
+locals {
+  lambda_error_alarm_arn            = "${data.terraform_remote_state.shared_infra.lambda_error_alarm_arn}"
+  run_ecs_task_topic_arn            = "${data.terraform_remote_state.shared_infra.run_ecs_task_topic_arn}"
+  run_ecs_task_topic_publish_policy = "${data.terraform_remote_state.shared_infra.run_ecs_task_topic_publish_policy}"
+
+  bucket_miro_images_public_arn  = "${data.terraform_remote_state.loris.bucket_wellcomecollectio_miro_images_public_arn}"
+  bucket_miro_images_public_name = "${data.terraform_remote_state.loris.bucket_wellcomecollectio_miro_images_public_id}"
+
+  bucket_miro_images_sync_arn  = "${data.terraform_remote_state.catalogue_api.bucket_miro_images_sync_arn}"
+  bucket_miro_images_sync_name = "${data.terraform_remote_state.catalogue_api.bucket_miro_images_sync_id}"
+
+  bucket_miro_data_id  = "${data.terraform_remote_state.catalogue_api.bucket_miro_data_id}"
+  bucket_miro_data_arn = "${data.terraform_remote_state.catalogue_api.bucket_miro_data_arn}"
+
+  ecs_services_cluster_name = "${data.terraform_remote_state.catalogue_pipeline.ecs_services_cluster_name}"
+
+  table_miro_data_arn  = "${data.terraform_remote_state.catalogue_pipeline.table_miro_data_arn}"
+  table_miro_data_name = "${data.terraform_remote_state.catalogue_pipeline.table_miro_data_name}"
+}

--- a/miro_preprocessor/main.tf
+++ b/miro_preprocessor/main.tf
@@ -1,7 +1,7 @@
 module "xml_to_json_converter" {
   source = "xml_to_json_converter"
 
-  bucket_miro_data_id = "${data.terraform_remote_state.platform.bucket_miro_data_id}"
+  bucket_miro_data_id = "${local.bucket_miro_data_id}"
   release_ids         = "${var.release_ids}"
 
   s3_read_miro_data_json  = "${data.aws_iam_policy_document.s3_read_miro_data.json}"
@@ -11,36 +11,37 @@ module "xml_to_json_converter" {
 module "xml_to_json_run_task" {
   source = "xml_to_json_run_task"
 
-  bucket_miro_data_id    = "${data.terraform_remote_state.platform.bucket_miro_data_id}"
-  bucket_miro_data_arn   = "${data.terraform_remote_state.platform.bucket_miro_data_arn}"
-  lambda_error_alarm_arn = "${data.terraform_remote_state.lambda.lambda_error_alarm_arn}"
+  bucket_miro_data_id    = "${local.bucket_miro_data_id}"
+  bucket_miro_data_arn   = "${local.bucket_miro_data_arn}"
+  lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
 
   s3_read_miro_data_json = "${data.aws_iam_policy_document.s3_read_miro_data.json}"
 
   container_name      = "${module.xml_to_json_converter.container_name}"
-  topic_arn           = "${data.terraform_remote_state.lambda.run_ecs_task_topic_arn}"
-  cluster_name        = "${data.terraform_remote_state.platform.ecs_services_cluster_name}"
+  topic_arn           = "${local.run_ecs_task_topic_arn}"
+  cluster_name        = "${local.ecs_services_cluster_name}"
   task_definition_arn = "${module.xml_to_json_converter.task_definition_arn}"
 
-  run_ecs_task_topic_publish_policy = "${data.terraform_remote_state.lambda.run_ecs_task_topic_publish_policy}"
+  run_ecs_task_topic_publish_policy = "${local.run_ecs_task_topic_publish_policy}"
 }
 
 module "miro_image_to_dynamo" {
   source = "miro_image_to_dynamo"
 
   topic_miro_image_to_dynamo_arn = "${module.topic_miro_image_to_dynamo.arn}"
-  miro_data_table_arn            = "${data.terraform_remote_state.platform.table_miro_data_arn}"
-  miro_data_table_name           = "${data.terraform_remote_state.platform.table_miro_data_name}"
-  lambda_error_alarm_arn         = "${data.terraform_remote_state.lambda.lambda_error_alarm_arn}"
+  miro_data_table_arn            = "${local.table_miro_data_arn}"
+  miro_data_table_name           = "${local.table_miro_data_name}"
+  lambda_error_alarm_arn         = "${local.lambda_error_alarm_arn}"
 }
 
 module "miro_image_sorter" {
   source = "image_sorter"
 
-  lambda_error_alarm_arn = "${data.terraform_remote_state.lambda.lambda_error_alarm_arn}"
+  lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
 
-  s3_miro_data_id   = "${data.terraform_remote_state.platform.bucket_miro_data_id}"
-  s3_miro_data_arn  = "${data.terraform_remote_state.platform.bucket_miro_data_arn}"
+  s3_miro_data_id  = "${local.bucket_miro_data_id}"
+  s3_miro_data_arn = "${local.bucket_miro_data_arn}"
+
   s3_exceptions_key = "source/exceptions.csv"
 
   topic_cold_store_arn                 = "${module.cold_store_topic.arn}"
@@ -58,12 +59,13 @@ module "miro_image_sorter" {
 module "miro_copy_s3_asset" {
   source                         = "miro_copy_s3_asset"
   topic_miro_copy_s3_asset_arn   = "${module.catalogue_api_topic.arn}"
-  lambda_error_alarm_arn         = "${data.terraform_remote_state.lambda.lambda_error_alarm_arn}"
   topic_miro_image_to_dynamo_arn = "${module.topic_miro_image_to_dynamo.arn}"
-  bucket_miro_images_public_arn  = "${data.terraform_remote_state.loris.bucket_wellcomecollectio_miro_images_public_arn}"
-  bucket_miro_images_public_name = "${data.terraform_remote_state.loris.bucket_wellcomecollectio_miro_images_public_id}"
-  bucket_miro_images_sync_arn    = "${data.terraform_remote_state.platform.bucket_miro_images_sync_arn}"
-  bucket_miro_images_sync_name   = "${data.terraform_remote_state.platform.bucket_miro_images_sync_id}"
+
+  lambda_error_alarm_arn         = "${local.lambda_error_alarm_arn}"
+  bucket_miro_images_public_arn  = "${local.bucket_miro_images_public_arn}"
+  bucket_miro_images_public_name = "${local.bucket_miro_images_public_name}"
+  bucket_miro_images_sync_arn    = "${local.bucket_miro_images_sync_arn}"
+  bucket_miro_images_sync_name   = "${local.bucket_miro_images_sync_name}"
 }
 
 resource "aws_iam_role_policy" "miro_copy_s3_asset_sns_publish" {
@@ -73,7 +75,7 @@ resource "aws_iam_role_policy" "miro_copy_s3_asset_sns_publish" {
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
-  bucket = "${data.terraform_remote_state.platform.bucket_miro_data_id}"
+  bucket = "${local.bucket_miro_data_id}"
 
   lambda_function {
     lambda_function_arn = "${module.xml_to_json_run_task.arn}"

--- a/miro_preprocessor/terraform.tf
+++ b/miro_preprocessor/terraform.tf
@@ -9,7 +9,17 @@ terraform {
   }
 }
 
-data "terraform_remote_state" "platform" {
+data "terraform_remote_state" "catalogue_pipeline" {
+  backend = "s3"
+
+  config {
+    bucket = "platform-infra"
+    key    = "platform-pipeline.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "catalogue_api" {
   backend = "s3"
 
   config {
@@ -29,7 +39,7 @@ data "terraform_remote_state" "loris" {
   }
 }
 
-data "terraform_remote_state" "lambda" {
+data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 
   config {


### PR DESCRIPTION
### What is this PR trying to achieve?

The miro_preproc stack should refer to the correct shared resources.

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
