### PR TITLE
Write Miro Image data to ES Cluster

### DIFF
--- a/miro_preprocessor/Makefile
+++ b/miro_preprocessor/Makefile
@@ -90,7 +90,7 @@ miro_inventory-test: $(ROOT)/.docker/python3.6_ci
 		python3.6_ci:latest
 
 miro_preprocessor_lambdas-publish: $(ROOT)/.docker/publish_lambda_zip
-	for l in image_sorter miro_copy_s3_asset miro_image_to_dynamo xml_to_json_run_task; \
+	for l in image_sorter miro_copy_s3_asset miro_image_to_dynamo xml_to_json_run_task miro_inventory-build; \
 	do																		\
 		$(ROOT)/builds/docker_run.py --aws -- 								\
 			--volume $(ROOT):/repo 											\

--- a/miro_preprocessor/Makefile
+++ b/miro_preprocessor/Makefile
@@ -90,7 +90,7 @@ miro_inventory-test: $(ROOT)/.docker/python3.6_ci
 		python3.6_ci:latest
 
 miro_preprocessor_lambdas-publish: $(ROOT)/.docker/publish_lambda_zip
-	for l in image_sorter miro_copy_s3_asset miro_image_to_dynamo xml_to_json_run_task miro_inventory-build; \
+	for l in image_sorter miro_copy_s3_asset miro_image_to_dynamo xml_to_json_run_task miro_inventory; \
 	do																		\
 		$(ROOT)/builds/docker_run.py --aws -- 								\
 			--volume $(ROOT):/repo 											\

--- a/miro_preprocessor/Makefile
+++ b/miro_preprocessor/Makefile
@@ -76,6 +76,19 @@ image_sorter-test: $(ROOT)/.docker/python3.6_ci
 		--env FIND_MATCH_PATHS="/data" --tty \
 		python3.6_ci:latest
 
+miro_inventory-build: $(ROOT)/.docker/python3.6_ci
+	docker run \
+		--volume $(ROOT)/miro_preprocessor/miro_inventory:/data \
+		--env OP=build-lambda \
+		python3.6_ci:latest
+
+miro_inventory-test: $(ROOT)/.docker/python3.6_ci
+	$(ROOT)/builds/docker_run.py --aws -- \
+		--volume $(ROOT)/miro_preprocessor/miro_inventory/src:/data \
+		--env OP=test \
+		--env FIND_MATCH_PATHS="/data" \
+		python3.6_ci:latest
+
 miro_preprocessor_lambdas-publish: $(ROOT)/.docker/publish_lambda_zip
 	for l in image_sorter miro_copy_s3_asset miro_image_to_dynamo xml_to_json_run_task; \
 	do																		\
@@ -86,9 +99,9 @@ miro_preprocessor_lambdas-publish: $(ROOT)/.docker/publish_lambda_zip
 	done
 
 
-miro_preprocessor-test: xml_to_json_converter-test xml_to_json_run_task-test miro_image_to_dynamo-test image_sorter-test miro_copy_s3_asset-test
+miro_preprocessor-test: xml_to_json_converter-test xml_to_json_run_task-test miro_image_to_dynamo-test image_sorter-test miro_copy_s3_asset-test miro_inventory-test
 
-miro_preprocessor-build-lambdas: xml_to_json_run_task-build miro_image_to_dynamo-build image_sorter-build miro_copy_s3_asset-build
+miro_preprocessor-build-lambdas: xml_to_json_run_task-build miro_image_to_dynamo-build image_sorter-build miro_copy_s3_asset-build miro_inventory-build
 
 miro_preprocessor-build: xml_to_json_converter-build miro_preprocessor-build-lambdas
 

--- a/miro_preprocessor/generate_tfvars.sh
+++ b/miro_preprocessor/generate_tfvars.sh
@@ -11,6 +11,9 @@ RELEASE_IDS_FILE="release_ids.tfvars"
 rm -f $TF_VARS
 rm -rf "$RELEASE_DIR"
 
+echo "Getting variables from S3"
+aws s3 cp s3://platform-infra/terraform-miro-preproc.tfvars terraform.tfvars
+
 # Download releases from S3
 mkdir -p "$RELEASE_DIR"
 aws s3 cp s3://platform-infra/releases "$RELEASE_DIR" --recursive

