### PR TITLE
Add a line about special copyright info to the usage text

### DIFF
--- a/miro_preprocessor/miro_image_to_tandem_vault/src/tandem_vault_metadata.py
+++ b/miro_preprocessor/miro_image_to_tandem_vault/src/tandem_vault_metadata.py
@@ -204,7 +204,7 @@ def create_usage(d):
     try:
         if d['image_copyright_info']:
             parts.append(
-                'This image has additional copyright information. '
+                'This image may have additional copyright information. '
                 'Please contact digitisation@wellcome.ac.uk.\n\n'
             )
     except KeyError:

--- a/miro_preprocessor/miro_image_to_tandem_vault/src/tandem_vault_metadata.py
+++ b/miro_preprocessor/miro_image_to_tandem_vault/src/tandem_vault_metadata.py
@@ -199,14 +199,25 @@ def _or(s1, s2):
 
 
 def create_usage(d):
-    parts = [
+    parts = []
+
+    try:
+        if d['image_copyright_info']:
+            parts.append(
+                'This image has additional copyright information. '
+                'Please contact digitisation@wellcome.ac.uk.\n\n'
+            )
+    except KeyError:
+        pass
+
+    parts.extend([
         _followed_by_newline(d, 'image_use_restrictions'),
         _followed_by_newline(d, 'image_copyright_cleared', "Likely in copyright. Cleared for open access? "),
         _show_only_if_match_hide_value(
             d, 'image_general_use', 'N',
             'May be sensitive or unsuitable for general use.'
         ),
-    ]
+    ])
 
     return "".join(parts)
 

--- a/miro_preprocessor/miro_image_to_tandem_vault/src/test_tandem_vault_metadata.py
+++ b/miro_preprocessor/miro_image_to_tandem_vault/src/test_tandem_vault_metadata.py
@@ -89,11 +89,6 @@ expected_tags = [
 ]
 
 
-def test_create_usage():
-    actual_text = tandem_vault_metadata.create_usage(image_data)
-    assert actual_text == expected_usage_text
-
-
 def test_create_caption():
     actual_text = tandem_vault_metadata.create_caption(image_data)
     assert actual_text == expected_caption_text
@@ -146,6 +141,7 @@ def test_lookup_contributor(metadata, expected_contributor):
 
 
 @pytest.mark.parametrize('metadata, expected_usage', [
+    (image_data, expected_usage_text),
     ({}, ''),
     ({'image_use_restrictions': 'Can only be used on Tuesdays.'},
      'Can only be used on Tuesdays.\n'),

--- a/miro_preprocessor/miro_image_to_tandem_vault/src/test_tandem_vault_metadata.py
+++ b/miro_preprocessor/miro_image_to_tandem_vault/src/test_tandem_vault_metadata.py
@@ -143,3 +143,25 @@ def test_lookup_contributor(metadata, expected_contributor):
         metadata, contrib_map={'WEL': 'Wellcome Collection'}
     )
     assert actual_contributor == expected_contributor
+
+
+@pytest.mark.parametrize('metadata, expected_usage', [
+    ({}, ''),
+    ({'image_use_restrictions': 'Can only be used on Tuesdays.'},
+     'Can only be used on Tuesdays.\n'),
+    ({'image_copyright_cleared': 'Y'},
+     'Likely in copyright. Cleared for open access? Y\n'),
+    ({'image_use_restrictions': 'Must be displayed upside down',
+      'image_copyright_cleared': 'Y'},
+     'Must be displayed upside down\n'
+     'Likely in copyright. Cleared for open access? Y\n'),
+    ({'image_general_use': 'N'},
+     'May be sensitive or unsuitable for general use.\n'),
+    ({'image_copyright_info': 'Copyright (C) Henry Wellcome',
+      'image_general_use': 'N'},
+     'This image has additional copyright information. '
+     'Please contact digitisation@wellcome.ac.uk.\n\n'
+     'May be sensitive or unsuitable for general use.\n'),
+])
+def test_create_usage(metadata, expected_usage):
+    assert tandem_vault_metadata.create_usage(metadata) == expected_usage

--- a/miro_preprocessor/miro_image_to_tandem_vault/src/test_tandem_vault_metadata.py
+++ b/miro_preprocessor/miro_image_to_tandem_vault/src/test_tandem_vault_metadata.py
@@ -155,7 +155,7 @@ def test_lookup_contributor(metadata, expected_contributor):
      'May be sensitive or unsuitable for general use.\n'),
     ({'image_copyright_info': 'Copyright (C) Henry Wellcome',
       'image_general_use': 'N'},
-     'This image has additional copyright information. '
+     'This image may have additional copyright information. '
      'Please contact digitisation@wellcome.ac.uk.\n\n'
      'May be sensitive or unsuitable for general use.\n'),
 ])


### PR DESCRIPTION
Adds this text to any record with something in the `image_copyright_info` field:

> This image has additional copyright information. Please contact digitisation@wellcome.ac.uk.

Part of #1172.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
