### PR TITLE
Move the dicts-to-S3 function to the Lambda utils

### DIFF
--- a/lambda_utils/src/wellcome_lambda_utils/s3_utils.py
+++ b/lambda_utils/src/wellcome_lambda_utils/s3_utils.py
@@ -75,3 +75,20 @@ def parse_s3_record(event):
     Extracts a simple subset of an S3 update event.
     """
     return [_extract_s3_event(record) for record in event["Records"]]
+
+
+def write_dicts_to_s3(bucket, key, dicts):
+    """
+    Given an iterable of dictionaries, convert them to JSON, one per line,
+    and write them to S3.
+    """
+    # We use sort_keys=True to ensure deterministic results.  The separators
+    # flag allows us to write more compact JSON, which makes things faster!
+    # See https://twitter.com/raymondh/status/842777864193769472
+    json_str = b'\n'.join([
+        json.dumps(m, sort_keys=True, separators=(',',':')).encode('ascii')
+        for m in dicts
+    ])
+
+    client = boto3.client('s3')
+    client.put_object(Bucket=bucket, Key=key, Body=json_str)

--- a/lambda_utils/src/wellcome_lambda_utils/s3_utils.py
+++ b/lambda_utils/src/wellcome_lambda_utils/s3_utils.py
@@ -87,7 +87,7 @@ def write_dicts_to_s3(bucket, key, dicts):
     # flag allows us to write more compact JSON, which makes things faster!
     # See https://twitter.com/raymondh/status/842777864193769472
     json_str = b'\n'.join([
-        json.dumps(m, sort_keys=True, separators=(',',':')).encode('ascii')
+        json.dumps(m, sort_keys=True, separators=(',', ':')).encode('ascii')
         for m in dicts
     ])
 

--- a/lambda_utils/src/wellcome_lambda_utils/s3_utils.py
+++ b/lambda_utils/src/wellcome_lambda_utils/s3_utils.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 import dateutil.parser
+import json
 
 import boto3
 from botocore.exceptions import ClientError

--- a/lambda_utils/tests/test_s3_utils.py
+++ b/lambda_utils/tests/test_s3_utils.py
@@ -171,3 +171,18 @@ def test_parse_s3_event():
     }]
 
     assert parsed_events == expected_events
+
+
+@mock_s3
+def test_write_dicts_to_s3():
+    client = boto3.client('s3')
+    client.create_bucket(Bucket='bukkit')
+
+    s3_utils.write_dicts_to_s3(
+        bucket='bukkit', key='dicts.txt',
+        dicts=[{'a': 1, 'b': 2}, {'c': 3, 'd': 4}]
+    )
+
+    assert s3_utils.is_object(bucket='bukkit', key='dicts.txt')
+    body = client.get_object(Bucket='bukkit', Key='key')['Body'].read()
+    assert body == b'{"a":1,"b":2}\n{"c":3,"d":4}'

--- a/lambda_utils/tests/test_s3_utils.py
+++ b/lambda_utils/tests/test_s3_utils.py
@@ -184,5 +184,5 @@ def test_write_dicts_to_s3():
     )
 
     assert s3_utils.is_object(bucket='bukkit', key='dicts.txt')
-    body = client.get_object(Bucket='bukkit', Key='key')['Body'].read()
+    body = client.get_object(Bucket='bukkit', Key='dicts.txt')['Body'].read()
     assert body == b'{"a":1,"b":2}\n{"c":3,"d":4}'


### PR DESCRIPTION
A utility function extracted from #1118. This is a format we use in other places, so let’s put it in the shared library.