### PR TITLE
Use new cluster module for Sierra

### DIFF
--- a/catalogue_pipeline/terraform/outputs.tf
+++ b/catalogue_pipeline/terraform/outputs.tf
@@ -25,7 +25,3 @@ output "table_miro_data_arn" {
 output "table_miro_data_name" {
   value = "${aws_dynamodb_table.miro_table.name}"
 }
-
-output "ecr_nginx_services_repository_url" {
-  value = "${module.ecr_repository_nginx_services.repository_url}"
-}

--- a/catalogue_pipeline/terraform/outputs.tf
+++ b/catalogue_pipeline/terraform/outputs.tf
@@ -26,22 +26,6 @@ output "table_miro_data_name" {
   value = "${aws_dynamodb_table.miro_table.name}"
 }
 
-output "vpc_services_id" {
-  value = "${module.vpc_services.vpc_id}"
-}
-
-output "services_alb_listener_http_arn" {
-  value = "${module.services_alb.listener_http_arn}"
-}
-
-output "services_alb_listener_https_arn" {
-  value = "${module.services_alb.listener_https_arn}"
-}
-
-output "services_alb_cloudwatch_id" {
-  value = "${module.services_alb.cloudwatch_id}"
-}
-
 output "ecr_nginx_services_repository_url" {
   value = "${module.ecr_repository_nginx_services.repository_url}"
 }

--- a/loris/terraform/variables.tf
+++ b/loris/terraform/variables.tf
@@ -3,6 +3,18 @@ variable "aws_region" {
   default     = "eu-west-1"
 }
 
+# We can't look up the ARN of our IIIF ACM certificate using the Terraform
+# data providers because most of our infrastructure runs in eu-west-1, but
+# the certificate for CloudFront has to live in us-east-1.
+#
+# Quoting http://docs.aws.amazon.com/acm/latest/userguide/acm-regions.html:
+#
+#     To use an ACM Certificate with Amazon CloudFront, you must request or
+#     import the certificate in the US East (N. Virginia) region.
+#     ACM Certificates in this region that are associated with a CloudFront
+#     distribution are distributed to all the geographic locations configured
+#     for that distribution.
+#
 variable "iiif_acm_cert_arn" {
   description = "ARN of ACM cert for iiif API (in us-east-1) for CloudFront"
 }

--- a/sierra_adapter/terraform/cluster.tf
+++ b/sierra_adapter/terraform/cluster.tf
@@ -1,0 +1,15 @@
+module "sierra_adapter_cluster" {
+  source = "cluster"
+  name   = "sierra_adapter"
+
+  vpc_subnets = ["${module.vpc_sierra_adapter.subnets}"]
+  vpc_id      = "${module.vpc_sierra_adapter.vpc_id}"
+
+  key_name = "${var.key_name}"
+
+  ec2_terminating_topic_arn                       = "${local.ec2_terminating_topic_arn}"
+  ec2_terminating_topic_publish_policy            = "${local.ec2_terminating_topic_publish_policy}"
+  ec2_instance_terminating_for_too_long_alarm_arn = "${local.ec2_instance_terminating_for_too_long_alarm_arn}"
+
+  alb_log_bucket_id = "${local.alb_log_bucket_id}"
+}

--- a/sierra_adapter/terraform/cluster.tf
+++ b/sierra_adapter/terraform/cluster.tf
@@ -1,6 +1,6 @@
 module "sierra_adapter_cluster" {
   source = "git::https://github.com/wellcometrust/terraform.git//ecs/cluster?ref=bugix3"
-  name   = "sierra-adapter_cluster"
+  name   = "sierra-adapter"
 
   vpc_subnets = ["${module.vpc_sierra_adapter.subnets}"]
   vpc_id      = "${module.vpc_sierra_adapter.vpc_id}"

--- a/sierra_adapter/terraform/cluster.tf
+++ b/sierra_adapter/terraform/cluster.tf
@@ -5,6 +5,8 @@ module "sierra_adapter_cluster" {
   vpc_subnets = ["${module.vpc_sierra_adapter.subnets}"]
   vpc_id      = "${module.vpc_sierra_adapter.vpc_id}"
 
+  alb_certificate_domain = "sierra.wellcomecollection.org"
+
   key_name = "${var.key_name}"
 
   ec2_terminating_topic_arn                       = "${local.ec2_terminating_topic_arn}"

--- a/sierra_adapter/terraform/cluster.tf
+++ b/sierra_adapter/terraform/cluster.tf
@@ -1,6 +1,6 @@
 module "sierra_adapter_cluster" {
-  source = "git::https://github.com/wellcometrust/terraform.git//ecs/cluster?ref=bugix2"
-  name   = "sierra_adapter"
+  source = "git::https://github.com/wellcometrust/terraform.git//ecs/cluster?ref=bugix3"
+  name   = "sierra-adapter_cluster"
 
   vpc_subnets = ["${module.vpc_sierra_adapter.subnets}"]
   vpc_id      = "${module.vpc_sierra_adapter.vpc_id}"

--- a/sierra_adapter/terraform/cluster.tf
+++ b/sierra_adapter/terraform/cluster.tf
@@ -1,5 +1,5 @@
 module "sierra_adapter_cluster" {
-  source = "cluster"
+  source = "git::https://github.com/wellcometrust/terraform.git//cluster?ref=v5.2.0"
   name   = "sierra_adapter"
 
   vpc_subnets = ["${module.vpc_sierra_adapter.subnets}"]

--- a/sierra_adapter/terraform/cluster.tf
+++ b/sierra_adapter/terraform/cluster.tf
@@ -1,5 +1,5 @@
 module "sierra_adapter_cluster" {
-  source = "git::https://github.com/wellcometrust/terraform.git//ecs/cluster?ref=bugix3"
+  source = "git::https://github.com/wellcometrust/terraform.git//ecs/cluster?ref=v5.2.1"
   name   = "sierra-adapter"
 
   vpc_subnets = ["${module.vpc_sierra_adapter.subnets}"]

--- a/sierra_adapter/terraform/cluster.tf
+++ b/sierra_adapter/terraform/cluster.tf
@@ -1,11 +1,11 @@
 module "sierra_adapter_cluster" {
-  source = "git::https://github.com/wellcometrust/terraform.git//cluster?ref=v5.2.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//ecs/cluster?ref=bugix2"
   name   = "sierra_adapter"
 
   vpc_subnets = ["${module.vpc_sierra_adapter.subnets}"]
   vpc_id      = "${module.vpc_sierra_adapter.vpc_id}"
 
-  alb_certificate_domain = "sierra.wellcomecollection.org"
+  alb_certificate_domain = "sierra-adapter.wellcomecollection.org"
 
   key_name = "${var.key_name}"
 

--- a/sierra_adapter/terraform/locals.tf
+++ b/sierra_adapter/terraform/locals.tf
@@ -13,5 +13,5 @@ locals {
   ec2_instance_terminating_for_too_long_alarm_arn = "${data.terraform_remote_state.shared_infra.ec2_instance_terminating_for_too_long_alarm_arn}"
   ec2_terminating_topic_publish_policy            = "${data.terraform_remote_state.shared_infra.ec2_terminating_topic_publish_policy}"
 
-  ecr_nginx_services_repository_url = "${data.terraform_remote_state.catalogue_pipeline.ecr_nginx_services_repository_url}"
+
 }

--- a/sierra_adapter/terraform/locals.tf
+++ b/sierra_adapter/terraform/locals.tf
@@ -12,6 +12,4 @@ locals {
   ec2_terminating_topic_arn                       = "${data.terraform_remote_state.shared_infra.ec2_terminating_topic_arn}"
   ec2_instance_terminating_for_too_long_alarm_arn = "${data.terraform_remote_state.shared_infra.ec2_instance_terminating_for_too_long_alarm_arn}"
   ec2_terminating_topic_publish_policy            = "${data.terraform_remote_state.shared_infra.ec2_terminating_topic_publish_policy}"
-
-
 }

--- a/sierra_adapter/terraform/locals.tf
+++ b/sierra_adapter/terraform/locals.tf
@@ -1,15 +1,17 @@
 locals {
-  services_alb_listener_http_arn  = "${data.terraform_remote_state.catalogue_pipeline.services_alb_listener_http_arn}"
-  services_alb_listener_https_arn = "${data.terraform_remote_state.catalogue_pipeline.services_alb_listener_https_arn}"
+  alb_cloudwatch_id      = "${module.sierra_adapter_cluster.alb_cloudwatch_id}"
+  alb_listener_http_arn  = "${module.sierra_adapter_cluster.alb_listener_http_arn}"
+  alb_listener_https_arn = "${module.sierra_adapter_cluster.alb_listener_https_arn}"
 
-  services_alb_cloudwatch_id = "${data.terraform_remote_state.catalogue_pipeline.services_alb_cloudwatch_id}"
+  alb_server_error_alarm_arn = "${data.terraform_remote_state.shared_infra.alb_server_error_alarm_arn}"
+  alb_client_error_alarm_arn = "${data.terraform_remote_state.shared_infra.alb_client_error_alarm_arn}"
+  lambda_error_alarm_arn     = "${data.terraform_remote_state.shared_infra.lambda_error_alarm_arn}"
 
-  services_alb_server_error_alarm_arn = "${data.terraform_remote_state.shared_infra.alb_server_error_alarm_arn}"
-  services_alb_client_error_alarm_arn = "${data.terraform_remote_state.shared_infra.alb_client_error_alarm_arn}"
+  alb_log_bucket_id = "${data.terraform_remote_state.shared_infra.bucket_alb_logs_id}"
 
-  services_vpc_id = "${data.terraform_remote_state.catalogue_pipeline.vpc_services_id}"
-
-  lambda_error_alarm_arn = "${data.terraform_remote_state.shared_infra.lambda_error_alarm_arn}"
+  ec2_terminating_topic_arn                       = "${data.terraform_remote_state.shared_infra.ec2_terminating_topic_arn}"
+  ec2_instance_terminating_for_too_long_alarm_arn = "${data.terraform_remote_state.shared_infra.ec2_instance_terminating_for_too_long_alarm_arn}"
+  ec2_terminating_topic_publish_policy            = "${data.terraform_remote_state.shared_infra.ec2_terminating_topic_publish_policy}"
 
   ecr_nginx_services_repository_url = "${data.terraform_remote_state.catalogue_pipeline.ecr_nginx_services_repository_url}"
 }

--- a/sierra_adapter/terraform/locals.tf
+++ b/sierra_adapter/terraform/locals.tf
@@ -1,8 +1,4 @@
 locals {
-  alb_cloudwatch_id      = "${module.sierra_adapter_cluster.alb_cloudwatch_id}"
-  alb_listener_http_arn  = "${module.sierra_adapter_cluster.alb_listener_http_arn}"
-  alb_listener_https_arn = "${module.sierra_adapter_cluster.alb_listener_https_arn}"
-
   alb_server_error_alarm_arn = "${data.terraform_remote_state.shared_infra.alb_server_error_alarm_arn}"
   alb_client_error_alarm_arn = "${data.terraform_remote_state.shared_infra.alb_client_error_alarm_arn}"
   lambda_error_alarm_arn     = "${data.terraform_remote_state.shared_infra.lambda_error_alarm_arn}"

--- a/sierra_adapter/terraform/main.tf
+++ b/sierra_adapter/terraform/main.tf
@@ -25,9 +25,9 @@ module "sierra_to_dynamo_bibs" {
   alb_priority               = 106
   alb_server_error_alarm_arn = "${local.alb_server_error_alarm_arn}"
   alb_client_error_alarm_arn = "${local.alb_client_error_alarm_arn}"
-  alb_cloudwatch_id          = "${local.alb_cloudwatch_id}"
-  alb_listener_http_arn      = "${local.alb_listener_http_arn}"
-  alb_listener_https_arn     = "${local.alb_listener_https_arn}"
+  alb_cloudwatch_id          = "${module.sierra_adapter_cluster.alb_cloudwatch_id}"
+  alb_listener_http_arn      = "${module.sierra_adapter_cluster.alb_listener_http_arn}"
+  alb_listener_https_arn     = "${module.sierra_adapter_cluster.alb_listener_https_arn}"
 
   release_id = "${var.release_ids["sierra_bibs_to_dynamo"]}"
 
@@ -89,9 +89,9 @@ module "sierra_bib_merger" {
   alb_priority               = 107
   alb_server_error_alarm_arn = "${local.alb_server_error_alarm_arn}"
   alb_client_error_alarm_arn = "${local.alb_client_error_alarm_arn}"
-  alb_cloudwatch_id          = "${local.alb_cloudwatch_id}"
-  alb_listener_http_arn      = "${local.alb_listener_http_arn}"
-  alb_listener_https_arn     = "${local.alb_listener_https_arn}"
+  alb_cloudwatch_id          = "${module.sierra_adapter_cluster.alb_cloudwatch_id}"
+  alb_listener_http_arn      = "${module.sierra_adapter_cluster.alb_listener_http_arn}"
+  alb_listener_https_arn     = "${module.sierra_adapter_cluster.alb_listener_https_arn}"
 
   vpc_id = "${module.vpc_sierra_adapter.vpc_id}"
 

--- a/sierra_adapter/terraform/main.tf
+++ b/sierra_adapter/terraform/main.tf
@@ -49,14 +49,14 @@ module "sierra_to_dynamo_items" {
   windows_topic_name = "${module.sierra_window_generator_items.topic_name}"
 
   dlq_alarm_arn = "${data.terraform_remote_state.shared_infra.dlq_alarm_arn}"
-  cluster_name  = "${data.terraform_remote_state.catalogue_pipeline.ecs_services_cluster_name}"
+  cluster_name  = "${module.sierra_adapter_cluster.cluster_name}"
 
   alb_priority               = 109
-  alb_server_error_alarm_arn = "${local.services_alb_server_error_alarm_arn}"
-  alb_client_error_alarm_arn = "${local.services_alb_client_error_alarm_arn}"
-  alb_cloudwatch_id          = "${local.services_alb_cloudwatch_id}"
-  alb_listener_http_arn      = "${local.services_alb_listener_http_arn}"
-  alb_listener_https_arn     = "${local.services_alb_listener_https_arn}"
+  alb_server_error_alarm_arn = "${local.alb_server_error_alarm_arn}"
+  alb_client_error_alarm_arn = "${local.alb_client_error_alarm_arn}"
+  alb_cloudwatch_id          = "${module.sierra_adapter_cluster.alb_cloudwatch_id}"
+  alb_listener_http_arn      = "${module.sierra_adapter_cluster.alb_listener_http_arn}"
+  alb_listener_https_arn     = "${module.sierra_adapter_cluster.alb_listener_https_arn}"
 
   release_id = "${var.release_ids["sierra_items_to_dynamo"]}"
 
@@ -65,7 +65,7 @@ module "sierra_to_dynamo_items" {
   sierra_oauth_secret = "${var.sierra_oauth_secret}"
   sierra_fields       = "${var.sierra_items_fields}"
 
-  vpc_id = "${local.services_vpc_id}"
+  vpc_id = "${module.vpc_sierra_adapter.vpc_id}"
 
   account_id = "${data.aws_caller_identity.current.account_id}"
 

--- a/sierra_adapter/terraform/main.tf
+++ b/sierra_adapter/terraform/main.tf
@@ -20,14 +20,14 @@ module "sierra_to_dynamo_bibs" {
   windows_topic_name = "${module.sierra_window_generator_bibs.topic_name}"
 
   dlq_alarm_arn = "${data.terraform_remote_state.shared_infra.dlq_alarm_arn}"
-  cluster_name  = "${data.terraform_remote_state.catalogue_pipeline.ecs_services_cluster_name}"
+  cluster_name  = "${module.sierra_adapter_cluster.cluster_name}"
 
   alb_priority               = 106
-  alb_server_error_alarm_arn = "${local.services_alb_server_error_alarm_arn}"
-  alb_client_error_alarm_arn = "${local.services_alb_client_error_alarm_arn}"
-  alb_cloudwatch_id          = "${local.services_alb_cloudwatch_id}"
-  alb_listener_http_arn      = "${local.services_alb_listener_http_arn}"
-  alb_listener_https_arn     = "${local.services_alb_listener_https_arn}"
+  alb_server_error_alarm_arn = "${local.alb_server_error_alarm_arn}"
+  alb_client_error_alarm_arn = "${local.alb_client_error_alarm_arn}"
+  alb_cloudwatch_id          = "${local.alb_cloudwatch_id}"
+  alb_listener_http_arn      = "${local.alb_listener_http_arn}"
+  alb_listener_https_arn     = "${local.alb_listener_https_arn}"
 
   release_id = "${var.release_ids["sierra_bibs_to_dynamo"]}"
 
@@ -36,7 +36,7 @@ module "sierra_to_dynamo_bibs" {
   sierra_oauth_secret = "${var.sierra_oauth_secret}"
   sierra_fields       = "${var.sierra_bibs_fields}"
 
-  vpc_id = "${local.services_vpc_id}"
+  vpc_id = "${module.vpc_sierra_adapter.vpc_id}"
 
   account_id = "${data.aws_caller_identity.current.account_id}"
 
@@ -84,16 +84,16 @@ module "sierra_bib_merger" {
   release_id         = "${var.release_ids["sierra_bib_merger"]}"
 
   dlq_alarm_arn = "${data.terraform_remote_state.shared_infra.dlq_alarm_arn}"
-  cluster_name  = "${data.terraform_remote_state.catalogue_pipeline.ecs_services_cluster_name}"
+  cluster_name  = "${module.sierra_adapter_cluster.cluster_name}"
 
   alb_priority               = 107
-  alb_server_error_alarm_arn = "${local.services_alb_server_error_alarm_arn}"
-  alb_client_error_alarm_arn = "${local.services_alb_client_error_alarm_arn}"
-  alb_cloudwatch_id          = "${local.services_alb_cloudwatch_id}"
-  alb_listener_http_arn      = "${local.services_alb_listener_http_arn}"
-  alb_listener_https_arn     = "${local.services_alb_listener_https_arn}"
+  alb_server_error_alarm_arn = "${local.alb_server_error_alarm_arn}"
+  alb_client_error_alarm_arn = "${local.alb_client_error_alarm_arn}"
+  alb_cloudwatch_id          = "${local.alb_cloudwatch_id}"
+  alb_listener_http_arn      = "${local.alb_listener_http_arn}"
+  alb_listener_https_arn     = "${local.alb_listener_https_arn}"
 
-  vpc_id = "${local.services_vpc_id}"
+  vpc_id = "${module.vpc_sierra_adapter.vpc_id}"
 
   account_id = "${data.aws_caller_identity.current.account_id}"
 }

--- a/sierra_adapter/terraform/sierra_merger/services.tf
+++ b/sierra_adapter/terraform/sierra_merger/services.tf
@@ -1,5 +1,5 @@
 module "sierra_merger_service" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v4.0.0"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v5.0.2"
   name   = "sierra_${var.resource_type}_merger"
 
   source_queue_name  = "${module.update_events_queue.name}"
@@ -12,6 +12,8 @@ module "sierra_merger_service" {
     metrics_namespace = "sierra_${var.resource_type}_merger"
     dynamo_table_name = "${var.target_dynamo_table_name}"
   }
+
+  env_vars_length = 3
 
   alb_priority = "${var.alb_priority}"
 

--- a/sierra_adapter/terraform/terraform.tf
+++ b/sierra_adapter/terraform/terraform.tf
@@ -18,13 +18,3 @@ data "terraform_remote_state" "shared_infra" {
     region = "eu-west-1"
   }
 }
-
-data "terraform_remote_state" "catalogue_pipeline" {
-  backend = "s3"
-
-  config {
-    bucket = "platform-infra"
-    key    = "platform-pipeline.tfstate"
-    region = "eu-west-1"
-  }
-}

--- a/sierra_adapter/terraform/variables.tf
+++ b/sierra_adapter/terraform/variables.tf
@@ -7,10 +7,13 @@ variable "release_ids" {
   type = "map"
 }
 
+variable "key_name" {
+  description = "Name of AWS key pair"
+}
+
 variable "sierra_api_url" {}
 variable "sierra_oauth_key" {}
 variable "sierra_oauth_secret" {}
 
 variable "sierra_bibs_fields" {}
-
 variable "sierra_items_fields" {}

--- a/sierra_adapter/terraform/vpc.tf
+++ b/sierra_adapter/terraform/vpc.tf
@@ -1,0 +1,6 @@
+module "vpc_sierra_adapter" {
+  source     = "git::https://github.com/wellcometrust/terraform.git//network?ref=v1.0.0"
+  cidr_block = "10.60.0.0/16"
+  az_count   = "2"
+  name       = "sierra_adapter"
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

Use the new cluster module to split the sierra adapter out.

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [x] Deployed new versions
