### PR TITLE
Add unlink logic to MergedSierraRecord

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
@@ -67,7 +67,8 @@ case class MergedSierraRecord(
     //    new record.
     //
     val isNewerData = this.itemData.get(itemRecord.id) match {
-      case Some(existing) => itemRecord.modifiedDate.isAfter(existing.modifiedDate)
+      case Some(existing) =>
+        itemRecord.modifiedDate.isAfter(existing.modifiedDate)
       case None => true
     }
 
@@ -86,7 +87,8 @@ case class MergedSierraRecord(
     }
 
     val itemData: Map[String, SierraItemRecord] = this.itemData
-      .filterNot { case (id, currentItemRecord) => {
+      .filterNot {
+        case (id, currentItemRecord) => {
           val matchesCurrentItemRecord = id == itemRecord.id
 
           val modifiedAfter = itemRecord.modifiedDate.isAfter(

--- a/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MergedSierraRecord.scala
@@ -52,7 +52,11 @@ case class MergedSierraRecord(
     *
     * Returns the merged record.
     */
-  def mergeItemRecord(record: SierraItemRecord): MergedSierraRecord = {
+  def mergeItemRecord(itemRecord: SierraItemRecord): MergedSierraRecord = {
+    if (!itemRecord.bibIds.contains(this.id)) {
+      throw new RuntimeException(
+        s"Non-matching bib id ${this.id} in item bib ${itemRecord.bibIds}")
+    }
 
     // We can decide whether to insert the new data in two steps:
     //
@@ -62,20 +66,39 @@ case class MergedSierraRecord(
     //    just received?  If the existing data is older, we need to merge the
     //    new record.
     //
-    val isNewerData = this.itemData.get(record.id) match {
-      case Some(existing) => record.modifiedDate.isAfter(existing.modifiedDate)
+    val isNewerData = this.itemData.get(itemRecord.id) match {
+      case Some(existing) => itemRecord.modifiedDate.isAfter(existing.modifiedDate)
       case None => true
     }
 
     if (isNewerData) {
-      val itemData = this.itemData + (record.id -> record)
+      val itemData = this.itemData + (itemRecord.id -> itemRecord)
       this.copy(itemData = itemData)
     } else {
       this
     }
   }
 
-  def unlinkItemRecord(itemRecord: SierraItemRecord): MergedSierraRecord = ???
+  def unlinkItemRecord(itemRecord: SierraItemRecord): MergedSierraRecord = {
+    if (!itemRecord.unlinkedBibIds.contains(this.id)) {
+      throw new RuntimeException(
+        s"Non-matching bib id ${this.id} in item unlink bibs ${itemRecord.unlinkedBibIds}")
+    }
+
+    val itemData: Map[String, SierraItemRecord] = this.itemData
+      .filterNot { case (id, currentItemRecord) => {
+          val matchesCurrentItemRecord = id == itemRecord.id
+
+          val modifiedAfter = itemRecord.modifiedDate.isAfter(
+            currentItemRecord.modifiedDate
+          )
+
+          matchesCurrentItemRecord && modifiedAfter
+        }
+      }
+
+    this.copy(itemData = itemData)
+  }
 
   override def transform: Try[Option[Work]] =
     maybeBibData

--- a/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.models
 
 import java.time.Instant
+import java.time.Instant._
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.utils.JsonUtil
@@ -195,42 +196,149 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
     }
 
     describe("when the merged record is unlinked from the item") {
-      ignore("should remove the item if it already exists") {
-        val unlinkedBibId = "222"
+      it("removes the item if it already exists") {
+        val bibId = "222"
+
         val record = sierraItemRecord(
           id = "i111",
           title = "Only otters occupy the orange oval",
           modifiedDate = "2001-01-01T01:01:01Z",
-          bibIds = List("i111"),
-          unlinkedBibIds = List(unlinkedBibId)
+          bibIds = List(bibId),
+          unlinkedBibIds = List()
         )
-        val mergedSierraRecord = MergedSierraRecord(id = unlinkedBibId,
-                                                    itemData =
-                                                      Map(record.id -> record))
-        mergedSierraRecord.unlinkItemRecord(record) shouldBe mergedSierraRecord
-          .copy(itemData = Map.empty)
+
+        val unlinkedItemRecord = record.copy(
+          bibIds = Nil,
+          modifiedDate = record.modifiedDate.plusSeconds(1),
+          unlinkedBibIds = List(bibId)
+        )
+
+        val mergedSierraRecord = MergedSierraRecord(
+          id = bibId,
+          itemData = Map(record.id -> record)
+        )
+
+        val expectedMergedSierraRecord =  mergedSierraRecord.copy(
+          itemData = Map.empty
+        )
+
+        mergedSierraRecord.unlinkItemRecord(unlinkedItemRecord) shouldBe expectedMergedSierraRecord
       }
 
-      ignore(
-        "should return the original record when merging an unlinked record which is already absent") {
-        true shouldBe false
+      it("returns the original record when merging an unlinked record which is already absent") {
+        val bibId = "333"
+
+        val record = sierraItemRecord(
+          id = "i111",
+          title = "Only otters occupy the orange oval",
+          modifiedDate = "2001-01-01T01:01:01Z",
+          bibIds = List(bibId),
+          unlinkedBibIds = List()
+        )
+
+        val previouslyUnlinkedRecord = sierraItemRecord(
+          id = "i222",
+          title = "Only otters occupy the orange oval",
+          modifiedDate = "2001-01-01T01:01:01Z",
+          bibIds = List(),
+          unlinkedBibIds = List(bibId)
+        )
+
+        val mergedSierraRecord = MergedSierraRecord(
+          id = bibId,
+          itemData = Map(record.id -> record)
+        )
+
+        val expectedMergedSierraRecord =  mergedSierraRecord
+
+        mergedSierraRecord.unlinkItemRecord(previouslyUnlinkedRecord) shouldBe expectedMergedSierraRecord
       }
 
-      ignore(
-        "should return the original record when merging an unlinked record which has linked more recently") {
-        true shouldBe false
+      it("returns the original record when merging an unlinked record which has linked more recently") {
+        val bibId = "444"
+        val itemId = "i111"
+
+        val record = sierraItemRecord(
+          id = itemId,
+          title = "Only otters occupy the orange oval",
+          modifiedDate = "2001-01-01T01:01:01Z",
+          bibIds = List(bibId),
+          unlinkedBibIds = List()
+        )
+
+        val outOfDateUnlinkedRecord = sierraItemRecord(
+          id = record.id,
+          title = "Curious clams caught in caul",
+          modifiedDate = "2000-01-01T01:01:01Z",
+          bibIds = List(),
+          unlinkedBibIds = List(bibId)
+        )
+
+        val mergedSierraRecord = MergedSierraRecord(
+          id = bibId,
+          itemData = Map(record.id -> record)
+        )
+
+        val expectedMergedSierraRecord =  mergedSierraRecord
+
+        mergedSierraRecord.unlinkItemRecord(outOfDateUnlinkedRecord) shouldBe expectedMergedSierraRecord
       }
     }
 
     describe("when the merged record is unrelated to the item") {
       describe("mergeSierraItemRecord") {
-        ignore("should only merge item records with matching bib IDs") {
-          true shouldBe false
+        it("should only merge item records with matching bib IDs") {
+          val bibId = "444"
+          val unrelatedBibId = "666"
+
+          val record = sierraItemRecord(
+            id = "i999",
+            title = "Only otters occupy the orange oval",
+            modifiedDate = "2001-01-01T01:01:01Z",
+            bibIds = List(unrelatedBibId),
+            unlinkedBibIds = List()
+          )
+
+          val mergedSierraRecord = MergedSierraRecord(id = bibId)
+
+          val caught = intercept[RuntimeException] {
+            mergedSierraRecord.mergeItemRecord(record)
+          }
+
+          caught.getMessage shouldEqual "Non-matching bib id 444 in item bib List(666)"
         }
       }
       describe("unlinkSierraItemRecord") {
-        ignore("should only unlink item records with matching bib IDs") {
-          true shouldBe false
+        it("should only unlink item records with matching bib IDs") {
+          val bibId = "222"
+          val unrelatedBibId = "846"
+
+          val record = sierraItemRecord(
+            id = "i111",
+            title = "Only otters occupy the orange oval",
+            modifiedDate = "2001-01-01T01:01:01Z",
+            bibIds = List(bibId),
+            unlinkedBibIds = List()
+          )
+
+          val unrelatedItemRecord = sierraItemRecord(
+            id = "i999",
+            title = "Only otters occupy the orange oval",
+            modifiedDate = "2001-01-01T01:01:01Z",
+            bibIds = List(),
+            unlinkedBibIds = List(unrelatedBibId)
+          )
+
+          val mergedSierraRecord = MergedSierraRecord(
+            id = bibId,
+            itemData = Map(record.id -> record)
+          )
+
+          val caught = intercept[RuntimeException] {
+            mergedSierraRecord.unlinkItemRecord(unrelatedItemRecord)
+          }
+
+          caught.getMessage shouldEqual "Non-matching bib id 222 in item unlink bibs List(846)"
         }
       }
     }
@@ -280,7 +388,7 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
       val mergedSierraRecord = MergedSierraRecord(
         id = id,
         maybeBibData = Some(
-          SierraBibRecord(id = id, data = data, modifiedDate = Instant.now())))
+          SierraBibRecord(id = id, data = data, modifiedDate = now())))
 
       val transformedSierraRecord = mergedSierraRecord.transform
       transformedSierraRecord.isSuccess shouldBe true

--- a/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MergedSierraRecordTest.scala
@@ -218,7 +218,7 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
           itemData = Map(record.id -> record)
         )
 
-        val expectedMergedSierraRecord =  mergedSierraRecord.copy(
+        val expectedMergedSierraRecord = mergedSierraRecord.copy(
           itemData = Map.empty
         )
 
@@ -249,7 +249,7 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
           itemData = Map(record.id -> record)
         )
 
-        val expectedMergedSierraRecord =  mergedSierraRecord
+        val expectedMergedSierraRecord = mergedSierraRecord
 
         mergedSierraRecord.unlinkItemRecord(previouslyUnlinkedRecord) shouldBe expectedMergedSierraRecord
       }
@@ -279,7 +279,7 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
           itemData = Map(record.id -> record)
         )
 
-        val expectedMergedSierraRecord =  mergedSierraRecord
+        val expectedMergedSierraRecord = mergedSierraRecord
 
         mergedSierraRecord.unlinkItemRecord(outOfDateUnlinkedRecord) shouldBe expectedMergedSierraRecord
       }
@@ -387,8 +387,8 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
 
       val mergedSierraRecord = MergedSierraRecord(
         id = id,
-        maybeBibData = Some(
-          SierraBibRecord(id = id, data = data, modifiedDate = now())))
+        maybeBibData =
+          Some(SierraBibRecord(id = id, data = data, modifiedDate = now())))
 
       val transformedSierraRecord = mergedSierraRecord.transform
       transformedSierraRecord.isSuccess shouldBe true


### PR DESCRIPTION
### What is this PR trying to achieve?

Adds the unlinking logic to MergedSierraRecord. 

### Who is this change for?

⛓ ‼️ 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.
