### PR TITLE
Run 'terraform fmt' directly in the hashicorp container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,9 @@ terraform.plan
 .terraform
 shared_infra/.releases
 *.tfvars
-terraform.tfstate.backup
+*.tfstate
+*.tfstate.backup
+*.tfstate.*.backup
 .releases
 .docker
 .lambda_zips

--- a/docker/terraform_ci/run.sh
+++ b/docker/terraform_ci/run.sh
@@ -33,9 +33,6 @@ then
     echo "terraform.plan not found. Have you run a plan?"
     exit 1
   fi
-elif [[ "$OP" == "fmt" ]]
-then
-  terraform fmt
 else
   echo "Unrecognised operation: $OP! Stopping."
   exit 1

--- a/shared.Makefile
+++ b/shared.Makefile
@@ -63,11 +63,11 @@ lint-js: $(ROOT)/.docker/jslint_ci
 uptodate-git: $(ROOT)/.docker/python3.6_ci
 	docker run -v $$HOME/.ssh:/root/.ssh -v $(ROOT):/data -e OP=is-master-head python3.6_ci:latest
 
-## Format terraform in the current directory
-format-terraform: $(ROOT)/.docker/terraform_ci
+format-terraform:
 	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $$(pwd):/data \
-		--env OP=fmt terraform_ci
+		--volume $(ROOT):/repo \
+		--workdir /repo \
+		hashicorp/terraform:light fmt
 
 $(ROOT)/.docker/scalafmt:
 	$(ROOT)/builds/build_ci_docker_image.py \


### PR DESCRIPTION
### What is this PR trying to achieve?

Reduce the layers underneath `make terraform-format`.

### Who is this change for?

Simpler repo, faster build (slightly) – `check-format` no longer needs to build the terraform_ci container.