### PR TITLE
Extend the timeout of the window_generator Lambda

### DIFF
--- a/sierra_adapter/terraform/sierra_window_generator/lambdas.tf
+++ b/sierra_adapter/terraform/sierra_window_generator/lambdas.tf
@@ -6,6 +6,7 @@ module "lambda_sierra_window_generator" {
   description     = "Generate windows of a specified length and push them to sns"
   name            = "sierra_window_generator_${var.resource_type}"
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  timeout         = 10
 
   environment_variables = {
     "TOPIC_ARN"             = "${module.topic_sierra_windows.arn}"


### PR DESCRIPTION
We had one warning from the Sierra pipeline in Slack overnight:

> **lambda-sierra_bibs_window_generator-errors**
> Threshold Crossed: 1 datapoint [1.0 (02/01/18 22:32:00)] was greater than or equal to the threshold (1.0).
>
> **CloudWatch messages**
> Task timed out after 3.00 seconds
>
> http://amzn.to/2lIQ6DR / http://amzn.to/2CvVbty

Make it not be so!

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.