### PR TITLE
Remove 'should' from test descriptions in sierra

### DIFF
--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
@@ -8,7 +8,7 @@ class ServerTest extends FeatureTest {
 
   val server = new EmbeddedHttpServer(new Server)
 
-  test("it should show the healthcheck message") {
+  test("it shows the healthcheck message") {
     server.httpGet(path = "/management/healthcheck",
                    andExpect = Ok,
                    withJsonBody = """{"message": "ok"}""")

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -17,7 +17,8 @@ class SierraBibMergerWorkerServiceTest
     with Matchers
     with ExtendedPatience {
 
-  it("does not throw a NullPointerException when receiving a message with null body") {
+  it(
+    "does not throw a NullPointerException when receiving a message with null body") {
 
     val sqsReader = mock[SQSReader]
     val metricsSender = mock[MetricsSender]

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -17,8 +17,7 @@ class SierraBibMergerWorkerServiceTest
     with Matchers
     with ExtendedPatience {
 
-  it(
-    "should not throw a NullPointerException when receiving a message with null body") {
+  it("does not throw a NullPointerException when receiving a message with null body") {
 
     val sqsReader = mock[SQSReader]
     val metricsSender = mock[MetricsSender]

--- a/sierra_adapter/sierra_bibs_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/ServerTest.scala
+++ b/sierra_adapter/sierra_bibs_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/ServerTest.scala
@@ -8,7 +8,7 @@ class ServerTest extends FeatureTest {
 
   val server = new EmbeddedHttpServer(new Server)
 
-  test("it should show the healthcheck message") {
+  test("it shows the healthcheck message") {
     server.httpGet(path = "/management/healthcheck",
                    andExpect = Ok,
                    withJsonBody = """{"message": "ok"}""")

--- a/sierra_adapter/sierra_bibs_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/SierraBibsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_bibs_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/SierraBibsToDynamoFeatureTest.scala
@@ -38,7 +38,7 @@ class SierraBibsToDynamoFeatureTest
     ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
   )
 
-  it("should read bibs from Sierra and add them to DynamoDB") {
+  it("reads bibs from Sierra and adds them to DynamoDB") {
     val message =
       """
         |{

--- a/sierra_adapter/sierra_bibs_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/services/SierraBibsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bibs_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/services/SierraBibsToDynamoWorkerServiceTest.scala
@@ -58,7 +58,8 @@ class SierraBibsToDynamoWorkerServiceTest
       ))
   }
 
-  it("reads a window message from sqs, retrieves the bibs from sierra and inserts them into DynamoDb") {
+  it(
+    "reads a window message from sqs, retrieves the bibs from sierra and inserts them into DynamoDb") {
     worker = createSierraWorkerService(
       fields = "updatedDate,deletedDate,deleted,suppressed,author,title")
     worker.get.runSQSWorker()
@@ -81,7 +82,8 @@ class SierraBibsToDynamoWorkerServiceTest
 
   }
 
-  it("returns a SQSReaderGracefulException if it receives a message that doesn't contain start or end values") {
+  it(
+    "returns a SQSReaderGracefulException if it receives a message that doesn't contain start or end values") {
     worker = createSierraWorkerService(fields = "")
 
     val message =
@@ -99,7 +101,8 @@ class SierraBibsToDynamoWorkerServiceTest
 
   }
 
-  it("does not return a SQSReaderGracefulException if it cannot reach the Sierra Api") {
+  it(
+    "does not return a SQSReaderGracefulException if it cannot reach the Sierra Api") {
     worker = Some(
       new SierraBibsToDynamoWorkerService(
         reader = new SQSReader(sqsClient, SQSConfig(queueUrl, 1.second, 1)),

--- a/sierra_adapter/sierra_bibs_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/services/SierraBibsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bibs_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/services/SierraBibsToDynamoWorkerServiceTest.scala
@@ -58,8 +58,7 @@ class SierraBibsToDynamoWorkerServiceTest
       ))
   }
 
-  it(
-    "should read a window message from sqs, retrieve the bibs from sierra and insert them into DynamoDb") {
+  it("reads a window message from sqs, retrieves the bibs from sierra and inserts them into DynamoDb") {
     worker = createSierraWorkerService(
       fields = "updatedDate,deletedDate,deleted,suppressed,author,title")
     worker.get.runSQSWorker()
@@ -82,8 +81,7 @@ class SierraBibsToDynamoWorkerServiceTest
 
   }
 
-  it(
-    "should return a SQSReaderGracefulException if it receives a message that doesn't contain start or end values") {
+  it("returns a SQSReaderGracefulException if it receives a message that doesn't contain start or end values") {
     worker = createSierraWorkerService(fields = "")
 
     val message =
@@ -101,8 +99,7 @@ class SierraBibsToDynamoWorkerServiceTest
 
   }
 
-  it(
-    "should not return a SQSReaderGracefulException if it cannot reach the Sierra Api") {
+  it("does not return a SQSReaderGracefulException if it cannot reach the Sierra Api") {
     worker = Some(
       new SierraBibsToDynamoWorkerService(
         reader = new SQSReader(sqsClient, SQSConfig(queueUrl, 1.second, 1)),

--- a/sierra_adapter/sierra_bibs_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/sink/SierraBibsDynamoSinkTest.scala
+++ b/sierra_adapter/sierra_bibs_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/sink/SierraBibsDynamoSinkTest.scala
@@ -41,7 +41,7 @@ class SierraBibsDynamoSinkTest
     super.afterAll()
   }
 
-  it("should ingest a json into DynamoDB") {
+  it("ingests a json into DynamoDB") {
     val id = "100001"
     val updatedDate = "2013-12-13T12:43:16Z"
     val json = parse(s"""
@@ -69,7 +69,7 @@ class SierraBibsDynamoSinkTest
     }
   }
 
-  it("should be able to handle deleted bibs") {
+  it("is able to handle deleted bibs") {
     val id = "1357947"
     val deletedDate = "2014-01-31"
     val json = parse(s"""{
@@ -98,7 +98,7 @@ class SierraBibsDynamoSinkTest
     }
   }
 
-  it("should not overwrite new data with old data") {
+  it("does not overwrite new data with old data") {
     val id = "200002"
     val oldUpdatedDate = "2001-01-01T00:00:01Z"
     val newUpdatedDate = "2017-12-12T23:59:59Z"
@@ -126,7 +126,7 @@ class SierraBibsDynamoSinkTest
     }
   }
 
-  it("should overwrite old data with new data") {
+  it("overwrites old data with new data") {
     val id = "300003"
     val oldUpdatedDate = "2001-01-01T01:01:01Z"
     val newUpdatedDate = "2011-11-11T11:11:11Z"
@@ -160,7 +160,7 @@ class SierraBibsDynamoSinkTest
     }
   }
 
-  it("should fail the stream if the record contains invalid JSON") {
+  it("fails the stream if the record contains invalid JSON") {
     val invalidSierraJson = parse(s"""
          |{
          |  "missing": ["id", "updatedDate"],
@@ -175,7 +175,7 @@ class SierraBibsDynamoSinkTest
     }
   }
 
-  it("should fail the stream if DynamoDB returns an error") {
+  it("fails the stream if DynamoDB returns an error") {
     val json = parse(s"""
          |{
          | "id": "500005",
@@ -198,7 +198,7 @@ class SierraBibsDynamoSinkTest
     }
   }
 
-  it("should prepend a B to bib IDs") {
+  it("prepends a B to bib IDs") {
     val json = parse(s"""
       |{
       |  "id": "6000006",

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
@@ -8,7 +8,7 @@ class ServerTest extends FeatureTest {
 
   val server = new EmbeddedHttpServer(new Server)
 
-  test("it should show the healthcheck message") {
+  test("it shows the healthcheck message") {
     server.httpGet(path = "/management/healthcheck",
                    andExpect = Ok,
                    withJsonBody = """{"message": "ok"}""")

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
@@ -8,7 +8,7 @@ class ServerTest extends FeatureTest {
 
   val server = new EmbeddedHttpServer(new Server)
 
-  test("it should show the healthcheck message") {
+  test("it shows the healthcheck message") {
     server.httpGet(path = "/management/healthcheck",
                    andExpect = Ok,
                    withJsonBody = """{"message": "ok"}""")

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
@@ -38,7 +38,7 @@ class SierraItemsToDynamoFeatureTest
     ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
   )
 
-  it("should read items from Sierra and add them to DynamoDB") {
+  it("reads items from Sierra and adds them to DynamoDB") {
     val message =
       """
         |{

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -58,7 +58,8 @@ class SierraItemsToDynamoWorkerServiceTest
       ))
   }
 
-  it("reads a window message from sqs, retrieves the items from sierra and inserts them into DynamoDb") {
+  it(
+    "reads a window message from sqs, retrieves the items from sierra and inserts them into DynamoDb") {
     worker = createSierraWorkerService(
       fields = "updatedDate,deleted,deletedDate,bibIds,fixedFields,varFields")
     worker.get.runSQSWorker()
@@ -81,7 +82,8 @@ class SierraItemsToDynamoWorkerServiceTest
 
   }
 
-  it("returns a SQSReaderGracefulException if it receives a message that doesn't contain start or end values") {
+  it(
+    "returns a SQSReaderGracefulException if it receives a message that doesn't contain start or end values") {
     worker = createSierraWorkerService(fields = "")
 
     val message =
@@ -99,7 +101,8 @@ class SierraItemsToDynamoWorkerServiceTest
 
   }
 
-  it("does not return a SQSReaderGracefulException when the Sierra Api is unreachable") {
+  it(
+    "does not return a SQSReaderGracefulException when the Sierra Api is unreachable") {
     worker = Some(
       new SierraItemsToDynamoWorkerService(
         reader = new SQSReader(sqsClient, SQSConfig(queueUrl, 1.second, 1)),

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -58,8 +58,7 @@ class SierraItemsToDynamoWorkerServiceTest
       ))
   }
 
-  it(
-    "should read a window message from sqs, retrieve the items from sierra and insert them into DynamoDb") {
+  it("reads a window message from sqs, retrieves the items from sierra and inserts them into DynamoDb") {
     worker = createSierraWorkerService(
       fields = "updatedDate,deleted,deletedDate,bibIds,fixedFields,varFields")
     worker.get.runSQSWorker()
@@ -82,8 +81,7 @@ class SierraItemsToDynamoWorkerServiceTest
 
   }
 
-  it(
-    "should return a SQSReaderGracefulException if it receives a message that doesn't contain start or end values") {
+  it("returns a SQSReaderGracefulException if it receives a message that doesn't contain start or end values") {
     worker = createSierraWorkerService(fields = "")
 
     val message =
@@ -101,8 +99,7 @@ class SierraItemsToDynamoWorkerServiceTest
 
   }
 
-  it(
-    "should not return a SQSReaderGracefulException if it cannot reach the Sierra Api") {
+  it("does not return a SQSReaderGracefulException when the Sierra Api is unreachable") {
     worker = Some(
       new SierraItemsToDynamoWorkerService(
         reader = new SQSReader(sqsClient, SQSConfig(queueUrl, 1.second, 1)),

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/sink/SierraItemRecordMergerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/sink/SierraItemRecordMergerTest.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.utils.JsonUtil
 
 class SierraItemRecordMergerTest extends FunSpec with Matchers {
 
-  it("should combine the bibIds in the final result") {
+  it("combines the bibIds in the final result") {
     val oldRecord = sierraItemRecord(bibIds = List("1", "2", "3"))
     val newRecord = sierraItemRecord(bibIds = List("1", "2", "3", "4", "5"))
 
@@ -18,7 +18,7 @@ class SierraItemRecordMergerTest extends FunSpec with Matchers {
     mergedRecord.unlinkedBibIds shouldEqual List()
   }
 
-  it("should record unlinked bibIds") {
+  it("records unlinked bibIds") {
     val oldRecord = sierraItemRecord(bibIds = List("1", "2", "3"))
     val newRecord = sierraItemRecord(bibIds = List("3", "4", "5"))
 
@@ -28,7 +28,7 @@ class SierraItemRecordMergerTest extends FunSpec with Matchers {
     mergedRecord.unlinkedBibIds shouldEqual List("1", "2")
   }
 
-  it("should preserve existing unlinked bibIds") {
+  it("preserves existing unlinked bibIds") {
     val oldRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
                                      unlinkedBibIds = List("4", "5"))
     val newRecord = sierraItemRecord(bibIds = List("1", "2", "3"))
@@ -38,7 +38,7 @@ class SierraItemRecordMergerTest extends FunSpec with Matchers {
     mergedRecord.unlinkedBibIds shouldEqual List("4", "5")
   }
 
-  it("should not duplicate unlinked bibIds") {
+  it("does not duplicate unlinked bibIds") {
     // This would be an unusual scenario to arise, but check we handle it anyway!
     val oldRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
                                      unlinkedBibIds = List("3"))
@@ -50,7 +50,7 @@ class SierraItemRecordMergerTest extends FunSpec with Matchers {
     mergedRecord.unlinkedBibIds shouldEqual List("3")
   }
 
-  it("should remove an unlinked bibId if it appears on a new record") {
+  it("removes an unlinked bibId if it appears on a new record") {
     val oldRecord =
       sierraItemRecord(bibIds = List(), unlinkedBibIds = List("1", "2", "3"))
     val newRecord = sierraItemRecord(bibIds = List("1", "2"))

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/sink/SierraItemsDynamoSinkTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/sink/SierraItemsDynamoSinkTest.scala
@@ -47,7 +47,7 @@ class SierraItemsDynamoSinkTest
     super.afterAll()
   }
 
-  it("should ingest a json into DynamoDB") {
+  it("ingests a json into DynamoDB") {
     val id = "100001"
     val updatedDate = "2013-12-13T12:43:16Z"
     val json = parse(s"""
@@ -78,7 +78,7 @@ class SierraItemsDynamoSinkTest
     }
   }
 
-  it("should be able to handle deleted items") {
+  it("can handle deleted items") {
     val id = "1357947"
     val deletedDate = "2014-01-31"
     val json = parse(s"""{
@@ -102,7 +102,7 @@ class SierraItemsDynamoSinkTest
     }
   }
 
-  it("should not overwrite new data with old data") {
+  it("does not overwrite new data with old data") {
     val id = "200002"
     val oldUpdatedDate = "2001-01-01T00:00:01Z"
     val newUpdatedDate = "2017-12-12T23:59:59Z"
@@ -132,7 +132,7 @@ class SierraItemsDynamoSinkTest
     }
   }
 
-  it("should overwrite old data with new data") {
+  it("overwrites old data with new data") {
     val id = "300003"
     val oldUpdatedDate = "2001-01-01T01:01:01Z"
     val newUpdatedDate = "2011-11-11T11:11:11Z"
@@ -168,7 +168,7 @@ class SierraItemsDynamoSinkTest
     }
   }
 
-  it("should record unlinked bibIds") {
+  it("records unlinked bibIds") {
     val id = "300003"
     val oldUpdatedDate = "2001-01-01T01:01:01Z"
     val newUpdatedDate = "2011-11-11T11:11:11Z"
@@ -204,7 +204,7 @@ class SierraItemsDynamoSinkTest
     }
   }
 
-  it("should add new bibIds and record unlinked bibIds in the same update") {
+  it("adds new bibIds and records unlinked bibIds in the same update") {
     val id = "300003"
     val oldUpdatedDate = "2001-01-01T01:01:01Z"
     val newUpdatedDate = "2011-11-11T11:11:11Z"
@@ -240,7 +240,7 @@ class SierraItemsDynamoSinkTest
     }
   }
 
-  it("should preserve existing unlinked bibIds in DynamoDB") {
+  it("preserves existing unlinked bibIds in DynamoDB") {
     val id = "300003"
     val oldUpdatedDate = "2001-01-01T01:01:01Z"
     val newUpdatedDate = "2011-11-11T11:11:11Z"
@@ -276,7 +276,7 @@ class SierraItemsDynamoSinkTest
     }
   }
 
-  it("should fail the stream if the record contains invalid JSON") {
+  it("fails the stream if the record contains invalid JSON") {
     val invalidSierraJson = parse(s"""
          |{
          |  "missing": ["id", "updatedDate"],
@@ -291,7 +291,7 @@ class SierraItemsDynamoSinkTest
     }
   }
 
-  it("should fail the stream if DynamoDB Put returns an error") {
+  it("fails the stream if DynamoDB Put returns an error") {
     val json = parse(s"""
          |{
          | "id": "500005",
@@ -317,7 +317,7 @@ class SierraItemsDynamoSinkTest
     }
   }
 
-  it("should fail the stream if a DynamoDB GetItem returns an error") {
+  it("fails the stream if a DynamoDB GetItem returns an error") {
     val json = parse(s"""
          |{
          | "id": "50505",
@@ -340,7 +340,7 @@ class SierraItemsDynamoSinkTest
     }
   }
 
-  it("should prepend a I to item IDs") {
+  it("prepends a 'i' to item IDs") {
     val json = parse(s"""
       |{
       |  "id": "6000006",


### PR DESCRIPTION
### What is this PR trying to achieve?

The word "should" is redundant in test definitions. It can safely be removed.

### Who is this change for?

☯️ 🏡 
