### PR TITLE
Use circe in the bib merger

### DIFF
--- a/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/circe/package.scala
+++ b/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/circe/package.scala
@@ -1,0 +1,21 @@
+package uk.ac.wellcome.sierra_adapter
+
+import java.time.Instant
+
+import io.circe.{Decoder, HCursor}
+import cats.syntax.either._
+import io.circe.generic.extras.Configuration
+
+package object circe {
+  implicit val decodeInstant: Decoder[Instant] = new Decoder[Instant] {
+    final def apply(c: HCursor): Decoder.Result[Instant] =
+      for {
+        epochSeconds <- c.as[Long]
+      } yield {
+        Instant.ofEpochSecond(epochSeconds)
+      }
+  }
+
+  implicit val customConfig: Configuration =
+    Configuration.default.withDefaults.withDiscriminator("type")
+}

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerService.scala
@@ -3,15 +3,16 @@ package uk.ac.wellcome.platform.sierra_bib_merger.services
 import akka.actor.ActorSystem
 import com.google.inject.Inject
 import grizzled.slf4j.Logging
+import io.circe.generic.extras.auto._
+import io.circe.parser.decode
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.SierraBibRecord
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.sqs.{SQSReader, SQSReaderGracefulException, SQSWorker}
-import uk.ac.wellcome.utils.JsonUtil
+import uk.ac.wellcome.sierra_adapter.circe._
 
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{Failure, Success}
+import scala.concurrent.Future
 
 class SierraBibMergerWorkerService @Inject()(
   reader: SQSReader,
@@ -22,9 +23,9 @@ class SierraBibMergerWorkerService @Inject()(
     with Logging {
 
   override def processMessage(message: SQSMessage): Future[Unit] =
-    JsonUtil.fromJson[SierraBibRecord](message.body) match {
-      case Success(record) => sierraBibMergerUpdaterService.update(record)
-      case Failure(e) =>
+    decode[SierraBibRecord](message.body) match {
+      case Right(record) => sierraBibMergerUpdaterService.update(record)
+      case Left(e) =>
         Future {
           logger.warn(s"Failed processing $message", e)
           throw SQSReaderGracefulException(e)

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -10,19 +10,35 @@ import uk.ac.wellcome.platform.sierra_adapter.dynamo.MergedSierraRecordDao
 import uk.ac.wellcome.sqs.{SQSReader, SQSReaderGracefulException}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
-class SierraBibMergerWorkerServiceTest extends FunSpec with MockitoSugar with ScalaFutures with Matchers with ExtendedPatience{
+class SierraBibMergerWorkerServiceTest
+    extends FunSpec
+    with MockitoSugar
+    with ScalaFutures
+    with Matchers
+    with ExtendedPatience {
 
-  it("should not throw a NullPointerException when receiving a message with null body") {
+  it(
+    "should not throw a NullPointerException when receiving a message with null body") {
 
     val sqsReader = mock[SQSReader]
     val metricsSender = mock[MetricsSender]
-    val mergerUpdaterService = new SierraBibMergerUpdaterService(mock[MergedSierraRecordDao], metricsSender)
-    val worker = new SierraBibMergerWorkerService(sqsReader, ActorSystem(), metricsSender, mergerUpdaterService)
+    val mergerUpdaterService =
+      new SierraBibMergerUpdaterService(mock[MergedSierraRecordDao],
+                                        metricsSender)
+    val worker = new SierraBibMergerWorkerService(sqsReader,
+                                                  ActorSystem(),
+                                                  metricsSender,
+                                                  mergerUpdaterService)
 
-    val future = worker.processMessage(SQSMessage(subject = Some("default-subject"), body = "null", topic = "", messageType = "", timestamp = ""))
+    val future = worker.processMessage(
+      SQSMessage(subject = Some("default-subject"),
+                 body = "null",
+                 topic = "",
+                 messageType = "",
+                 timestamp = ""))
 
-    whenReady(future.failed) {ex =>
-      ex shouldBe a [SQSReaderGracefulException]
+    whenReady(future.failed) { ex =>
+      ex shouldBe a[SQSReaderGracefulException]
     }
 
   }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -1,0 +1,29 @@
+package uk.ac.wellcome.platform.sierra_bib_merger.services
+
+import akka.actor.ActorSystem
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.metrics.MetricsSender
+import uk.ac.wellcome.models.aws.SQSMessage
+import uk.ac.wellcome.platform.sierra_adapter.dynamo.MergedSierraRecordDao
+import uk.ac.wellcome.sqs.{SQSReader, SQSReaderGracefulException}
+import uk.ac.wellcome.test.utils.ExtendedPatience
+
+class SierraBibMergerWorkerServiceTest extends FunSpec with MockitoSugar with ScalaFutures with Matchers with ExtendedPatience{
+
+  it("should not throw a NullPointerException when receiving a message with null body") {
+
+    val sqsReader = mock[SQSReader]
+    val metricsSender = mock[MetricsSender]
+    val mergerUpdaterService = new SierraBibMergerUpdaterService(mock[MergedSierraRecordDao], metricsSender)
+    val worker = new SierraBibMergerWorkerService(sqsReader, ActorSystem(), metricsSender, mergerUpdaterService)
+
+    val future = worker.processMessage(SQSMessage(subject = Some("default-subject"), body = "null", topic = "", messageType = "", timestamp = ""))
+
+    whenReady(future.failed) {ex =>
+      ex shouldBe a [SQSReaderGracefulException]
+    }
+
+  }
+}

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerWorkerService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerWorkerService.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.SierraItemRecord
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.sqs.{SQSReader, SQSReaderGracefulException, SQSWorker}
-import uk.ac.wellcome.circe._
+import uk.ac.wellcome.sierra_adapter.circe._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerWorkerService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerWorkerService.scala
@@ -1,19 +1,15 @@
 package uk.ac.wellcome.platform.sierra_item_merger.services
 
-import java.time.Instant
-
 import akka.actor.ActorSystem
-import cats.syntax.either._
 import com.google.inject.Inject
 import grizzled.slf4j.Logging
-import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
 import io.circe.parser._
-import io.circe.{Decoder, HCursor}
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.SierraItemRecord
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.sqs.{SQSReader, SQSReaderGracefulException, SQSWorker}
+import uk.ac.wellcome.circe._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -26,20 +22,8 @@ class SierraItemMergerWorkerService @Inject()(
 ) extends SQSWorker(reader, system, metrics)
     with Logging {
 
-  // Using Circe here because Jackson creates nulls for empty lists
-  implicit val decodeInstant: Decoder[Instant] = new Decoder[Instant] {
-    final def apply(c: HCursor): Decoder.Result[Instant] =
-      for {
-        epochSeconds <- c.as[Long]
-      } yield {
-        Instant.ofEpochSecond(epochSeconds)
-      }
-  }
-
-  implicit val customConfig: Configuration =
-    Configuration.default.withDefaults.withDiscriminator("type")
-
   override def processMessage(message: SQSMessage): Future[Unit] =
+    // Using Circe here because Jackson creates nulls for empty lists
     decode[SierraItemRecord](message.body) match {
       case Right(record) => sierraItemMergerUpdaterService.update(record)
       case Left(e) =>


### PR DESCRIPTION
To solve #1281 for the bib merger (Still needs some work for the rest of our apps cause I think this affects anything that reads from SQS)
Basically a message like the following in our SQS queues causes NullPointerException in our applications
```json
{
  "Type" : "Notification",
  "MessageId" : "f589a60f-2fa1-5440-b416-f4a2f510f7e6",
  "TopicArn" : "arn:aws:sns:eu-west-1:123456789:sierra_bib_merger_events",
  "Subject" : "default-subject",
  "Message" : "null",
  "Timestamp" : "2017-12-15T14:13:05.242Z"
}
```
This is because, when we try to do `JsonUtil.fromJson[SierraBibRecord](message.body)` using Jackson, Jackson succeeds and returs a `null` `SierraItemRecord`. As we don't check for null downstream this eventually fails with NullPointerException.

I don't think we should be checking for null. This is a problem that comes from the fact that Jackson is a Java native library where sending `null` around is common, but in Scala this should be avoided. Circe, being a Scala native library, does not send nulls around, so let's use that