### PR TITLE
Two code cleanups for the Sierra adapters

### DIFF
--- a/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/modules/SierraDynamoConfigModule.scala
+++ b/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/modules/SierraDynamoConfigModule.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.sierra_adapter.modules
+package uk.ac.wellcome.sierra_adapter.modules
 
 import com.google.inject.Provides
 import uk.ac.wellcome.finatra.modules.DynamoConfigModule

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/Server.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/Server.scala
@@ -10,7 +10,7 @@ import com.twitter.finatra.http.filters.{
 import com.twitter.finatra.http.routing.HttpRouter
 import uk.ac.wellcome.finatra.modules._
 import uk.ac.wellcome.finatra.controllers.ManagementController
-import uk.ac.wellcome.platform.sierra_adapter.modules.SierraDynamoConfigModule
+import uk.ac.wellcome.sierra_adapter.modules.SierraDynamoConfigModule
 import uk.ac.wellcome.platform.sierra_bib_merger.modules.SierraBibMergerModule
 
 object ServerMain extends Server

--- a/sierra_adapter/sierra_bibs_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/Server.scala
+++ b/sierra_adapter/sierra_bibs_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/Server.scala
@@ -10,7 +10,7 @@ import com.twitter.finatra.http.filters.{
 import com.twitter.finatra.http.routing.HttpRouter
 import uk.ac.wellcome.finatra.modules._
 import uk.ac.wellcome.finatra.controllers.ManagementController
-import uk.ac.wellcome.platform.sierra_adapter.modules.SierraDynamoConfigModule
+import uk.ac.wellcome.sierra_adapter.modules.SierraDynamoConfigModule
 import uk.ac.wellcome.platform.sierra_bibs_to_dynamo.modules.SierraBibsToDynamoModule
 
 object ServerMain extends Server

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/Server.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/Server.scala
@@ -10,7 +10,7 @@ import com.twitter.finatra.http.filters.{
 import com.twitter.finatra.http.routing.HttpRouter
 import uk.ac.wellcome.finatra.modules._
 import uk.ac.wellcome.finatra.controllers.ManagementController
-import uk.ac.wellcome.platform.sierra_adapter.modules.SierraDynamoConfigModule
+import uk.ac.wellcome.sierra_adapter.modules.SierraDynamoConfigModule
 import uk.ac.wellcome.platform.sierra_item_merger.modules.SierraItemMergerModule
 
 object ServerMain extends Server

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/Server.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/Server.scala
@@ -9,7 +9,7 @@ import com.twitter.finatra.http.filters.{
 }
 import com.twitter.finatra.http.routing.HttpRouter
 import uk.ac.wellcome.finatra.modules._
-import uk.ac.wellcome.platform.sierra_adapter.modules.SierraDynamoConfigModule
+import uk.ac.wellcome.sierra_adapter.modules.SierraDynamoConfigModule
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.controllers.ManagementController
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.modules.SierraItemsToDynamoModule
 


### PR DESCRIPTION
* Fix namespacing of the DynamoConfig module
* Use the ManagementController from the shared lib