### PR TITLE
Build id_minter with env config

### DIFF
--- a/builds/publish_service_to_aws.Dockerfile
+++ b/builds/publish_service_to_aws.Dockerfile
@@ -8,7 +8,8 @@ RUN apk add docker git python3
 
 RUN pip3 install awscli docopt boto3
 
-COPY . /builds
+COPY publish_service_to_aws.py /builds/publish_service_to_aws.py
+COPY tooling.py /builds/tooling.py
 
 VOLUME /repo
 WORKDIR /repo

--- a/catalogue_pipeline/Makefile
+++ b/catalogue_pipeline/Makefile
@@ -5,10 +5,6 @@ include $(ROOT)/functions.Makefile
 include $(CATALOGUE_PIPELINE)/schedule_reindexer/Makefile
 
 
-id_minter-build: $(ROOT)/.docker/sbt_image_builder
-	TARGET=catalogue_pipeline/id_minter/target \
-	PROJECT=id_minter $(ROOT)/builds/run_sbt_image_build.sh
-
 ingestor-build: $(ROOT)/.docker/sbt_image_builder
 	TARGET=catalogue_pipeline/ingestor/target \
 	PROJECT=ingestor $(ROOT)/builds/run_sbt_image_build.sh
@@ -21,6 +17,10 @@ transformer-build: $(ROOT)/.docker/sbt_image_builder
 	TARGET=catalogue_pipeline/transformer/target \
 	PROJECT=transformer $(ROOT)/builds/run_sbt_image_build.sh
 
+
+id_minter-build:
+	$(call sbt_build, id_minter)
+	$(call build_image,id_minter,catalogue_pipeline/id_minter/Dockerfile)
 
 id_minter-test:
 	$(call sbt_test,id_minter)

--- a/catalogue_pipeline/id_minter/Dockerfile
+++ b/catalogue_pipeline/id_minter/Dockerfile
@@ -1,0 +1,7 @@
+FROM finatra_service_base:latest
+
+ADD target/universal/stage /opt/docker
+
+ENV project=id_minter
+
+CMD ["/run.sh"]

--- a/catalogue_pipeline/id_minter/Dockerfile
+++ b/catalogue_pipeline/id_minter/Dockerfile
@@ -1,4 +1,4 @@
-FROM finatra_service_base:latest
+FROM wellcome/finatra_service_base
 
 ADD target/universal/stage /opt/docker
 

--- a/catalogue_pipeline/id_minter/Dockerfile
+++ b/catalogue_pipeline/id_minter/Dockerfile
@@ -2,6 +2,10 @@ FROM finatra_service_base:latest
 
 ADD target/universal/stage /opt/docker
 
+USER root
+RUN chown -R daemon:daemon /opt/docker
+
 ENV project=id_minter
 
+USER daemon
 CMD ["/run.sh"]

--- a/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
@@ -1,0 +1,10 @@
+-aws.rds.host=${cluster_url}
+-aws.rds.identifiers.database=identifiers
+-aws.rds.identifiers.table=identifiers
+-aws.rds.password=${db_password}
+-aws.rds.port=${db_port}
+-aws.rds.userName=${db_username}
+-aws.sqs.queue.url=${queue_url}
+-aws.sns.topic.arn=${topic_arn}
+-aws.metrics.namespace=id-minter
+-known.identifierSchemes=miro-image-number,sierra-system-number

--- a/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
@@ -7,4 +7,3 @@
 -aws.sqs.queue.url=${queue_url}
 -aws.sns.topic.arn=${topic_arn}
 -aws.metrics.namespace=id-minter
--known.identifierSchemes=miro-image-number,sierra-system-number

--- a/catalogue_pipeline/terraform/config/id_minter.ini.template
+++ b/catalogue_pipeline/terraform/config/id_minter.ini.template
@@ -1,9 +1,0 @@
--aws.rds.host=${rds_host}
--aws.rds.identifiers.database=${rds_database_name}
--aws.rds.identifiers.table=identifiers
--aws.rds.password=${rds_password}
--aws.rds.port=${rds_port}
--aws.rds.userName=${rds_username}
--aws.sqs.queue.url=${id_minter_queue_id}
--aws.sns.topic.arn=${es_ingest_topic_arn}
--aws.metrics.namespace=${metrics_namespace}

