### PR TITLE
Add a MergedSierraRecord class, and the ability to merge SierraBibRecords

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
@@ -9,7 +9,8 @@ case class MergedSierraRecord(
 ) {
   def mergeBibRecord(record: SierraBibRecord): Option[MergedSierraRecord] = {
     if (record.id != this.id) {
-      throw new RuntimeException(s"Non-matching bib ids ${record.id} != ${this.id}")
+      throw new RuntimeException(
+        s"Non-matching bib ids ${record.id} != ${this.id}")
     }
 
     val isNewerData = this.bibData match {
@@ -18,10 +19,11 @@ case class MergedSierraRecord(
     }
 
     if (isNewerData) {
-      Some(this.copy(
-        bibData = Some(record),
-        version = this.version + 1
-      ))
+      Some(
+        this.copy(
+          bibData = Some(record),
+          version = this.version + 1
+        ))
     } else {
       None
     }

--- a/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
@@ -12,10 +12,19 @@ case class MergedSierraRecord(
       throw new RuntimeException(s"Non-matching bib ids ${record.id} != ${this.id}")
     }
 
-    Some(this.copy(
-      bibData = Some(record),
-      version = this.version + 1
-    ))
+    val isNewerData = this.bibData match {
+      case Some(bibData) => record.modifiedDate.isAfter(bibData.modifiedDate)
+      case None => true
+    }
+
+    if (isNewerData) {
+      Some(this.copy(
+        bibData = Some(record),
+        version = this.version + 1
+      ))
+    } else {
+      None
+    }
   }
 }
 

--- a/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
@@ -1,15 +1,16 @@
 package uk.ac.wellcome.models
 
+import uk.ac.wellcome.utils.JsonUtil
+
 case class MergedSierraRecord(
   id: String,
-  bibData: Option[String] = None,
+  bibData: Option[SierraBibRecord] = None,
   version: Int = 1
 ) {
-  def mergeBibRecord(record: SierraRecord): Option[MergedSierraRecord] = {
+  def mergeBibRecord(record: SierraBibRecord): Option[MergedSierraRecord] = {
     if(record.id != this.id) {
       throw new RuntimeException(s"Non-matching bib ids ${record.id} != ${this.id}")
     }
-
 
     Some(this.copy(
       bibData = Some(record.data),
@@ -19,6 +20,8 @@ case class MergedSierraRecord(
 }
 
 object MergedSierraRecord {
-  def apply(id: String, bibData: String): MergedSierraRecord =
-    MergedSierraRecord(id = id, bibData = Some(bibData))
+  def apply(id: String, bibData: String): MergedSierraRecord = {
+    val bibRecord = JsonUtil.fromJson[SierraBibRecord](bibData).get
+    MergedSierraRecord(id = id, bibData = Some(bibRecord))
+  }
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
@@ -8,12 +8,12 @@ case class MergedSierraRecord(
   version: Int = 1
 ) {
   def mergeBibRecord(record: SierraBibRecord): Option[MergedSierraRecord] = {
-    if(record.id != this.id) {
+    if (record.id != this.id) {
       throw new RuntimeException(s"Non-matching bib ids ${record.id} != ${this.id}")
     }
 
     Some(this.copy(
-      bibData = Some(record.data),
+      bibData = Some(record),
       version = this.version + 1
     ))
   }

--- a/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
@@ -1,0 +1,24 @@
+package uk.ac.wellcome.models
+
+case class MergedSierraRecord(
+  id: String,
+  bibData: Option[String] = None,
+  version: Int = 1
+) {
+  def mergeBibRecord(record: SierraRecord): Option[MergedSierraRecord] = {
+    if(record.id != this.id) {
+      throw new RuntimeException(s"Non-matching bib ids ${record.id} != ${this.id}")
+    }
+
+
+    Some(this.copy(
+      bibData = Some(record.data),
+      version = this.version + 1
+    ))
+  }
+}
+
+object MergedSierraRecord {
+  def apply(id: String, bibData: String): MergedSierraRecord =
+    MergedSierraRecord(id = id, bibData = Some(bibData))
+}

--- a/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
@@ -2,11 +2,21 @@ package uk.ac.wellcome.models
 
 import uk.ac.wellcome.utils.JsonUtil
 
+/** Represents a row in the DynamoDB database of "merged" Sierra records;
+  * that is, records that contain data for both bibs and
+  * their associated items.
+  */
 case class MergedSierraRecord(
   id: String,
   bibData: Option[SierraBibRecord] = None,
   version: Int = 1
 ) {
+
+  /** Given a new bib record, construct the new merged row that we should
+    * insert into the merged database.
+    *
+    * Returns None if there's nothing to do.
+    */
   def mergeBibRecord(record: SierraBibRecord): Option[MergedSierraRecord] = {
     if (record.id != this.id) {
       throw new RuntimeException(

--- a/common/src/main/scala/uk/ac/wellcome/models/SierraBibRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/SierraBibRecord.scala
@@ -1,0 +1,27 @@
+package uk.ac.wellcome.models
+
+import java.time.Instant
+
+import com.gu.scanamo.DynamoFormat
+
+case class SierraBibRecord(
+  id: String,
+  data: String,
+  modifiedDate: Instant
+)
+
+object SierraBibRecord {
+  implicit val instantLongFormat =
+    DynamoFormat.coercedXmap[Instant, Long, IllegalArgumentException](
+      Instant.ofEpochSecond
+    )(
+      _.getEpochSecond
+    )
+
+  def apply(id: String, data: String, modifiedDate: String): SierraBibRecord =
+    SierraBibRecord(
+      id = id,
+      data = data,
+      modifiedDate = Instant.parse(modifiedDate)
+    )
+}

--- a/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
@@ -55,7 +55,7 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
       id = "777",
       bibData = Some(
         sierraBibRecord(
-          id = "888",
+          id = "777",
           title = "Shiny McNewRecordz 2.0",
           modifiedDate = "2009-09-09T09:09:09Z"
         )
@@ -67,7 +67,25 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
   }
 
   it("should update bibData when merging bib records with newer data") {
+    val record = sierraBibRecord(
+      id = "888",
+      title = "New and Shiny Data",
+      modifiedDate = "2011-11-11T11:11:11Z"
+    )
 
+    val mergedSierraRecord = MergedSierraRecord(
+      id = "888",
+      bibData = Some(
+        sierraBibRecord(
+          id = "888",
+          title = "Old and Dusty Data",
+          modifiedDate = "2001-01-01T01:01:01Z"
+        )
+      )
+    )
+
+    val result = mergedSierraRecord.mergeBibRecord(record)
+    result.get.bibData.get shouldBe record
   }
 
   def sierraBibRecord(

--- a/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
@@ -1,0 +1,107 @@
+package uk.ac.wellcome.models
+
+import java.time.Instant
+
+import org.scalatest.{FunSpec, Matchers}
+
+class MergedSierraRecordTest extends FunSpec with Matchers {
+
+  it("should allow creation of MergedSierraRecord with no data") {
+    MergedSierraRecord(id = "100")
+  }
+
+  it("should merge data from a bibRecord when empty") {
+    val sierraRecord = SierraRecord(id = "100", data = "", modifiedDate = Instant.now)
+    val originalRecord = MergedSierraRecord(id = "100")
+
+    val newRecord: Option[MergedSierraRecord] =
+      originalRecord.mergeBibRecord(sierraRecord)
+
+    newRecord.get.bibData.get shouldEqual sierraRecord.data
+  }
+
+  it("should only merge bib records with matching ids") {
+    val sierraRecord = SierraRecord(id = "100", data = "", modifiedDate = Instant.now)
+    val originalRecord = MergedSierraRecord(id = "200")
+
+    val caught = intercept[RuntimeException] {
+      originalRecord.mergeBibRecord(sierraRecord)
+    }
+
+    caught.getMessage shouldEqual "Non-matching bib ids 100 != 200"
+  }
+
+  it("should be at version 1 when first created") {
+    val record = MergedSierraRecord(id = "300")
+    record.version shouldEqual 1
+  }
+
+  it("should always increment the version when mergeBibRecord is called") {
+    val sierraRecord = SierraRecord(id = "400", data = "", modifiedDate = Instant.now)
+    val originalRecord = MergedSierraRecord(id = "400", version = 10)
+    val newRecord = originalRecord.mergeBibRecord(sierraRecord)
+
+    newRecord.get.version shouldEqual 11
+  }
+
+  it("should return None when merging bib records with stale data"){
+    val sierraRecord = SierraRecord(
+      id = "400",
+      data = bibRecordString(
+        id = "400",
+        updatedDate = "2001-01-01T01:01:01Z",
+        title = "Olde McOlde Recorde"
+      ),
+      modifiedDate = "2001-01-01T01:01:01Z"
+    )
+
+    val mergedSierraRecord = MergedSierraRecord(
+      id = "400",
+      bibData = Some(bibRecordString(
+        id = "400",
+        updatedDate = "2009-09-09T09:09:09Z",
+        title = "Shiny McNewRecordz 2.0"
+      ))
+    )
+
+    val result = mergedSierraRecord.mergeBibRecord(sierraRecord)
+
+    result shouldBe None
+  }
+
+
+  def bibRecordString(id: String,
+                      updatedDate: String,
+                      title: String = "Lehrbuch und Atlas der Gastroskopie") =
+    s"""
+       |{
+       |      "id": "$id",
+       |      "updatedDate": "$updatedDate",
+       |      "createdDate": "1999-11-01T16:36:51Z",
+       |      "deleted": false,
+       |      "suppressed": false,
+       |      "lang": {
+       |        "code": "ger",
+       |        "name": "German"
+       |      },
+       |      "title": "$title",
+       |      "author": "Schindler, Rudolf, 1888-",
+       |      "materialType": {
+       |        "code": "a",
+       |        "value": "Books"
+       |      },
+       |      "bibLevel": {
+       |        "code": "m",
+       |        "value": "MONOGRAPH"
+       |      },
+       |      "publishYear": 1923,
+       |      "catalogDate": "1999-01-01",
+       |      "country": {
+       |        "code": "gw ",
+       |        "name": "Germany"
+       |      }
+       |    }
+    """.stripMargin
+
+}
+


### PR DESCRIPTION
This model implements the logic for combining a bib record from the MergedSierraData table, and a new bib record that comes from the Sierra API (via our Sierra To Dynamo app).

Item merging is **explicitly out of scope**.

This is for #1196, spun out of #1232, and makes a start on #1236.