### PR TITLE
End loris experiments

### DIFF
--- a/loris/terraform/alb.tf
+++ b/loris/terraform/alb.tf
@@ -13,19 +13,3 @@ module "loris_alb" {
 
   alb_access_log_bucket = "${local.bucket_alb_logs_id}"
 }
-
-module "loris_alb_ebs" {
-  source  = "git::https://github.com/wellcometrust/terraform.git//ecs_alb?ref=v1.0.0"
-  name    = "loris-ebs"
-  subnets = ["${local.vpc_api_subnets}"]
-
-  loadbalancer_security_groups = [
-    "${module.loris_cluster_asg_ebs.loadbalancer_sg_https_id}",
-    "${module.loris_cluster_asg_ebs.loadbalancer_sg_http_id}",
-  ]
-
-  certificate_domain = "api.wellcomecollection.org"
-  vpc_id             = "${local.vpc_api_id}"
-
-  alb_access_log_bucket = "${local.bucket_alb_logs_id}"
-}

--- a/loris/terraform/asg.tf
+++ b/loris/terraform/asg.tf
@@ -7,32 +7,7 @@ module "loris_cluster_asg" {
   user_data             = "${module.loris_userdata.rendered}"
   vpc_id                = "${local.vpc_api_id}"
 
-  asg_desired = "2"
-  asg_max     = "4"
-
-  image_id      = "${data.aws_ami.stable_coreos.id}"
-  instance_type = "c4.xlarge"
-
-  sns_topic_arn         = "${local.ec2_terminating_topic_arn}"
-  publish_to_sns_policy = "${local.ec2_terminating_topic_publish_policy}"
-  alarm_topic_arn       = "${local.ec2_instance_terminating_for_too_long_alarm_arn}"
-
-  ebs_device_name = "/dev/xvdb"
-  ebs_size        = 180
-  ebs_volume_type = "io1"
-  ebs_iops        = "2000"
-}
-
-module "loris_cluster_asg_ebs" {
-  source                = "git::https://github.com/wellcometrust/terraform.git//ecs_asg?ref=v1.0.0"
-  asg_name              = "loris-cluster-ebs"
-  subnet_list           = ["${local.vpc_api_subnets}"]
-  key_name              = "${var.key_name}"
-  instance_profile_name = "${module.ecs_loris_iam.instance_profile_name}"
-  user_data             = "${module.loris_userdata_ebs.rendered}"
-  vpc_id                = "${local.vpc_api_id}"
-
-  asg_desired = "2"
+  asg_desired = "4"
   asg_max     = "4"
 
   image_id      = "${data.aws_ami.stable_coreos.id}"

--- a/loris/terraform/ecs.tf
+++ b/loris/terraform/ecs.tf
@@ -1,7 +1,3 @@
 resource "aws_ecs_cluster" "loris" {
   name = "loris_cluster"
 }
-
-resource "aws_ecs_cluster" "loris_ebs" {
-  name = "loris_cluster_ebs"
-}

--- a/loris/terraform/services.tf
+++ b/loris/terraform/services.tf
@@ -30,36 +30,3 @@ module "loris" {
   server_error_alarm_topic_arn = "${local.alb_server_error_alarm_arn}"
   client_error_alarm_topic_arn = "${local.alb_client_error_alarm_arn}"
 }
-
-module "loris_ebs" {
-  source             = "git::https://github.com/wellcometrust/terraform.git//services?ref=v1.0.0"
-  name               = "loris-ebs"
-  cluster_id         = "${aws_ecs_cluster.loris_ebs.id}"
-  task_role_arn      = "${module.ecs_loris_iam.task_role_arn}"
-  vpc_id             = "${local.vpc_api_id}"
-  app_uri            = "${module.ecr_loris.repository_url}:${var.release_ids["loris"]}"
-  nginx_uri          = "${module.ecr_nginx_loris.repository_url}:${var.release_ids["nginx_loris"]}"
-  listener_https_arn = "${module.loris_alb_ebs.listener_https_arn}"
-  listener_http_arn  = "${module.loris_alb_ebs.listener_http_arn}"
-  infra_bucket       = "${var.infra_bucket}"
-  config_key         = "config/${var.build_env}/loris-ebs.ini"
-  path_pattern       = "/image*"
-  healthcheck_path   = "/image/"
-  alb_priority       = "101"
-
-  cpu    = 3960
-  memory = 7350
-
-  desired_count = 4
-
-  deployment_minimum_healthy_percent = "50"
-  deployment_maximum_percent         = "200"
-
-  volume_name      = "loris"
-  volume_host_path = "${module.loris_userdata_ebs.efs_mount_directory}/loris"
-  container_path   = "/mnt/loris"
-
-  loadbalancer_cloudwatch_id   = "${module.loris_alb.cloudwatch_id}"
-  server_error_alarm_topic_arn = "${local.alb_server_error_alarm_arn}"
-  client_error_alarm_topic_arn = "${local.alb_client_error_alarm_arn}"
-}

--- a/loris/terraform/userdata.tf
+++ b/loris/terraform/userdata.tf
@@ -6,12 +6,3 @@ module "loris_userdata" {
   ebs_cache_max_age_days             = "30"
   ebs_cache_max_size                 = "160G"
 }
-
-module "loris_userdata_ebs" {
-  source                             = "git::https://github.com/wellcometrust/terraform.git//userdata?ref=v1.0.0"
-  cluster_name                       = "${aws_ecs_cluster.loris_ebs.name}"
-  ebs_block_device                   = "/dev/xvdb"
-  cache_cleaner_cloudwatch_log_group = "${aws_cloudwatch_log_group.cache_cleaner_log_group.name}"
-  ebs_cache_max_age_days             = "30"
-  ebs_cache_max_size                 = "160G"
-}


### PR DESCRIPTION
### What is this PR trying to achieve?
Settle for c4.xlarge with 180 gb gp2 EBS volume for Loris. 
The on demand price for c4.xlarge is $0.226000, so the overall cost per year of each instance would be 0.226000 * 24 * 365 = $1979.76 which means a total of $1979.04 * 4= $7919.04
The EBS volume cost is $0.11 per GB-month of provisioned storage so one volume is 0.11 * 180= $19.8 per month. 4 volumes (one for each instance) will be 19.8 * 4 = $79.2 per month which means 79.2 * 12 = $950.4 per year.

In total Loris provision will come at about 7919.04 + 950.4 = $8869.44 per year

- [x] Run `terraform apply`.