--- a/catalogue_pipeline/terraform/id_minter-ingestor/service_id_minter.tf
+++ b/catalogue_pipeline/terraform/id_minter-ingestor/service_id_minter.tf
@@ -5,7 +5,7 @@ module "id_minter" {
   source_queue_name  = "${module.id_minter_queue.name}"
   source_queue_arn   = "${module.id_minter_queue.arn}"
   ecr_repository_url = "${var.id_minter_repository_url}"
-  release_id         = "1f74eda6f16c79b3c8c760f5bb8832a27b3436c0"
+  release_id         = "${var.release_ids["id_minter"]}"
 
   config_template    = "id_minter"
   is_config_managed = false

--- a/catalogue_pipeline/terraform/id_minter-ingestor/service_id_minter.tf
+++ b/catalogue_pipeline/terraform/id_minter-ingestor/service_id_minter.tf
@@ -8,16 +8,14 @@ module "id_minter" {
   release_id         = "${var.release_ids["id_minter"]}"
   config_template    = "id_minter"
 
-  config_vars = {
-    rds_database_name   = "${var.identifiers_rds_cluster["database_name"]}"
-    rds_host            = "${var.identifiers_rds_cluster["host"]}"
-    rds_port            = "${var.identifiers_rds_cluster["port"]}"
-    rds_username        = "${var.identifiers_rds_cluster["username"]}"
-    rds_password        = "${var.identifiers_rds_cluster["password"]}"
-    id_minter_queue_id  = "${module.id_minter_queue.id}"
-    es_ingest_topic_arn = "${module.es_ingest_topic.arn}"
-    metrics_namespace   = "id-minter"
-  }
+  extra_vars = [
+    "{ \"name\" : \"cluster_url\", \"value\" : \"${var.identifiers_rds_cluster["host"]}\" }",
+    "{ \"name\" : \"db_port\", \"value\" : \"${var.identifiers_rds_cluster["port"]}\" }",
+    "{ \"name\" : \"db_username\", \"value\" : \"${var.identifiers_rds_cluster["username"]}\" }",
+    "{ \"name\" : \"db_password\", \"value\" : \"${var.identifiers_rds_cluster["password"]}\" }",
+    "{ \"name\" : \"queue_url\", \"value\" : \"${module.id_minter_queue.id}\" }",
+    "{ \"name\" : \"topic_arn\", \"value\" : \"${module.es_ingest_topic.arn}\" }",
+  ]
 
   alb_priority = "${random_integer.priority_id_minter.result}"
 

--- a/catalogue_pipeline/terraform/id_minter-ingestor/service_id_minter.tf
+++ b/catalogue_pipeline/terraform/id_minter-ingestor/service_id_minter.tf
@@ -7,7 +7,7 @@ module "id_minter" {
   ecr_repository_url = "${var.id_minter_repository_url}"
   release_id         = "${var.release_ids["id_minter"]}"
 
-  config_template    = "id_minter"
+  config_template   = "id_minter"
   is_config_managed = false
 
   extra_vars = [

--- a/catalogue_pipeline/terraform/id_minter-ingestor/service_id_minter.tf
+++ b/catalogue_pipeline/terraform/id_minter-ingestor/service_id_minter.tf
@@ -1,12 +1,14 @@
 module "id_minter" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v3.0.2"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v3.0.5"
   name   = "id_minter_${var.name}"
 
   source_queue_name  = "${module.id_minter_queue.name}"
   source_queue_arn   = "${module.id_minter_queue.arn}"
   ecr_repository_url = "${var.id_minter_repository_url}"
-  release_id         = "${var.release_ids["id_minter"]}"
+  release_id         = "1f74eda6f16c79b3c8c760f5bb8832a27b3436c0"
+
   config_template    = "id_minter"
+  is_config_managed = false
 
   extra_vars = [
     "{ \"name\" : \"cluster_url\", \"value\" : \"${var.identifiers_rds_cluster["host"]}\" }",

--- a/functions.Makefile
+++ b/functions.Makefile
@@ -110,3 +110,16 @@ define sbt_test
 		wellcome/sbt_wrapper \
 		"project $(1)" ";dockerComposeUp;test;dockerComposeStop"
 endef
+
+
+# Build an sbt project.
+#
+# Args:
+#   $1 - Name of the project.
+#
+define sbt_build
+	$(ROOT)/builds/docker_run.py --dind --sbt --root -- \
+		--net host \
+		wellcome/sbt_wrapper \
+		"project $(1)" ";stage"
+endef


### PR DESCRIPTION
### What is this PR trying to achieve?

Discard S3 config in favour of env variable config only to make running application containers more flexible.

This change uses a new base container for the finatra service and a project local `Dockerfile`.  We should eventually be able to get rid of the sbt image builder container locally and simpligy ouf build and configuration process. 

Depends: https://github.com/wellcometrust/dockerfiles/pull/8

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
