### PR TITLE
Use 'docker run --rm' everywhere; clean up our Makefiles

### DIFF
--- a/builds/docker_run.py
+++ b/builds/docker_run.py
@@ -64,7 +64,7 @@ def parse_args():
 if __name__ == '__main__':
     namespace, additional_args = parse_args()
 
-    cmd = ['docker', 'run', '--tty']
+    cmd = ['docker', 'run', '--tty', '--rm']
 
     if namespace.share_aws_creds:
         cmd += _aws_credentials_args()

--- a/catalogue_pipeline/Makefile
+++ b/catalogue_pipeline/Makefile
@@ -48,11 +48,8 @@ transformer-deploy: transformer-build
 	$(call publish_service,transformer)
 
 
-transformer_sns_filter-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(CATALOGUE_PIPELINE)/transformer_sns_filter:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
+transformer_sns_filter-build:
+	$(call build_lambda,$(CATALOGUE_PIPELINE)/transformer_sns_filter)
 
 transformer_sns_filter-publish:
 	$(call publish_lambda,catalogue_pipeline/transformer_sns_filter)

--- a/catalogue_pipeline/schedule_reindexer/Makefile
+++ b/catalogue_pipeline/schedule_reindexer/Makefile
@@ -1,9 +1,5 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
-export CATALOGUE_PIPELINE = $(ROOT)/catalogue_pipeline
 
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
 include $(ROOT)/functions.Makefile
 
 schedule_reindexer-build:

--- a/catalogue_pipeline/schedule_reindexer/Makefile
+++ b/catalogue_pipeline/schedule_reindexer/Makefile
@@ -1,6 +1,5 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
 export CATALOGUE_PIPELINE = $(ROOT)/catalogue_pipeline
-export INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/catalogue_pipeline/schedule_reindexer/Makefile
+++ b/catalogue_pipeline/schedule_reindexer/Makefile
@@ -6,20 +6,11 @@ ifneq ($(ROOT), $(shell pwd))
 endif
 include $(ROOT)/functions.Makefile
 
-## Build schedule_reindexer lambda
-schedule_reindexer-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(CATALOGUE_PIPELINE)/schedule_reindexer:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
+schedule_reindexer-build:
+	$(call build_lambda,catalogue_pipeline/schedule_reindexer)
 
-## Test schedule_reindexer lambda
-schedule_reindexer-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(CATALOGUE_PIPELINE)/schedule_reindexer/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+schedule_reindexer-test:
+	$(call test_lambda,catalogue_pipeline/schedule_reindexer)
 
 schedule_reindexer-publish:
 	$(call publish_lambda,catalogue_pipeline/schedule_reindexer)

--- a/functions.Makefile
+++ b/functions.Makefile
@@ -33,13 +33,42 @@ endef
 # Publish a ZIP file containing a Lambda definition to S3.
 #
 # Args:
-#   $1 - Path to the Lambda source, relative to the root of the repo.
+#   $1 - Path to the Lambda src directory, relative to the root of the repo.
 #
 define publish_lambda
 	$(ROOT)/builds/docker_run.py --aws -- \
 		--volume $(ROOT):/repo \
 		wellcome/publish_lambda:latest \
 		"$(1)/src" --key="lambdas/$(1).zip" --bucket="$(INFRA_BUCKET)"
+endef
+
+
+# Build a Lambda project.
+#
+# Args:
+#   $1 - Path to the Lambda src directory, relative to the root of the repo.
+#
+define build_lambda
+	make  $(ROOT)/.docker/python3.6_ci
+	$(ROOT)/builds/docker_run.py -- \
+		--volume $(ROOT)/$(1):/data \
+		--env OP=build-lambda \
+		python3.6_ci:latest
+endef
+
+
+# Test a Lambda project.
+#
+# Args:
+#   $1 - Path to the Lambda directory, relative to the root of the repo.
+#
+define test_lambda
+	make $(ROOT)/.docker/python3.6_ci
+	$(ROOT)/builds/docker_run.py --aws -- \
+		--volume $(ROOT)/$(1)/src:/data \
+		--env OP=test \
+		--env FIND_MATCH_PATHS="/data" --tty \
+		python3.6_ci:latest
 endef
 
 

--- a/loris/Makefile
+++ b/loris/Makefile
@@ -1,5 +1,6 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 LORIS = $(ROOT)/loris
+INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/loris/Makefile
+++ b/loris/Makefile
@@ -10,7 +10,7 @@ include $(ROOT)/functions.Makefile
 # TODO: Flip this to using micktwomey/pip-tools when that's updated
 # with a newer version of pip-tools.
 $(LORIS)/requirements.txt: $(LORIS)/requirements.in $(ROOT)/.docker/python3.6_ci
-	docker run \
+	docker run --rm \
 		-v $(LORIS):/data \
 		-e OP=build-lock-file \
 		python3.6_ci:latest

--- a/miro_preprocessor/Makefile
+++ b/miro_preprocessor/Makefile
@@ -1,6 +1,5 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 MIRO_PREPROC = $(ROOT)/miro_preprocessor
-INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/miro_preprocessor/Makefile
+++ b/miro_preprocessor/Makefile
@@ -44,5 +44,3 @@ miro_preprocessor-terraform-plan:
 
 miro_preprocessor-terraform-apply:
 	$(call terraform_apply,$(MIRO_PREPROC))
-
-.PHONY: miro_preprocessor-build miro_preprocessor-test miro_preprocessor-deploy

--- a/miro_preprocessor/image_sorter/Makefile
+++ b/miro_preprocessor/image_sorter/Makefile
@@ -6,21 +6,11 @@ endif
 
 include $(ROOT)/functions.Makefile
 
