### PR TITLE
Make SQSWorker deal with bad messages in a more graceful way

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
@@ -82,7 +82,8 @@ class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
     Future {
       blocking {
         sqsClient.deleteMessage(
-          new DeleteMessageRequest(sqsConfig.queueUrl, message.getReceiptHandle)
+          new DeleteMessageRequest(sqsConfig.queueUrl,
+                                   message.getReceiptHandle)
         )
         info(s"Deleted message ${message.getMessageId}")
       }

--- a/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
@@ -69,7 +69,7 @@ class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
         })
         .flatMap(_ => deleteMessage(message))
         .recover {
-          case e :SQSReaderGracefulException =>
+          case e: SQSReaderGracefulException =>
             warn(s"An error occurred while processing the message $message", e)
             ()
           case e: Throwable =>
@@ -82,8 +82,7 @@ class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
     Future {
       blocking {
         sqsClient.deleteMessage(
-          new DeleteMessageRequest(sqsConfig.queueUrl,
-                                   message.getReceiptHandle)
+          new DeleteMessageRequest(sqsConfig.queueUrl, message.getReceiptHandle)
         )
         info(s"Deleted message ${message.getMessageId}")
       }

--- a/common/src/main/scala/uk/ac/wellcome/sqs/SQSWorker.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sqs/SQSWorker.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.sqs
 
 import akka.actor.ActorSystem
 import com.amazonaws.services.sqs.model.Message
+import com.fasterxml.jackson.core.JsonParseException
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -31,9 +32,9 @@ abstract class SQSWorker(sqsReader: SQSReader,
 
   private def extractMessage(sqsMessage: Message): Try[SQSMessage] =
     JsonUtil.fromJson[SQSMessage](sqsMessage.getBody).recover {
-      case e: Throwable =>
-        error("Invalid message structure (not via SNS?)", e)
-        throw e
+      case e: Exception =>
+        warn("Invalid message structure (not via SNS?)", e)
+        throw SQSReaderGracefulException(e)
     }
 
   override def terminalFailureHook(): Unit =

--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerTest.scala
@@ -1,0 +1,37 @@
+package uk.ac.wellcome.sqs
+
+import akka.actor.ActorSystem
+import org.mockito.Matchers.{anyDouble, anyString}
+import org.mockito.Mockito
+import org.mockito.Mockito.{never, verify}
+import org.scalatest.FunSpec
+import org.scalatest.mockito.MockitoSugar
+import uk.ac.wellcome.metrics.MetricsSender
+import uk.ac.wellcome.models.aws.{SQSConfig, SQSMessage}
+import uk.ac.wellcome.test.utils.SQSLocal
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.collection.JavaConversions._
+
+class SQSWorkerTest extends FunSpec with SQSLocal with MockitoSugar{
+
+  val queueUrl = createQueueAndReturnUrl("worker-test-queue")
+  private val metricsSender: MetricsSender = mock[MetricsSender]
+  sqsClient.setQueueAttributes(queueUrl, Map("VisibilityTimeout" -> "0"))
+
+  val worker = new SQSWorker(new SQSReader(sqsClient, SQSConfig(queueUrl, 1.second, 1)), ActorSystem(), metricsSender) {
+    override lazy val totalWait = 1.second
+
+    override def processMessage(message: SQSMessage): Future[Unit] = Future.successful(())
+  }
+
+  it("should not fail the TryBackoff run if it's unable to parse a message into SQSMessage"){
+    worker.runSQSWorker()
+    sqsClient.sendMessage(queueUrl, "this is not valid Json")
+
+    Thread.sleep(worker.totalWait.toMillis + 1000)
+
+    verify(metricsSender, never()).incrementCount(anyString(), anyDouble())
+  }
+}


### PR DESCRIPTION
### What is this PR trying to achieve?
Make SQSReader and SQSWorker deal gracefully with bad sqs messages, without triggering TryBackoff failures if we keep receiving them
### Who is this change for?
Devs
