### PR TITLE
Refactor the bib merging code in the sierra_bib_merger

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
@@ -23,7 +23,7 @@ case class MergedSierraRecord(
   id: String,
   maybeBibData: Option[SierraBibRecord] = None,
   itemData: Map[String, SierraItemRecord] = Map[String, SierraItemRecord](),
-  version: Int = 1
+  version: Int = 0
 ) extends Transformable {
 
   /** Given a new bib record, construct the new merged row that we should
@@ -31,7 +31,7 @@ case class MergedSierraRecord(
     *
     * Returns None if there's nothing to do.
     */
-  def mergeBibRecord(record: SierraBibRecord): Option[MergedSierraRecord] = {
+  def mergeBibRecord(record: SierraBibRecord): MergedSierraRecord = {
     if (record.id != this.id) {
       throw new RuntimeException(
         s"Non-matching bib ids ${record.id} != ${this.id}")
@@ -43,13 +43,9 @@ case class MergedSierraRecord(
     }
 
     if (isNewerData) {
-      Some(
-        this.copy(
-          maybeBibData = Some(record),
-          version = this.version + 1
-        ))
+      this.copy(maybeBibData = Some(record))
     } else {
-      None
+      this
     }
   }
 

--- a/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
@@ -26,10 +26,8 @@ case class MergedSierraRecord(
   version: Int = 0
 ) extends Transformable {
 
-  /** Given a new bib record, construct the new merged row that we should
-    * insert into the merged database.
-    *
-    * Returns None if there's nothing to do.
+  /** Return the most up-to-date combination of the merged record and the
+    * bib record we've just received.
     */
   def mergeBibRecord(record: SierraBibRecord): MergedSierraRecord = {
     if (record.id != this.id) {

--- a/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
@@ -51,11 +51,11 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
     record.version shouldEqual 0
   }
 
-  it("should always increment the version when mergeBibRecord is called") {
+  it("should never increment the version when mergeBibRecord is called") {
     val record = sierraBibRecord(id = "666")
     val originalRecord = MergedSierraRecord(id = "666", version = 10)
     val newRecord = originalRecord.mergeBibRecord(record)
-    newRecord.version shouldEqual 11
+    newRecord.version shouldEqual 10
   }
 
   it("should return None when merging bib records with stale data") {

--- a/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
@@ -48,16 +48,16 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
     caught.getMessage shouldEqual "Non-matching bib ids 333 != 444"
   }
 
-  it("should be at version 1 when first created") {
+  it("should be at version 0 when first created") {
     val record = MergedSierraRecord(id = "555")
-    record.version shouldEqual 1
+    record.version shouldEqual 0
   }
 
   it("should always increment the version when mergeBibRecord is called") {
     val record = sierraBibRecord(id = "666")
     val originalRecord = MergedSierraRecord(id = "666", version = 10)
     val newRecord = originalRecord.mergeBibRecord(record)
-    newRecord.get.version shouldEqual 11
+    newRecord.version shouldEqual 11
   }
 
   it("should return None when merging bib records with stale data") {
@@ -79,7 +79,7 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
     )
 
     val result = mergedSierraRecord.mergeBibRecord(record)
-    result shouldBe None
+    result shouldBe mergedSierraRecord
   }
 
   it("should update bibData when merging bib records with newer data") {
@@ -101,7 +101,7 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
     )
 
     val result = mergedSierraRecord.mergeBibRecord(record)
-    result.get.maybeBibData.get shouldBe record
+    result.maybeBibData.get shouldBe record
   }
 
   it("should add itemData when there isn't already an item") {

--- a/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
@@ -32,10 +32,8 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
     val record = sierraBibRecord(id = "222")
     val originalRecord = MergedSierraRecord(id = "222")
 
-    val newRecord: Option[MergedSierraRecord] =
-      originalRecord.mergeBibRecord(record)
-
-    newRecord.get.maybeBibData.get shouldEqual record
+    val newRecord = originalRecord.mergeBibRecord(record)
+    newRecord.maybeBibData.get shouldEqual record
   }
 
   it("should only merge bib records with matching ids") {

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
@@ -36,48 +36,42 @@ class SierraBibMergerUpdaterService @Inject()(
       table.get('id -> bibRecord.id)
     )
 
-    val newRecord = existingRecord
+    existingRecord
       .map {
         case Left(error) =>
-          Left(
-            new RuntimeException(error.toString)
-          )
+          throw new RuntimeException(error.toString)
         case Right(record) => {
           logger.info(s"Found $record, attempting merge.")
 
-          record
-            .mergeBibRecord(bibRecord)
-            .toRight(
-              new RuntimeException("Unable to merge record!")
-            )
+          val newRecord = record.mergeBibRecord(bibRecord)
+          if (record != newRecord) {
+            writeRecordToDynamo(newRecord)
+          }
         }
       }
       .getOrElse {
         val record = MergedSierraRecord(bibRecord)
         logger.info(s"No match found, creating new record: $record")
-
-        Right(record)
+        writeRecordToDynamo(record)
       }
+  }
 
-    val putOperation = newRecord match {
-      case Right(record) => {
-        logger.info(s"Attempting to conditionally update $record.")
+  private def writeRecordToDynamo(record: MergedSierraRecord) {
+    val recordToWrite = record.copy(version = record.version + 1)
+    logger.info(s"Attempting to conditionally update $recordToWrite.")
 
-        Scanamo
-          .exec(dynamoDBClient)(
-            putRecord(record)
-          )
-          .left
-          .map(e => new RuntimeException(e.toString))
-      }
-      case Left(e) => Left(e)
-    }
+    val putOperation = Scanamo
+      .exec(dynamoDBClient)(
+        putRecord(newRecord)
+      )
+      .left
+      .map(e => new RuntimeException(e.toString))
 
     putOperation match {
       case Right(_) =>
-        logger.info(s"${bibRecord.id} saved successfully to DynamoDB")
+        logger.info(s"${record.id} saved successfully to DynamoDB")
       case Left(error) =>
-        logger.warn(s"Failed processing ${bibRecord.id}", error)
+        logger.warn(s"Failed processing ${record.id}", error)
     }
   }
 }

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
@@ -62,7 +62,7 @@ class SierraBibMergerUpdaterService @Inject()(
 
     val putOperation = Scanamo
       .exec(dynamoDBClient)(
-        putRecord(newRecord)
+        putRecord(recordToWrite)
       )
       .left
       .map(e => new RuntimeException(e.toString))

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -136,7 +136,7 @@ class SierraBibMergerWorkerServiceTest
       ),
       modifiedDate = "2003-03-03T03:03:03Z"
     )
-    val oldRecord = MergedSierraRecord(bibRecord = oldBibRecord)
+    val oldRecord = MergedSierraRecord(bibRecord = oldBibRecord, version = 1)
     Scanamo.put(dynamoDbClient)(tableName)(oldRecord)
 
     val newTitle = "A number of new narwhals near Newmarket"
@@ -150,7 +150,6 @@ class SierraBibMergerWorkerServiceTest
       ),
       modifiedDate = newUpdatedDate
     )
-    println("@@AWLC Sent the second record to SQS")
     sendBibRecordToSQS(record)
 
     val expectedSierraRecord =
@@ -195,7 +194,7 @@ class SierraBibMergerWorkerServiceTest
 
   it("should put a bib from SQS into DynamoDB if the ID exists but no bibData") {
     val id = "7000007"
-    val newRecord = MergedSierraRecord(id = id)
+    val newRecord = MergedSierraRecord(id = id, version = 1)
     Scanamo.put(dynamoDbClient)(tableName)(newRecord)
 
     val title = "Inside an inquisitive igloo of ice imps"


### PR DESCRIPTION
* Return a complete record, not an Option[MergedSierraRecord]
* Push version handling code down into the merger