-## Build image_sorter lambda
-image_sorter-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(ROOT)/miro_preprocessor/image_sorter:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
+image_sorter-build:
+	$(call build_lambda,miro_preprocessor/image_sorter)
 
-## Test image_sorter lambda
-image_sorter-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(ROOT)/miro_preprocessor/image_sorter/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+image_sorter-test:
+	$(call test_lambda,miro_preprocessor/image_sorter)
 
-## Publish image_sorter lambda
 image_sorter-publish:
 	$(call publish_lambda,miro_preprocessor/image_sorter)

--- a/miro_preprocessor/image_sorter/Makefile
+++ b/miro_preprocessor/image_sorter/Makefile
@@ -1,9 +1,5 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
-
 include $(ROOT)/functions.Makefile
 
 image_sorter-build:

--- a/miro_preprocessor/image_sorter/Makefile
+++ b/miro_preprocessor/image_sorter/Makefile
@@ -1,5 +1,4 @@
 ROOT = $(shell git rev-parse --show-toplevel)
-INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/miro_preprocessor/miro_copy_s3_asset/Makefile
+++ b/miro_preprocessor/miro_copy_s3_asset/Makefile
@@ -6,38 +6,29 @@ endif
 
 include $(ROOT)/functions.Makefile
 
-miro_copy_s3_derivative_asset-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-	-v $(ROOT)/miro_preprocessor/miro_copy_s3_asset/miro_copy_s3_derivative_asset/src:/data \
-	-e OP=test \
-	python3.6_ci:latest
 
-miro_copy_s3_master_asset-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-	-v $(ROOT)/miro_preprocessor/miro_copy_s3_asset/miro_copy_s3_master_asset/src:/data \
-	-e OP=test \
-	python3.6_ci:latest
+miro_copy_s3_master_asset-build:
+	$(call build_lambda,miro_preprocessor/miro_copy_s3_asset/miro_copy_s3_master_asset)
 
-miro_copy_s3_derivative_asset-build: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-	-v $(ROOT)/miro_preprocessor/miro_copy_s3_asset/miro_copy_s3_derivative_asset:/data \
-	-e OP=build-lambda \
-	python3.6_ci:latest
+miro_copy_s3_master_asset-test:
+	$(call test_lambda,miro_preprocessor/miro_copy_s3_asset/miro_copy_s3_master_asset)
 
-miro_copy_s3_master_asset-build: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-	-v $(ROOT)/miro_preprocessor/miro_copy_s3_asset/miro_copy_s3_master_asset:/data \
-	-e OP=build-lambda \
-	python3.6_ci:latest
+miro_copy_s3_master_asset-publish:
+	$(call publish_lambda,miro_preprocessor/miro_copy_s3_asset/miro_copy_s3_master_asset)
 
-## Build miro_copy_s3_asset lambda
+
+miro_copy_s3_derivative_asset-build:
+	$(call build_lambda,miro_preprocessor/miro_copy_s3_asset/miro_copy_s3_derivative_asset)
+
+miro_copy_s3_derivative_asset-test:
+	$(call test_lambda,miro_preprocessor/miro_copy_s3_asset/miro_copy_s3_derivative_asset)
+
+miro_copy_s3_derivative_asset-publish:
+	$(call publish_lambda,miro_preprocessor/miro_copy_s3_asset/miro_copy_s3_derivative_asset)
+
+
 miro_copy_s3_asset-build: miro_copy_s3_master_asset-build miro_copy_s3_derivative_asset-build
 
-
-## Test miro_copy_s3_asset lambda
 miro_copy_s3_asset-test: miro_copy_s3_derivative_asset-test miro_copy_s3_master_asset-test
 
-## Publish miro_copy_s3_asset lambda
-miro_copy_s3_asset-publish:
-	$(call publish_lambda,miro_preprocessor/miro_copy_s3_asset/miro_copy_s3_derivative_asset)
-	$(call publish_lambda,miro_preprocessor/miro_copy_s3_asset/miro_copy_s3_master_asset)
+miro_copy_s3_asset-publish: miro_copy_s3_master_asset-publish miro_copy_s3_derivative_asset-publish

--- a/miro_preprocessor/miro_copy_s3_asset/Makefile
+++ b/miro_preprocessor/miro_copy_s3_asset/Makefile
@@ -1,5 +1,4 @@
 ROOT = $(shell git rev-parse --show-toplevel)
-INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/miro_preprocessor/miro_copy_s3_asset/Makefile
+++ b/miro_preprocessor/miro_copy_s3_asset/Makefile
@@ -1,9 +1,5 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
-
 include $(ROOT)/functions.Makefile
 
 

--- a/miro_preprocessor/miro_image_to_dynamo/Makefile
+++ b/miro_preprocessor/miro_image_to_dynamo/Makefile
@@ -1,5 +1,4 @@
 ROOT = $(shell git rev-parse --show-toplevel)
-INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/miro_preprocessor/miro_image_to_dynamo/Makefile
+++ b/miro_preprocessor/miro_image_to_dynamo/Makefile
@@ -1,9 +1,5 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
-
 include $(ROOT)/functions.Makefile
 
 miro_image_to_dynamo-build:

--- a/miro_preprocessor/miro_image_to_dynamo/Makefile
+++ b/miro_preprocessor/miro_image_to_dynamo/Makefile
@@ -6,21 +6,11 @@ endif
 
 include $(ROOT)/functions.Makefile
 
