### PR TITLE
Rearrange the Scala make tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,18 +53,16 @@ env:
     - TASK=check-format
     - TASK=nginx-build
 
-    # (Not under active development)
-    # - TASK=api_docs-build
-
     # Catalogue pipeline stack
-    - TASK=sbt-test-common
-    - TASK=sbt-test-transformer
-    - TASK=sbt-test-ingestor
-    - TASK=sbt-test-id_minter
-    - TASK=sbt-test-reindexer
+    - TASK=common-test
+    - TASK=transformer-test
+    - TASK=ingestor-test
+    - TASK=id_minter-test
+    - TASK=reindexer-test
 
     # Catalogue API stack
-    - TASK=sbt-test-api
+    - TASK=api-test
+    # - TASK=api_docs-build  # (not under active development)
 
     # Miro preprocessor stack  (not under active development)
     # - TASK=miro_preprocessor-test
@@ -82,7 +80,7 @@ env:
     # Sierra adapter stack
     - TASK=sierra_adapter-test
 
-    - TASK=sbt-test-sierra_to_dynamo
+    - TASK=sierra_to_dynamo-test
 
 
 # This has a Slack API token for posting messages about build failures to

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,9 @@ env:
 
   matrix:
     - TASK=check-format
-    - TASK=nginx-build
+
+    # (not under active development)
+    # - TASK=nginx-build
 
     # Catalogue pipeline stack
     - TASK=sbt-common-test
@@ -62,7 +64,8 @@ env:
 
     # Catalogue API stack
     - TASK=api-test
-    # - TASK=api_docs-build  # (not under active development)
+    # (not under active development)
+    # - TASK=api_docs-build
 
     # Miro preprocessor stack  (not under active development)
     # - TASK=miro_preprocessor-test
@@ -72,7 +75,8 @@ env:
 
     # Loris stack
     - TASK=loris-build
-    - TASK=cache_cleaner-build
+    # (not under active development)
+    # - TASK=cache_cleaner-build
 
     # Monitoring stack
     - TASK=monitoring-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ env:
     - TASK=nginx-build
 
     # Catalogue pipeline stack
-    - TASK=common-test
+    - TASK=sbt-common-test
     - TASK=transformer-test
     - TASK=ingestor-test
     - TASK=id_minter-test

--- a/Makefile
+++ b/Makefile
@@ -10,83 +10,20 @@ include sierra_adapter/Makefile
 include nginx/Makefile
 
 
-.docker/sbt_test:
+$(ROOT)/.docker/sbt_test:
 	./builds/build_ci_docker_image.py \
 		--project=sbt_test \
 		--dir=builds \
 		--file=builds/sbt_test.Dockerfile
 
-sbt-test-common: .docker/sbt_test
+sbt-common-test: $(ROOT)/.docker/sbt_test
 	PROJECT=common ./builds/test_sbt_project.sh
 
-sbt-test-api: .docker/sbt_test
-	PROJECT=api ./builds/test_sbt_project.sh
-
-sbt-test-id_minter: .docker/sbt_test
-	PROJECT=id_minter ./builds/test_sbt_project.sh
-
-sbt-test-ingestor: .docker/sbt_test
-	PROJECT=ingestor ./builds/test_sbt_project.sh
-
-sbt-test-reindexer: .docker/sbt_test
-	PROJECT=reindexer ./builds/test_sbt_project.sh
-
-sbt-test-transformer: .docker/sbt_test
-	PROJECT=transformer ./builds/test_sbt_project.sh
-
-sbt-test-sierra_to_dynamo: .docker/sbt_test
-	PROJECT=sierra_to_dynamo ./builds/test_sbt_project.sh
-
-
-
-.docker/sbt_image_builder:
+$(ROOT)/.docker/sbt_image_builder:
 	./builds/build_ci_docker_image.py \
 		--project=sbt_image_builder \
 		--dir=builds \
 		--file=builds/sbt_image_builder.Dockerfile
