### PR TITLE
Add envsubst to config loading

### DIFF
--- a/builds/scala_service/Dockerfile
+++ b/builds/scala_service/Dockerfile
@@ -3,7 +3,7 @@ FROM anapsix/alpine-java
 ARG project
 
 RUN apk update && apk add python3 && pip3 install awscli && rm -rf /var/cache/apk
-RUN apk add --virtual build_deps gettext
+RUN apk add gettext
 
 ADD target/$project /opt/docker
 RUN chown -R daemon:daemon /opt/docker

--- a/builds/scala_service/Dockerfile
+++ b/builds/scala_service/Dockerfile
@@ -3,6 +3,7 @@ FROM anapsix/alpine-java
 ARG project
 
 RUN apk update && apk add python3 && pip3 install awscli && rm -rf /var/cache/apk
+RUN apk add --virtual build_deps gettext
 
 ADD target/$project /opt/docker
 RUN chown -R daemon:daemon /opt/docker

--- a/builds/scala_service/run.sh
+++ b/builds/scala_service/run.sh
@@ -8,7 +8,9 @@ echo "Running project $PROJECT"
 
 echo "Fetching config from AWS..."
 aws s3 ls s3://$INFRA_BUCKET/$CONFIG_KEY
-aws s3 cp s3://$INFRA_BUCKET/$CONFIG_KEY /opt/docker/conf/application.ini
+aws s3 cp s3://$INFRA_BUCKET/$CONFIG_KEY /opt/docker/conf/application.ini.template
+
+envsubst < /opt/docker/conf/application.ini.template > /opt/docker/conf/application.ini
 
 echo "=== config ==="
 cat /opt/docker/conf/application.ini


### PR DESCRIPTION
### What is this PR trying to achieve?

Allows environment variables in containers to be substituted for app config.

This is a step towards providing app config via env variable only, removing the S3 step.

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Deployed new versions