-## Build miro_image_to_dynamo lambda
-miro_image_to_dynamo-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(ROOT)/miro_preprocessor/miro_image_to_dynamo:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
+miro_image_to_dynamo-build:
+	$(call build_lambda,miro_preprocessor/miro_image_to_dynamo)
 
-## Test miro_image_to_dynamo lambda
-miro_image_to_dynamo-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(ROOT)/miro_preprocessor/miro_image_to_dynamo/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+miro_image_to_dynamo-test:
+	$(call test_lambda,miro_preprocessor/miro_image_to_dynamo)
 
-## Publish miro_image_to_dynamo lambda
 miro_image_to_dynamo-publish:
 	$(call publish_lambda,miro_preprocessor/miro_image_to_dynamo)

--- a/miro_preprocessor/miro_image_to_tandem_vault/Makefile
+++ b/miro_preprocessor/miro_image_to_tandem_vault/Makefile
@@ -1,5 +1,4 @@
 ROOT = $(shell git rev-parse --show-toplevel)
-INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/miro_preprocessor/miro_inventory/Makefile
+++ b/miro_preprocessor/miro_inventory/Makefile
@@ -6,21 +6,11 @@ endif
 
 include $(ROOT)/functions.Makefile
 
-## Build miro_inventory lambda
-miro_inventory-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(ROOT)/miro_preprocessor/miro_inventory:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
+miro_inventory-build:
+	$(call build_lambda,miro_preprocessor/miro_inventory)
 
-## Test miro_inventory lambda
-miro_inventory-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(ROOT)/miro_preprocessor/miro_inventory/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+miro_inventory-test:
+	$(call test_lambda,miro_preprocessor/miro_inventory)
 
-## Publish miro_inventory lambda
 miro_inventory-publish:
 	$(call publish_lambda,miro_preprocessor/miro_inventory)

--- a/miro_preprocessor/miro_inventory/Makefile
+++ b/miro_preprocessor/miro_inventory/Makefile
@@ -1,5 +1,4 @@
 ROOT = $(shell git rev-parse --show-toplevel)
-INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/miro_preprocessor/miro_inventory/Makefile
+++ b/miro_preprocessor/miro_inventory/Makefile
@@ -1,9 +1,5 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
-
 include $(ROOT)/functions.Makefile
 
 miro_inventory-build:

--- a/miro_preprocessor/xml_to_json_converter/Makefile
+++ b/miro_preprocessor/xml_to_json_converter/Makefile
@@ -8,7 +8,7 @@ xml_to_json_converter-build:
 	$(call build_image,xml_to_json_converter,miro_preprocessor/xml_to_json_converter/Dockerfile)
 
 xml_to_json_converter-test: $(ROOT)/.docker/python3.6_ci
-	docker run \
+	docker run --rm --tty \
 		--volume $(ROOT)/miro_preprocessor/xml_to_json_converter/src:/data \
 		--env OP=test \
 		python3.6_ci:latest

--- a/miro_preprocessor/xml_to_json_converter/Makefile
+++ b/miro_preprocessor/xml_to_json_converter/Makefile
@@ -1,5 +1,4 @@
 ROOT = $(shell git rev-parse --show-toplevel)
-INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/miro_preprocessor/xml_to_json_run_task/Makefile
+++ b/miro_preprocessor/xml_to_json_run_task/Makefile
@@ -1,9 +1,5 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
-
 include $(ROOT)/functions.Makefile
 
 xml_to_json_run_task-build: $(ROOT)/.docker/python3.6_ci

--- a/miro_preprocessor/xml_to_json_run_task/Makefile
+++ b/miro_preprocessor/xml_to_json_run_task/Makefile
@@ -1,5 +1,4 @@
 ROOT = $(shell git rev-parse --show-toplevel)
-INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/miro_preprocessor/xml_to_json_run_task/Makefile
+++ b/miro_preprocessor/xml_to_json_run_task/Makefile
@@ -6,21 +6,11 @@ endif
 
 include $(ROOT)/functions.Makefile
 
-## Build xml_to_json_run_task lambda
 xml_to_json_run_task-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(ROOT)/miro_preprocessor/xml_to_json_run_task:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
+	$(call build_lambda,miro_preprocessor/xml_to_json_run_task)
 
-## Test xml_to_json_run_task lambda
 xml_to_json_run_task-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(ROOT)/miro_preprocessor/xml_to_json_run_task/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+	$(call test_lambda,miro_preprocessor/xml_to_json_run_task)
 
-## Publish xml_to_json_run_task lambda
 xml_to_json_run_task-publish:
 	$(call publish_lambda,miro_preprocessor/xml_to_json_run_task)

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -43,8 +43,3 @@ monitoring-terraform-plan:
 ## Terraform apply on monitoring stack
 monitoring-terraform-apply:
 	$(call terraform_apply,$(MONITORING))
-
-
-.PHONY: post_to_slack-build post_to_slack-test post_to_slack-publish \
-		monitoring-terraform-plan monitoring-terraform-apply \
-		monitoring-test monitoring-deploy

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -11,35 +11,24 @@ endif
 
 include $(ROOT)/functions.Makefile
 
-## Build post_to_slack lambda
-post_to_slack-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(MONITORING)/post_to_slack:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
 
-## Test post_to_slack lambda
-post_to_slack-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(MONITORING)/post_to_slack/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+post_to_slack-build:
+	$(call build_lambda,monitoring/post_to_slack)
 
-## Publish post_to_slack lambda
+post_to_slack-test:
+	$(call test_lambda,monitoring/post_to_slack)
+
 post_to_slack-publish:
 	$(call publish_lambda,monitoring/post_to_slack)
 
