### PR TITLE
Remove unused fields from DynamoConfig

### DIFF
--- a/catalogue_pipeline/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
+++ b/catalogue_pipeline/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
@@ -35,10 +35,8 @@ class ReindexModuleTest
   val requestedVersion = 2
 
   val dynamoConfigs = Map(
-    "reindex" -> DynamoConfig("applicationName",
-                              "streamArn",
-                              reindexTableName),
-    "calm" -> DynamoConfig("applicationName", "streamArn", calmDataTableName)
+    "reindex" -> DynamoConfig("streamArn", reindexTableName),
+    "calm" -> DynamoConfig("streamArn", calmDataTableName)
   )
 
   var maybeServer: Option[EmbeddedHttpServer] = None

--- a/catalogue_pipeline/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
+++ b/catalogue_pipeline/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
@@ -35,8 +35,8 @@ class ReindexModuleTest
   val requestedVersion = 2
 
   val dynamoConfigs = Map(
-    "reindex" -> DynamoConfig("streamArn", reindexTableName),
-    "calm" -> DynamoConfig("streamArn", calmDataTableName)
+    "reindex" -> DynamoConfig(table = reindexTableName),
+    "calm" -> DynamoConfig(table = calmDataTableName)
   )
 
   var maybeServer: Option[EmbeddedHttpServer] = None

