### PR TITLE
[WIP] Task status notifier

### DIFF
--- a/monitoring/deployment_tracking/main.tf
+++ b/monitoring/deployment_tracking/main.tf
@@ -29,3 +29,14 @@ module "task_tracking" {
 
   lambda_error_alarm_arn = "${var.lambda_error_alarm_arn}"
 }
+
+module "task_status_notifier" {
+  source = "task_status_notifier"
+
+  every_minute_name = "${var.every_minute_name}"
+  every_minute_arn  = "${var.every_minute_arn}"
+
+  sns_trigger_arn = "${module.task_tracking.task_updates_topic_arn}"
+
+  lambda_error_alarm_arn = "${var.lambda_error_alarm_arn}"
+}

--- a/monitoring/deployment_tracking/outputs.tf
+++ b/monitoring/deployment_tracking/outputs.tf
@@ -1,0 +1,3 @@
+output "task_status_change_topic_arn" {
+  value = "${module.task_status_notifier.task_status_change_topic_arn}"
+}

--- a/monitoring/deployment_tracking/task_status_notifier/iam_role_policy.tf
+++ b/monitoring/deployment_tracking/task_status_notifier/iam_role_policy.tf
@@ -1,0 +1,4 @@
+resource "aws_iam_role_policy" "task_status_change_to_sns" {
+  role   = "${module.lambda_task_status_notifier.role_name}"
+  policy = "${module.task_status_change_topic.publish_policy}"
+}

--- a/monitoring/deployment_tracking/task_status_notifier/main.tf
+++ b/monitoring/deployment_tracking/task_status_notifier/main.tf
@@ -1,0 +1,23 @@
+module "lambda_task_status_notifier" {
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.4"
+
+  name        = "task_status_notifier"
+  description = "Lambda for notifiying changes in task status"
+
+  environment_variables = {
+    TASK_STOPPED_TOPIC_ARN = "${module.task_status_change_topic.arn}"
+    TASK_STARTED_TOPIC_ARN = "${module.task_status_change_topic.arn}"
+    TASK_UPDATED_TOPIC_ARN = "${module.task_status_change_topic.arn}"
+  }
+
+  alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_key          = "lambdas/deployment_tracking/task_status_notifier.zip"
+}
+
+module "trigger_task_status_notifier" {
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda/trigger_sns?ref=v1.0.4"
+
+  lambda_function_name = "${module.lambda_task_status_notifier.function_name}"
+  lambda_function_arn  = "${module.lambda_task_status_notifier.arn}"
+  sns_trigger_arn      = "${var.sns_trigger_arn}"
+}

--- a/monitoring/deployment_tracking/task_status_notifier/outputs.tf
+++ b/monitoring/deployment_tracking/task_status_notifier/outputs.tf
@@ -1,0 +1,3 @@
+output "task_status_change_topic_arn" {
+  value = "${module.task_status_change_topic.arn}"
+}

--- a/monitoring/deployment_tracking/task_status_notifier/src/requirements.txt
+++ b/monitoring/deployment_tracking/task_status_notifier/src/requirements.txt
@@ -1,0 +1,1 @@
+wellcome_aws_utils==2.0.0

--- a/monitoring/deployment_tracking/task_status_notifier/src/task_status_notifier.py
+++ b/monitoring/deployment_tracking/task_status_notifier/src/task_status_notifier.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+"""
+Task Status Notifier
+
+Provides SNS topic notifications for task status changes
+"""
+
+import os
+
+import boto3
+
+from wellcome_aws_utils.sns_utils import extract_json_message, publish_sns_message
+from wellcome_aws_utils.dynamo_event import DynamoEvent, DynamoEventType
+
+
+def main(event, _):
+    print(f'event = {event!r}')
+
+    sns_client = boto3.client('sns')
+
+    task_stopped_topic = os.environ["TASK_STOPPED_TOPIC_ARN"]
+    task_started_topic = os.environ["TASK_STARTED_TOPIC_ARN"]
+    task_updated_topic = os.environ["TASK_UPDATED_TOPIC_ARN"]
+
+    event = DynamoEvent(
+        extract_json_message(event)
+    )
+
+    if event.event_type == DynamoEventType.INSERT:
+        topic_arn = task_started_topic
+        subject = 'STARTED'
+        image = event.new_image(True)
+    if event.event_type == DynamoEventType.REMOVE:
+        topic_arn = task_stopped_topic
+        subject = 'STOPPED'
+        image = event.old_image(True)
+    if event.event_type == DynamoEventType.MODIFY:
+        topic_arn = task_updated_topic
+        subject = 'MODIFIED'
+        image = event.new_image(True)
+
+    if (not topic_arn) or (not subject) or (not image):
+        raise Exception(f'Unable to publish task status change for {event}')
+
+    publish_sns_message(
+        sns_client=sns_client,
+        topic_arn=topic_arn,
+        message=image,
+        subject=subject
+    )

