### PR TITLE
No copyright when image_source_code is WEL

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/miro/MiroTransformable.scala
@@ -308,6 +308,7 @@ case class MiroTransformable(MiroID: String,
       case None =>
         miroData.sourceCode match {
           case Some(code) => Some(contributorMap(code.toUpperCase))
+          case Some("WEL") => None
           case None => None
         }
     }

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -761,6 +761,16 @@ class MiroTransformableCopyrightTest
     )
   }
 
+  it("should provide no copyright if the image_source_code is WEL") {
+    transformRecordAndCheckCopyright(
+      data = s"""
+        "image_title": "A tumultuous transformation of trees",
+        "image_credit_line": null,
+        "image_source_code": "WEL"
+      """,
+      expectedCopyright = None
+    )
+  }
 
   it("should use the uppercased version of the source_code if necessary") {
     transformRecordAndCheckCopyright(


### PR DESCRIPTION
### What is this PR trying to achieve?

"Wellcome Collection" is _never_ valid copyright when referring to `image_source_code` so reflect that.

### Who is this change for?

@jennpb 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run reindex
