### PR TITLE
Add model code for putting items on a MergedSierraRecord

### DIFF
--- a/.travis/tooling.py
+++ b/.travis/tooling.py
@@ -58,7 +58,10 @@ def are_there_job_relevant_changes(changed_files, task):
     if any(f.startswith('builds/') for f in changed_files):
         reasons.append('Changes to the build scripts')
 
-    if any(task.startswith(p) for p in _sbt_projects()):
+    if (
+        any(task.startswith(p) for p in _sbt_projects()) or
+        task == 'sbt-common-test'
+    ):
         reasons.extend(_are_there_sbt_relevant_changes(changed_files, task))
 
     for project in os.listdir(ROOT):

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/parsers/SierraParserTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/parsers/SierraParserTest.scala
@@ -23,7 +23,8 @@ class SierraParserTest
 
     triedSierraTransformable.isSuccess shouldBe true
     triedSierraTransformable.get shouldBe a[MergedSierraRecord]
-    val actualRecord = triedSierraTransformable.get.asInstanceOf[MergedSierraRecord]
+    val actualRecord =
+      triedSierraTransformable.get.asInstanceOf[MergedSierraRecord]
     actualRecord.id shouldEqual id
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/parsers/SierraParserTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/parsers/SierraParserTest.scala
@@ -23,7 +23,7 @@ class SierraParserTest
 
     triedSierraTransformable.isSuccess shouldBe true
     triedSierraTransformable.get shouldBe a[MergedSierraRecord]
-    triedSierraTransformable.get
-      .asInstanceOf[MergedSierraRecord] shouldBe MergedSierraRecord(id, None)
+    val actualRecord = triedSierraTransformable.get.asInstanceOf[MergedSierraRecord]
+    actualRecord.id shouldEqual id
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformableSQSMessageUtils.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformableSQSMessageUtils.scala
@@ -7,7 +7,8 @@ import uk.ac.wellcome.models.transformable.miro.MiroTransformable
 import uk.ac.wellcome.models.{
   CalmTransformable,
   MergedSierraRecord,
-  SierraBibRecord
+  SierraBibRecord,
+  SierraItemRecord
 }
 import uk.ac.wellcome.utils.JsonUtil
 
@@ -25,7 +26,11 @@ trait TransformableSQSMessageUtils {
   }
 
   def createValidEmptySierraBibSQSMessage(id: String): SQSMessage = {
-    val mergedSierraRecord = MergedSierraRecord(id = id, maybeBibData = None)
+    val mergedSierraRecord = MergedSierraRecord(
+      id = id,
+      maybeBibData = None,
+      itemData = Map[String, SierraItemRecord]()
+    )
 
     sqsMessage(JsonUtil.toJson(mergedSierraRecord).get)
   }
@@ -43,7 +48,8 @@ trait TransformableSQSMessageUtils {
 
     val mergedSierraRecord = MergedSierraRecord(
       id = id,
-      maybeBibData = Some(SierraBibRecord(id, data, lastModifiedDate)))
+      maybeBibData = Some(SierraBibRecord(id, data, lastModifiedDate))
+    )
 
     sqsMessage(JsonUtil.toJson(mergedSierraRecord).get)
   }

