### PR TITLE
Fix errors around INNOPAC IDs rejected by the transformer

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -235,6 +235,41 @@ case class MiroTransformable(MiroID: String,
     // but there are other types in Sierra (e.g. item, holding) with matching
     // IDs but different prefixes.
     val sierraList: List[SourceIdentifier] = miroData.innopacID match {
+
+      // There are a couple of INNOPAC IDs that were entered badly in Miro,
+      // where a digit was repeated.  In these cases, we hard-code the correct
+      // INNOPAC ID, but double-check with the Miro ID to ensure nothing
+      // faulty gets through!
+      case Some("113183382") => {
+        MiroID match {
+          case "L0001138EA" | "L0001138EB" =>
+            SourceIdentifier(IdentifierSchemes.sierraSystemNumber, "b1318338")
+          case _ => throw new RuntimeException(
+            s"Unexpected Miro record with faulty INNOPAC ID 113183382: ${MiroID}"
+          )
+        }
+      }
+
+      case Some("150056628") => {
+        MiroID match {
+          case "L0035213" =>
+            SourceIdentifier(IdentifierSchemes.sierraSystemNumber, "b15005628")
+          case _ => throw new RuntimeException(
+            s"Unexpected Miro record with faulty INNOPAC ID 150056628: ${MiroID}"
+          )
+        }
+      }
+
+      case Some("L 35411 \n\n15551040") => {
+        MiroID match {
+          case "L0035411" =>
+            SourceIdentifier(IdentifierSchemes.sierraSystemNumber, "b1555104")
+          case _ => throw new RuntimeException(
+            s"Unexpected Miro record with faulty INNOPAC ID 'L 35411': ${MiroID}"
+          )
+        }
+      }
+
       case Some(s) => {
 
         // The ID in the Miro record is an 8-digit number with a check digit

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -235,41 +235,6 @@ case class MiroTransformable(MiroID: String,
     // but there are other types in Sierra (e.g. item, holding) with matching
     // IDs but different prefixes.
     val sierraList: List[SourceIdentifier] = miroData.innopacID match {
-
-      // There are a couple of INNOPAC IDs that were entered badly in Miro,
-      // where a digit was repeated.  In these cases, we hard-code the correct
-      // INNOPAC ID, but double-check with the Miro ID to ensure nothing
-      // faulty gets through!
-      case Some("113183382") => {
-        MiroID match {
-          case "L0001138EA" | "L0001138EB" =>
-            SourceIdentifier(IdentifierSchemes.sierraSystemNumber, "b1318338")
-          case _ => throw new RuntimeException(
-            s"Unexpected Miro record with faulty INNOPAC ID 113183382: ${MiroID}"
-          )
-        }
-      }
-
-      case Some("150056628") => {
-        MiroID match {
-          case "L0035213" =>
-            SourceIdentifier(IdentifierSchemes.sierraSystemNumber, "b15005628")
-          case _ => throw new RuntimeException(
-            s"Unexpected Miro record with faulty INNOPAC ID 150056628: ${MiroID}"
-          )
-        }
-      }
-
-      case Some("L 35411 \n\n15551040") => {
-        MiroID match {
-          case "L0035411" =>
-            SourceIdentifier(IdentifierSchemes.sierraSystemNumber, "b1555104")
-          case _ => throw new RuntimeException(
-            s"Unexpected Miro record with faulty INNOPAC ID 'L 35411': ${MiroID}"
-          )
-        }
-      }
-
       case Some(s) => {
 
         // The ID in the Miro record is an 8-digit number with a check digit

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -239,7 +239,19 @@ case class MiroTransformable(MiroID: String,
 
         // The ID in the Miro record is an 8-digit number with a check digit
         // (which may be x), but the system number is 7-digits, sans checksum.
-        val regexMatch = """^([0-9]{7})[0-9xX]$""".r.unapplySeq(s)
+        //
+        // Regex explanation:
+        //
+        //    ^                 start of string
+        //    (?:\.?[bB])?      non-capturing group, which trims 'b' or 'B'
+        //                      or '.b' or '.B' from the start of the string,
+        //                      but *not* a lone '.'
+        //    ([0-9]{7})        capturing group, the 7 digits of the system
+        //                      number
+        //    [0-9xX]           the final check digit, which may be X
+        //    $                 end of the string
+        //
+        val regexMatch = """^(?:\.?[bB])?([0-9]{7})[0-9xX]$""".r.unapplySeq(s)
         regexMatch match {
           case Some(s) =>
             s.map { id =>

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -198,22 +198,13 @@ class MiroTransformableTest
     work.identifiers shouldBe List(SourceIdentifier(IdentifierSchemes.miroImageNumber, MiroID))
   }
 
-  it("should pass through the INNOPAC ID, if present") {
-    val sierraNumber = "1161183"
-    val innopacID = s"${sierraNumber}2"
-    val miroID = "V0000832_test"
-    val work = transformWork(
-      data =
-        s"""
-        "image_title": "A bouncing bundle of bison",
-        "image_innopac_id": "$innopacID"
-      """,
-      MiroID = miroID
-    )
-    work.identifiers shouldBe List(
-      SourceIdentifier(IdentifierSchemes.miroImageNumber, miroID),
-      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, s"b${sierraNumber}")
-    )
+  describe("The INNOPAC ID should be passed through as the Sierra system number") {
+    it("plain numeric ID") {
+      transformRecordAndCheckSierraSystemNumber(
+        innopacId = "12345678",
+        expectedSierraNumber = "b1234567"
+      )
+    }
   }
 
   it("should have an empty list if no image_creator field is present") {
@@ -369,6 +360,24 @@ class MiroTransformableTest
 
     work.title shouldBe "A café for cats"
     work.creators shouldBe List(Agent("Gyokushō, a cät Ôwnêr"))
+  }
+
+  private def transformRecordAndCheckSierraSystemNumber(
+    innopacId: String,
+    expectedSierraNumber: String
+  ) = {
+    val miroID = "V0000832_test"
+    val work = transformWork(
+      data = s"""
+        "image_title": "A bouncing bundle of bison",
+        "image_innopac_id": "$innopacId"
+      """,
+      MiroID = miroID
+    )
+    work.identifiers shouldBe List(
+      SourceIdentifier(IdentifierSchemes.miroImageNumber, miroID),
+      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, expectedSierraNumber)
+    )
   }
 }
 

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -233,30 +233,6 @@ class MiroTransformableTest
         expectedSierraNumber = "b1234567"
       )
     }
-
-    it("with a hard-coded ID that's malformed in Miro (L0035213)") {
-      transformRecordAndCheckSierraSystemNumber(
-        innopacId = "150056628",
-        expectedSierraNumber = "b15005628",
-        miroID = "L0035213"
-      )
-    }
-
-    it("with a hard-coded ID that's malformed in Miro (L0001138EA)") {
-      transformRecordAndCheckSierraSystemNumber(
-        innopacId = "113183382",
-        expectedSierraNumber = "b1318338",
-        miroID = "L0001138EA"
-      )
-    }
-
-    it("with a hard-coded ID that's malformed in Miro (L0001138EB)") {
-      transformRecordAndCheckSierraSystemNumber(
-        innopacId = "113183382",
-        expectedSierraNumber = "b1318338",
-        miroID = "L0001138EB"
-      )
-    }
   }
 
   it("should have an empty list if no image_creator field is present") {

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -392,9 +392,9 @@ class MiroTransformableTest
 
   private def transformRecordAndCheckSierraSystemNumber(
     innopacId: String,
-    expectedSierraNumber: String
+    expectedSierraNumber: String,
+    miroID = "V0000832"
   ) = {
-    val miroID = "V0000832_test"
     val work = transformWork(
       data = s"""
         "image_title": "A bouncing bundle of bison",

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -205,6 +205,34 @@ class MiroTransformableTest
         expectedSierraNumber = "b1234567"
       )
     }
+
+    it("with an x for a check digit") {
+      transformRecordAndCheckSierraSystemNumber(
+        innopacId = "1234567x",
+        expectedSierraNumber = "b1234567"
+      )
+    }
+
+    it("with a leading b on the b-number") {
+      transformRecordAndCheckSierraSystemNumber(
+        innopacId = "b12345678",
+        expectedSierraNumber = "b1234567"
+      )
+    }
+
+    it("with a leading B on the b-number") {
+      transformRecordAndCheckSierraSystemNumber(
+        innopacId = "b12345678",
+        expectedSierraNumber = "b1234567"
+      )
+    }
+
+    it("with a leading .b on the b-number") {
+      transformRecordAndCheckSierraSystemNumber(
+        innopacId = ".b12345678",
+        expectedSierraNumber = "b1234567"
+      )
+    }
   }
 
   it("should have an empty list if no image_creator field is present") {

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -393,7 +393,7 @@ class MiroTransformableTest
   private def transformRecordAndCheckSierraSystemNumber(
     innopacId: String,
     expectedSierraNumber: String,
-    miroID = "V0000832"
+    miroID: String = "V0000832"
   ) = {
     val work = transformWork(
       data = s"""

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -233,6 +233,30 @@ class MiroTransformableTest
         expectedSierraNumber = "b1234567"
       )
     }
+
+    it("with a hard-coded ID that's malformed in Miro (L0035213)") {
+      transformRecordAndCheckSierraSystemNumber(
+        innopacId = "150056628",
+        expectedSierraNumber = "b15005628",
+        miroID = "L0035213"
+      )
+    }
+
+    it("with a hard-coded ID that's malformed in Miro (L0001138EA)") {
+      transformRecordAndCheckSierraSystemNumber(
+        innopacId = "113183382",
+        expectedSierraNumber = "b1318338",
+        miroID = "L0001138EA"
+      )
+    }
+
+    it("with a hard-coded ID that's malformed in Miro (L0001138EB)") {
+      transformRecordAndCheckSierraSystemNumber(
+        innopacId = "113183382",
+        expectedSierraNumber = "b1318338",
+        miroID = "L0001138EB"
+      )
+    }
   }
 
   it("should have an empty list if no image_creator field is present") {


### PR DESCRIPTION
### What is this PR trying to achieve?

Get a clean run of L and M in the transformer. Related: #1124.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