--- a/miro_preprocessor/image_sorter/src/miro_image_sorter.py
+++ b/miro_preprocessor/image_sorter/src/miro_image_sorter.py
@@ -82,5 +82,5 @@ def main(event, _):
         publish_sns_message(
             topic_arn=topic_arns[decision],
             message=data,
-            subject="foop"
+            subject=decision.value
         )

--- a/miro_preprocessor/image_sorter/src/miro_image_sorter.py
+++ b/miro_preprocessor/image_sorter/src/miro_image_sorter.py
@@ -77,5 +77,10 @@ def main(event, _):
     }
 
     for decision in decisions:
+
         print(f'Sorting this image into {decision}')
-        publish_sns_message(topic_arn=topic_arns[decision], message=data)
+        publish_sns_message(
+            topic_arn=topic_arns[decision],
+            message=data,
+            subject="foop"
+        )

--- a/miro_preprocessor/image_sorter/src/sns_utils.py
+++ b/miro_preprocessor/image_sorter/src/sns_utils.py
@@ -21,7 +21,7 @@ class EnhancedJSONEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-def publish_sns_message(topic_arn, message):
+def publish_sns_message(topic_arn, message, subject="none_set"):
     """
     Given a topic ARN and a series of key-value pairs, publish the key-value
     data to the SNS topic.
@@ -35,7 +35,8 @@ def publish_sns_message(topic_arn, message):
                 message,
                 cls=EnhancedJSONEncoder
             )
-        })
+        }),
+        Subject=subject
     )
     print(f'SNS response = {resp!r}')
     assert resp['ResponseMetadata']['HTTPStatusCode'] == 200

--- a/miro_preprocessor/main.tf
+++ b/miro_preprocessor/main.tf
@@ -90,3 +90,13 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
     filter_suffix       = ".json"
   }
 }
+
+module "miro_inventory" {
+  source = "miro_inventory"
+
+  cluster_url  = "${var.cluster_url}"
+  es_passsword = "${var.es_passsword}"
+  es_username  = "${var.es_username}"
+
+  lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
+}

--- a/miro_preprocessor/main.tf
+++ b/miro_preprocessor/main.tf
@@ -99,4 +99,10 @@ module "miro_inventory" {
   es_username  = "${var.es_username}"
 
   lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
+
+  none_topic_arn            = "${module.none_topic.arn}"
+  catalogue_api_topic_arn   = "${module.catalogue_api_topic.arn}"
+  tandem_vault_topic_arn    = "${module.tandem_vault_topic.arn}"
+  cold_store_topic_arn      = "${module.cold_store_topic.arn}"
+  digital_library_topic_arn = "${module.digital_library_topic.arn}"
 }

--- a/miro_preprocessor/miro_image_to_dynamo/main.tf
+++ b/miro_preprocessor/miro_image_to_dynamo/main.tf
@@ -10,7 +10,7 @@ module "miro_image_to_dynamo_lambda" {
 
   environment_variables = {
     TABLE_NAME      = "${var.miro_data_table_name}"
-    REINDEX_VERSION = 2
+    REINDEX_VERSION = 1
   }
 }
 

--- a/miro_preprocessor/miro_image_to_dynamo/main.tf
+++ b/miro_preprocessor/miro_image_to_dynamo/main.tf
@@ -10,7 +10,7 @@ module "miro_image_to_dynamo_lambda" {
 
   environment_variables = {
     TABLE_NAME      = "${var.miro_data_table_name}"
-    REINDEX_VERSION = 1
+    REINDEX_VERSION = 2
   }
 }
 

--- a/miro_preprocessor/miro_inventory/main.tf
+++ b/miro_preprocessor/miro_inventory/main.tf
@@ -1,0 +1,20 @@
+module "miro_inventory_lambda" {
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.0"
+  s3_key = "lambdas/miro_preprocessor/miro_inventory.zip"
+
+  description     = "Push miro inventory data to ES"
+  name            = "miro_inventory"
+  alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+
+  timeout = "30"
+
+  environment_variables = {
+    ES_CLUSTER_URL = "${var.cluster_url}"
+    ES_USERNAME    = "${var.es_username}"
+    ES_PASSWORD    = "${var.es_passsword}"
+
+    ES_INDEX = "miro"
+    ES_TYPE  = "image"
+    ID_FIELD = "image_data.image_no_calc"
+  }
+}

--- a/miro_preprocessor/miro_inventory/main.tf
+++ b/miro_preprocessor/miro_inventory/main.tf
@@ -18,3 +18,43 @@ module "miro_inventory_lambda" {
     ID_FIELD = "image_data.image_no_calc"
   }
 }
+
+module "miro_inventory_lambda_trigger_cold_store_topic" {
+  source               = "git::https://github.com/wellcometrust/terraform.git//lambda/trigger_sns?ref=v1.0.0"
+  lambda_function_name = "${module.miro_inventory_lambda.function_name}"
+  lambda_function_arn  = "${module.miro_inventory_lambda.arn}"
+
+  sns_trigger_arn = "${var.cold_store_topic_arn}"
+}
+
+module "miro_inventory_lambda_trigger_tandem_vault_topic" {
+  source               = "git::https://github.com/wellcometrust/terraform.git//lambda/trigger_sns?ref=v1.0.0"
+  lambda_function_name = "${module.miro_inventory_lambda.function_name}"
+  lambda_function_arn  = "${module.miro_inventory_lambda.arn}"
+
+  sns_trigger_arn = "${var.tandem_vault_topic_arn}"
+}
+
+module "miro_inventory_lambda_trigger_catalogue_api_topic" {
+  source               = "git::https://github.com/wellcometrust/terraform.git//lambda/trigger_sns?ref=v1.0.0"
+  lambda_function_name = "${module.miro_inventory_lambda.function_name}"
+  lambda_function_arn  = "${module.miro_inventory_lambda.arn}"
+
+  sns_trigger_arn = "${var.catalogue_api_topic_arn}"
+}
+
+module "miro_inventory_lambda_trigger_digital_library_topic" {
+  source               = "git::https://github.com/wellcometrust/terraform.git//lambda/trigger_sns?ref=v1.0.0"
+  lambda_function_name = "${module.miro_inventory_lambda.function_name}"
+  lambda_function_arn  = "${module.miro_inventory_lambda.arn}"
+
+  sns_trigger_arn = "${var.digital_library_topic_arn}"
+}
+
+module "miro_inventory_lambda_trigger_none_topic" {
+  source               = "git::https://github.com/wellcometrust/terraform.git//lambda/trigger_sns?ref=v1.0.0"
+  lambda_function_name = "${module.miro_inventory_lambda.function_name}"
+  lambda_function_arn  = "${module.miro_inventory_lambda.arn}"
+
+  sns_trigger_arn = "${var.none_topic_arn}"
+}

--- a/miro_preprocessor/miro_inventory/src/miro_inventory.py
+++ b/miro_preprocessor/miro_inventory/src/miro_inventory.py
@@ -9,6 +9,7 @@ import os
 
 from botocore.vendored import requests
 
+
 # Super naive jsonpath!
 def _extract_id_field(o, id_field):
     path = id_field.split(".")

--- a/miro_preprocessor/miro_inventory/src/miro_inventory.py
+++ b/miro_preprocessor/miro_inventory/src/miro_inventory.py
@@ -38,17 +38,13 @@ def _generate_auth_token(username, password):
 
 
 def _post_to_es(es_cluster_url, es_index, es_type, es_username, es_password, payload):
-    token = _generate_auth_token(es_username, es_password)
     post_url = f'{es_cluster_url}/{es_index}/{es_type}'
-
     print(f'POSTing to {post_url}')
-
-    ascii_token = token.decode('ascii')
 
     return requests.post(
         post_url,
         data=payload,
-        headers={'Authorization': f'Basic {ascii_token}'}
+        auth=(es_username, es_password)
     )
 
 

--- a/miro_preprocessor/miro_inventory/src/miro_inventory.py
+++ b/miro_preprocessor/miro_inventory/src/miro_inventory.py
@@ -1,0 +1,78 @@
+# -*- encoding: utf-8 -*-
+"""
+Description
+"""
+
+import base64
+import json
+import os
+
+from botocore.vendored import requests
+
+# Super naive jsonpath!
+def _extract_id_field(o, id_field):
+    path = id_field.split(".")
+
+    for node in path:
+        o = o[node]
+
+    return o
+
+
+def _generate_indexable_json(event, id_field):
+    subject = event['Records'][0]['Sns']['Subject']
+    message = json.loads(event['Records'][0]['Sns']['Message'])
+    id = _extract_id_field(message, id_field)
+
+    return json.dumps({
+        'id': id,
+        'subject': subject,
+        'message': message
+    })
+
+
+def _generate_auth_token(username, password):
+    plaintext = f'{username}:{password}'
+    return base64.b64encode(plaintext.encode())
+
+
+def _post_to_es(es_cluster_url, es_index, es_type, es_username, es_password, payload):
+    token = _generate_auth_token(es_username, es_password)
+    post_url = f'{es_cluster_url}/{es_index}/{es_type}'
+
+    print(f'POSTing to {post_url}')
+
+    ascii_token = token.decode('ascii')
+
+    return requests.post(
+        post_url,
+        data=payload,
+        headers={'Authorization': f'Basic {ascii_token}'}
+    )
+
+
+def main(event, _):
+    print(f'event = {event!r}')
+
+    es_cluster_url = os.environ["ES_CLUSTER_URL"]
+    es_index = os.environ["ES_INDEX"]
+    es_type = os.environ["ES_TYPE"]
+
+    es_username = os.environ["ES_USERNAME"]
+    es_password = os.environ["ES_PASSWORD"]
+
+    id_field = os.environ["ID_FIELD"]
+
+    indexable_json = _generate_indexable_json(event, id_field)
+    print(f'indexable_json: {indexable_json}')
+
+    response = _post_to_es(
+        es_cluster_url,
+        es_index,
+        es_type,
+        es_username,
+        es_password,
+        indexable_json
+    )
+    print(f'_post_to_es response: {response}')
+    response.raise_for_status()

--- a/miro_preprocessor/miro_inventory/src/miro_inventory.py
+++ b/miro_preprocessor/miro_inventory/src/miro_inventory.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 """
-Description
+Lambda which passes on miro_image data from a SNS topic to an Elasticsearch cluster
 """
 
 import base64

--- a/miro_preprocessor/miro_inventory/src/miro_inventory.py
+++ b/miro_preprocessor/miro_inventory/src/miro_inventory.py
@@ -3,7 +3,6 @@
 Lambda which passes on miro_image data from a SNS topic to an Elasticsearch cluster
 """
 
