### PR TITLE
Send WIA winners to Tandem Vault

### DIFF
--- a/miro_preprocessor/Makefile
+++ b/miro_preprocessor/Makefile
@@ -73,7 +73,7 @@ image_sorter-test: $(ROOT)/.docker/python3.6_ci
 	$(ROOT)/builds/docker_run.py --aws -- \
 		--volume $(ROOT)/miro_preprocessor/image_sorter/src:/data \
 		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" \
+		--env FIND_MATCH_PATHS="/data" --tty \
 		python3.6_ci:latest
 
 miro_preprocessor_lambdas-publish: $(ROOT)/.docker/publish_lambda_zip

--- a/miro_preprocessor/image_sorter/src/sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/sorter_logic.py
@@ -223,7 +223,7 @@ def _get_decisions_from_rules(collection, image_data):
     if not r.is_cold_store and not r.is_catalogue_api and not r.is_tandem_vault:
         decisions.append(Decision.none)
 
-    print(decisions)
+    print(f'_get_decisions_from_rules = {decisions}')
 
     return decisions
 
@@ -232,15 +232,15 @@ def _assess_rules(rule_list):
     for rule in rule_list:
         decisions = rule()
 
-        print(decisions)
+        print(f'_assess_rules = {decisions}')
 
         if decisions is not None:
             return decisions
 
 
 def sort_image(collection, image_data, id_exceptions, contrib_exceptions):
-    print(collection)
-    print(image_data)
+    print(f'collection = {collection}')
+    print(f'image_data = {image_data}')
 
     decisions = _assess_rules([
         lambda: _get_decisions_from_id_exceptions(id_exceptions, image_data),

--- a/miro_preprocessor/image_sorter/src/sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/sorter_logic.py
@@ -252,9 +252,9 @@ def sort_image(collection, image_data, id_exceptions, contrib_exceptions):
 
     # Wellcome Images Awards winners *always* go to Tandem Vault, in addition
     # to any other rules we might have applied.
-    if decision.tandem_vault not in decisions:
+    if Decision.tandem_vault not in decisions:
         r = Rules(collection=collection, image_data=image_data)
         if r.is_a_wellcome_image_awards_winner:
-            decisions.append(decision.tandem_vault)
+            decisions.append(Decision.tandem_vault)
 
     return decisions

--- a/miro_preprocessor/image_sorter/src/sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/sorter_logic.py
@@ -134,6 +134,13 @@ class Rules:
         return not self.is_not_for_public_access
 
     @property
+    def is_a_wellcome_image_awards_winner(self):
+        return self._key_matches(
+            'image_award',
+            ['Biomedical Image Awards', 'Wellcome Image Awards']
+        )
+
+    @property
     def is_cold_store(self):
         return self.is_collection("F", "AS", "FP") or \
             (self.is_collection("L", "M", "V") and self.image_library_dept_is_Archives_and_Manuscripts) or \
@@ -146,9 +153,12 @@ class Rules:
 
     @property
     def is_tandem_vault(self):
-        return self.image_library_dept_is_Public_programmes or \
-            self.is_collection("L") and self.is_after_first_march_2016 or \
-            self.is_collection("L", "M", "V") and self.is_not_for_public_access
+        return (
+            self.image_library_dept_is_Public_programmes or
+            self.is_collection("L") and self.is_after_first_march_2016 or
+            self.is_collection("L", "M", "V") and self.is_not_for_public_access or
+            self.is_a_wellcome_image_awards_winner
+        )
 
     # TODO: Remove `and self.is_innopac_id_8_digits`
     @property

--- a/miro_preprocessor/image_sorter/src/sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/sorter_logic.py
@@ -237,6 +237,8 @@ def _assess_rules(rule_list):
         if decisions is not None:
             return decisions
 
+    return []
+
 
 def sort_image(collection, image_data, id_exceptions, contrib_exceptions):
     print(f'collection = {collection}')
@@ -247,5 +249,12 @@ def sort_image(collection, image_data, id_exceptions, contrib_exceptions):
         lambda: _get_decisions_from_contrib_exceptions(collection, contrib_exceptions, image_data),
         lambda: _get_decisions_from_rules(collection, image_data)
     ])
+
+    # Wellcome Images Awards winners *always* go to Tandem Vault, in addition
+    # to any other rules we might have applied.
+    if decision.tandem_vault not in decisions:
+        r = Rules(collection=collection, image_data=image_data)
+        if r.is_a_wellcome_image_awards_winner:
+            decisions.append(decision.tandem_vault)
 
     return decisions

--- a/miro_preprocessor/image_sorter/src/test_sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/test_sorter_logic.py
@@ -269,3 +269,49 @@ def test_raise_exception_if_collection_is_not_f_v_m_fp_as():
     collection, image_data = collection_image_data(collection="images-A")
     with pytest.raises(InvalidCollectionException):
         sort_image(collection, image_data, _empty_id_exceptions(), _empty_contrib_exceptions())
+
+
+class TestWellcomeImageAwards:
+
+    @pytest.mark.parametrize('collection', ['images-F', 'images-AS', 'images-V'])
+    @pytest.mark.parametrize('award', [
+        'Biomedical Image Awards',
+        'Wellcome Image Awards',
+    ])
+    def test_images_with_wia_go_to_tandem_vault(self, collection, award):
+        """
+        Images that wouldn't otherwise go to Tandem Vault end up there if
+        they have the right image_award field.
+        """
+        collection, image_data = collection_image_data(
+            collection=collection, image_award=award
+        )
+        result = sort_image(
+            collection=collection,
+            image_data=image_data,
+            id_exceptions=_empty_id_exceptions(),
+            contrib_exceptions=_empty_contrib_exceptions()
+        )
+        assert Decision.tandem_vault in result
+
+    @pytest.mark.parametrize('collection', ['images-F', 'images-L', 'images-V'])
+    @pytest.mark.parametrize('award', [
+        'Physical Image Awards',
+        'Nobel Prize',
+        'Wooden Spoon',
+    ])
+    def test_images_without_wia_dont_go_to_tandem_vault(self, collection, award):
+        """
+        Images that wouldn't otherwise go to Tandem Vault don't end up there
+        if they don't have the right image_award field.
+        """
+        collection, image_data = collection_image_data(
+            collection=collection, image_award=award
+        )
+        result = sort_image(
+            collection=collection,
+            image_data=image_data,
+            id_exceptions=_empty_id_exceptions(),
+            contrib_exceptions=_empty_contrib_exceptions()
+        )
+        assert Decision.tandem_vault not in result


### PR DESCRIPTION
### What is this PR trying to achieve?

All images that won WIA get sent to Tandem Vault in addition to anywhere else.

Resolves #1058.

### Who is this change for?

Folks who want correctly sorted images.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