-
-sbt-build-api: .docker/sbt_image_builder
-	TARGET=catalogue_api/api/target \
-	PROJECT=api ./builds/run_sbt_image_build.sh
-
-sbt-build-id_minter: .docker/sbt_image_builder
-	TARGET=catalogue_pipeline/id_minter/target \
-	PROJECT=id_minter ./builds/run_sbt_image_build.sh
-
-sbt-build-ingestor: .docker/sbt_image_builder
-	TARGET=catalogue_pipeline/ingestor/target \
-	PROJECT=ingestor ./builds/run_sbt_image_build.sh
-
-sbt-build-reindexer: .docker/sbt_image_builder
-	TARGET=catalogue_pipeline/reindexer/target \
-	PROJECT=reindexer ./builds/run_sbt_image_build.sh
-
-sbt-build-transformer: .docker/sbt_image_builder
-	TARGET=catalogue_pipeline/transformer/target \
-	PROJECT=transformer ./builds/run_sbt_image_build.sh
-
-sbt-build-sierra_to_dynamo: .docker/sbt_test
-	PROJECT=sierra_to_dynamo ./builds/run_sbt_image_build.sh
-
-
-
-sbt-deploy-api: sbt-build-api
-	$(call publish_service,api)
-
-sbt-deploy-id_minter: sbt-build-id_minter
-	$(call publish_service,id_minter)
-
-sbt-deploy-ingestor: sbt-build-ingestor
-	$(call publish_service,ingestor)
-
-sbt-deploy-reindexer: sbt-build-reindexer
-	$(call publish_service,reindexer)
-
-sbt-deploy-transformer: sbt-build-transformer
-	$(call publish_service,transformer)
-
-sbt-deploy-sierra_to_dynamo:
-	echo "Hello world"
 
 format: format-terraform format-scala
 

--- a/catalogue_api/Makefile
+++ b/catalogue_api/Makefile
@@ -9,8 +9,27 @@ api_docs-build:
 api_docs-deploy: api_docs-build
 	$(call publish_service,update_api_docs)
 
+
+api-test: $(ROOT)/.docker/sbt_test
+	PROJECT=api ./builds/test_sbt_project.sh
+
+api-build: $(ROOT)/.docker/sbt_image_builder
+	TARGET=catalogue_api/api/target \
+	PROJECT=api ./builds/run_sbt_image_build.sh
+
+api-deploy: api-build
+	$(call publish_service,api)
+
+
 catalogue_api-terraform-plan:
 	$(call terraform_plan,$(CATALOGUE_API)/terraform)
 
 catalogue_api-terraform-apply:
 	$(call terraform_apply,$(CATALOGUE_API)/terraform)
+
+
+catalogue_api-build: api-build api_docs-build
+
+catalogue_api-test: api-test
+
+catalogue_api-deploy: api-deploy api_docs-deploy

--- a/catalogue_pipeline/Makefile
+++ b/catalogue_pipeline/Makefile
@@ -5,33 +5,33 @@ include $(ROOT)/functions.Makefile
 include $(CATALOGUE_PIPELINE)/schedule_reindexer/Makefile
 
 
-id_minter-build: $(ROOT).docker/sbt_image_builder
+id_minter-build: $(ROOT)/.docker/sbt_image_builder
 	TARGET=catalogue_pipeline/id_minter/target \
 	PROJECT=id_minter $(ROOT)/builds/run_sbt_image_build.sh
 
-ingestor-build: $(ROOT).docker/sbt_image_builder
+ingestor-build: $(ROOT)/.docker/sbt_image_builder
 	TARGET=catalogue_pipeline/ingestor/target \
 	PROJECT=ingestor $(ROOT)/builds/run_sbt_image_build.sh
 
-reindexer-build: $(ROOT).docker/sbt_image_builder
+reindexer-build: $(ROOT)/.docker/sbt_image_builder
 	TARGET=catalogue_pipeline/reindexer/target \
 	PROJECT=reindexer $(ROOT)/builds/run_sbt_image_build.sh
 
-transformer-build: $(ROOT).docker/sbt_image_builder
+transformer-build: $(ROOT)/.docker/sbt_image_builder
 	TARGET=catalogue_pipeline/transformer/target \
 	PROJECT=transformer $(ROOT)/builds/run_sbt_image_build.sh
 
 
-id_minter-test: $(ROOT).docker/sbt_test
+id_minter-test: $(ROOT)/.docker/sbt_test
 	PROJECT=id_minter $(ROOT)/builds/test_sbt_project.sh
 
-ingestor-test: $(ROOT).docker/sbt_test
+ingestor-test: $(ROOT)/.docker/sbt_test
 	PROJECT=ingestor $(ROOT)/builds/test_sbt_project.sh
 
-reindexer-test: $(ROOT).docker/sbt_test
+reindexer-test: $(ROOT)/.docker/sbt_test
 	PROJECT=reindexer $(ROOT)/builds/test_sbt_project.sh
 
