### PR TITLE
Fix the lambda_utils-publish task

### DIFF
--- a/lambda_utils/Makefile
+++ b/lambda_utils/Makefile
@@ -6,6 +6,9 @@ ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile
 endif
 
+PUBLISH_VERSION := $(shell curl "https://pypi.python.org/pypi/wellcome-lambda-utils/json" 2>/dev/null | jq -r '.info.version')
+SETUP_VERSION := $(shell grep 'version' $(LAMBDA_UTILS)/setup.py | tr "'" ' ' | awk '{print $$2}')
+
 lambda_utils-test: $(ROOT)/.docker/python3.6_ci
 	$(ROOT)/builds/docker_run.py --aws -- \
 		--volume $(LAMBDA_UTILS):/data \
@@ -20,20 +23,15 @@ lambda_utils-build:
 		python:3-alpine python setup.py sdist
 
 lambda_utils-publish: lambda_utils-build
-	@# We check if we have a more up-to-date package than PyPI, and only trigger
-	@# the upload task if we do.
-	export PUBLISH_VERSION=$(shell curl "https://pypi.python.org/pypi/wellcome-lambda-utils/json" 2>/dev/null | jq -r '.info.version')
-	export SETUP_VERSION=$(shell grep 'version' $(LAMBDA_UTILS)/setup.py | tr "'" ' ' | awk '{print $$2}')
-
-	@if [[ "$(PUBLISH_VERSION)" == "$(SETUP_VERSION)" ]]; then 				\
+	if [[ "$(PUBLISH_VERSION)" == "$(SETUP_VERSION)" ]]; then 				\
 		echo "*** Uploaded package is up-to-date, nothing to do"; 			\
 	else 																	\
 		echo "*** Newer version available, uploading new package";			\
 		docker run 															\
 			--volume $(LAMBDA_UTILS):/src 									\
 			--workdir /src 													\
-			--env TWINE_USERNAME="$PYPI_USERNAME" 							\
-			--env TWINE_PASSWORD="$PYPI_PASSWORD" 							\
+			--env TWINE_USERNAME="$(PYPI_USERNAME)" 						\
+			--env TWINE_PASSWORD="$(PYPI_PASSWORD)" 						\
 			greengloves/twine:1.9.1 upload dist/*.tar.gz; 					\
 	fi
 


### PR DESCRIPTION
### What is this PR trying to achieve?

Ensure we can publish the `lambda_utils` package to PyPi

### Who is this change for?

Folk who want to make use of our shared `lambda_utils` package 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
