### PR TITLE
Increase the timeout on the update_service_list Lambda

### DIFF
--- a/monitoring/terraform/lambda_update_service_list.tf
+++ b/monitoring/terraform/lambda_update_service_list.tf
@@ -4,7 +4,7 @@ module "lambda_update_service_list" {
 
   name        = "update_service_list"
   description = "Publish ECS service status summary to S3"
-  timeout     = 10
+  timeout     = 15
 
   environment_variables = {
     BUCKET_NAME     = "${aws_s3_bucket.dashboard.id}"


### PR DESCRIPTION
We’ve seen a couple of Slack alarms about this Lambda timing out, mostly due to bad luck it seems. Let’s increase the timeout and see if it goes away.

- [ ] Run `terraform apply`.