### PR TITLE
Fix sierra to dynamo flaky tests (hopefully)

### DIFF
--- a/sierra_adapter/sierra_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_to_dynamo/locals/SierraDynamoDBLocal.scala
+++ b/sierra_adapter/sierra_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_to_dynamo/locals/SierraDynamoDBLocal.scala
@@ -15,24 +15,11 @@ trait SierraDynamoDBLocal
 
   val tableName = "SierraData"
 
-  deleteTables()
-  createTable()
-
   override def beforeEach(): Unit = {
     super.beforeEach()
-    clearTable()
+    deleteTables()
+    createTable()
   }
-
-  private def clearTable(): List[DeleteItemResult] =
-    Scanamo.scan[SierraRecord](dynamoDbClient)(tableName).map {
-      case Right(record) =>
-        dynamoDbClient.deleteItem(
-          tableName,
-          Map("id" -> new AttributeValue(record.id))
-        )
-      case e =>
-        throw new Exception(s"Unable to clear the table $tableName error $e")
-    }
 
   private def deleteTables() = {
     dynamoDbClient

--- a/sierra_adapter/sierra_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_to_dynamo/sink/SierraDynamoSinkTest.scala
+++ b/sierra_adapter/sierra_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_to_dynamo/sink/SierraDynamoSinkTest.scala
@@ -7,7 +7,7 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.model.PutItemRequest
 import com.gu.scanamo.Scanamo
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import com.gu.scanamo.syntax._
 import io.circe.parser._
 import org.mockito.Mockito
@@ -25,12 +25,18 @@ class SierraDynamoSinkTest
     with SierraDynamoDBLocal
     with Matchers
     with ExtendedPatience
-    with MockitoSugar {
+    with MockitoSugar with BeforeAndAfterAll {
   implicit val system = ActorSystem()
   implicit val materialiser = ActorMaterializer()
   implicit val executionContext = system.dispatcher
 
   val sink = SierraDynamoSink(client = dynamoDbClient, tableName = tableName)
+
+  override def afterAll(): Unit = {
+    system.terminate()
+    materialiser.shutdown()
+    super.afterAll()
+  }
 
   it("should ingest a json into DynamoDB") {
     val id = "100001"


### PR DESCRIPTION
Check that each worker in SierraToDynamoWorkerServiceTest has stopped before starting another one. Previously we could have more than one worker running at the same time and that, depending on which one picked up the sqs message, could cause test failures.

Also, simplify DynamoDB cleaning logic and make sure we kill the actor system when a test suite has finished, although I don't think this was cause for errors