### PR TITLE
Fixes for recent Lambda alarms

### DIFF
--- a/shared_infra/lambdas/service_deployment_status/main.tf
+++ b/shared_infra/lambdas/service_deployment_status/main.tf
@@ -5,7 +5,7 @@ module "lambda_service_deployment_status" {
 
   name        = "service_deployment_status"
   description = "Lambda for tracking deployment status in dynamo db"
-  timeout     = 10
+  timeout     = 15
 
   environment_variables = {
     TABLE_NAME = "${var.dynamodb_table_deployments_name}"


### PR DESCRIPTION
### What is this PR trying to achieve?

Two alarms we’ve seen recently:

* Timeouts in service_deployment_status
* 429 Rate Limit Exceeded in miro_inventory

So let’s fix them both!

### Have the following been considered/are they needed?

<!-- Delete bullets if they don't apply to this patch -->

- [ ] Deployed new versions
- [ ] Run `terraform apply`.
