### PR TITLE
Rewrite the Travis logic to "fail safe"

### DIFF
--- a/.travis/tooling.py
+++ b/.travis/tooling.py
@@ -3,8 +3,6 @@
 
 from __future__ import print_function
 
-import os
-import re
 import subprocess
 
 
@@ -130,7 +128,7 @@ def are_there_job_relevant_changes(changed_files, task):
     # when it was important, we remove any files which we know are safe to
     # ignore, and run tests if there's anything left.
     interesting_changed_files = [
-        c for c in changed_files if not has_no_effect_on_tests(f, task=task)
+        f for f in changed_files if not has_no_effect_on_tests(f, task=task)
     ]
 
     if interesting_changed_files:


### PR DESCRIPTION
After hitting another bug in the Travis logic (#1270) and porting it to another repo this weekend (https://github.com/HypothesisWorks/hypothesis-python/pull/1014), I realised the current version was built back-to-front.

The previous approach was _don’t test unless we’re sure we need to_. This falls over if we make a logic error – it defaults to not testing.

The better approach is _test unless we’re sure we don’t need to_. It defaults to running tests. That way, if we’re a bit slow in updating the Travis logic, the worst that will happen is we burn a bit more build time, rather than letting broken code into master.