### PR TITLE
[WIP] Adds dynamo_event_to_sns lambda

### DIFF
--- a/lambdas/Makefile
+++ b/lambdas/Makefile
@@ -1,0 +1,30 @@
+export ROOT = $(shell git rev-parse --show-toplevel)
+export LAMBDAS = $(ROOT)/lambdas
+export INFRA_BUCKET = platform-infra
+
+ifneq ($(ROOT), $(shell pwd))
+	include $(ROOT)/shared.Makefile
+endif
+
+## Build dynamo_event_to_sns lambda
+dynamo_event_to_sns-build: $(ROOT)/.docker/python3.6_ci
+	docker run \
+		--volume $(LAMBDAS)/dynamo_event_to_sns:/data \
+		--env OP=build-lambda \
+		python3.6_ci:latest
+
+## Test dynamo_event_to_sns lambda
+dynamo_event_to_sns-test: $(ROOT)/.docker/python3.6_ci
+	$(ROOT)/builds/docker_run.py --aws -- \
+		--volume $(LAMBDAS)/dynamo_event_to_sns/src:/data \
+		--env OP=test \
+		--env FIND_MATCH_PATHS="/data" --tty \
+		python3.6_ci:latest
+
+## Publish dynamo_event_to_sns lambda
+dynamo_event_to_sns-publish: $(ROOT)/.docker/publish_lambda_zip
+	$(ROOT)/builds/docker_run.py --aws -- \
+		--volume $(ROOT):/repo \
+		publish_lambda_zip "lambdas/dynamo_event_to_sns/src" \
+		--key="lambdas/dynamo_event_to_sns.zip" \
+		--bucket="$(INFRA_BUCKET)";

--- a/lambdas/dynamo_event_to_sns/src/conftest.py
+++ b/lambdas/dynamo_event_to_sns/src/conftest.py
@@ -1,0 +1,80 @@
+# -*- encoding: utf-8 -*-
+
+import pytest
+import boto3
+from moto import mock_sns, mock_sqs
+
+
+def pytest_runtest_setup(item):
+    set_region()
+
+
+@pytest.fixture()
+def set_region():
+    # Without this, boto3 is complaining about not having a region defined
+    # in tests (despite one being set in the Travis env variables and passed
+    # into the image).
+    # TODO: Investigate this properly.
+    boto3.setup_default_session(region_name='eu-west-1')
+
+
+@pytest.fixture()
+def moto_start(set_region):
+    mock_sns().start()
+    mock_sqs().start()
+    yield
+    mock_sns().stop()
+    mock_sqs().stop()
+
+
+def _create_topic_and_queue(sns_client, sqs_client, name):
+    queue_name = f"test-{name}"
+    topic_name = f"test-{name}"
+
+    print(f"Creating topic {topic_name} and queue {queue_name}")
+
+    sns_client.create_topic(Name=topic_name)
+    response = sns_client.list_topics()
+
+    topics = [topic for topic in response["Topics"] if name in topic["TopicArn"]]
+    topic_arn = topics[0]['TopicArn']
+
+    queue = sqs_client.create_queue(QueueName=queue_name)
+
+    sns_client.subscribe(
+        TopicArn=topic_arn,
+        Protocol="sqs",
+        Endpoint=f"arn:aws:sqs:eu-west-1:123456789012:{queue_name}"
+    )
+
+    return topic_arn, queue['QueueUrl']
+
+
+@pytest.fixture()
+def dynamo_to_sns_event_sns_sqs(set_region, moto_start):
+    fake_sns_client = boto3.client('sns')
+    fake_sqs_client = boto3.client('sqs')
+
+    modify_topic, modify_queue = _create_topic_and_queue(
+        fake_sns_client, fake_sqs_client, "modify")
+
+    insert_topic, insert_queue = _create_topic_and_queue(
+        fake_sns_client, fake_sqs_client, "insert")
+
+    remove_topic, remove_queue = _create_topic_and_queue(
+        fake_sns_client, fake_sqs_client, "remove")
+
+    yield {
+        "modify": {
+            "topic": modify_topic,
+            "queue": modify_queue
+        },
+        "insert": {
+            "topic": insert_topic,
+            "queue": insert_queue
+        },
+        "remove": {
+            "topic": remove_topic,
+            "queue": remove_queue
+        }
+    }

