### PR TITLE
Avoid timeouts in image_to_dynamo and copy_s3_asset lambdas

### DIFF
--- a/miro_preprocessor/miro_copy_s3_asset/main.tf
+++ b/miro_preprocessor/miro_copy_s3_asset/main.tf
@@ -14,7 +14,7 @@ module "miro_copy_s3_asset_lambda" {
     "TOPIC_ARN"             = "${var.topic_forward_sns_message_arn}"
   }
 
-  timeout = "30"
+  timeout = "120"
 }
 
 module "miro_copy_s3_asset_trigger" {

--- a/miro_preprocessor/miro_image_to_dynamo/main.tf
+++ b/miro_preprocessor/miro_image_to_dynamo/main.tf
@@ -6,7 +6,7 @@ module "miro_image_to_dynamo_lambda" {
   name            = "miro_image_to_dynamo"
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
 
-  timeout = "30"
+  timeout = "120"
 
   environment_variables = {
     TABLE_NAME      = "${var.miro_data_table_name}"


### PR DESCRIPTION
### What is this PR trying to achieve?
Give more time to the miro_image_to_dynamo lambda and miro_copy_s3_asset lambda

- [ ] Deployed new versions

- [ ] Run `terraform apply`.