--- a/catalogue_pipeline/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexServiceTest.scala
+++ b/catalogue_pipeline/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexServiceTest.scala
@@ -25,8 +25,8 @@ class ReindexServiceTest
     with MockitoSugar {
 
   val dynamoConfigs = Map(
-    "reindex" -> DynamoConfig("streamArn", reindexTableName),
-    "calm" -> DynamoConfig("streamArn", calmDataTableName)
+    "reindex" -> DynamoConfig(table = reindexTableName),
+    "calm" -> DynamoConfig(table = calmDataTableName)
   )
 
   val metricsSender: MetricsSender =

--- a/catalogue_pipeline/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexServiceTest.scala
+++ b/catalogue_pipeline/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexServiceTest.scala
@@ -25,10 +25,8 @@ class ReindexServiceTest
     with MockitoSugar {
 
   val dynamoConfigs = Map(
-    "reindex" -> DynamoConfig("applicationName",
-                              "streamArn",
-                              reindexTableName),
-    "calm" -> DynamoConfig("applicationName", "streamArn", calmDataTableName)
+    "reindex" -> DynamoConfig("streamArn", reindexTableName),
+    "calm" -> DynamoConfig("streamArn", calmDataTableName)
   )
 
   val metricsSender: MetricsSender =

--- a/catalogue_pipeline/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTrackerServiceTest.scala
+++ b/catalogue_pipeline/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTrackerServiceTest.scala
@@ -16,8 +16,8 @@ class ReindexTrackerServiceTest
     with ExtendedPatience {
 
   val dynamoConfigs = Map(
-    "reindex" -> DynamoConfig("streamArn", reindexTableName),
-    "calm" -> DynamoConfig("streamArn", calmDataTableName))
+    "reindex" -> DynamoConfig(table = reindexTableName),
+    "calm" -> DynamoConfig(table = calmDataTableName))
 
   it(
     "should return the index and shard in need of reindexing"

--- a/catalogue_pipeline/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTrackerServiceTest.scala
+++ b/catalogue_pipeline/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTrackerServiceTest.scala
@@ -16,10 +16,8 @@ class ReindexTrackerServiceTest
     with ExtendedPatience {
 
   val dynamoConfigs = Map(
-    "reindex" -> DynamoConfig("applicationName",
-                              "streamArn",
-                              reindexTableName),
-    "calm" -> DynamoConfig("applicationName", "streamArn", calmDataTableName))
+    "reindex" -> DynamoConfig("streamArn", reindexTableName),
+    "calm" -> DynamoConfig("streamArn", calmDataTableName))
 
   it(
     "should return the index and shard in need of reindexing"

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/DynamoConfigModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/DynamoConfigModule.scala
@@ -7,12 +7,10 @@ import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.models.aws.DynamoConfig
 
 trait DynamoConfigModule extends TwitterModule {
-  val appNameTpl: String = "aws.dynamo.%s.streams.appName"
   val arnTpl: String = "aws.dynamo.%s.streams.arn"
   val tableTpl: String = "aws.dynamo.%s.tableName"
 
   def flags(tableName: String) = (
-    flag[String](appNameTpl.format(tableName), "", "Name of the Kinesis app"),
     flag[String](arnTpl.format(tableName), "", "ARN of the DynamoDB stream"),
     flag[String](tableTpl.format(tableName), "", "Name of the DynamoDB table")
   )
@@ -20,19 +18,19 @@ trait DynamoConfigModule extends TwitterModule {
 
 object PlatformDynamoConfigModule extends DynamoConfigModule {
 
-  val (miroAppName, miroArn, miroTable) = flags("miroData")
-  val (identAppName, identArn, identTable) = flags("identifiers")
-  val (calmAppName, calmArn, calmTable) = flags("calmData")
-  val (reindexAppName, reindexArn, reindexTable) = flags("reindexTracker")
+  val (miroArn, miroTable) = flags("miroData")
+  val (identArn, identTable) = flags("identifiers")
+  val (calmArn, calmTable) = flags("calmData")
+  val (reindexArn, reindexTable) = flags("reindexTracker")
 
   @Singleton
   @Provides
   def providesDynamoConfig(): Map[String, DynamoConfig] =
     Map(
-      "calm" -> DynamoConfig(calmAppName(), calmArn(), calmTable()),
-      "identifiers" -> DynamoConfig(identAppName(), identArn(), identTable()),
-      "miro" -> DynamoConfig(miroAppName(), miroArn(), miroTable()),
-      "reindex" -> DynamoConfig(reindexAppName(), reindexArn(), reindexTable())
+      "calm" -> DynamoConfig(calmArn(), calmTable()),
+      "identifiers" -> DynamoConfig(identArn(), identTable()),
+      "miro" -> DynamoConfig(miroArn(), miroTable()),
+      "reindex" -> DynamoConfig(reindexArn(), reindexTable())
     ).filterNot {
       case (_, v) => v.table.isEmpty
     }

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/DynamoConfigModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/DynamoConfigModule.scala
@@ -7,30 +7,27 @@ import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.models.aws.DynamoConfig
 
 trait DynamoConfigModule extends TwitterModule {
-  val arnTpl: String = "aws.dynamo.%s.streams.arn"
   val tableTpl: String = "aws.dynamo.%s.tableName"
 
-  def flags(tableName: String) = (
-    flag[String](arnTpl.format(tableName), "", "ARN of the DynamoDB stream"),
+  def flags(tableName: String) =
     flag[String](tableTpl.format(tableName), "", "Name of the DynamoDB table")
-  )
 }
 
 object PlatformDynamoConfigModule extends DynamoConfigModule {
 
-  val (miroArn, miroTable) = flags("miroData")
-  val (identArn, identTable) = flags("identifiers")
-  val (calmArn, calmTable) = flags("calmData")
-  val (reindexArn, reindexTable) = flags("reindexTracker")
+  val miroTable = flags("miroData")
+  val identTable = flags("identifiers")
+  val calmTable = flags("calmData")
+  val reindexTable = flags("reindexTracker")
 
   @Singleton
   @Provides
   def providesDynamoConfig(): Map[String, DynamoConfig] =
     Map(
-      "calm" -> DynamoConfig(calmArn(), calmTable()),
-      "identifiers" -> DynamoConfig(identArn(), identTable()),
-      "miro" -> DynamoConfig(miroArn(), miroTable()),
-      "reindex" -> DynamoConfig(reindexArn(), reindexTable())
+      "calm" -> DynamoConfig(calmTable()),
+      "identifiers" -> DynamoConfig(identTable()),
+      "miro" -> DynamoConfig(miroTable()),
+      "reindex" -> DynamoConfig(reindexTable())
     ).filterNot {
       case (_, v) => v.table.isEmpty
     }

--- a/common/src/main/scala/uk/ac/wellcome/models/aws/DynamoConfig.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/aws/DynamoConfig.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.models.aws
 
-case class DynamoConfig(applicationName: String, arn: String, table: String)
+case class DynamoConfig(arn: String, table: String)
 
 case object DynamoConfig {
   def findWithTable(configs: List[DynamoConfig]): DynamoConfig =

--- a/common/src/main/scala/uk/ac/wellcome/models/aws/DynamoConfig.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/aws/DynamoConfig.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.models.aws
 
-case class DynamoConfig(arn: String, table: String)
+case class DynamoConfig(table: String)
 
 case object DynamoConfig {
   def findWithTable(configs: List[DynamoConfig]): DynamoConfig =


### PR DESCRIPTION
Reduce a bit of unused config from DynamoConfig. This turned out to be a bit more involved than I expected.

We don't have any apps that read from a Dynamo stream or use Kinesis (everything goes via SQS now), so we can delete these flags.