### PR TITLE
Some more Loris experiments

### DIFF
--- a/loris/terraform/asg.tf
+++ b/loris/terraform/asg.tf
@@ -11,11 +11,16 @@ module "loris_cluster_asg" {
   asg_max     = "4"
 
   image_id      = "${data.aws_ami.stable_coreos.id}"
-  instance_type = "t2.xlarge"
+  instance_type = "c4.xlarge"
 
   sns_topic_arn         = "${local.ec2_terminating_topic_arn}"
   publish_to_sns_policy = "${local.ec2_terminating_topic_publish_policy}"
   alarm_topic_arn       = "${local.ec2_instance_terminating_for_too_long_alarm_arn}"
+
+  ebs_device_name = "/dev/xvdb"
+  ebs_size        = 180
+  ebs_volume_type = "io1"
+  ebs_iops        = "2000"
 }
 
 module "loris_cluster_asg_ebs" {
@@ -31,7 +36,7 @@ module "loris_cluster_asg_ebs" {
   asg_max     = "4"
 
   image_id      = "${data.aws_ami.stable_coreos.id}"
-  instance_type = "t2.xlarge"
+  instance_type = "c4.xlarge"
 
   sns_topic_arn         = "${local.ec2_terminating_topic_arn}"
   publish_to_sns_policy = "${local.ec2_terminating_topic_publish_policy}"
@@ -39,6 +44,5 @@ module "loris_cluster_asg_ebs" {
 
   ebs_device_name = "/dev/xvdb"
   ebs_size        = 180
-  ebs_volume_type = "io1"
-  ebs_iops        = "2000"
+  ebs_volume_type = "gp2"
 }

--- a/loris/terraform/efs.tf
+++ b/loris/terraform/efs.tf
@@ -1,8 +1,0 @@
-module "loris_efs" {
-  name                         = "loris_cache"
-  source                       = "git::https://github.com/wellcometrust/terraform.git//efs?ref=v1.0.0"
-  vpc_id                       = "${local.vpc_api_id}"
-  subnets                      = "${local.vpc_api_subnets}"
-  efs_access_security_group_id = "${module.loris_cluster_asg.instance_sg_id}"
-  performance_mode             = "maxIO"
-}

--- a/loris/terraform/services.tf
+++ b/loris/terraform/services.tf
@@ -14,8 +14,8 @@ module "loris" {
   healthcheck_path   = "/image/"
   alb_priority       = "100"
 
-  cpu    = 1792
-  memory = 4096
+  cpu    = 2560
+  memory = 3276
 
   desired_count = 4
 
@@ -47,8 +47,8 @@ module "loris_ebs" {
   healthcheck_path   = "/image/"
   alb_priority       = "101"
 
-  cpu    = 1792
-  memory = 4096
+  cpu    = 2560
+  memory = 3276
 
   desired_count = 4
 

--- a/loris/terraform/services.tf
+++ b/loris/terraform/services.tf
@@ -14,8 +14,8 @@ module "loris" {
   healthcheck_path   = "/image/"
   alb_priority       = "100"
 
-  cpu    = 2560
-  memory = 3276
+  cpu    = 3960
+  memory = 7350
 
   desired_count = 4
 
@@ -47,8 +47,8 @@ module "loris_ebs" {
   healthcheck_path   = "/image/"
   alb_priority       = "101"
 
-  cpu    = 2560
-  memory = 3276
+  cpu    = 3960
+  memory = 7350
 
   desired_count = 4
 

--- a/loris/terraform/userdata.tf
+++ b/loris/terraform/userdata.tf
@@ -1,6 +1,6 @@
 module "loris_userdata" {
-  source            = "git::https://github.com/wellcometrust/terraform.git//userdata?ref=v1.0.0"
-  cluster_name      = "${aws_ecs_cluster.loris.name}"
+  source                             = "git::https://github.com/wellcometrust/terraform.git//userdata?ref=v1.0.0"
+  cluster_name                       = "${aws_ecs_cluster.loris.name}"
   ebs_block_device                   = "/dev/xvdb"
   cache_cleaner_cloudwatch_log_group = "${aws_cloudwatch_log_group.cache_cleaner_log_group.name}"
   ebs_cache_max_age_days             = "30"

--- a/loris/terraform/userdata.tf
+++ b/loris/terraform/userdata.tf
@@ -1,7 +1,10 @@
 module "loris_userdata" {
   source            = "git::https://github.com/wellcometrust/terraform.git//userdata?ref=v1.0.0"
   cluster_name      = "${aws_ecs_cluster.loris.name}"
-  efs_filesystem_id = "${module.loris_efs.efs_id}"
+  ebs_block_device                   = "/dev/xvdb"
+  cache_cleaner_cloudwatch_log_group = "${aws_cloudwatch_log_group.cache_cleaner_log_group.name}"
+  ebs_cache_max_age_days             = "30"
+  ebs_cache_max_size                 = "160G"
 }
 
 module "loris_userdata_ebs" {


### PR DESCRIPTION
After our tests we've decided that the c4.xlarge backed by EBS volume cache is the best one for now.
Each Ec2 instance can fit only one Loris task because of Loris CPU usage. That means that, to have 4 tasks running we need 4 instances.
The on demand price for c4.xlarge is $0.226000, so the overall cost per year of each instance would be 0.226000 * 24 * 365 = $1979.76 which means a total of $1979.04 * 4= $7919.04

The EBS volume currently in use is an IO1 volume with 2000 IOPS. The cost of the volume is $0.138 per GB-month of provisioned storage plus $0.072 per provisioned IOPS-month, which means 0.138 * 180 + 0.072 * 2000 = 24.84 + 144 = $168.84 per volume per month. 4 volumes (a volume per instance) would be 168.84 * 4 * 12= $8104.32 per year

I think the volumes cost, at least, could be reduced quite a bit, so I want to keep two clusters running to experiment on that