### PR TITLE
Further cleanups in the Loris Slack logs

### DIFF
--- a/monitoring/post_to_slack/post_to_slack.py
+++ b/monitoring/post_to_slack/post_to_slack.py
@@ -243,7 +243,7 @@ def simplify_message(message):
     #     14:02:47.249 [ForkJoinPool-2-worker-17]
     #
     # Bin it!
-    messages = re.sub(
+    message = re.sub(
         r'\d{2}:\d{2}:\d{2}\.\d{3} \[ForkJoinPool-\d+-worker-\d+\] ', '',
         message
     )

--- a/monitoring/post_to_slack/post_to_slack.py
+++ b/monitoring/post_to_slack/post_to_slack.py
@@ -261,6 +261,15 @@ def simplify_message(message):
         r'\[[A-Za-z0-9: ]+\]', '', message
     )
 
+    # Loris messages also have an uninteresting suffix:
+    #
+    #     3 headers in 147 bytes (1 switches on core 0)
+    #
+    # Throw it away!
+    message = re.sub(
+        r'\d+ headers in \d+ bytes \(\d+ switches on core \d+\)', '', message
+    )
+
     return message.strip()
 
 

--- a/monitoring/post_to_slack/test_post_to_slack.py
+++ b/monitoring/post_to_slack/test_post_to_slack.py
@@ -152,7 +152,7 @@ class TestAlarm:
 
     # We strip UWGSI and timestamp prefixes from Loris logs
     (
-        'pid: 88|app: 0|req: 1871/9531] 172.17.0.4 () {46 vars in 937 bytes} [Wed Oct 11 22:42:03 2017] GET //wordpress:2014/05/untitled3.png/full/320,/0/default.jpg => generated 260 bytes in 227 msecs (HTTP/1.0 500)',
+        '[pid: 88|app: 0|req: 1871/9531] 172.17.0.4 () {46 vars in 937 bytes} [Wed Oct 11 22:42:03 2017] GET //wordpress:2014/05/untitled3.png/full/320,/0/default.jpg => generated 260 bytes in 227 msecs (HTTP/1.0 500)',
         'GET //wordpress:2014/05/untitled3.png/full/320,/0/default.jpg => generated 260 bytes in 227 msecs (HTTP/1.0 500)',
     ),
 

--- a/monitoring/post_to_slack/test_post_to_slack.py
+++ b/monitoring/post_to_slack/test_post_to_slack.py
@@ -141,3 +141,20 @@ class TestAlarm:
     def test_human_reason(self, alarm_data, expected_reason):
         a = post_to_slack.Alarm(json.dumps(alarm_data))
         assert a.human_reason() == expected_reason
+
+
+@pytest.mark.parametrize('message, expected', [
+    # We correctly strip timestamp and thread information from Scala logs
+    (
+        '13:25:56.965 [ForkJoinPool-1-worker-61] ERROR u.a.w.p.a.f.e.ElasticsearchResponseExceptionMapper - Sending HTTP 500 from ElasticsearchResponseExceptionMapper (Error (com.fasterxml.jackson.core.JsonParseException: Unrecognized token ‘No’: was expecting ‘null’, ‘true’, ‘false’ or NaN',
+        'ERROR u.a.w.p.a.f.e.ElasticsearchResponseExceptionMapper - Sending HTTP 500 from ElasticsearchResponseExceptionMapper (Error (com.fasterxml.jackson.core.JsonParseException: Unrecognized token ‘No’: was expecting ‘null’, ‘true’, ‘false’ or NaN'
+    ),
+
+    # We strip UWGSI and timestamp prefixes from Loris logs
+    (
+        'pid: 88|app: 0|req: 1871/9531] 172.17.0.4 () {46 vars in 937 bytes} [Wed Oct 11 22:42:03 2017] GET //wordpress:2014/05/untitled3.png/full/320,/0/default.jpg => generated 260 bytes in 227 msecs (HTTP/1.0 500)',
+        'GET //wordpress:2014/05/untitled3.png/full/320,/0/default.jpg => generated 260 bytes in 227 msecs (HTTP/1.0 500)',
+    )
+])
+def test_simplify_message(message, expected):
+    assert post_to_slack.simplify_message(message) == expected

--- a/monitoring/post_to_slack/test_post_to_slack.py
+++ b/monitoring/post_to_slack/test_post_to_slack.py
@@ -154,7 +154,13 @@ class TestAlarm:
     (
         'pid: 88|app: 0|req: 1871/9531] 172.17.0.4 () {46 vars in 937 bytes} [Wed Oct 11 22:42:03 2017] GET //wordpress:2014/05/untitled3.png/full/320,/0/default.jpg => generated 260 bytes in 227 msecs (HTTP/1.0 500)',
         'GET //wordpress:2014/05/untitled3.png/full/320,/0/default.jpg => generated 260 bytes in 227 msecs (HTTP/1.0 500)',
-    )
+    ),
+
+    # We strip UWSGI suffixes from Loris logs
+    (
+        'GET //wordpress:2014/05/untitled2.png/full/320,/0/default.jpg => generated 260 bytes in 197 msecs (HTTP/1.0 500) 3 headers in 147 bytes (1 switches on core 0)',
+        'GET //wordpress:2014/05/untitled2.png/full/320,/0/default.jpg => generated 260 bytes in 197 msecs (HTTP/1.0 500)'
+    ),
 ])
 def test_simplify_message(message, expected):
     assert post_to_slack.simplify_message(message) == expected


### PR DESCRIPTION
### What is this PR trying to achieve?

Turn this error:

> GET //wordpress:2014/05/untitled2.png/full/320,/0/default.jpg => generated 260 bytes in 197 msecs (HTTP/1.0 500) 3 headers in 147 bytes (1 switches on core 0)

into:

> GET //wordpress:2014/05/untitled2.png/full/320,/0/default.jpg => generated 260 bytes in 197 msecs (HTTP/1.0 500)

because I don’t think the latter is useful (does anyone even understand what it means!?).

### Who is this change for?

Folks who want tight, focused Slack alarms.

Devs who want it to be easier to tweak the way we modify these messages in future.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.