### PR TITLE
Add non-MPL references from Miro

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/IdentifierSchemeModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/IdentifierSchemeModule.scala
@@ -15,4 +15,7 @@ object IdentifierSchemes {
   val calmAltRefNo = "calm-altrefno"
 
   val sierraSystemNumber = "sierra-system-number"
+
+  // Corresponds to
+  val miroLibraryReference = "miro-library-reference"
 }

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/IdentifierSchemeModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/IdentifierSchemeModule.scala
@@ -8,6 +8,12 @@ object IdentifierSchemes {
   // Corresponds to the image number in Miro, e.g. V00127563.
   val miroImageNumber = "miro-image-number"
 
+  // Corresponds to legacy image IDs from the Miro data.  Eventually these
+  // should be tackled properly: either assigned proper identifier schemes
+  // and normalised, or removed entirely.  For now, this is a stopgap to
+  // get these IDs into the API until we deal with them properly.
+  val miroLibraryReference = "miro-library-reference"
+
   // Placeholder until we ingest real Calm records.
   // TODO: Replace this with something more appropriate
   val calmPlaceholder = "calm-placeholder"
@@ -15,7 +21,4 @@ object IdentifierSchemes {
   val calmAltRefNo = "calm-altrefno"
 
   val sierraSystemNumber = "sierra-system-number"
-
-  // Corresponds to
-  val miroLibraryReference = "miro-library-reference"
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -347,61 +347,58 @@ case class MiroTransformable(MiroID: String,
     // Add any other legacy identifiers to this record.  Right now we
     // put them all in the same identifier scheme, because we're not doing
     // any transformation or cleaning.
-    //
-    // This data is supplied in two fields in Miro: a pair of lists, with
-    // the keys in one and the values in another.
-
-    // First we check that both fields are non-empty, then they're the same
-    // length, then finally we construct the identifiers.
     val libraryRefsList: List[SourceIdentifier] =
-      miroData.libraryRefDepartment match {
-        case Some(dept) => {
-          miroData.libraryRefId match {
-            case Some(ids) => {
-              // If the two lists have different lengths, we can't match
-              // labels to values.  Error out!
-              if (dept.length != ids.length) {
-                throw new RuntimeException(
-                  s"Different lengths! library_ref_department=$dept but library_ref_id=$ids"
-                )
-              }
-
-              // Otherwise construct the lists as key-value pairs of IDs
-              (dept, ids).zipped
-                .map { (label, value) =>
-                  SourceIdentifier(
-                    IdentifierSchemes.miroLibraryReference,
-                    s"$label $value"
-                  )
-                }
-            }
-
-            // If there's something in the reference IDs but no labels for them,
-            // we throw an error.  The correct answer is *probably* to return
-            // unlabelled IDs, but this is sufficiently unusual to just throw
-            // an error now, and inspect/fix if it actually occurs.
-            case None =>
-              throw new RuntimeException(
-                s"library_ref_department=$dept but library_ref_id=null"
-              )
-          }
-        }
-
-        // If there's nothing in library_ref_department, we check
-        // the same holds for library_ref_id, and if so, we don't
-        // return any identifiers here.
-        case None => {
-          miroData.libraryRefId match {
-            case Some(ids) =>
-              throw new RuntimeException(
-                s"library_ref_department=null but library_ref_id=$ids"
-              )
-            case None => List()
-          }
-        }
-      }
+      zipMiroFields(
+        keys = miroData.libraryRefDepartment,
+        values = miroData.libraryRefId)
+      .map { case (label, value) => SourceIdentifier(
+        IdentifierSchemes.miroLibraryReference,
+        s"$label $value"
+      )}
 
     miroIDList ++ sierraList ++ libraryRefsList
+  }
+
+  /** Some Miro fields contain keys/values in different fields.  For example:
+    *
+    *     "image_library_ref_department": ["ICV No", "External Reference"],
+    *     "image_library_ref_id": ["1234", "Sanskrit manuscript 5678"]
+    *
+    * This represents the mapping:
+    *
+    *     "ICV No"             -> "1234"
+    *     "External Reference" -> "Sanskrit manuscript 5678"
+    *
+    * This method takes two such fields, combines them, and returns a list
+    * of (key, value) tuples.  Note: we don't use a map because keys aren't
+    * guaranteed to be unique.
+    */
+  def zipMiroFields(keys: Option[List[String]],
+                    values: Option[List[String]]): List[(String, String)] = {
+    (keys, values) match {
+      case (Some(k), Some(v)) => {
+        if (k.length != v.length) {
+          throw new RuntimeException(
+            s"Different lengths! keys=$k, values=$v"
+          )
+        }
+
+        (k, v).zipped.toList
+      }
+
+      // If both fields are empty, we fall straight through.
+      case (None, None) => List()
+
+      // If only one of the fields is non-empty, for now we just raise
+      // an exception -- this probably indicates an issue in the source data.
+      case (Some(k), None) => throw new RuntimeException(
+        s"Inconsistent k/v pairs: keys=$k, values=null"
+      )
+      case (None, Some(v)) => throw new RuntimeException(
+        s"Inconsistent k/v pairs: keys=null, values=$v"
+      )
+    }
+
   }
 
   override def transform: Try[Work] = Try {

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -353,9 +353,9 @@ case class MiroTransformable(MiroID: String,
 
     // First we check that both fields are non-empty, then they're the same
     // length, then finally we construct the identifiers.
-    val libraryRefsList: List[SourceIdentifier] = libraryRefDepartment match {
+    val libraryRefsList: List[SourceIdentifier] = miroData.libraryRefDepartment match {
       case Some(dept) => {
-        libraryRefId match {
+        miroData.libraryRefId match {
           case Some(ids) => {
             // If the two lists have different lengths, we can't match
             // labels to values.  Error out!
@@ -368,7 +368,7 @@ case class MiroTransformable(MiroID: String,
             // Otherwise construct the lists as key-value pairs of IDs
             (dept, ids).zipped
               .map { (label, value) => SourceIdentifier(
-                IdentifierSchemes.miroLibraryReference, s"{label} {value}"
+                IdentifierSchemes.miroLibraryReference, s"$label $value"
               )}
           }
 
@@ -386,7 +386,7 @@ case class MiroTransformable(MiroID: String,
       // the same holds for library_ref_id, and if so, we don't
       // return any identifiers here.
       case None => {
-        libraryRefId match {
+        miroData.libraryRefId match {
           case Some(ids) => throw new RuntimeException(
             s"library_ref_department=null but library_ref_id=$ids"
           )

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -348,13 +348,15 @@ case class MiroTransformable(MiroID: String,
     // put them all in the same identifier scheme, because we're not doing
     // any transformation or cleaning.
     val libraryRefsList: List[SourceIdentifier] =
-      zipMiroFields(
-        keys = miroData.libraryRefDepartment,
-        values = miroData.libraryRefId)
-      .map { case (label, value) => SourceIdentifier(
-        IdentifierSchemes.miroLibraryReference,
-        s"$label $value"
-      )}
+      zipMiroFields(keys = miroData.libraryRefDepartment,
+                    values = miroData.libraryRefId)
+        .map {
+          case (label, value) =>
+            SourceIdentifier(
+              IdentifierSchemes.miroLibraryReference,
+              s"$label $value"
+            )
+        }
 
     miroIDList ++ sierraList ++ libraryRefsList
   }
@@ -391,12 +393,14 @@ case class MiroTransformable(MiroID: String,
 
       // If only one of the fields is non-empty, for now we just raise
       // an exception -- this probably indicates an issue in the source data.
-      case (Some(k), None) => throw new RuntimeException(
-        s"Inconsistent k/v pairs: keys=$k, values=null"
-      )
-      case (None, Some(v)) => throw new RuntimeException(
-        s"Inconsistent k/v pairs: keys=null, values=$v"
-      )
+      case (Some(k), None) =>
+        throw new RuntimeException(
+          s"Inconsistent k/v pairs: keys=$k, values=null"
+        )
+      case (None, Some(v)) =>
+        throw new RuntimeException(
+          s"Inconsistent k/v pairs: keys=null, values=$v"
+        )
     }
 
   }

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformableData.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformableData.scala
@@ -27,7 +27,8 @@ case class MiroTransformableData(
   @JsonProperty("image_innopac_id") innopacID: Option[String],
   @JsonProperty("image_credit_line") creditLine: Option[String],
   @JsonProperty("image_source_code") sourceCode: Option[String],
-  @JsonProperty("image_library_ref_department") libraryRefDepartment: Option[List[String]],
+  @JsonProperty("image_library_ref_department") libraryRefDepartment: Option[
+    List[String]],
   @JsonProperty("image_library_ref_id") libraryRefId: Option[List[String]]
 )
 

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformableData.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformableData.scala
@@ -26,7 +26,9 @@ case class MiroTransformableData(
   @JsonProperty("image_supp_lettering") suppLettering: Option[String],
   @JsonProperty("image_innopac_id") innopacID: Option[String],
   @JsonProperty("image_credit_line") creditLine: Option[String],
-  @JsonProperty("image_source_code") sourceCode: Option[String]
+  @JsonProperty("image_source_code") sourceCode: Option[String],
+  @JsonProperty("image_library_ref_department") libraryRefDepartment: Option[List[String]],
+  @JsonProperty("image_library_ref_id") libraryRefId: Option[List[String]]
 )
 
 case object MiroTransformableData {

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -235,6 +235,10 @@ class MiroTransformableTest
     }
   }
 
+  describe("non-MPL references should be passed through as identifiers") {
+    it("")
+  }
+
   it("should have an empty list if no image_creator field is present") {
     val work = transformWork(data = s""""image_title": "A guide to giraffes"""")
     work.creators shouldBe List[Agent]()
@@ -406,6 +410,26 @@ class MiroTransformableTest
       SourceIdentifier(IdentifierSchemes.miroImageNumber, miroID),
       SourceIdentifier(IdentifierSchemes.sierraSystemNumber, expectedSierraNumber)
     )
+  }
+
+  private def transformRecordAndCheckMiroLibraryReferences(
+    data: String,
+    expectedValues: List[String]
+  ) = {
+    val work = transformWork(
+      data = s"""
+        "image_title": "A fanciful frolicking of fish",
+        $data
+      """,
+      MiroID = "V0175278"
+    )
+    miroIDList = List(
+      SourceIdentifier(IdentifierSchemes.miroImageNumber, "V0175278")
+    )
+    libraryRefList = expectedValues.map {
+      SourceIdentifier(IdentifierSchemes.miroLibraryReference)
+    }
+    work.identifiers shouldBe
   }
 }
 

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -483,10 +483,10 @@ class MiroTransformableTest
       """,
       MiroID = "V0175278"
     )
-    miroIDList = List(
+    val miroIDList = List(
       SourceIdentifier(IdentifierSchemes.miroImageNumber, "V0175278")
     )
-    libraryRefList = expectedValues.map {
+    val libraryRefList = expectedValues.map {
       SourceIdentifier(IdentifierSchemes.miroLibraryReference, _)
     }
     work.identifiers shouldBe (miroIDList ++ libraryRefList)

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -236,14 +236,40 @@ class MiroTransformableTest
   }
 
   describe("non-MPL references should be passed through as identifiers") {
-    it("")
+    it("no references") {
+      transformRecordAndCheckMiroLibraryReferences(
+        data = """
+          "image_library_ref_department": null,
+          "image_library_ref_id": null
+        """,
+        expectedValues = List()
+      )
+    }
 
-    // No references
+    it("one reference") {
+      transformRecordAndCheckMiroLibraryReferences(
+        data = """
+          "image_library_ref_department": ["External Reference"],
+          "image_library_ref_id": ["Sanskrit ID 1924"]
+        """,
+        expectedValues = List(
+          "External Reference Sanskrit ID 1924"
+        )
+      )
+    }
 
-    // One reference
-
-    // Multiple references
-
+    it("two references") {
+      transformRecordAndCheckMiroLibraryReferences(
+        data = """
+          "image_library_ref_department": ["External Reference", "ICV No"],
+          "image_library_ref_id": ["Sanskrit ID 1924", "1234"]
+        """,
+        expectedValues = List(
+          "External Reference Sanskrit ID 1924",
+          "ICV No 1234"
+        )
+      )
+    }
     // len(labels) != len(IDs) => failure
   }
 

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -270,7 +270,15 @@ class MiroTransformableTest
         )
       )
     }
-    // len(labels) != len(IDs) => failure
+
+    it("with mismatched ref IDs/department") {
+      assertTransformWorkFails(
+        data = """
+          "image_library_ref_department": ["External Reference"],
+          "image_library_ref_id": ["Sanskrit ID 1924", "1234"]
+        """
+      )
+    }
   }
 
   it("should have an empty list if no image_creator field is present") {

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -237,6 +237,14 @@ class MiroTransformableTest
 
   describe("non-MPL references should be passed through as identifiers") {
     it("")
+
+    // No references
+
+    // One reference
+
+    // Multiple references
+
+    // len(labels) != len(IDs) => failure
   }
 
   it("should have an empty list if no image_creator field is present") {
@@ -427,9 +435,9 @@ class MiroTransformableTest
       SourceIdentifier(IdentifierSchemes.miroImageNumber, "V0175278")
     )
     libraryRefList = expectedValues.map {
-      SourceIdentifier(IdentifierSchemes.miroLibraryReference)
+      SourceIdentifier(IdentifierSchemes.miroLibraryReference, _)
     }
-    work.identifiers shouldBe
+    work.identifiers shouldBe (miroIDList ++ libraryRefList)
   }
 }
 

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -279,6 +279,24 @@ class MiroTransformableTest
         """
       )
     }
+
+    it("with ref IDs null but department non-null") {
+      assertTransformWorkFails(
+        data = """
+          "image_library_ref_department": ["External Reference"],
+          "image_library_ref_id": null
+        """
+      )
+    }
+
+    it("with ref IDs non-null but department null") {
+      assertTransformWorkFails(
+        data = """
+          "image_library_ref_department": null,
+          "image_library_ref_id": ["Sanskrit ID 1924", "1234"]
+        """
+      )
+    }
   }
 
   it("should have an empty list if no image_creator field is present") {

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/MiroTransformableWrapper.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/MiroTransformableWrapper.scala
@@ -35,4 +35,17 @@ trait MiroTransformableWrapper extends Matchers { this: Suite =>
     miroTransformable.transform.isSuccess shouldBe true
     miroTransformable.transform.get
   }
+
+  def assertTransformWorkFails(
+    data: String,
+    MiroID: String = "M0000001",
+    MiroCollection: String = "TestCollection"
+  ) = {
+    val miroTransformable = MiroTransformable(
+      MiroID = MiroID,
+      MiroCollection = MiroCollection,
+      data = buildJSONForWork(data)
+    )
+    miroTransformable.transform.isSuccess shouldBe false
+  }
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

Expose other legacy identifiers in the API content.

Resolves #1129.

### Who is this change for?

Folks who have old references lying around.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