-import base64
 import json
 import os
 
@@ -30,11 +29,6 @@ def _generate_indexable_json(event, id_field):
         'subject': subject,
         'message': message
     })
-
-
-def _generate_auth_token(username, password):
-    plaintext = f'{username}:{password}'
-    return base64.b64encode(plaintext.encode())
 
 
 def _post_to_es(es_cluster_url, es_index, es_type, es_username, es_password, payload):

--- a/miro_preprocessor/miro_inventory/src/test_miro_inventory.py
+++ b/miro_preprocessor/miro_inventory/src/test_miro_inventory.py
@@ -77,7 +77,7 @@ def test_miro_inventory(mock_get):
     mock_get.assert_called_with(
         'https://example.com/index/type',
         data='{"id": "A0000002", "subject": "catalogue_api", "message": {"collection": "Images-C", "image_data": {"image_no_calc": "A0000002", "image_int_default": null, "image_artwork_date_from": "01/02/2000", "image_artwork_date_to": "13/12/2000", "image_barcode": "10000000", "image_creator": ["Caspar Bauhin"]}}}',
-        headers={'Authorization': "Basic Zm9vOmZvbw=="}
+        auth=('foo', 'foo')
     )
 
 

--- a/miro_preprocessor/miro_inventory/src/test_miro_inventory.py
+++ b/miro_preprocessor/miro_inventory/src/test_miro_inventory.py
@@ -1,0 +1,90 @@
+import json
+import os
+import pytest
+
+from botocore.vendored import requests
+from botocore.vendored.requests.exceptions import HTTPError
+from unittest import mock
+
+import miro_inventory
+
+
+miro_id = "A0000002"
+
+collection = "Images-C"
+image_data = {
+    'image_no_calc': miro_id,
+    'image_int_default': None,
+    'image_artwork_date_from': "01/02/2000",
+    'image_artwork_date_to': "13/12/2000",
+    'image_barcode': "10000000",
+    'image_creator': ["Caspar Bauhin"]
+}
+
+image_json = json.dumps({
+    'collection': collection,
+    'image_data': image_data
+})
+
+os.environ = {
+    "ES_CLUSTER_URL": 'https://example.com',
+    "ES_INDEX": 'index',
+    "ES_TYPE": 'type',
+    "ES_USERNAME": 'foo',
+    "ES_PASSWORD": 'foo',
+    "ID_FIELD": 'image_data.image_no_calc',
+}
+
+event = {
+    'Records': [{
+        'EventSource': 'aws:sns',
+        'EventVersion': '1.0',
+        'EventSubscriptionArn':
+            'arn:aws:sns:region:account_id:sns:stuff',
+        'Sns': {
+            'Type': 'Notification',
+            'MessageId': 'b20eb72b-ffc7-5d09-9636-e6f65d67d10f',
+            'TopicArn':
+                'arn:aws:sns:region:account_id:sns',
+            'Subject': 'catalogue_api',
+            'Message': image_json,
+            'Timestamp': '2017-07-10T15:42:24.307Z',
+            'SignatureVersion': '1',
+            'Signature': 'signature',
+            'SigningCertUrl': 'https://certificate.pem',
+            'UnsubscribeUrl': 'https://unsubscribe-url',
+            'MessageAttributes': {}}
+    }]
+}
+
+
+# This method will be used by the mock to replace requests.post
+def mocked_requests_post(*args, **kwargs):
+    class MockResponse(requests.Response):
+        def __init__(self, status_code):
+            self.status_code = status_code
+            self.reason = "I am a mock object, don't ask me"
+
+    if args[0] == 'https://example.com/index/type':
+        return MockResponse(200)
+
+    return MockResponse(500)
+
+
+@mock.patch('miro_inventory.requests.post', side_effect=mocked_requests_post)
+def test_miro_inventory(mock_get):
+    miro_inventory.main(event, None)
+
+    mock_get.assert_called_with(
+        'https://example.com/index/type',
+        data='{"id": "A0000002", "subject": "catalogue_api", "message": {"collection": "Images-C", "image_data": {"image_no_calc": "A0000002", "image_int_default": null, "image_artwork_date_from": "01/02/2000", "image_artwork_date_to": "13/12/2000", "image_barcode": "10000000", "image_creator": ["Caspar Bauhin"]}}}',
+        headers={'Authorization': "Basic Zm9vOmZvbw=="}
+    )
+
+
+@mock.patch('miro_inventory.requests.post', side_effect=mocked_requests_post)
+def test_miro_inventory_raises_error_on_500(mock_get):
+    with pytest.raises(HTTPError):
+        os.environ["ES_INDEX"] = "nope"
+
+        miro_inventory.main(event, None)