--- a/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
@@ -8,6 +8,16 @@ import scala.util.{Success, Try}
 /** Represents a row in the DynamoDB database of "merged" Sierra records;
   * that is, records that contain data for both bibs and
   * their associated items.
+  *
+  * Fields:
+  *
+  *   - `id`: the ID of the associated bib record
+  *   - `maybeBibData`: data from the associated bib.  This may be None if
+  *     we've received an item but haven't had the bib yet.
+  *   - `itemData`: a map from item IDs to item records
+  *   - `version`: used to track updates to the record in DynamoDB.  The exact
+  *     value at any time is unimportant, but it should only ever increase.
+  *
   */
 case class MergedSierraRecord(
   id: String,

--- a/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
@@ -22,7 +22,7 @@ import scala.util.{Success, Try}
 case class MergedSierraRecord(
   id: String,
   maybeBibData: Option[SierraBibRecord] = None,
-  itemData: Map[String, SierraItemRecord] = Map(),
+  itemData: Map[String, SierraItemRecord] = Map[String, SierraItemRecord](),
   version: Int = 1
 ) extends Transformable {
 

--- a/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
@@ -12,6 +12,7 @@ import scala.util.{Success, Try}
 case class MergedSierraRecord(
   id: String,
   maybeBibData: Option[SierraBibRecord] = None,
+  itemData: Map[String, SierraItemRecord] = Map(),
   version: Int = 1
 ) extends Transformable {
 
@@ -40,6 +41,15 @@ case class MergedSierraRecord(
     } else {
       None
     }
+  }
+
+  /** Given a new item record, construct the new merged row that we should
+    * insert into the merged database.
+    *
+    * Returns None if there's nothing to do.
+    */
+  def mergeItemRecord(record: SierraItemRecord): Option[MergedSierraRecord] = {
+    None
   }
 
   override def transform: Try[Option[Work]] =

--- a/common/src/main/scala/uk/ac/wellcome/models/SierraItemRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/SierraItemRecord.scala
@@ -1,0 +1,27 @@
+package uk.ac.wellcome.models
+
+import java.time.Instant
+
+import com.gu.scanamo.DynamoFormat
+
+case class SierraItemRecord(
+  id: String,
+  data: String,
+  modifiedDate: Instant
+)
+
+object SierraItemRecord {
+  implicit val instantLongFormat =
+    DynamoFormat.coercedXmap[Instant, Long, IllegalArgumentException](
+      Instant.ofEpochSecond
+    )(
+      _.getEpochSecond
+    )
+
+  def apply(id: String, data: String, modifiedDate: String): SierraItemRecord =
+    SierraItemRecord(
+      id = id,
+      data = data,
+      modifiedDate = Instant.parse(modifiedDate)
+    )
+}

--- a/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
@@ -195,7 +195,7 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
       itemData = Map("i111" -> sierraItemRecord(
         id = "i111",
         title = "An incomplete invocation of items",
-        modifiedDate = "2000-00-00T00:00:00Z"
+        modifiedDate = "2001-01-01T01:01:01Z"
       ))
     )
 

--- a/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
@@ -114,7 +114,7 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
     val mergedSierraRecord = MergedSierraRecord(id = "b888")
     val result = mergedSierraRecord.mergeItemRecord(record).get
 
-    result.itemData.get(record.id) shouldBe record
+    result.itemData.get(record.id).get shouldBe record
   }
 
   it("should overwrite existing itemData when there's a newer update") {
@@ -135,7 +135,7 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
     )
     val result = mergedSierraRecord.mergeItemRecord(newerRecord).get
 
-    result.itemData.get(record.id) shouldBe newerRecord
+    result.itemData.get(record.id).get shouldBe newerRecord
   }
 
   it("should not overwrite existing itemData when there's a older update") {
@@ -152,7 +152,7 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
     val newerRecord = sierraItemRecord(
       id = record.id,
       title = "Old otters outside the oblong",
-      modifiedDate = "2000-00-00T00:00:00Z"
+      modifiedDate = "2000-01-01T01:01:01Z"
     )
     val result = mergedSierraRecord.mergeItemRecord(newerRecord)
     result shouldBe None
@@ -174,8 +174,8 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
     val result1 = mergedSierraRecord.mergeItemRecord(record1).get
     val result2 = result1.mergeItemRecord(record2).get
 
-    result1.itemData.get(record1.id) shouldBe record1
-    result2.itemData.get(record2.id) shouldBe record2
+    result1.itemData.get(record1.id).get shouldBe record1
+    result2.itemData.get(record2.id).get shouldBe record2
   }
 
   it("should not perform a transformation without bibData") {

--- a/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
@@ -192,11 +192,12 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
     val mergedSierraRecord = MergedSierraRecord(
       id = "b111",
       maybeBibData = None,
-      itemData = Map("i111" -> sierraItemRecord(
-        id = "i111",
-        title = "An incomplete invocation of items",
-        modifiedDate = "2001-01-01T01:01:01Z"
-      ))
+      itemData = Map(
+        "i111" -> sierraItemRecord(
+          id = "i111",
+          title = "An incomplete invocation of items",
+          modifiedDate = "2001-01-01T01:01:01Z"
+        ))
     )
 
     val transformedSierraRecord = mergedSierraRecord.transform


### PR DESCRIPTION
### What is this PR trying to achieve?

This creates a new class `SierraItemRecord`, which is currently identical to `SierraBibRecord` but is a different type for the purposes of type safety.

It adds a way to store item records on a `MergedSierraRecord`, and adds a new method `mergeItemRecord()`, which adds information from a new item to the merged record.

This patch only covers the model changes; exercising the model outside our tests is beyond the scope of this patch.

Required for #1195.

### Who is this change for?

Anybody who wants more than bib data from Sierra.