### PR TITLE
Tweak the size of the API ASG

### DIFF
--- a/catalogue_api/terraform/asg.tf
+++ b/catalogue_api/terraform/asg.tf
@@ -7,11 +7,11 @@ module "api_cluster_asg" {
   user_data             = "${module.api_userdata.rendered}"
   vpc_id                = "${module.vpc_api.vpc_id}"
 
-  asg_desired = "2"
-  asg_max     = "4"
+  asg_desired = 3
+  asg_max     = 6
 
   image_id      = "${data.aws_ami.stable_coreos.id}"
-  instance_type = "t2.large"
+  instance_type = "t2.medium"
 
   sns_topic_arn         = "${local.ec2_terminating_topic_arn}"
   publish_to_sns_policy = "${local.ec2_terminating_topic_publish_policy}"


### PR DESCRIPTION
### What is this PR trying to achieve?

More efficient use of resources.

### Who is this change for?

This is the current state of the ECS cluster:

![screen shot 2017-10-23 at 13 35 37](https://user-images.githubusercontent.com/301220/31889265-192be132-b7f7-11e7-9c3f-7b3ab3e5bd8d.png)

t2.large is (2 vCPUs, 8GB memory), t2.medium is (2 vCPUs, 4GB memory). A bit less bursty, but we make up for that by adding an extra instance (and allowing us to run three tasks again), then turning up those tasks to use all the available memory.

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.