### PR TITLE
More improvements to our Slack alarms

### DIFF
--- a/monitoring/post_to_slack/post_to_slack.py
+++ b/monitoring/post_to_slack/post_to_slack.py
@@ -144,7 +144,6 @@ class Alarm:
 
         return timeframe(start=start, end=end)
 
-
     def cloudwatch_urls(self):
         """
         Return some CloudWatch URLs that might be useful to check.

--- a/monitoring/post_to_slack/post_to_slack.py
+++ b/monitoring/post_to_slack/post_to_slack.py
@@ -124,7 +124,7 @@ class Alarm:
             return 'platform/api_remus_v1'
         else:
             raise CloudWatchException(
-                "I don't know where to look for logs for %r" % self.alarm
+                "I don't know where to look for logs for %r" % self.name
             )
 
     @property

--- a/monitoring/post_to_slack/post_to_slack.py
+++ b/monitoring/post_to_slack/post_to_slack.py
@@ -237,19 +237,20 @@ def main(event, _):
 
     alarm = Alarm(event['Records'][0]['Sns']['Message'])
 
-    slack_data = {'username': 'cloudwatch-alert',
-                  "icon_emoji": ":rotating_light:",
-                  "attachments": [{
-                      'color': 'danger',
-                      'fallback': alarm.name,
-                      "title": alarm.name,
-                      "fields": [
-                          {
-                              "title": "Reason",
-                              "value": alarm.human_reason() or alarm.state_reason
-                          },
-                      ]
-                  }]}
+    slack_data = {
+        'username': 'cloudwatch-alert',
+        'icon_emoji': ':rotating_light:',
+        'attachments': [
+            {
+                'color': 'danger',
+                'fallback': alarm.name,
+                'title': alarm.name,
+                'fields': [{
+                    'value': alarm.human_reason() or alarm.state_reason
+                }]
+            }
+        ]
+    }
 
     messages = alarm.cloudwatch_messages()
     if messages:

--- a/monitoring/post_to_slack/post_to_slack.py
+++ b/monitoring/post_to_slack/post_to_slack.py
@@ -144,14 +144,17 @@ def to_bitly(url, access_token):
     Try to shorten a URL with bit.ly.  If it fails, just return the
     original URL.
     """
-    resp = requests.get(
-        'https://api-ssl.bitly.com/v3/user/link_save',
-        params={'access_token': access_token, 'longUrl': url}
-    )
-    try:
-        return resp.json()['data']['link_save']['link']
-    except KeyError:
-        return url
+    def _to_bity_single_url(url):
+        resp = requests.get(
+            'https://api-ssl.bitly.com/v3/user/link_save',
+            params={'access_token': access_token, 'longUrl': url}
+        )
+        try:
+            return resp.json()['data']['link_save']['link']
+        except KeyError:
+            return url
+
+    return ' / '.join([_to_bity_single_url(u) for u in url.split(' / ')])
 
 
 def main(event, _):

--- a/monitoring/post_to_slack/test_post_to_slack.py
+++ b/monitoring/post_to_slack/test_post_to_slack.py
@@ -7,11 +7,6 @@ import pytest
 import post_to_slack
 
 
-def _assert_field_contains(field, title, value):
-    assert field['title'] == title
-    assert field['value'] == value
-
-
 @mock.patch('post_to_slack.requests.post')
 def test_post_to_slack(mock_post):
     url = "http://blah.com"
@@ -101,12 +96,7 @@ def test_post_to_slack(mock_post):
     assert attachment['fallback'] == alarm_name
     assert attachment['title'] == alarm_name
     assert len(attachment['fields']) == 1
-
-    _assert_field_contains(
-        field=attachment['fields'][0],
-        title='Reason',
-        value=reason
-    )
+    assert attachment['fields'][0]['value'] == reason
 
 
 class TestAlarm:

--- a/monitoring/terraform/iam_policy_document.tf
+++ b/monitoring/terraform/iam_policy_document.tf
@@ -54,3 +54,15 @@ data "aws_iam_policy_document" "s3_put_gatling_reports" {
     ]
   }
 }
+
+data "aws_iam_policy_document" "cloudwatch_allow_filterlogs" {
+  statement {
+    actions = [
+      "logs:FilterLogEvents",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/monitoring/terraform/iam_role_policy.tf
+++ b/monitoring/terraform/iam_role_policy.tf
@@ -30,6 +30,11 @@ resource "aws_iam_role_policy" "update_service_list_read_from_webplatform" {
 EOF
 }
 
+resource "aws_iam_role_policy" "post_to_slack_get_cloudwatch" {
+  role   = "${module.lambda_post_to_slack.role_name}"
+  policy = "${data.aws_iam_policy_document.cloudwatch_allow_filterlogs.json}"
+}
+
 resource "aws_iam_role_policy" "gatling_push_to_s3" {
   role   = "${module.ecs_gatling_iam.task_role_name}"
   policy = "${data.aws_iam_policy_document.s3_put_gatling_reports.json}"


### PR DESCRIPTION
### What is this PR trying to achieve?

Improve our Slack alarms in a couple of ways:

* Ensure we really do get two CloudWatch URLs for Lambda failures (one for tracebacks, one for timeouts)
* Include the text of possible CloudWatch messages for easier assessment in Slack
* Tweaks to output to reduce space taken up in Slack

![screen shot 2017-10-10 at 15 37 36](https://user-images.githubusercontent.com/301220/31392508-57c62ff4-add1-11e7-860a-20d7c22bb135.png)

Resolves #1000.

### Who is this change for?

Devs who want useful alarms.

### Have the following been considered/are they needed?

<!-- If you're making application changes -->
- [x] Deployed new versions
<!-- Remove this section if you don't have Terraform changes -->
- [x] Run `terraform apply`.