--- a/monitoring/deployment_tracking/task_status_notifier/src/test_task_status_notifier.py
+++ b/monitoring/deployment_tracking/task_status_notifier/src/test_task_status_notifier.py
@@ -1,0 +1,57 @@
+import json
+import os
+
+import task_status_notifier
+
+record = json.dumps({
+    "ApproximateCreationDateTime": 1479499740,
+    "Keys": {
+        "task_definition_arn": {
+            "S": "2016-11-18:12:09:36"
+        },
+        "task_arn": {
+            "S": "John Doe"
+        }
+    },
+    "NewImage": {
+        "task_definition_arn": {
+            "S": "2016-11-18:12:09:36"
+        },
+        "task_arn": {
+            "S": "John Doe"
+        },
+        "started_at": {
+            "S": "2016-11-18:12:09:36"
+        },
+        "completed": {
+            "BOOL": True
+        },
+        "success": {
+            "BOOL": False
+        }
+    },
+    "SequenceNumber": "13021600000000001596893679",
+    "SizeBytes": 112,
+    "StreamViewType": "NEW_IMAGE"
+})
+
+event = {
+    "Records": [
+        {
+            "Sns": {
+                "Message": record
+            }
+
+        }
+    ]
+}
+
+
+def test_task_status_notifier():
+    os.environ["TASK_STOPPED_TOPIC_ARN"] = 'foo'
+    os.environ["TASK_STARTED_TOPIC_ARN"] = 'foo'
+    os.environ["TASK_UPDATED_TOPIC_ARN"] = 'foo'
+
+    task_status_notifier.main(event, {})
+
+    assert True is False

--- a/monitoring/deployment_tracking/task_status_notifier/topics.tf
+++ b/monitoring/deployment_tracking/task_status_notifier/topics.tf
@@ -1,0 +1,4 @@
+module "task_status_change_topic" {
+  source = "git::https://github.com/wellcometrust/terraform.git//sns?ref=v1.0.0"
+  name   = "task_status_change_topic"
+}

--- a/monitoring/deployment_tracking/task_status_notifier/variables.tf
+++ b/monitoring/deployment_tracking/task_status_notifier/variables.tf
@@ -1,0 +1,4 @@
+variable "lambda_error_alarm_arn" {}
+variable "every_minute_arn" {}
+variable "every_minute_name" {}
+variable "sns_trigger_arn" {}

--- a/monitoring/deployment_tracking/task_tracking/iam_role_policy.tf
+++ b/monitoring/deployment_tracking/task_tracking/iam_role_policy.tf
@@ -8,7 +8,7 @@ resource "aws_iam_role_policy" "task_tracking_tasks_table" {
   policy = "${data.aws_iam_policy_document.tasks_table.json}"
 }
 
-resource "aws_iam_role_policy" "dynamo_to_sns" {
-  role   = "${module.lambda_dynamo_to_sns.role_name}"
+resource "aws_iam_role_policy" "dynamo_event_to_sns" {
+  role   = "${module.lambda_dynamo_event_to_sns.role_name}"
   policy = "${module.task_updates_topic.publish_policy}"
 }

--- a/monitoring/deployment_tracking/task_tracking/outputs.tf
+++ b/monitoring/deployment_tracking/task_tracking/outputs.tf
@@ -5,3 +5,7 @@ output "dynamodb_table_tasks_arn" {
 output "dynamodb_table_tasks_name" {
   value = "${aws_dynamodb_table.tasks.name}"
 }
+
+output "task_updates_topic_arn" {
+  value = "${module.task_updates_topic.arn}"
+}

--- a/monitoring/deployment_tracking/task_tracking/src/task_tracking.py
+++ b/monitoring/deployment_tracking/task_tracking/src/task_tracking.py
@@ -222,5 +222,5 @@ def main(event, _):
     operations = _compare_tasks(tasks_from_ecs, tasks_from_dynamo)
     print(f'operations = {operations!r}')
 
-    operation_resulsts = _run_operations(operations, table)
-    print(f'operation_resulsts = {operation_resulsts!r}')
+    operation_results = _run_operations(operations, table)
+    print(f'operation_results = {operation_results!r}')


### PR DESCRIPTION
### What is this PR trying to achieve?

Adds a lambda that reads the tasks table dynamo event stream updates (from the dynamo_event_to_sns lambda: https://github.com/wellcometrust/platform/pull/1170).

The event is parsed and converted into a task status change event which is then republished.

This is in order to track when tasks change status.

### Who is this change for?

For: https://github.com/wellcometrust/platform/issues/1005

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.
