### PR TITLE
Fix the TypeError in notify_old_deploys.py

### DIFF
--- a/monitoring/deployment_tracking/notify_old_deploys/src/notify_old_deploys.py
+++ b/monitoring/deployment_tracking/notify_old_deploys/src/notify_old_deploys.py
@@ -38,7 +38,12 @@ def filter_old_deployments(deployments, age_boundary_mins):
 
 def publish_deployments(topic_arn, deployments):
     if deployments:
-        publish_sns_message(topic_arn=topic_arn, message=deployments)
+        sns_client = boto3.client('sns')
+        publish_sns_message(
+            sns_client=sns_client,
+            topic_arn=topic_arn,
+            message=deployments
+        )
 
 
 def main(event, _):


### PR DESCRIPTION
Should fix the intermittent Slack alarm we've been seeing.

- [ ] Deployed new versions
