### PR TITLE
Fix sns_utils

### DIFF
--- a/lambda_utils/setup.py
+++ b/lambda_utils/setup.py
@@ -13,7 +13,7 @@ setup(
     name='wellcome_lambda_utils',
     packages=find_packages(SOURCE),
     package_dir={'': SOURCE},
-    version='2017.10.20',
+    version='2017.10.23',
     install_requires=[
         'attrs>=17.2.0',
         'boto3',

--- a/lambda_utils/src/wellcome_lambda_utils/sns_utils.py
+++ b/lambda_utils/src/wellcome_lambda_utils/sns_utils.py
@@ -19,7 +19,7 @@ class EnhancedJSONEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-def publish_sns_message(sns_client, topic_arn, message, subject=""):
+def publish_sns_message(sns_client, topic_arn, message, subject="default-subject"):
     """
     Given a topic ARN and a series of key-value pairs, publish the key-value
     data to the SNS topic.


### PR DESCRIPTION
### What is this PR trying to achieve?
Make it not crash when sending a message without specifying a subjects. Boto3 doesn't like an empty string subject
### Who is this change for?
Devs

- [ ] Deployed new versions
