### PR TITLE
[DO NOT MERGE] Add alarms for healthy/unhealthy hosts in the Romulus API

### DIFF
--- a/catalogue_api/terraform/services.tf
+++ b/catalogue_api/terraform/services.tf
@@ -8,7 +8,7 @@ data "template_file" "es_cluster_host_romulus" {
 }
 
 module "api_romulus_v1" {
-  source             = "git::https://github.com/wellcometrust/terraform.git//service?ref=v5.0.2"
+  source             = "git::https://github.com/wellcometrust/terraform.git//ecs/service?ref=new-alarms4"
   name               = "api_romulus_v1"
   cluster_id         = "${aws_ecs_cluster.api.id}"
   vpc_id             = "${module.vpc_api.vpc_id}"
@@ -23,7 +23,7 @@ module "api_romulus_v1" {
   alb_priority = "114"
   host_name    = "${var.production_api == "romulus" ? var.api_host : var.api_host_stage}"
 
-  enable_alb_alarm = "${var.production_api == "romulus" ? 1 : 0}"
+  enable_alb_alarm = "1" #"${var.production_api == "romulus" ? 1 : 0}"
 
   cpu    = 1024
   memory = 2048

--- a/catalogue_api/terraform/variables.tf
+++ b/catalogue_api/terraform/variables.tf
@@ -59,12 +59,12 @@ variable "pinned_romulus_api_nginx" {
 
 variable "pinned_remus_api" {
   description = "Which version of the API image to pin remus to, if any"
-  default     = ""
+  default     = "258770078cf085f97138193337bdfedb869a98d3"
 }
 
 variable "pinned_remus_api_nginx" {
   description = "Which version of the nginx API image to pin remus to, if any"
-  default     = ""
+  default     = "4d0b58c7cd5feefbe77637f7fcda0d93b645e11b"
 }
 
 variable "api_task_count_stage" {


### PR DESCRIPTION
This is a realisation of https://github.com/wellcometrust/terraform-modules/pull/35

It manifests as a Slack alarm, for example:

![screen shot 2017-12-22 at 14 04 54](https://user-images.githubusercontent.com/301220/34300694-212d28a6-e721-11e7-814c-5e4552d286ca.png)

So we’ll have more insight into when a new task definition has failed to deploy.

Relates: #1304.

### Don’t merge this yet

* I don’t want to be fiddling with the API stack right before Christmas
* The alarms are based on the desired counts set in Terraform; right now we adjust them in the API manually

We probably want to get at least #1316 sorted, and maybe #1317 to simplify matters.

### Who is this change for?

📉 🚨 📈  

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.