-## Test monitoring
+
 monitoring-test: post_to_slack-test deployment_tracking-test ecs_dashboard-test load_test-test
 
-## Publish monitoring
 monitoring-deploy: post_to_slack-publish deployment_tracking-deploy ecs_dashboard-deploy load_test-deploy
 
-## Terraform plan on monitoring stack
+
 monitoring-terraform-plan:
 	$(call terraform_plan,$(MONITORING))
 
-## Terraform apply on monitoring stack
 monitoring-terraform-apply:
 	$(call terraform_apply,$(MONITORING))

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -1,6 +1,5 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 MONITORING = $(ROOT)/monitoring
-INFRA_BUCKET = platform-infra
 
 include $(MONITORING)/deployment_tracking/Makefile
 include $(MONITORING)/ecs_dashboard/Makefile

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -5,10 +5,6 @@ include $(MONITORING)/deployment_tracking/Makefile
 include $(MONITORING)/ecs_dashboard/Makefile
 include $(MONITORING)/load_test/Makefile
 
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
-
 include $(ROOT)/functions.Makefile
 
 

--- a/monitoring/deployment_tracking/Makefile
+++ b/monitoring/deployment_tracking/Makefile
@@ -1,9 +1,4 @@
 ROOT = $(shell git rev-parse --show-toplevel)
-DEPLOYMENT_TRACKING = $(ROOT)/monitoring/deployment_tracking
-
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
 
 include $(ROOT)/functions.Makefile
 

--- a/monitoring/deployment_tracking/Makefile
+++ b/monitoring/deployment_tracking/Makefile
@@ -53,8 +53,3 @@ deployment_tracking-test: notify_old_deploys-test service_deployment_status-test
 
 ## Publish all for deployment_tracking
 deployment_tracking-deploy: notify_old_deploys-publish service_deployment_status-publish
-
-.PHONY: notify_old_deploys-build notify_old_deploys-test notify_old_deploys-publish \
-		service_deployment_status-build service_deployment_status-test service_deployment_status-publish \
-		deployment_tracking-build deployment_tracking-test deployment_tracking-deploy
-

--- a/monitoring/deployment_tracking/Makefile
+++ b/monitoring/deployment_tracking/Makefile
@@ -7,49 +7,29 @@ endif
 
 include $(ROOT)/functions.Makefile
 
-## Build notify_old_deploys lambda
-notify_old_deploys-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(DEPLOYMENT_TRACKING)/notify_old_deploys:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
 
-## Test notify_old_deploys lambda
-notify_old_deploys-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(DEPLOYMENT_TRACKING)/notify_old_deploys/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+notify_old_deploys-build:
+	$(call build_lambda,monitoring/deployment_tracking/notify_old_deploys)
 
-## Publish notify_old_deploys lambda
+notify_old_deploys-test:
+	$(call test_lambda,monitoring/deployment_tracking/notify_old_deploys)
+
 notify_old_deploys-publish:
 	$(call publish_lambda,monitoring/deployment_tracking/notify_old_deploys)
 
-## Build service_deployment_status lambda
-service_deployment_status-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(DEPLOYMENT_TRACKING)/service_deployment_status:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
 
-## Test service_deployment_status lambda
-service_deployment_status-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(DEPLOYMENT_TRACKING)/service_deployment_status/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+service_deployment_status-build:
+	$(call build_lambda,monitoring/deployment_tracking/service_deployment_status)
 
-## Publish service_deployment_status lambda
+service_deployment_status-test:
+	$(call test_lambda,monitoring/deployment_tracking/service_deployment_status)
+
 service_deployment_status-publish:
 	$(call publish_lambda,monitoring/deployment_tracking/service_deployment_status)
 
-## Build all for deployment_tracking
+
 deployment_tracking-build: notify_old_deploys-build service_deployment_status-build
 
-## Test all for deployment_tracking
 deployment_tracking-test: notify_old_deploys-test service_deployment_status-test
 
-## Publish all for deployment_tracking
 deployment_tracking-deploy: notify_old_deploys-publish service_deployment_status-publish

--- a/monitoring/deployment_tracking/Makefile
+++ b/monitoring/deployment_tracking/Makefile
@@ -1,6 +1,5 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 DEPLOYMENT_TRACKING = $(ROOT)/monitoring/deployment_tracking
-INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/monitoring/ecs_dashboard/Makefile
+++ b/monitoring/ecs_dashboard/Makefile
@@ -1,6 +1,5 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 ECS_DASHBOARD = $(ROOT)/monitoring/ecs_dashboard
-INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/monitoring/ecs_dashboard/Makefile
+++ b/monitoring/ecs_dashboard/Makefile
@@ -49,6 +49,3 @@ ecs_dashboard-test: update_service_list-test
 
 ## Publish all for ecs_dashboard
 ecs_dashboard-deploy: update_service_list-publish
-
-.PHONY: ecs_dashboard-deploy update_service_list-build update_service_list-test update_service_list-publish \
-		ecs_dashboard-build ecs_dashboard-test ecs_dashboard_client-deploy

--- a/monitoring/ecs_dashboard/Makefile
+++ b/monitoring/ecs_dashboard/Makefile
@@ -1,10 +1,6 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 ECS_DASHBOARD = $(ROOT)/monitoring/ecs_dashboard
 
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
-
 include $(ROOT)/functions.Makefile
 
 

--- a/monitoring/ecs_dashboard/Makefile
+++ b/monitoring/ecs_dashboard/Makefile
@@ -22,30 +22,19 @@ ecs_dashboard_client-deploy: $(ROOT)/.docker/ecs_dashboard
 		--env PATH_PREFIX=https://s3-eu-west-1.amazonaws.com/wellcome-platform-dash/ \
 		ecs_dashboard
 
