### PR TITLE
Prepend b and i to IDs in Sierra to Dynamo

### DIFF
--- a/sierra_adapter/sierra_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_to_dynamo/services/SierraToDynamoWorkerService.scala
+++ b/sierra_adapter/sierra_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_to_dynamo/services/SierraToDynamoWorkerService.scala
@@ -44,11 +44,11 @@ class SierraToDynamoWorkerService @Inject()(
   private def runSierraStream(params: Map[String, String]): Future[Done] = {
     SierraSource(apiUrl, sierraOauthKey, sierraOauthSecret, throttleRate)(
       resourceType,
-      params).runWith(SierraDynamoSink(
+      params).runWith(
+      SierraDynamoSink(
         client = dynamoDbClient,
         tableName = dynamoConfig.table,
         resourceType = resourceType
-      )
-    )
+      ))
   }
 }

--- a/sierra_adapter/sierra_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_to_dynamo/services/SierraToDynamoWorkerService.scala
+++ b/sierra_adapter/sierra_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_to_dynamo/services/SierraToDynamoWorkerService.scala
@@ -44,6 +44,11 @@ class SierraToDynamoWorkerService @Inject()(
   private def runSierraStream(params: Map[String, String]): Future[Done] = {
     SierraSource(apiUrl, sierraOauthKey, sierraOauthSecret, throttleRate)(
       resourceType,
-      params).runWith(SierraDynamoSink(dynamoDbClient, dynamoConfig.table))
+      params).runWith(SierraDynamoSink(
+        client = dynamoDbClient,
+        tableName = dynamoConfig.table,
+        resourceType = resourceType
+      )
+    )
   }
 }