--- a/lambdas/dynamo_event_to_sns/src/dynamo_event_to_sns.py
+++ b/lambdas/dynamo_event_to_sns/src/dynamo_event_to_sns.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+"""
+Receives DynamoDB events and publishes the event to an SNS topic
+
+"""
+
+import os
+
+import boto3
+
+from wellcome_lambda_utils.dynamo_utils import DynamoEventFactory, DynamoEventType
+from wellcome_lambda_utils.sns_utils import publish_sns_message
+
+
+def main(event, _):
+    print(f'Received event:\n{event}')
+
+    sns_client = boto3.client('sns')
+
+    remove_topic_arn = os.environ["REMOVE_TOPIC_ARN"]
+    modify_topic_arn = os.environ["MODIFY_TOPIC_ARN"]
+    insert_topic_arn = os.environ["INSERT_TOPIC_ARN"]
+
+    for dynamo_event in DynamoEventFactory.create(event):
+
+        if dynamo_event.event_type == DynamoEventType.REMOVE:
+            topic_arn = remove_topic_arn
+            subject = "REMOVE"
+        if dynamo_event.event_type == DynamoEventType.MODIFY:
+            topic_arn = modify_topic_arn
+            subject = "MODIFY"
+        if dynamo_event.event_type == DynamoEventType.INSERT:
+            topic_arn = insert_topic_arn
+            subject = "INSERT"
+
+        if (not topic_arn) or (not subject):
+            raise Exception(f'Topic or Subject unset based on {dynamo_event}')
+
+        publish_sns_message(
+            topic_arn=topic_arn,
+            message=dynamo_event,
+            subject=subject,
+            sns_client=sns_client
+        )

--- a/lambdas/dynamo_event_to_sns/src/requirements.txt
+++ b/lambdas/dynamo_event_to_sns/src/requirements.txt
@@ -1,0 +1,1 @@
+wellcome_lambda_utils==2.0.0

