### PR TITLE
Reduce the size of our Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,11 @@ env:
   matrix:
     - TASK=check-format
     - TASK=nginx-build
-    - TASK=tif-metadata-build
-    - TASK=elasticdump-build
-    - TASK=api_docs-build
+
+    # (Not under active development)
+    # - TASK=tif-metadata-build
+    # - TASK=elasticdump-build
+    # - TASK=api_docs-build
 
     # Catalogue pipeline stack
     - TASK=sbt-test-common
@@ -66,8 +68,8 @@ env:
     # Catalogue API stack
     - TASK=sbt-test-api
 
-    # Miro preprocessor stack
-    - TASK=miro_preprocessor-test
+    # Miro preprocessor stack  (not under active development)
+    # - TASK=miro_preprocessor-test
 
     # Shared infra stack
     - TASK=shared_infra-build


### PR DESCRIPTION
### What is this PR trying to achieve?

Reduce the number of jobs we run in Travis. This should reduce build contention and speed up tests, as we’ll be using less VMs per build.

### Who is this change for?

Devs who want fast builds.