--- a/miro_preprocessor/miro_inventory/src/test_miro_inventory.py
+++ b/miro_preprocessor/miro_inventory/src/test_miro_inventory.py
@@ -8,7 +8,6 @@ from unittest import mock
 
 import miro_inventory
 
-
 miro_id = "A0000002"
 
 collection = "Images-C"

--- a/miro_preprocessor/miro_inventory/variables.tf
+++ b/miro_preprocessor/miro_inventory/variables.tf
@@ -1,0 +1,4 @@
+variable "lambda_error_alarm_arn" {}
+variable "cluster_url" {}
+variable "es_username" {}
+variable "es_passsword" {}

--- a/miro_preprocessor/miro_inventory/variables.tf
+++ b/miro_preprocessor/miro_inventory/variables.tf
@@ -2,3 +2,9 @@ variable "lambda_error_alarm_arn" {}
 variable "cluster_url" {}
 variable "es_username" {}
 variable "es_passsword" {}
+
+variable "cold_store_topic_arn" {}
+variable "tandem_vault_topic_arn" {}
+variable "catalogue_api_topic_arn" {}
+variable "digital_library_topic_arn" {}
+variable "none_topic_arn" {}

--- a/miro_preprocessor/variables.tf
+++ b/miro_preprocessor/variables.tf
@@ -7,3 +7,15 @@ variable "release_ids" {
   description = "Release tags for Miro preprocessor"
   type        = "map"
 }
+
+variable "cluster_url" {
+  description = "Cluster URL for miro inventory"
+}
+
+variable "es_passsword" {
+  description = "Password for acccess to miro inventory cluster"
+}
+
+variable "es_username" {
+  description = "Username for acccess to miro inventory cluster"
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

Keep track of where Miro images are ending up after being sorted in a way that's accessible and searchable.

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