--- a/sierra_adapter/sierra_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_to_dynamo/sink/SierraDynamoSink.scala
+++ b/sierra_adapter/sierra_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_to_dynamo/sink/SierraDynamoSink.scala
@@ -20,9 +20,9 @@ object SierraDynamoSink extends Logging {
   def apply(client: AmazonDynamoDB, tableName: String, resourceType: String)(
     implicit executionContext: ExecutionContext): Sink[Json, Future[Done]] =
     Sink.foreachParallel(10)(unprefixedJson => {
-      logger.debug(s"Inserting ${json.noSpaces} in dynamo Db")
       val json =
         addIDPrefix(json = unprefixedJson, resourceType = resourceType)
+      logger.debug(s"Inserting ${json.noSpaces} in dynamo Db")
       val maybeUpdatedDate = root.updatedDate.string.getOption(json)
       val record = maybeUpdatedDate match {
         case Some(updatedDate) =>
@@ -78,7 +78,7 @@ object SierraDynamoSink extends Logging {
       case "items" => root.id.string.modify(id => s"i$id")(json)
       case _ => {
         warn(
-          "Unable to add disambiguating prefix for unknown resourceType=$resourceType")
+          s"Unable to add disambiguating prefix for unknown resourceType=$resourceType")
         json
       }
     }

--- a/sierra_adapter/sierra_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_to_dynamo/sink/SierraDynamoSink.scala
+++ b/sierra_adapter/sierra_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_to_dynamo/sink/SierraDynamoSink.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.models.SierraRecord._
 import scala.concurrent.{ExecutionContext, Future}
 
 object SierraDynamoSink extends Logging {
-  def apply(client: AmazonDynamoDB, tableName: String)(
+  def apply(client: AmazonDynamoDB, tableName: String, resourceType: String)(
     implicit executionContext: ExecutionContext): Sink[Json, Future[Done]] =
     Sink.foreachParallel(10)(json => {
       logger.debug(s"Inserting ${json.noSpaces} in dynamo Db")
@@ -58,6 +58,20 @@ object SierraDynamoSink extends Logging {
       .parse(root.deletedDate.string.getOption(json).get, formatter)
       .atStartOfDay()
       .toInstant(ZoneOffset.UTC)
+  }
+
+  // Sierra assigns IDs for bibs and items in the same namespace.  A record
+  // with ID "1234567" could be a bib or an item (or something else!).
+  //
+  // Outside Sierra, IDs are prefixed with a little to denote what type of
+  // record they are, e.g. "b1234567" and "i1234567" refer to a bib and item,
+  // respectively.
+  //
+  // This updates the ID in a block of JSON to add this disambiguating prefix.
+  //
+  // TODO: Should this also update the bibIds on items?
+  def addIDPrefix(json: Json, resourceType: String): Json = {
+    json
   }
 
   private def getId(json: Json) = {

--- a/sierra_adapter/sierra_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_to_dynamo/sink/SierraDynamoSinkTest.scala
+++ b/sierra_adapter/sierra_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_to_dynamo/sink/SierraDynamoSinkTest.scala
@@ -162,15 +162,15 @@ class SierraDynamoSinkTest
        """.stripMargin).right.get
 
     val futureUnit = Source.single(newJson).runWith(sink)
-    val newRecord = SierraRecord(
-      id = id,
+    val expectedRecord = SierraRecord(
+      id = s"b$id",
       modifiedDate = newUpdatedDate,
       data =
-        s"""{"id":"$id","updatedDate":"$newUpdatedDate","comment":"Nice! New notes about narwhals in November"}"""
+        s"""{"id":"b$id","updatedDate":"$newUpdatedDate","comment":"Nice! New notes about narwhals in November"}"""
     )
     whenReady(futureUnit) { _ =>
       Scanamo.get[SierraRecord](dynamoDbClient)(tableName)('id -> s"b$id") shouldBe Some(
-        Right(newRecord))
+        Right(expectedRecord))
     }
   }
 

--- a/sierra_adapter/sierra_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_to_dynamo/sink/SierraDynamoSinkTest.scala
+++ b/sierra_adapter/sierra_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_to_dynamo/sink/SierraDynamoSinkTest.scala
@@ -220,7 +220,8 @@ class SierraDynamoSinkTest
       |  "updatedDate": "2006-06-06T06:06:06Z"
       |}
       """.stripMargin).right.get
-    val prefixedJson = SierraDynamoSink.addIDPrefix(json = json, resourceType = "bibs")
+    val prefixedJson =
+      SierraDynamoSink.addIDPrefix(json = json, resourceType = "bibs")
 
     val expectedJson = parse(s"""
       |{
@@ -238,7 +239,8 @@ class SierraDynamoSinkTest
       |  "updatedDate": "2007-07-07T07:07:07Z"
       |}
       """.stripMargin).right.get
-    val prefixedJson = SierraDynamoSink.addIDPrefix(json = json, resourceType = "items")
+    val prefixedJson =
+      SierraDynamoSink.addIDPrefix(json = json, resourceType = "items")
 
     val expectedJson = parse(s"""
       |{
@@ -256,7 +258,8 @@ class SierraDynamoSinkTest
       |  "updatedDate": "2007-07-07T07:07:07Z"
       |}
       """.stripMargin).right.get
-    val prefixedJson = SierraDynamoSink.addIDPrefix(json = json, resourceType = "holdings")
+    val prefixedJson =
+      SierraDynamoSink.addIDPrefix(json = json, resourceType = "holdings")
 
     prefixedJson shouldEqual json
   }

--- a/sierra_adapter/sierra_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_to_dynamo/sink/SierraDynamoSinkTest.scala
+++ b/sierra_adapter/sierra_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_to_dynamo/sink/SierraDynamoSinkTest.scala
@@ -93,7 +93,7 @@ class SierraDynamoSinkTest
     val futureUnit = Source.single(json).runWith(itemSink)
 
     val expectedRecord = SierraRecord(
-      id = s"b$id",
+      id = s"i$id",
       data = parse(s"""
         |{
         | "id": "i$id",
@@ -146,10 +146,10 @@ class SierraDynamoSinkTest
     val newUpdatedDate = "2011-11-11T11:11:11Z"
 
     val oldRecord = SierraRecord(
-      id = id,
+      id = s"b$id",
       modifiedDate = oldUpdatedDate,
       data =
-        s"""{"id": "$id", "updatedDate": "$oldUpdatedDate", "comment": "Legacy line of lamentable leopards"}"""
+        s"""{"id": "b$id", "updatedDate": "$oldUpdatedDate", "comment": "Legacy line of lamentable leopards"}"""
     )
     Scanamo.put(dynamoDbClient)(tableName)(oldRecord)
 
@@ -169,7 +169,7 @@ class SierraDynamoSinkTest
         s"""{"id":"$id","updatedDate":"$newUpdatedDate","comment":"Nice! New notes about narwhals in November"}"""
     )
     whenReady(futureUnit) { _ =>
-      Scanamo.get[SierraRecord](dynamoDbClient)(tableName)('id -> id) shouldBe Some(
+      Scanamo.get[SierraRecord](dynamoDbClient)(tableName)('id -> s"b$id") shouldBe Some(
         Right(newRecord))
     }
   }
@@ -219,7 +219,7 @@ class SierraDynamoSinkTest
       |  "id": "6000006",
       |  "updatedDate": "2006-06-06T06:06:06Z"
       |}
-      """).right.get
+      """.stripMargin).right.get
     val prefixedJson = SierraDynamoSink.addIDPrefix(json = json, resourceType = "bibs")
 
     val expectedJson = parse(s"""
@@ -227,7 +227,7 @@ class SierraDynamoSinkTest
       |  "id": "b6000006",
       |  "updatedDate": "2006-06-06T06:06:06Z"
       |}
-      """).right.get
+      """.stripMargin).right.get
     prefixedJson shouldEqual expectedJson
   }
 
@@ -237,7 +237,7 @@ class SierraDynamoSinkTest
       |  "id": "7000007",
       |  "updatedDate": "2007-07-07T07:07:07Z"
       |}
-      """).right.get
+      """.stripMargin).right.get
     val prefixedJson = SierraDynamoSink.addIDPrefix(json = json, resourceType = "items")
 
     val expectedJson = parse(s"""
@@ -245,7 +245,7 @@ class SierraDynamoSinkTest
       |  "id": "i7000007",
       |  "updatedDate": "2007-07-07T07:07:07Z"
       |}
-      """).right.get
+      """.stripMargin).right.get
     prefixedJson shouldEqual expectedJson
   }
 
@@ -255,7 +255,7 @@ class SierraDynamoSinkTest
       |  "id": "8000008",
       |  "updatedDate": "2007-07-07T07:07:07Z"
       |}
-      """).right.get
+      """.stripMargin).right.get
     val prefixedJson = SierraDynamoSink.addIDPrefix(json = json, resourceType = "holdings")
 
     prefixedJson shouldEqual json


### PR DESCRIPTION
### What is this PR trying to achieve?

Prepend a "b" or an "i" to our records before we send them beyond the source.

Resolves #1253.

### Who is this change for?

Folks who want unambiguous Sierra IDs.