### PR TITLE
Create UTC timestamps in the Sierra window generator

### DIFF
--- a/sierra_adapter/sierra_window_generator/Makefile
+++ b/sierra_adapter/sierra_window_generator/Makefile
@@ -9,7 +9,8 @@ include $(ROOT)/functions.Makefile
 
 
 $(SIERRA_WINDOW_GENERATOR)/src/requirements.txt: $(SIERRA_WINDOW_GENERATOR)/src/requirements.in
-	docker run --volume $(SIERRA_WINDOW_GENERATOR):/src micktwomey/pip-tools
+	$(ROOT)/builds/docker_run.py -- \
+		--volume $(SIERRA_WINDOW_GENERATOR)/src:/src micktwomey/pip-tools
 
 sierra_window_generator-test: $(ROOT)/.docker/python3.6_ci
 	$(ROOT)/builds/docker_run.py --aws -- \

--- a/sierra_adapter/sierra_window_generator/src/requirements.in
+++ b/sierra_adapter/sierra_window_generator/src/requirements.in
@@ -1,1 +1,2 @@
+pytz
 wellcome_aws_utils<2

--- a/sierra_adapter/sierra_window_generator/src/requirements.txt
+++ b/sierra_adapter/sierra_window_generator/src/requirements.txt
@@ -4,10 +4,13 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-boto3==1.4.7              # via wellcome-aws-utils
-botocore==1.7.44          # via boto3, s3transfer
+boto3==1.4.8              # via wellcome-aws-utils
+botocore==1.8.5           # via boto3, s3transfer
 daiquiri==1.3.0           # via wellcome-aws-utils
 docutils==0.14            # via botocore
 jmespath==0.9.3           # via boto3, botocore
-s3transfer==0.1.11        # via boto3
+python-dateutil==2.6.1    # via botocore, wellcome-aws-utils
+pytz==2017.3
+s3transfer==0.1.12        # via boto3
+six==1.11.0               # via python-dateutil
 wellcome-aws-utils==1.1.0

--- a/sierra_adapter/sierra_window_generator/src/sierra_window_generator.py
+++ b/sierra_adapter/sierra_window_generator/src/sierra_window_generator.py
@@ -5,9 +5,11 @@ Publish a new Sierra update window to SNS.
 
 import datetime as dt
 import os
-import time
 
 import boto3
+import pytz
+
+
 
 from wellcome_aws_utils.sns_utils import publish_sns_message
 
@@ -16,12 +18,12 @@ def build_window(minutes):
     """Construct the Sierra update window."""
     seconds = minutes * 60
 
-    end = time.time()
-    start = end - seconds
+    end = pytz.utc.localize(dt.datetime.utcnow())
+    start = end - dt.timedelta(seconds=seconds)
 
     return {
-        'start': dt.datetime.fromtimestamp(start).isoformat(),
-        'end': dt.datetime.fromtimestamp(end).isoformat(),
+        'start': start.isoformat(),
+        'end': end.isoformat(),
     }
 
 

--- a/sierra_adapter/sierra_window_generator/src/sierra_window_generator.py
+++ b/sierra_adapter/sierra_window_generator/src/sierra_window_generator.py
@@ -10,7 +10,6 @@ import boto3
 import pytz
 
 
-
 from wellcome_aws_utils.sns_utils import publish_sns_message
 
 

--- a/sierra_adapter/sierra_window_generator/src/test_sierra_window_generator.py
+++ b/sierra_adapter/sierra_window_generator/src/test_sierra_window_generator.py
@@ -10,19 +10,22 @@ import mock
 
 from sierra_window_generator import build_window, main
 
-mock_time = mock.Mock()
-mock_time.return_value = time.mktime(dt.datetime(2011, 6, 21).timetuple())
+
+class patched_datetime(dt.datetime):
+    @classmethod
+    def utcnow(cls):
+        return dt.datetime(2011, 6, 21, 0, 0, 0, 0)
 
 
-@mock.patch('time.time', mock_time)
+@mock.patch('datetime.datetime', patched_datetime)
 def test_build_window():
     assert build_window(minutes=15) == {
-        'start': '2011-06-20T23:45:00',
-        'end': '2011-06-21T00:00:00',
+        'start': '2011-06-20T23:45:00+00:00',
+        'end': '2011-06-21T00:00:00+00:00',
     }
 
 
-@mock.patch('time.time', mock_time)
+@mock.patch('datetime.datetime', patched_datetime)
 def test_end_to_end(sns_sqs):
     topic_arn, queue_url = sns_sqs
 
@@ -42,6 +45,6 @@ def test_end_to_end(sns_sqs):
     parsed_message = json.loads(json.loads(inner_message)['default'])
 
     assert parsed_message == {
-        'start': '2011-06-20T23:35:00',
-        'end': '2011-06-21T00:00:00',
+        'start': '2011-06-20T23:35:00+00:00',
+        'end': '2011-06-21T00:00:00+00:00',
     }

--- a/sierra_adapter/sierra_window_generator/src/test_sierra_window_generator.py
+++ b/sierra_adapter/sierra_window_generator/src/test_sierra_window_generator.py
@@ -3,7 +3,6 @@
 import datetime as dt
 import json
 import os
-import time
 
 import boto3
 import mock


### PR DESCRIPTION
### What is this PR trying to achieve?

Return unambiguous timestamps for Sierra to fetch dates from.

I’ve tested the sierra_to_dynamo app with the `+(offset)` format; it works fine and seems to pick up the correct dates.

Resolves #1218.

### Who is this change for?

💻 🕵️ 

### Have the following been considered/are they needed?

- [ ] Deployed new versions