--- a/lambdas/dynamo_event_to_sns/src/test_dynamo_event_to_sns.py
+++ b/lambdas/dynamo_event_to_sns/src/test_dynamo_event_to_sns.py
@@ -1,0 +1,138 @@
+import json
+import os
+
+import boto3
+
+import dynamo_event_to_sns
+
+
+modify_record = {
+    'eventID': '81659528846ddb9826c612c16043c2ea',
+    'eventName': 'MODIFY',
+    'eventVersion': '1.1',
+    'eventSource': 'aws:dynamodb',
+    'awsRegion': 'eu-west-1',
+    'dynamodb': {
+        'ApproximateCreationDateTime': 1499243940.0,
+        'Keys': {
+            'MiroID': {'S': 'V0010033'},
+            'MiroCollection': {'S': 'Images-V'}
+        },
+        'NewImage': {
+            'ReindexVersion': {'N': '0'},
+            'ReindexShard': {'S': 'default'},
+            'data': {'S': 'test-json-data-new'},
+            'MiroID': {'S': 'V0010033'},
+            'MiroCollection': {'S': 'Images-V'}
+        },
+        'OldImage': {
+            'ReindexVersion': {'N': '0'},
+            'ReindexShard': {'S': 'default'},
+            'data': {'S': 'test-json-data-old'},
+            'MiroID': {'S': 'V0010033'},
+            'MiroCollection': {'S': 'Images-V'}
+        },
+        'SequenceNumber': '167031600000000009949839133',
+        'SizeBytes': 6422,
+        'StreamViewType': 'NEW_AND_OLD_IMAGES'
+    },
+    'eventSourceARN': 'arn:aws:dynamodb:eu-west-1:123456789012:table/table-stream'
+}
+
+insert_record = {
+    'eventID': '81659528846ddb9826c612c16043c2ea',
+    'eventName': 'INSERT',
+    'eventVersion': '1.1',
+    'eventSource': 'aws:dynamodb',
+    'awsRegion': 'eu-west-1',
+    'dynamodb': {
+        'ApproximateCreationDateTime': 1499243940.0,
+        'Keys': {
+            'MiroID': {'S': 'V0010033'},
+            'MiroCollection': {'S': 'Images-V'}
+        },
+        'NewImage': {
+            'ReindexVersion': {'N': '0'},
+            'ReindexShard': {'S': 'default'},
+            'data': {'S': 'test-json-data-new'},
+            'MiroID': {'S': 'V0010033'},
+            'MiroCollection': {'S': 'Images-V'}
+        },
+        'SequenceNumber': '167031600000000009949839133',
+        'SizeBytes': 6422,
+        'StreamViewType': 'NEW_AND_OLD_IMAGES'
+    },
+    'eventSourceARN': 'arn:aws:dynamodb:eu-west-1:123456789012:table/table-stream'
+}
+
+remove_record = {
+    'eventID': '81659528846ddb9826c612c16043c2ea',
+    'eventName': 'REMOVE',
+    'eventVersion': '1.1',
+    'eventSource': 'aws:dynamodb',
+    'awsRegion': 'eu-west-1',
+    'dynamodb': {
+        'ApproximateCreationDateTime': 1499243940.0,
+        'Keys': {
+            'MiroID': {'S': 'V0010033'},
+            'MiroCollection': {'S': 'Images-V'}
+        },
+        'OldImage': {
+            'ReindexVersion': {'N': '0'},
+            'ReindexShard': {'S': 'default'},
+            'data': {'S': 'test-json-data-old'},
+            'MiroID': {'S': 'V0010033'},
+            'MiroCollection': {'S': 'Images-V'}
+        },
+        'SequenceNumber': '167031600000000009949839133',
+        'SizeBytes': 6422,
+        'StreamViewType': 'NEW_AND_OLD_IMAGES'
+    },
+    'eventSourceARN': 'arn:aws:dynamodb:eu-west-1:123456789012:table/table-stream'
+}
+
+event = {
+        'Records': [modify_record, insert_record, remove_record]
+}
+
+
+def _load_message(messages):
+    message_body = messages['Messages'][0]['Body']
+    return json.loads(message_body)['Message']
+
+
+def test_dynamo_event_to_sns(dynamo_to_sns_event_sns_sqs):
+    sqs_client = boto3.client('sqs')
+    sns_sqs = dynamo_to_sns_event_sns_sqs
+
+    os.environ = {
+        "REMOVE_TOPIC_ARN": sns_sqs['remove']['topic'],
+        "MODIFY_TOPIC_ARN": sns_sqs['modify']['topic'],
+        "INSERT_TOPIC_ARN": sns_sqs['insert']['topic']
+    }
+
+    dynamo_event_to_sns.main(event, None)
+
+    remove_message = sqs_client.receive_message(
+        QueueUrl=sns_sqs['remove']['queue'],
+        MaxNumberOfMessages=1
+    )
+
+    actual_remove_record = _load_message(remove_message.get("Messages"))
+    assert actual_remove_record == remove_record
+
+    modify_message = sqs_client.receive_message(
+        QueueUrl=sns_sqs['modify']['queue'],
+        MaxNumberOfMessages=1
+    )
+
+    actual_modify_record = _load_message(modify_message.get("Messages"))
+    assert actual_modify_record == modify_record
+
+    insert_message = sqs_client.receive_message(
+        QueueUrl=sns_sqs['insert']['queue'],
+        MaxNumberOfMessages=1
+    )
+
+    actual_insert_record = _load_message(insert_message.get("Messages"))
+    assert actual_insert_record == modify_record


### PR DESCRIPTION
### What is this PR trying to achieve?

Deprecates the dynamo_to_sns lambda using the proposed DynamoEvent class:

https://github.com/wellcometrust/aws_utils/pull/8

This lambda will pass on all events (including deletion and modify events), with the option of splitting events to different topics.

**Note:** I think we should try and further decouple reusable lambdas from their particular implementation.

### Who is this change for?

For https://github.com/wellcometrust/platform/issues/1005

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.