-transformer-test: $(ROOT).docker/sbt_test
+transformer-test: $(ROOT)/.docker/sbt_test
 	PROJECT=transformer $(ROOT)/builds/test_sbt_project.sh
 
 

--- a/catalogue_pipeline/Makefile
+++ b/catalogue_pipeline/Makefile
@@ -5,11 +5,69 @@ include $(ROOT)/functions.Makefile
 include $(CATALOGUE_PIPELINE)/schedule_reindexer/Makefile
 
 
-catalogue_pipeline-build: schedule_reindexer-build
+id_minter-build: $(ROOT).docker/sbt_image_builder
+	TARGET=catalogue_pipeline/id_minter/target \
+	PROJECT=id_minter $(ROOT)/builds/run_sbt_image_build.sh
 
-catalogue_pipeline-test: schedule_reindexer-test
+ingestor-build: $(ROOT).docker/sbt_image_builder
+	TARGET=catalogue_pipeline/ingestor/target \
+	PROJECT=ingestor $(ROOT)/builds/run_sbt_image_build.sh
 
-catalogue_pipeline-deploy: schedule_reindexer-publish
+reindexer-build: $(ROOT).docker/sbt_image_builder
+	TARGET=catalogue_pipeline/reindexer/target \
+	PROJECT=reindexer $(ROOT)/builds/run_sbt_image_build.sh
+
+transformer-build: $(ROOT).docker/sbt_image_builder
+	TARGET=catalogue_pipeline/transformer/target \
+	PROJECT=transformer $(ROOT)/builds/run_sbt_image_build.sh
+
+
+id_minter-test: $(ROOT).docker/sbt_test
+	PROJECT=id_minter $(ROOT)/builds/test_sbt_project.sh
+
+ingestor-test: $(ROOT).docker/sbt_test
+	PROJECT=ingestor $(ROOT)/builds/test_sbt_project.sh
+
+reindexer-test: $(ROOT).docker/sbt_test
+	PROJECT=reindexer $(ROOT)/builds/test_sbt_project.sh
+
+transformer-test: $(ROOT).docker/sbt_test
+	PROJECT=transformer $(ROOT)/builds/test_sbt_project.sh
+
+
+id_minter-deploy: id_minter-build
+	$(call publish_service,id_minter)
+
+ingestor-deploy: ingestor-build
+	$(call publish_service,ingestor)
+
+reindexer-deploy: reindexer-build
+	$(call publish_service,reindexer)
+
+transformer-deploy: transformer-build
+	$(call publish_service,transformer)
+
+
+catalogue_pipeline-build: \
+	schedule_reindexer-build \
+	id_minter-build \
+	ingestor-build \
+	reindexer-build \
+	transformer-build
+
+catalogue_pipeline-test: \
+	schedule_reindexer-test \
+	id_minter-test \
+	ingestor-test \
+	reindexer-test \
+	transformer-test
+
+catalogue_pipeline-deploy: \
+	schedule_reindexer-publish \
+	id_minter-deploy \
+	ingestor-deploy \
+	reindexer-deploy \
+	transformer-deploy
 
 
 catalogue_pipeline-terraform-plan:

--- a/sierra_adapter/Makefile
+++ b/sierra_adapter/Makefile
@@ -12,6 +12,17 @@ endif
 
 include $(ROOT)/functions.Makefile
 
+
+sierra_to_dynamo-test: $(ROOT)/.docker/sbt_test
+	PROJECT=sierra_to_dynamo $(ROOT)/builds/test_sbt_project.sh
+
+sierra_to_dynamo-build: $(ROOT)/.docker/sbt_test
+	PROJECT=sierra_to_dynamo $(ROOT)./builds/run_sbt_image_build.sh
+
+sierra_to_dynamo-deploy:
+	echo "Hello world"
+
+
 sierra_adapter-test: sierra_objects_to_s3-test sierra_window_generator-test
 sierra_adapter-adapter-publish: sierra_objects_to_s3-publish sierra_window_generator-publish
 


### PR DESCRIPTION
### What is this PR trying to achieve?

* Bring their naming into line with our other tasks
* Define their make tasks in the same place
* Make Travis smarter at auto-detecting sbt tasks
* Trim the Travis build matrix so our CI goes faster/reduces contention for VMs

### Who is this change for?

Devs who want a neat repo.