### PR TITLE
Add rules for Miro collection D

### DIFF
--- a/miro_preprocessor/image_sorter/src/sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/sorter_logic.py
@@ -135,7 +135,7 @@ class Rules:
 
     @property
     def is_cold_store(self):
-        return self.is_collection("F", "AS", "FP") or \
+        return self.is_collection("D", "F", "AS", "FP") or \
             (self.is_collection("L", "M", "V") and self.image_library_dept_is_Archives_and_Manuscripts) or \
             (self.is_collection("L", "M", "V") and self.image_tech_captured_mode_is_videodisc) or \
             (self.is_collection("L", "M", "V") and
@@ -195,7 +195,7 @@ def _get_decisions_from_contrib_exceptions(collection, exceptions, image_data):
 def _get_decisions_from_rules(collection, image_data):
     decisions = []
     r = Rules(collection, image_data)
-    if not r.is_collection("F", "L", "V", "M", "FP", "AS"):
+    if not r.is_collection("D", "F", "L", "V", "M", "FP", "AS"):
         raise InvalidCollectionException({
             "collection": collection,
             "image_data": image_data

--- a/miro_preprocessor/image_sorter/src/test_sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/test_sorter_logic.py
@@ -70,6 +70,7 @@ def id_exception(**kwargs):
 @pytest.mark.parametrize('collection, image_data', [
     collection_image_data(collection='images-AS'),
     collection_image_data(collection='images-FP'),
+    collection_image_data(collection='images-D'),
     collection_image_data(collection='images-F'),
     collection_image_data(collection='images-L', image_library_dept="Archives and Manuscripts"),
     collection_image_data(collection='images-V', image_library_dept="Archives and Manuscripts"),


### PR DESCRIPTION
### What is this PR trying to achieve?

Add rules for Miro collection D: all go to cold store

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.