-## Build update_service_list lambda
-update_service_list-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(ECS_DASHBOARD)/update_service_list:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
 
-## Test update_service_list lambda
-update_service_list-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(ECS_DASHBOARD)/update_service_list/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+update_service_list-build:
+	$(call build_lambda,monitoring/ecs_dashboard/update_service_list)
 
-## Publish update_service_list lambda
+update_service_list-test:
+	$(call test_lambda,monitoring/ecs_dashboard/update_service_list)
+
 update_service_list-publish:
 	$(call publish_lambda,monitoring/ecs_dashboard/update_service_list)
 
-## Build all for ecs_dashboard
+
 ecs_dashboard-build: update_service_list-build
 
-## Test all for ecs_dashboard
 ecs_dashboard-test: update_service_list-test
 
-## Publish all for ecs_dashboard
 ecs_dashboard-deploy: update_service_list-publish

--- a/monitoring/load_test/Makefile
+++ b/monitoring/load_test/Makefile
@@ -7,38 +7,26 @@ endif
 
 include $(ROOT)/functions.Makefile
 
-## Build docker image for gatling
+
 gatling-build:
 	$(call build_image,gatling,monitoring/load_test/gatling/Dockerfile)
 
-## Deploy docker image for gatling to ECR
 gatling-deploy: gatling-build
 	$(call publish_service,gatling)
 
-## Build gatling_to_cloudwatch lambda
-gatling_to_cloudwatch-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(LOAD_TEST)/gatling_to_cloudwatch:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
 
-## Test gatling_to_cloudwatch lambda
-gatling_to_cloudwatch-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(LOAD_TEST)/gatling_to_cloudwatch/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+gatling_to_cloudwatch-build:
+	$(call build_lambda,monitoring/load_test/gatling_to_cloudwatch)
 
-## Publish gatling_to_cloudwatch lambda
+gatling_to_cloudwatch-test:
+	$(call test_lambda,monitoring/load_test/gatling_to_cloudwatch)
+
 gatling_to_cloudwatch-publish:
 	$(call publish_lambda,monitoring/load_test/gatling_to_cloudwatch)
 
-## Build all for load_test
+
 load_test-build: gatling-build gatling_to_cloudwatch-build
 
-## Test all for load_test
 load_test-test: gatling_to_cloudwatch-test
 
-## Publish all for load_test
 load_test-deploy: gatling-deploy gatling_to_cloudwatch-publish

--- a/monitoring/load_test/Makefile
+++ b/monitoring/load_test/Makefile
@@ -1,9 +1,4 @@
 ROOT = $(shell git rev-parse --show-toplevel)
-LOAD_TEST = $(ROOT)/monitoring/load_test
-
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
 
 include $(ROOT)/functions.Makefile
 

--- a/monitoring/load_test/Makefile
+++ b/monitoring/load_test/Makefile
@@ -42,6 +42,3 @@ load_test-test: gatling_to_cloudwatch-test
 
 ## Publish all for load_test
 load_test-deploy: gatling-deploy gatling_to_cloudwatch-publish
-
-.PHONY:	gatling-build gatling-deploy gatling_to_cloudwatch-build gatling_to_cloudwatch-test gatling_to_cloudwatch-publish\
-		load_test-build load_test-test load_test-deploy

--- a/monitoring/load_test/Makefile
+++ b/monitoring/load_test/Makefile
@@ -1,6 +1,5 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 LOAD_TEST = $(ROOT)/monitoring/load_test
-INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/nginx/Makefile
+++ b/nginx/Makefile
@@ -1,13 +1,9 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
-export SHARED_INFRA = $(ROOT)/shared_infra
-
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
 
 include $(ROOT)/functions.Makefile
 
-# Build and tag a Docker image (specifically for ngnix).
+
+# Build and tag a Docker image (specifically for nginx).
 #
 # Args:
 #   $1 - Name of the variant.
@@ -20,6 +16,7 @@ define nginx_build_image
             --variant=$(1)
 endef
 
+
 nginx-build-api:
 	$(call nginx_build_image,api)
 
@@ -30,7 +27,6 @@ nginx-build-grafana:
 	$(call nginx_build_image,grafana)
 
 nginx-build: nginx-build-api nginx-build-loris nginx-build-grafana
-
 
 
 nginx-deploy-api: nginx-build-api

--- a/nginx/Makefile
+++ b/nginx/Makefile
@@ -1,6 +1,5 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
 export SHARED_INFRA = $(ROOT)/shared_infra
-export INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/ontologies/Makefile
+++ b/ontologies/Makefile
@@ -1,10 +1,6 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 ONTOLOGIES = $(ROOT)/ontologies
 
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
-
 lint-turtle:
 	docker run \
 		--rm \

--- a/ontologies/Makefile
+++ b/ontologies/Makefile
@@ -18,5 +18,3 @@ lint-json:
 	wellcome/jslint:latest
 
 lint-ontologies: lint-turtle lint-json
-
-.PHONY: lint-turtle lint-json lint-ontologies

--- a/ontologies/Makefile
+++ b/ontologies/Makefile
@@ -2,15 +2,11 @@ ROOT = $(shell git rev-parse --show-toplevel)
 ONTOLOGIES = $(ROOT)/ontologies
 
 lint-turtle:
-	docker run \
-		--rm \
-		--volume $(ONTOLOGIES):/data \
-		--tty \
-		wellcome/turtlelint:latest
+	$(ROOT)/builds/docker_run.py -- \
+		--volume $(ONTOLOGIES):/data wellcome/turtlelint
 
 lint-json:
