### PR TITLE
PUT don't POST to include ID in inventory lambda

### DIFF
--- a/miro_preprocessor/miro_inventory/src/miro_inventory.py
+++ b/miro_preprocessor/miro_inventory/src/miro_inventory.py
@@ -10,7 +10,7 @@ from botocore.vendored import requests
 
 
 # Super naive jsonpath!
-def _extract_id_field(o, id_field):
+def _extract_id(o, id_field):
     path = id_field.split(".")
 
     for node in path:
@@ -19,24 +19,32 @@ def _extract_id_field(o, id_field):
     return o
 
 
-def _generate_indexable_json(event, id_field):
-    subject = event['Records'][0]['Sns']['Subject']
-    message = json.loads(event['Records'][0]['Sns']['Message'])
-    id = _extract_id_field(message, id_field)
+def _extract_subject(event):
+    return event['Records'][0]['Sns']['Subject']
 
-    return json.dumps({
+
+def _extract_message(event):
+    return json.loads(event['Records'][0]['Sns']['Message'])
+
+
+def _generate_indexable_object(event, id_field):
+    message = _extract_message(event)
+    subject = _extract_subject(event)
+    id = _extract_id(message, id_field)
+
+    return {
         'id': id,
         'subject': subject,
         'message': message
-    })
+    }
 
 
-def _post_to_es(es_cluster_url, es_index, es_type, es_username, es_password, payload):
-    post_url = f'{es_cluster_url}/{es_index}/{es_type}'
-    print(f'POSTing to {post_url}')
+def _put_to_es(id, es_cluster_url, es_index, es_type, es_username, es_password, payload):
+    put_url = f'{es_cluster_url}/{es_index}/{es_type}/{id}'
+    print(f'PUTing to {put_url}')
 
-    return requests.post(
-        post_url,
+    return requests.put(
+        put_url,
         data=payload,
         auth=(es_username, es_password)
     )
@@ -53,17 +61,18 @@ def main(event, _):
     es_password = os.environ["ES_PASSWORD"]
 
     id_field = os.environ["ID_FIELD"]
+    indexable = _generate_indexable_object(event, id_field)
 
-    indexable_json = _generate_indexable_json(event, id_field)
-    print(f'indexable_json: {indexable_json}')
+    print(f'indexable_json: {indexable}')
 
-    response = _post_to_es(
+    response = _put_to_es(
+        indexable['id'],
         es_cluster_url,
         es_index,
         es_type,
         es_username,
         es_password,
-        indexable_json
+        json.dumps(indexable)
     )
-    print(f'_post_to_es response: {response}')
+    print(f'_put_to_es response: {response}')
     response.raise_for_status()

--- a/miro_preprocessor/miro_inventory/src/test_miro_inventory.py
+++ b/miro_preprocessor/miro_inventory/src/test_miro_inventory.py
@@ -9,8 +9,13 @@ from unittest import mock
 import miro_inventory
 
 miro_id = "A0000002"
-
+index = 'index'
+type = 'type'
 collection = "Images-C"
+cluster_url = 'https://example.com'
+
+put_url = f'{cluster_url}/{index}/{type}/{miro_id}'
+
 image_data = {
     'image_no_calc': miro_id,
     'image_int_default': None,
@@ -26,9 +31,9 @@ image_json = json.dumps({
 })
 
 os.environ = {
-    "ES_CLUSTER_URL": 'https://example.com',
-    "ES_INDEX": 'index',
-    "ES_TYPE": 'type',
+    "ES_CLUSTER_URL": cluster_url,
+    "ES_INDEX": index,
+    "ES_TYPE": type,
     "ES_USERNAME": 'foo',
     "ES_PASSWORD": 'foo',
     "ID_FIELD": 'image_data.image_no_calc',
@@ -57,31 +62,31 @@ event = {
 }
 
 
-# This method will be used by the mock to replace requests.post
-def mocked_requests_post(*args, **kwargs):
+# This method will be used by the mock to replace requests.put
+def mocked_requests_put(*args, **kwargs):
     class MockResponse(requests.Response):
         def __init__(self, status_code):
             self.status_code = status_code
             self.reason = "I am a mock object, don't ask me"
 
-    if args[0] == 'https://example.com/index/type':
+    if args[0] == put_url:
         return MockResponse(200)
 
     return MockResponse(500)
 
 
-@mock.patch('miro_inventory.requests.post', side_effect=mocked_requests_post)
+@mock.patch('miro_inventory.requests.put', side_effect=mocked_requests_put)
 def test_miro_inventory(mock_get):
     miro_inventory.main(event, None)
 
     mock_get.assert_called_with(
-        'https://example.com/index/type',
+        put_url,
         data='{"id": "A0000002", "subject": "catalogue_api", "message": {"collection": "Images-C", "image_data": {"image_no_calc": "A0000002", "image_int_default": null, "image_artwork_date_from": "01/02/2000", "image_artwork_date_to": "13/12/2000", "image_barcode": "10000000", "image_creator": ["Caspar Bauhin"]}}}',
         auth=('foo', 'foo')
     )
 
 
-@mock.patch('miro_inventory.requests.post', side_effect=mocked_requests_post)
+@mock.patch('miro_inventory.requests.put', side_effect=mocked_requests_put)
 def test_miro_inventory_raises_error_on_500(mock_get):
     with pytest.raises(HTTPError):
         os.environ["ES_INDEX"] = "nope"


### PR DESCRIPTION
### What is this PR trying to achieve?

Prevent dupes in the miro inventory index, so we can accurately judge the status of ingestions.

### Who is this change for?

Anyone who needs stats on the miro ingestion.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
