### PR TITLE
[WIP] Make sure the ID minter handles Sierra records and nulls correctly

### DIFF
--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -248,6 +248,43 @@ class IdentifiersDaoTest
         ontologyType = identifier.ontologyType
       )
     }
+    
+    // This test case was added when we first turned on the ID minter
+    // for Sierra records.  We had a whole stack of records from the Miro
+    // ingest as follows:
+    //
+    //      canonical ID    | miro ID   | sierra ID
+    //      ...             | A1111     | null
+    //      ...             | A2222     | null
+    //      ...             | A3333     | null
+    //
+    // and if you tried to mint an ID for a work whose only ID was a Sierra ID,
+    // you'd get back the entire database!
+    it("multiple existing IDs with a null for the field we're searching on") {
+      val identifier1 = Identifier(
+        CanonicalID = "aaaaaaa",
+        MiroID = "A1111",
+        ontologyType = "work"
+      )
+      val identifier2 = Identifier(
+        CanonicalID = "aaaaaaa",
+        MiroID = "A2222",
+        ontologyType = "work"
+      )
+      val identifier3 = Identifier(
+        CanonicalID = "aaaaaaa",
+        MiroID = "A3333",
+        ontologyType = "work"
+      )
+      assertInsertingIdentifierSucceeds(identifier1)
+      assertInsertingIdentifierSucceeds(identifier2)
+      assertInsertingIdentifierSucceeds(identifier3)
+      
+      assertLookupIDFindsNothing(
+        sourceIdentifiers = List(sierraSourceIdentifier),
+        ontologyType = identifier1.ontologyType
+      ) 
+    }
   }
 
   private def assertLookupIDFindsMatch(


### PR DESCRIPTION
Last night, when I ran the ID minter for the first time on Sierra records, it kept throwing an exception:

```
scalikejdbc.TooManyRowsException: null
```

Digging into the logs, I found the following SQL query:

```
Executing SQL query = 'select i.CanonicalID as C1_on_i, i.ontologyType as o_on_i, i.MiroID as M_on_i, i.CalmAltRefNo as C2_on_i, i.SierraSystemNumber as S_on_i from identifiers.identifiers i where i.ontologyType = work and ( i.SierraSystemNumber = b3010658 or i.SierraSystemNumber is null)'
```

which returns every row in the database. Oops!

Let’s not do that.

---

I've written a test case which should reproduce the error (if this build doesn't fail, that's suspicious!), and then two of us should pair on fixing it, as SQL will undoubtedly be fiddly.