-	docker run \
-	--volume $(ROOT)/ontologies:/data \
-	wellcome/jslint:latest
+	$(ROOT)/builds/docker_run.py -- \
+		--volume $(ROOT)/ontologies:/data wellcome/jslint
 
 lint-ontologies: lint-turtle lint-json

--- a/shared_infra/Makefile
+++ b/shared_infra/Makefile
@@ -1,10 +1,6 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
 export SHARED_INFRA = $(ROOT)/shared_infra
 
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
-
 include $(ROOT)/functions.Makefile
 
 include $(SHARED_INFRA)/drain_ecs_container_instance/Makefile

--- a/shared_infra/Makefile
+++ b/shared_infra/Makefile
@@ -59,6 +59,3 @@ shared_infra-terraform-plan:
 ## Run an apply on shared_infra stack
 shared_infra-terraform-apply:
 	$(call terraform_apply,$(SHARED_INFRA))
-
-
-.PHONY: shared_infra-test shared_infra-build shared_infra-deploy shared_infra-terraform-plan shared_infra-terraform-apply

--- a/shared_infra/Makefile
+++ b/shared_infra/Makefile
@@ -1,6 +1,5 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
 export SHARED_INFRA = $(ROOT)/shared_infra
-export INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/shared_infra/drain_ecs_container_instance/Makefile
+++ b/shared_infra/drain_ecs_container_instance/Makefile
@@ -1,9 +1,4 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
-export SHARED_INFRA = $(ROOT)/shared_infra
-
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
 
 include $(ROOT)/functions.Makefile
 

--- a/shared_infra/drain_ecs_container_instance/Makefile
+++ b/shared_infra/drain_ecs_container_instance/Makefile
@@ -7,21 +7,11 @@ endif
 
 include $(ROOT)/functions.Makefile
 
-## Build drain_ecs_container_instance lambda
-drain_ecs_container_instance-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(SHARED_INFRA)/drain_ecs_container_instance:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
+drain_ecs_container_instance-build:
+	$(call build_lambda,shared_infra/drain_ecs_container_instance)
 
-## Test drain_ecs_container_instance lambda
-drain_ecs_container_instance-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(SHARED_INFRA)/drain_ecs_container_instance/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+drain_ecs_container_instance-test:
+	$(call test_lambda,shared_infra/drain_ecs_container_instance)
 
-## Publish drain_ecs_container_instance lambda
 drain_ecs_container_instance-publish:
 	$(call publish_lambda,shared_infra/drain_ecs_container_instance)

--- a/shared_infra/drain_ecs_container_instance/Makefile
+++ b/shared_infra/drain_ecs_container_instance/Makefile
@@ -1,6 +1,5 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
 export SHARED_INFRA = $(ROOT)/shared_infra
-export INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/shared_infra/dynamo_to_sns/Makefile
+++ b/shared_infra/dynamo_to_sns/Makefile
@@ -1,9 +1,4 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
-export SHARED_INFRA = $(ROOT)/shared_infra
-
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
 
 include $(ROOT)/functions.Makefile
 

--- a/shared_infra/dynamo_to_sns/Makefile
+++ b/shared_infra/dynamo_to_sns/Makefile
@@ -7,21 +7,11 @@ endif
 
 include $(ROOT)/functions.Makefile
 
-## Build dynamo_to_sns lambda
-dynamo_to_sns-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(SHARED_INFRA)/dynamo_to_sns:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
+dynamo_to_sns-build:
+	$(call build_lambda,shared_infra/dynamo_to_sns)
 
-## Test dynamo_to_sns lambda
-dynamo_to_sns-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(SHARED_INFRA)/dynamo_to_sns/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+dynamo_to_sns-test:
+	$(call test_lambda,shared_infra/dynamo_to_sns)
 
-## Publish dynamo_to_sns lambda
 dynamo_to_sns-publish:
 	$(call publish_lambda,shared_infra/dynamo_to_sns)

--- a/shared_infra/dynamo_to_sns/Makefile
+++ b/shared_infra/dynamo_to_sns/Makefile
@@ -1,6 +1,5 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
 export SHARED_INFRA = $(ROOT)/shared_infra
-export INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/shared_infra/ecs_ec2_instance_tagger/Makefile
+++ b/shared_infra/ecs_ec2_instance_tagger/Makefile
@@ -1,9 +1,4 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
-export SHARED_INFRA = $(ROOT)/shared_infra
-
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
 
 include $(ROOT)/functions.Makefile
 

--- a/shared_infra/ecs_ec2_instance_tagger/Makefile
+++ b/shared_infra/ecs_ec2_instance_tagger/Makefile
@@ -7,21 +7,11 @@ endif
 
 include $(ROOT)/functions.Makefile
 
-## Build ecs_ec2_instance_tagger lambda
-ecs_ec2_instance_tagger-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(SHARED_INFRA)/ecs_ec2_instance_tagger:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
+ecs_ec2_instance_tagger-build:
+	$(call build_lambda,shared_infra/ecs_ec2_instance_tagger)
 
-## Test ecs_ec2_instance_tagger lambda
-ecs_ec2_instance_tagger-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(SHARED_INFRA)/ecs_ec2_instance_tagger/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+ecs_ec2_instance_tagger-test:
+	$(call test_lambda,shared_infra/ecs_ec2_instance_tagger)
 
-## Publish ecs_ec2_instance_tagger lambda
 ecs_ec2_instance_tagger-publish:
 	$(call publish_lambda,shared_infra/ecs_ec2_instance_tagger)

