### PR TITLE
Add information about Wellcome Image Awards winners to descriptions

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -127,7 +127,7 @@ case class MiroTransformable(MiroID: String,
     // Finally, remove any leading/trailing from the description, and drop
     // the description if it's *only* whitespace.
     val description =
-      if ((rawDescription + wiaAwardsString).trim.length > 0) {
+      if ((rawDescription + wiaAwardsString).trim.isNotEmpty) {
         Some((rawDescription + wiaAwardsString).trim)
       } else None
 

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -85,9 +85,50 @@ case class MiroTransformable(MiroID: String,
       candidateDescription
     }
 
+    // Add any information about Wellcome Image Awards winners to the
+    // description.  We append a sentence to the description, using one
+    // of the following patterns:
+    //
+    //    Biomedical Image Awards 1997.
+    //    Wellcome Image Awards 2015.
+    //    Wellcome Image Awards 2016 Overall Winner.
+    //    Wellcome Image Awards 2017, Julie Dorrington Award Winner.
+    //
+    // For now, any other award data gets discarded.
+    val wiaAwardsData: List[(String, String)] =
+      zipMiroFields(keys = miroData.award, values = miroData.awardDate)
+      .filter {
+        case (label, _) => (
+          label == "WIA Overall Winner" ||
+          label == "Wellcome Image Awards" ||
+          label == "Biomedical Image Awards")
+      }
+
+    val wiaAwardsString = wiaAwardsData.length match {
+      // Most images have no award, or only a single award string.
+      case 0 => ""
+      case 1 => {
+        val (label, year) = wiaAwardsData.head
+        s" $label $year."
+      }
+
+      // A handful of images have an award key pair for "WIA Overall Winner"
+      // and "Wellcome Image Awards", both with the same year.  In this case,
+      // we write a single sentence.
+      case 2 => {
+        val (_ , year) = wiaAwardsData.head
+        s" Wellcome Image Awards Overall Winner $year."
+      }
+
+      // Any more than two award-related entries in these fields would be
+      // unexpected, and we let it error as an unmatched case.
+    }
+
+    // Finally, remove any leading/trailing from the description, and drop
+    // the description if it's *only* whitespace.
     val description =
-      if (rawDescription.trim.length > 0) {
-        Some(rawDescription.trim)
+      if ((rawDescription + wiaAwardsString).trim.length > 0) {
+        Some((rawDescription + wiaAwardsString).trim)
       } else None
 
     (title, description)

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -97,12 +97,12 @@ case class MiroTransformable(MiroID: String,
     // For now, any other award data gets discarded.
     val wiaAwardsData: List[(String, String)] =
       zipMiroFields(keys = miroData.award, values = miroData.awardDate)
-      .filter {
-        case (label, _) => (
-          label == "WIA Overall Winner" ||
-          label == "Wellcome Image Awards" ||
-          label == "Biomedical Image Awards")
-      }
+        .filter {
+          case (label, _) =>
+            (label == "WIA Overall Winner" ||
+              label == "Wellcome Image Awards" ||
+              label == "Biomedical Image Awards")
+        }
 
     val wiaAwardsString = wiaAwardsData match {
       // Most images have no award, or only a single award string.
@@ -112,7 +112,8 @@ case class MiroTransformable(MiroID: String,
       // A handful of images have an award key pair for "WIA Overall Winner"
       // and "Wellcome Image Awards", both with the same year.  In this case,
       // we write a single sentence.
-      case List((_, year), (_, _)) => s" Wellcome Image Awards Overall Winner $year."
+      case List((_, year), (_, _)) =>
+        s" Wellcome Image Awards Overall Winner $year."
 
       // Any more than two award-related entries in these fields would be
       // unexpected, and we let it error as an unmatched case.

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -104,21 +104,15 @@ case class MiroTransformable(MiroID: String,
           label == "Biomedical Image Awards")
       }
 
-    val wiaAwardsString = wiaAwardsData.length match {
+    val wiaAwardsString = wiaAwardsData match {
       // Most images have no award, or only a single award string.
-      case 0 => ""
-      case 1 => {
-        val (label, year) = wiaAwardsData.head
-        s" $label $year."
-      }
+      case Nil => ""
+      case List((label, year)) => s" $label $year."
 
       // A handful of images have an award key pair for "WIA Overall Winner"
       // and "Wellcome Image Awards", both with the same year.  In this case,
       // we write a single sentence.
-      case 2 => {
-        val (_ , year) = wiaAwardsData.head
-        s" Wellcome Image Awards Overall Winner $year."
-      }
+      case List((_, year), (_, _)) => s" Wellcome Image Awards Overall Winner $year."
 
       // Any more than two award-related entries in these fields would be
       // unexpected, and we let it error as an unmatched case.
@@ -127,7 +121,7 @@ case class MiroTransformable(MiroID: String,
     // Finally, remove any leading/trailing from the description, and drop
     // the description if it's *only* whitespace.
     val description =
-      if ((rawDescription + wiaAwardsString).trim.isNotEmpty) {
+      if (!(rawDescription + wiaAwardsString).trim.isEmpty) {
         Some((rawDescription + wiaAwardsString).trim)
       } else None
 

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -443,7 +443,6 @@ case class MiroTransformable(MiroID: String,
           s"Inconsistent k/v pairs: keys=null, values=$v"
         )
     }
-
   }
 
   override def transform: Try[Work] = Try {

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformableData.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformableData.scala
@@ -29,7 +29,9 @@ case class MiroTransformableData(
   @JsonProperty("image_source_code") sourceCode: Option[String],
   @JsonProperty("image_library_ref_department") libraryRefDepartment: Option[
     List[String]],
-  @JsonProperty("image_library_ref_id") libraryRefId: Option[List[String]]
+  @JsonProperty("image_library_ref_id") libraryRefId: Option[List[String]],
+  @JsonProperty("image_award") award: Option[List[String]],
+  @JsonProperty("image_award_date") awardDate: Option[List[String]]
 )
 
 case object MiroTransformableData {

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -358,6 +358,64 @@ class MiroTransformableTest
     work.description shouldBe Some(description)
   }
 
+  describe("Wellcome Images Awards metadata") {
+    it("should do nothing for non-WIA metadata") {
+      val description = "Spotting sea snakes on sandbanks."
+      val work = transformWork(
+        data =
+          s"""
+          "image_title": "Snakes!",
+          "image_image_desc": "$description",
+          "image_award": ["Award of Excellence"],
+          "image_award_date": [null]
+        """
+      )
+      work.description shouldBe Some(description)
+    }
+
+    it("should add WIA metadata if present") {
+      val description = "Purple penguins play with paint."
+      val work = transformWork(
+        data =
+          s"""
+          "image_title": "Penguin feeding time",
+          "image_image_desc": "$description",
+          "image_award": ["Biomedical Image Awards"],
+          "image_award_date": ["2001"]
+        """
+      )
+      work.description shouldBe Some(description + " Biomedical Image Awards 2001.")
+    }
+
+    it("should only include WIA metadata") {
+      val description = "Giraffes can be grazing, galloping or graceful."
+      val work = transformWork(
+        data =
+          s"""
+          "image_title": "A giraffe trifecta",
+          "image_image_desc": "$description",
+          "image_award": ["Dirt, Wellcome Collection", "Biomedical Image Awards"],
+          "image_award_date": [None, "2002"]
+        """
+      )
+      work.description shouldBe Some(description + " Biomedical Image Awards 2002.")
+    }
+
+    it("should combine multiple WIA metadata fields if necessary") {
+      val description = "Amazed and awe-inspired by an adversarial aardvark."
+      val work = transformWork(
+        data =
+          s"""
+          "image_title": "Award-winning!",
+          "image_image_desc": "$description",
+          "image_award": ["WIA Overall Winner", "Wellcome Image Awards"],
+          "image_award_date": ["2015", "2015"]
+        """
+      )
+      work.description shouldBe Some(description + " Wellcome Image Awards Overall Winner 2015.")
+    }
+  }
+
   it("should pass through the value of the creation date on V records") {
     val date = "1820-1848"
     val work = transformWork(

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -367,7 +367,7 @@ class MiroTransformableTest
           "image_title": "Snakes!",
           "image_image_desc": "$description",
           "image_award": ["Award of Excellence"],
-          "image_award_date": [null]
+          "image_award_date": ["1990"]
         """
       )
       work.description shouldBe Some(description)

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -367,7 +367,7 @@ class MiroTransformableTest
           "image_title": "Snakes!",
           "image_image_desc": "$description",
           "image_award": ["Award of Excellence"],
-          "image_award_date": ["1990"]
+          "image_award_date": [null]
         """
       )
       work.description shouldBe Some(description)
@@ -395,7 +395,7 @@ class MiroTransformableTest
           "image_title": "A giraffe trifecta",
           "image_image_desc": "$description",
           "image_award": ["Dirt, Wellcome Collection", "Biomedical Image Awards"],
-          "image_award_date": [None, "2002"]
+          "image_award_date": [null, "2002"]
         """
       )
       work.description shouldBe Some(description + " Biomedical Image Awards 2002.")


### PR DESCRIPTION
### What is this PR trying to achieve?

Resolves #1100.

### Who is this change for?

API users who want to know about Award-Winning Images.

### Have the following been considered/are they needed?

- [ ] Deployed new versions