### PR TITLE
Include a link to the S3 plan summary

### DIFF
--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -76,4 +76,5 @@ module "terraform_tracker" {
   lambda_error_alarm_arn     = "${local.lambda_error_alarm_arn}"
   terraform_apply_topic_name = "${local.terraform_apply_topic_name}"
   slack_webhook              = "${var.non_critical_slack_webhook}"
+  bitly_access_token         = "${var.bitly_access_token}"
 }

--- a/monitoring/terraform_tracker/main.tf
+++ b/monitoring/terraform_tracker/main.tf
@@ -7,7 +7,8 @@ module "lambda_terraform_tracker" {
   timeout     = 10
 
   environment_variables = {
-    SLACK_WEBHOOK = "${var.slack_webhook}"
+    SLACK_WEBHOOK      = "${var.slack_webhook}"
+    BITLY_ACCESS_TOKEN = "${var.bitly_access_token}"
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"

--- a/monitoring/terraform_tracker/src/terraform_tracker.py
+++ b/monitoring/terraform_tracker/src/terraform_tracker.py
@@ -5,7 +5,6 @@ Sends Slack notifications for 'terraform apply' invocations.
 
 import json
 import os
-import sys
 
 from botocore.vendored import requests
 

--- a/monitoring/terraform_tracker/src/terraform_tracker.py
+++ b/monitoring/terraform_tracker/src/terraform_tracker.py
@@ -38,7 +38,7 @@ def main(event, context):
 
     if message['Subject'] != 'terraform-apply-notification':
         print("Ignoring this event")
-        sys.exit(0)
+        return
 
     data = json.loads(message['Message'])
 

--- a/monitoring/terraform_tracker/variables.tf
+++ b/monitoring/terraform_tracker/variables.tf
@@ -5,3 +5,5 @@ variable "terraform_apply_topic_name" {}
 variable "slack_webhook" {
   description = "Incoming Webhook URL to send Slack notifications"
 }
+
+variable "bitly_access_token" {}

--- a/shared_infra/s3.tf
+++ b/shared_infra/s3.tf
@@ -25,6 +25,16 @@ resource "aws_s3_bucket" "infra" {
       days = 30
     }
   }
+
+  lifecycle_rule {
+    id      = "terraform_plans"
+    prefix  = "terraform_plans/"
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
 }
 
 resource "aws_s3_bucket" "alb-logs" {


### PR DESCRIPTION
Makes our Slack alarms more useful, viz

![screen shot 2017-12-18 at 10 55 26](https://user-images.githubusercontent.com/301220/34102789-433165c6-e3e2-11e7-9dda-021a1cd65889.png)

Requires https://github.com/wellcometrust/dockerfiles/pull/11

### Have the following been considered/are they needed?

- [x] Deployed new versions
- [x] Run `terraform apply`.