--- a/shared_infra/ecs_ec2_instance_tagger/Makefile
+++ b/shared_infra/ecs_ec2_instance_tagger/Makefile
@@ -1,6 +1,5 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
 export SHARED_INFRA = $(ROOT)/shared_infra
-export INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/shared_infra/run_ecs_task/Makefile
+++ b/shared_infra/run_ecs_task/Makefile
@@ -1,9 +1,4 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
-export SHARED_INFRA = $(ROOT)/shared_infra
-
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
 
 include $(ROOT)/functions.Makefile
 

--- a/shared_infra/run_ecs_task/Makefile
+++ b/shared_infra/run_ecs_task/Makefile
@@ -7,21 +7,11 @@ endif
 
 include $(ROOT)/functions.Makefile
 
-## Build run_ecs_task lambda
-run_ecs_task-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(SHARED_INFRA)/run_ecs_task:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
+run_ecs_task-build:
+	$(call build_lambda,shared_infra/run_ecs_task)
 
-## Test run_ecs_task lambda
-run_ecs_task-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(SHARED_INFRA)/run_ecs_task/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+run_ecs_task-test:
+	$(call test_lambda,shared_infra/run_ecs_task)
 
-## Publish run_ecs_task lambda
 run_ecs_task-publish:
 	$(call publish_lambda,shared_infra/run_ecs_task)

--- a/shared_infra/run_ecs_task/Makefile
+++ b/shared_infra/run_ecs_task/Makefile
@@ -1,6 +1,5 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
 export SHARED_INFRA = $(ROOT)/shared_infra
-export INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/shared_infra/service_scheduler/Makefile
+++ b/shared_infra/service_scheduler/Makefile
@@ -1,9 +1,4 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
-export SHARED_INFRA = $(ROOT)/shared_infra
-
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
 
 include $(ROOT)/functions.Makefile
 

--- a/shared_infra/service_scheduler/Makefile
+++ b/shared_infra/service_scheduler/Makefile
@@ -7,21 +7,11 @@ endif
 
 include $(ROOT)/functions.Makefile
 
-## Build service_scheduler lambda
-service_scheduler-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(SHARED_INFRA)/service_scheduler:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
+service_scheduler-build:
+	$(call build_lambda,shared_infra/service_scheduler)
 
-## Test service_scheduler lambda
-service_scheduler-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(SHARED_INFRA)/service_scheduler/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+service_scheduler-test:
+	$(call test_lambda,shared_infra/service_scheduler)
 
-## Publish service_scheduler lambda
 service_scheduler-publish:
 	$(call publish_lambda,shared_infra/service_scheduler)

--- a/shared_infra/service_scheduler/Makefile
+++ b/shared_infra/service_scheduler/Makefile
@@ -1,6 +1,5 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
 export SHARED_INFRA = $(ROOT)/shared_infra
-export INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/shared_infra/sqs_freezeray/Makefile
+++ b/shared_infra/sqs_freezeray/Makefile
@@ -11,5 +11,3 @@ sqs_freezeray-build:
 
 sqs_freezeray-publish: sqs_freezeray-build
 	$(call publish_service,sqs_freezeray)
-
-.PHONY: sqs_freezeray-build

--- a/shared_infra/sqs_freezeray/Makefile
+++ b/shared_infra/sqs_freezeray/Makefile
@@ -4,7 +4,7 @@ FREEZERAY = $(ROOT)/shared_infra/sqs_freezeray
 include $(ROOT)/functions.Makefile
 
 $(FREEZERAY)/requirements.txt: $(FREEZERAY)/requirements.in
-	docker run --volume $(FREEZERAY):/src --rm micktwomey/pip-tools
+	docker run --rm --volume $(FREEZERAY):/src --rm micktwomey/pip-tools
 
 sqs_freezeray-build:
 	$(call build_image,sqs_freezeray,shared_infra/sqs_freezeray/Dockerfile)

--- a/shared_infra/update_dynamo_capacity/Makefile
+++ b/shared_infra/update_dynamo_capacity/Makefile
@@ -1,9 +1,4 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
-export SHARED_INFRA = $(ROOT)/shared_infra
-
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
 
 include $(ROOT)/functions.Makefile
 

--- a/shared_infra/update_dynamo_capacity/Makefile
+++ b/shared_infra/update_dynamo_capacity/Makefile
@@ -7,21 +7,11 @@ endif
 
 include $(ROOT)/functions.Makefile
 
-## Build update_dynamo_capacity lambda
-update_dynamo_capacity-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(SHARED_INFRA)/update_dynamo_capacity:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
+update_dynamo_capacity-build:
+	$(call build_lambda,shared_infra/update_dynamo_capacity)
 
-## Test update_dynamo_capacity lambda
-update_dynamo_capacity-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(SHARED_INFRA)/update_dynamo_capacity/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+update_dynamo_capacity-test:
+	$(call test_lambda,shared_infra/update_dynamo_capacity)
 
-## Publish update_dynamo_capacity lambda
 update_dynamo_capacity-publish:
 	$(call publish_lambda,shared_infra/update_dynamo_capacity)

--- a/shared_infra/update_dynamo_capacity/Makefile
+++ b/shared_infra/update_dynamo_capacity/Makefile
@@ -1,6 +1,5 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
 export SHARED_INFRA = $(ROOT)/shared_infra
-export INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/shared_infra/update_ecs_service_size/Makefile
+++ b/shared_infra/update_ecs_service_size/Makefile
@@ -1,9 +1,4 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
-export SHARED_INFRA = $(ROOT)/shared_infra
-
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
 
 include $(ROOT)/functions.Makefile
 

