### PR TITLE
Fix update_task_for_config_change lambda

### DIFF
--- a/shared_infra/update_task_for_config_change/src/update_task_for_config_change.py
+++ b/shared_infra/update_task_for_config_change/src/update_task_for_config_change.py
@@ -67,7 +67,7 @@ def parse_s3_event(event):
     records = event['Records']
     assert len(records) == 1
     changed_object_key = records[0]['s3']['object']['key']
-    match = re.match(r'^config/prod/(?P<app>[a-z_]+)\.ini', changed_object_key)
+    match = re.match(r'^config/prod/(?P<app>[a-z_0-9]+)\.ini', changed_object_key)
     assert match is not None, changed_object_key
     return match.group('app')
 


### PR DESCRIPTION
### What is this PR trying to achieve?

Ensure the update_task_for_config_change works with all task definitions, including those with numbers in the name for example the API.

### Who is this change for?

💻 🐩 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.
