### PR TITLE
When performing normalisations identified by key, allow lists

### DIFF
--- a/miro_preprocessor/image_sorter/src/sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/sorter_logic.py
@@ -6,7 +6,6 @@ It only has a single public function: ``sort_image``, which takes a Python
 dictionary and returns an instance of ``Decision``.
 """
 
-import collections
 import dateutil.parser
 import enum
 import re
@@ -37,14 +36,6 @@ class Rules:
     ]
 
     @staticmethod
-    def _is_a_list(obj):
-        return (
-            isinstance(obj, collections.Sequence) and (
-                not isinstance(obj, str)
-            )
-        )
-
-    @staticmethod
     def _normalise_string(s):
         if s is not None:
             s = s.lower().strip()
@@ -64,11 +55,11 @@ class Rules:
     def _compare(self, key, value):
         key_values = self._get(key)
 
-        if not Rules._is_a_list(key_values):
+        if not isinstance(key_values, list):
             key_values = [key_values]
 
         return any(
-            [self._compare_normalised(key_value, value) for key_value in key_values]
+            self._compare_normalised(key_value, value) for key_value in key_values
         )
 
     def _is_collection(self, collection_name):

--- a/miro_preprocessor/image_sorter/src/sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/sorter_logic.py
@@ -6,6 +6,7 @@ It only has a single public function: ``sort_image``, which takes a Python
 dictionary and returns an instance of ``Decision``.
 """
 
+import collections
 import dateutil.parser
 import enum
 import re
@@ -36,6 +37,14 @@ class Rules:
     ]
 
     @staticmethod
+    def _is_a_list(obj):
+        return (
+            isinstance(obj, collections.Sequence) and (
+                not isinstance(obj, str)
+            )
+        )
+
+    @staticmethod
     def _normalise_string(s):
         if s is not None:
             s = s.lower().strip()
@@ -49,8 +58,18 @@ class Rules:
     def _get_normalised(self, key):
         return self._normalise_string(self._get(key))
 
+    def _compare_normalised(self, a, b):
+        return self._normalise_string(a) == self._normalise_string(b)
+
     def _compare(self, key, value):
-        return self._get_normalised(key) == self._normalise_string(value)
+        key_values = self._get(key)
+
+        if not Rules._is_a_list(key_values):
+            key_values = [key_values]
+
+        return any(
+            [self._compare_normalised(key_value, value) for key_value in key_values]
+        )
 
     def _is_collection(self, collection_name):
         return self._normalise_string(self.collection) == self._normalise_string(f"images-{collection_name}")

--- a/miro_preprocessor/image_sorter/src/test_sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/test_sorter_logic.py
@@ -277,7 +277,7 @@ class TestWellcomeImageAwards:
     @pytest.mark.parametrize('collection', ['images-F', 'images-AS', 'images-V'])
     @pytest.mark.parametrize('award', [
         'Biomedical Image Awards',
-        'Wellcome Image Awards',
+        ['Wellcome Image Awards']
     ])
     def test_images_with_wia_go_to_tandem_vault(self, collection, award):
         """
@@ -300,6 +300,7 @@ class TestWellcomeImageAwards:
         'Physical Image Awards',
         'Nobel Prize',
         'Wooden Spoon',
+        ['Medicine Man Catalogue']
     ])
     def test_images_without_wia_dont_go_to_tandem_vault(self, collection, award):
         """


### PR DESCRIPTION
### What is this PR trying to achieve?

Proper sorting of images based on fields which can sometimes be lists and sometimes be strings.

Specifically this avoids an issue where Miro images with list values denoting awards are not being sorted correctly.

### Who is this change for?

🐋 🕷 🐊 🐒 

### Have the following been considered/are they needed?

- [ ] Deployed new versions

