### PR TITLE
Reduce the resources in the Catalogue API

### DIFF
--- a/catalogue_api/terraform/asg.tf
+++ b/catalogue_api/terraform/asg.tf
@@ -11,7 +11,7 @@ module "api_cluster_asg" {
   asg_max     = "4"
 
   image_id      = "${data.aws_ami.stable_coreos.id}"
-  instance_type = "t2.xlarge"
+  instance_type = "t2.large"
 
   sns_topic_arn         = "${local.ec2_terminating_topic_arn}"
   publish_to_sns_policy = "${local.ec2_terminating_topic_publish_policy}"

--- a/catalogue_api/terraform/services.tf
+++ b/catalogue_api/terraform/services.tf
@@ -25,7 +25,7 @@ module "api_romulus_v1" {
 
   enable_alb_alarm = "${var.production_api == "romulus" ? 1 : 0}"
 
-  cpu    = 1792
+  cpu    = 1024
   memory = 2048
 
   desired_count = "${var.production_api == "romulus" ? var.api_task_count : var.api_task_count_stage}"
@@ -77,7 +77,7 @@ module "api_remus_v1" {
 
   enable_alb_alarm = "${var.production_api == "remus" ? 1 : 0}"
 
-  cpu    = 1792
+  cpu    = 1024
   memory = 2048
 
   desired_count = "${var.production_api == "remus" ? var.api_task_count : var.api_task_count_stage}"


### PR DESCRIPTION
### What is this PR trying to achieve?

Reduce the resources we're using in the Catalogue API, because we're not stretching what we have now:

![screen shot 2017-10-11 at 11 34 22](https://user-images.githubusercontent.com/301220/31435702-71d58f6e-ae78-11e7-962c-49f882d78b6d.png)

A t2.xlarge is twice the price of a t2.large.

### Who is this change for?

💰 💰 💰 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.