### PR TITLE
Send holding images straight to cold store

### DIFF
--- a/miro_preprocessor/image_sorter/src/sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/sorter_logic.py
@@ -184,6 +184,13 @@ def _get_decisions_from_id_exceptions(exceptions, image_data):
             return [getattr(Decision, key) for key, value in exception.items()
                     if value is not "" and not value.strip().lower() == "false"]
 
+    # There are "holding images" in MIRO, which are thumbnails put into
+    # duplicate image records for some explicit AIDS posters.  All the
+    # posters are available, so we delete these records.  They all have
+    # image numbers in the L sequence ending with "FX", e.g. "L0052198FX".
+    # if re.match(r'^L\d+FX$', image_data['image_no_calc']):
+    #     return [Decision.cold_store]
+
 
 def _get_decisions_from_contrib_exceptions(collection, exceptions, image_data):
     collections = exceptions.fieldnames

--- a/miro_preprocessor/image_sorter/src/sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/sorter_logic.py
@@ -188,8 +188,8 @@ def _get_decisions_from_id_exceptions(exceptions, image_data):
     # duplicate image records for some explicit AIDS posters.  All the
     # posters are available, so we delete these records.  They all have
     # image numbers in the L sequence ending with "FX", e.g. "L0052198FX".
-    # if re.match(r'^L\d+FX$', image_data['image_no_calc']):
-    #     return [Decision.cold_store]
+    if re.match(r'^L\d+FX$', image_data['image_no_calc']):
+        return [Decision.cold_store]
 
 
 def _get_decisions_from_contrib_exceptions(collection, exceptions, image_data):

--- a/miro_preprocessor/image_sorter/src/test_sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/test_sorter_logic.py
@@ -272,17 +272,17 @@ def test_raise_exception_if_collection_is_not_f_v_m_fp_as():
         sort_image(collection, image_data, _empty_id_exceptions(), _empty_contrib_exceptions())
 
 
-@pytest.mark.parametrize('image_calc_no', [
+@pytest.mark.parametrize('image_no_calc', [
     'L0000001FX',
     'L1234567FX',
 ])
-def test_holding_image_dupes_are_expunged(image_calc_no):
+def test_holding_image_dupes_are_expunged(image_no_calc):
     """
     Images that wouldn't otherwise go to Cold Store end up there if they
     have the ID of a holding image.
     """
     collection, image_data = collection_image_data(
-        collection='images-L', image_calc_no=image_calc_no
+        collection='images-L', image_no_calc=image_no_calc
     )
     result = sort_image(
         collection=collection,

--- a/miro_preprocessor/image_sorter/src/test_sorter_logic.py
+++ b/miro_preprocessor/image_sorter/src/test_sorter_logic.py
@@ -272,6 +272,27 @@ def test_raise_exception_if_collection_is_not_f_v_m_fp_as():
         sort_image(collection, image_data, _empty_id_exceptions(), _empty_contrib_exceptions())
 
 
+@pytest.mark.parametrize('image_calc_no', [
+    'L0000001FX',
+    'L1234567FX',
+])
+def test_holding_image_dupes_are_expunged(image_calc_no):
+    """
+    Images that wouldn't otherwise go to Cold Store end up there if they
+    have the ID of a holding image.
+    """
+    collection, image_data = collection_image_data(
+        collection='images-L', image_calc_no=image_calc_no
+    )
+    result = sort_image(
+        collection=collection,
+        image_data=image_data,
+        id_exceptions=_empty_id_exceptions(),
+        contrib_exceptions=_empty_contrib_exceptions()
+    )
+    assert result == [Decision.cold_store]
+
+
 class TestWellcomeImageAwards:
 
     @pytest.mark.parametrize('collection', ['images-F', 'images-AS', 'images-V'])


### PR DESCRIPTION
### What is this PR trying to achieve?

Remove duplicate images which are holding thumbnails for other records.

Resolves #1070.

### Who is this change for?

Folks who don’t want duplicate, downsized images in their API.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