--- a/shared_infra/update_ecs_service_size/Makefile
+++ b/shared_infra/update_ecs_service_size/Makefile
@@ -7,21 +7,11 @@ endif
 
 include $(ROOT)/functions.Makefile
 
-## Build update_ecs_service_size lambda
-update_ecs_service_size-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(SHARED_INFRA)/update_ecs_service_size:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
+update_ecs_service_size-build:
+	$(call build_lambda,shared_infra/update_ecs_service_size)
 
-## Test update_ecs_service_size lambda
-update_ecs_service_size-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(SHARED_INFRA)/update_ecs_service_size/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+update_ecs_service_size-test:
+	$(call test_lambda,shared_infra/update_ecs_service_size)
 
-## Publish update_ecs_service_size lambda
 update_ecs_service_size-publish:
 	$(call publish_lambda,shared_infra/update_ecs_service_size)

--- a/shared_infra/update_ecs_service_size/Makefile
+++ b/shared_infra/update_ecs_service_size/Makefile
@@ -1,6 +1,5 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
 export SHARED_INFRA = $(ROOT)/shared_infra
-export INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/shared_infra/update_task_for_config_change/Makefile
+++ b/shared_infra/update_task_for_config_change/Makefile
@@ -1,9 +1,4 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
-export SHARED_INFRA = $(ROOT)/shared_infra
-
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
 
 include $(ROOT)/functions.Makefile
 

--- a/shared_infra/update_task_for_config_change/Makefile
+++ b/shared_infra/update_task_for_config_change/Makefile
@@ -7,21 +7,11 @@ endif
 
 include $(ROOT)/functions.Makefile
 
-## Build update_task_for_config_change lambda
-update_task_for_config_change-build: $(ROOT)/.docker/python3.6_ci
-	docker run \
-		--volume $(SHARED_INFRA)/update_task_for_config_change:/data \
-		--env OP=build-lambda \
-		python3.6_ci:latest
+update_task_for_config_change-build:
+	$(call build_lambda,shared_infra/update_task_for_config_change)
 
-## Test update_task_for_config_change lambda
-update_task_for_config_change-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(SHARED_INFRA)/update_task_for_config_change/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+update_task_for_config_change-test:
+	$(call test_lambda,shared_infra/update_task_for_config_change)
 
-## Publish update_task_for_config_change lambda
 update_task_for_config_change-publish:
 	$(call publish_lambda,shared_infra/update_task_for_config_change)

--- a/shared_infra/update_task_for_config_change/Makefile
+++ b/shared_infra/update_task_for_config_change/Makefile
@@ -1,6 +1,5 @@
 export ROOT = $(shell git rev-parse --show-toplevel)
 export SHARED_INFRA = $(ROOT)/shared_infra
-export INFRA_BUCKET = platform-infra
 
 ifneq ($(ROOT), $(shell pwd))
 	include $(ROOT)/shared.Makefile

--- a/sierra_adapter/Makefile
+++ b/sierra_adapter/Makefile
@@ -1,5 +1,4 @@
 ROOT = $(shell git rev-parse --show-toplevel)
-
 SIERRA_ADAPTER = $(ROOT)/sierra_adapter
 
 include $(SIERRA_ADAPTER)/sierra_window_generator/Makefile

--- a/sierra_adapter/Makefile
+++ b/sierra_adapter/Makefile
@@ -1,5 +1,4 @@
 ROOT = $(shell git rev-parse --show-toplevel)
-INFRA_BUCKET = platform-infra
 
 SIERRA_ADAPTER = $(ROOT)/sierra_adapter
 

--- a/sierra_adapter/sierra_window_generator/Makefile
+++ b/sierra_adapter/sierra_window_generator/Makefile
@@ -1,10 +1,6 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 SIERRA_WINDOW_GENERATOR = $(ROOT)/sierra_adapter/sierra_window_generator
 
-ifneq ($(ROOT), $(shell pwd))
-	include $(ROOT)/shared.Makefile
-endif
-
 include $(ROOT)/functions.Makefile
 
 

--- a/sierra_adapter/sierra_window_generator/Makefile
+++ b/sierra_adapter/sierra_window_generator/Makefile
@@ -12,12 +12,8 @@ $(SIERRA_WINDOW_GENERATOR)/src/requirements.txt: $(SIERRA_WINDOW_GENERATOR)/src/
 	$(ROOT)/builds/docker_run.py -- \
 		--volume $(SIERRA_WINDOW_GENERATOR)/src:/src micktwomey/pip-tools
 
-sierra_window_generator-test: $(ROOT)/.docker/python3.6_ci
-	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(SIERRA_WINDOW_GENERATOR)/src:/data \
-		--env OP=test \
-		--env FIND_MATCH_PATHS="/data" --tty \
-		python3.6_ci:latest
+sierra_window_generator-test:
+	$(call test_lambda,sierra_adapter/sierra_window_generator)
 
 sierra_window_generator-publish:
 	$(call publish_lambda,sierra_adapter/sierra_window_generator)


### PR DESCRIPTION
### What is this PR trying to achieve?

This started as a simple patch to add `--rm` to all our invocations of `docker run`, which deletes the container as soon as it’s finished. I had literally thousands of old containers on my machine. 😱 

As part of doing that, I had to DRY up the Lambda publishing/testing code, and some other old code from our Makefiles came along for the ride. This is an excellent line count with which to start the week.

### Who is this change for?

Devs who want tidy Makefiles and machines that aren’t filled with old containers.