### PR TITLE
Make the result type configurable in our Dynamo to SNS Lambda

### DIFF
--- a/shared_infra/dynamo_to_sns/main.tf
+++ b/shared_infra/dynamo_to_sns/main.tf
@@ -8,7 +8,8 @@ module "lambda_dynamo_to_sns" {
   memory_size = 1024
 
   environment_variables = {
-    TOPIC_ARN = "${var.dst_topic_arn}"
+    TOPIC_ARN        = "${var.dst_topic_arn}"
+    STREAM_VIEW_TYPE = "${var.stream_view_type}"
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"

--- a/shared_infra/dynamo_to_sns/src/conftest.py
+++ b/shared_infra/dynamo_to_sns/src/conftest.py
@@ -3,7 +3,7 @@
 import os
 
 import boto3
-from moto import mock_ec2, mock_autoscaling, mock_ecs, mock_sns, mock_sqs
+from moto import mock_sns, mock_sqs
 import pytest
 
 

--- a/shared_infra/dynamo_to_sns/src/conftest.py
+++ b/shared_infra/dynamo_to_sns/src/conftest.py
@@ -1,3 +1,7 @@
+# -*- encoding: utf-8 -*-
+
+import os
+
 import boto3
 from moto import mock_ec2, mock_autoscaling, mock_ecs, mock_sns, mock_sqs
 import pytest
@@ -18,30 +22,38 @@ def set_region():
 
 @pytest.fixture()
 def moto_start(set_region):
-    mock_autoscaling().start()
-    mock_ec2().start()
-    mock_ecs().start()
     mock_sns().start()
     mock_sqs().start()
     yield
-    mock_autoscaling().stop()
-    mock_ec2().stop()
-    mock_ecs().stop()
     mock_sns().stop()
     mock_sqs().stop()
 
 
 @pytest.fixture()
-def sns_sqs(set_region, moto_start):
+def topic_arn(moto_start):
+    fake_sns_client = boto3.client('sns')
+    topic_name = "test-topic"
+
+    print(f'Creating topic {topic_name}')
+    fake_sns_client.create_topic(Name=topic_name)
+    response = fake_sns_client.list_topics()
+
+    topic_arn = response['Topics'][0]['TopicArn']
+
+    # DynamoToSNS reads its topic ARN from the environment, so we'll just
+    # set it here.
+    os.environ = {
+        'TOPIC_ARN': topic_arn
+    }
+
+    yield topic_arn
+
+
+@pytest.fixture()
+def queue_url(set_region, moto_start, topic_arn):
     fake_sns_client = boto3.client('sns')
     fake_sqs_client = boto3.client('sqs')
     queue_name = "test-queue"
-    topic_name = "test-topic"
-    print(f"Creating topic {topic_name} and queue {queue_name}")
-
-    fake_sns_client.create_topic(Name=topic_name)
-    response = fake_sns_client.list_topics()
-    topic_arn = response["Topics"][0]['TopicArn']
 
     queue = fake_sqs_client.create_queue(QueueName=queue_name)
 
@@ -50,4 +62,4 @@ def sns_sqs(set_region, moto_start):
         Protocol="sqs",
         Endpoint=f"arn:aws:sqs:eu-west-1:123456789012:{queue_name}"
     )
-    yield topic_arn, queue['QueueUrl']
+    yield queue['QueueUrl']

--- a/shared_infra/dynamo_to_sns/src/conftest.py
+++ b/shared_infra/dynamo_to_sns/src/conftest.py
@@ -42,9 +42,7 @@ def topic_arn(moto_start):
 
     # DynamoToSNS reads its topic ARN from the environment, so we'll just
     # set it here.
-    os.environ = {
-        'TOPIC_ARN': topic_arn
-    }
+    os.environ.update({'TOPIC_ARN': topic_arn})
 
     yield topic_arn
 

--- a/shared_infra/dynamo_to_sns/src/dynamo_to_sns.py
+++ b/shared_infra/dynamo_to_sns/src/dynamo_to_sns.py
@@ -38,7 +38,7 @@ def get_sns_messages(trigger_event, stream_view_type):
             )
 
 
-def main(event, _):
+def main(event, context):
     print(f'Received event: {event!r}')
 
     topic_arn = os.environ['TOPIC_ARN']

--- a/shared_infra/dynamo_to_sns/src/dynamo_to_sns.py
+++ b/shared_infra/dynamo_to_sns/src/dynamo_to_sns.py
@@ -1,7 +1,6 @@
 # -*- encoding: utf-8 -*-
 """
-Receives DynamoDB events and publishes the new image from
-the event to an SNS topic
+Receives DynamoDB events and publishes the event to an SNS topic.
 """
 
 import os
@@ -12,21 +11,26 @@ from wellcome_aws_utils.dynamo_event import create_dynamo_events
 from wellcome_aws_utils.sns_utils import publish_sns_message
 
 
-def main(event, _):
-    print(f'Received event:\n{event}')
-
-    sns_client = boto3.client('sns')
-    topic_arn = os.environ['TOPIC_ARN']
-
+def get_sns_messages(dynamo_event):
+    """Given a DynamoDB Stream event, generate messages for sending to SNS."""
     for dynamo_event in create_dynamo_events(event):
-        print(dynamo_event)
-        parsed_event = {
+        yield {
             'event_type': dynamo_event.event_type.name,
             'old_image': dynamo_event.old_image(deserialize_values=True),
             'new_image': dynamo_event.new_image(deserialize_values=True),
         }
+
+
+def main(event, _):
+    print(f'Received event:\n{event}')
+
+    topic_arn = os.environ['TOPIC_ARN']
+
+    sns_client = boto3.client('sns')
+
+    for message in get_sns_messages(dynamo_event=event):
         publish_sns_message(
+            sns_client=sns_client,
             topic_arn=topic_arn,
-            message=parsed_event,
-            sns_client=sns_client
+            message=message
         )

--- a/shared_infra/dynamo_to_sns/src/dynamo_to_sns.py
+++ b/shared_infra/dynamo_to_sns/src/dynamo_to_sns.py
@@ -11,24 +11,45 @@ from wellcome_aws_utils.dynamo_event import create_dynamo_events
 from wellcome_aws_utils.sns_utils import publish_sns_message
 
 
-def get_sns_messages(dynamo_event):
-    """Given a DynamoDB Stream event, generate messages for sending to SNS."""
-    for dynamo_event in create_dynamo_events(event):
-        yield {
-            'event_type': dynamo_event.event_type.name,
-            'old_image': dynamo_event.old_image(deserialize_values=True),
-            'new_image': dynamo_event.new_image(deserialize_values=True),
-        }
+def get_sns_messages(trigger_event, stream_view_type):
+    """Given a DynamoDB Stream event, generate messages for sending to SNS.
+
+    ``stream_view_type`` must be one of the following values:
+
+    -   FULL_EVENT, which has "event_type", "old_image" and "new_image" keys
+    -   NEW_IMAGE_ONLY or OLD_IMAGE_ONLY, which post the corresponding image
+        directly into SNS.
+
+    """
+    for dynamo_event in create_dynamo_events(trigger_event):
+        if stream_view_type == 'FULL_EVENT':
+            yield {
+                'event_type': dynamo_event.event_type.name,
+                'old_image': dynamo_event.old_image(deserialize_values=True),
+                'new_image': dynamo_event.new_image(deserialize_values=True),
+            }
+        elif stream_view_type == 'OLD_IMAGE_ONLY':
+            yield dynamo_event.old_image(deserialize_values=True)
+        elif stream_view_type == 'NEW_IMAGE_ONLY':
+            yield dynamo_event.new_image(deserialize_values=True)
+        else:
+            raise ValueError(
+                f"Unrecognised stream view type: {stream_view_type!r}"
+            )
 
 
 def main(event, _):
-    print(f'Received event:\n{event}')
+    print(f'Received event: {event!r}')
 
     topic_arn = os.environ['TOPIC_ARN']
+    stream_view_type = os.environ.get('STREAM_VIEW_TYPE', 'FULL_EVENT')
 
     sns_client = boto3.client('sns')
 
-    for message in get_sns_messages(dynamo_event=event):
+    for message in get_sns_messages(
+        trigger_event=event,
+        stream_view_type=stream_view_type
+    ):
         publish_sns_message(
             sns_client=sns_client,
             topic_arn=topic_arn,

--- a/shared_infra/dynamo_to_sns/src/test_dynamo_to_sns.py
+++ b/shared_infra/dynamo_to_sns/src/test_dynamo_to_sns.py
@@ -11,14 +11,7 @@ import dynamo_to_sns
 TEST_STREAM_ARN = 'arn:aws:dynamodb:eu-west-1:123456789012:table/table-stream'
 
 
-def test_dynamo_to_sns_fails_gracefully_on_remove_event(sns_sqs):
-    sqs_client = boto3.client('sqs')
-    topic_arn, queue_url = sns_sqs
-
-    os.environ = {
-        'TOPIC_ARN': topic_arn
-    }
-
+def test_dynamo_to_sns_fails_gracefully_on_remove_event(topic_arn, queue_url):
     old_image = {
         'MiroID': {'S': 'V0000001'},
         'MiroCollection': {'S': 'Images-V'},
@@ -47,11 +40,7 @@ def test_dynamo_to_sns_fails_gracefully_on_remove_event(sns_sqs):
     )
 
 
-def test_dynamo_to_sns(sns_sqs):
-    sqs_client = boto3.client('sqs')
-    topic_arn, queue_url = sns_sqs
-    stream_arn = 'arn:aws:dynamodb:eu-west-1:123456789012:table/table-stream'
-
+def test_dynamo_to_sns(topic_arn, queue_url):
     new_image = {
         'ReindexVersion': {'N': '0'},
         'ReindexShard': {'S': 'default'},
@@ -76,10 +65,6 @@ def test_dynamo_to_sns(sns_sqs):
         'Records': [
             _dynamo_event(event_name='MODIFY', new_image=new_image)
         ]
-    }
-
-    os.environ = {
-        'TOPIC_ARN': topic_arn
     }
 
     dynamo_to_sns.main(event, None)

--- a/shared_infra/dynamo_to_sns/src/test_dynamo_to_sns.py
+++ b/shared_infra/dynamo_to_sns/src/test_dynamo_to_sns.py
@@ -71,14 +71,18 @@ def _dynamo_event(event_name, old_image=None, new_image=None):
     return event_data
 
 
-@pytest.mark.parametrize('input_event, expected_message', [
+@pytest.mark.parametrize('input_event, expected_message, stream_view_type', [
+
+    # These two tests simulate the old behaviour, when we didn't have a
+    # STREAM_VIEW_TYPE variable.
     (
         _dynamo_event(event_name='MODIFY', new_image=NEW_IMAGE),
         {
             'event_type': 'MODIFY',
             'old_image': None,
             'new_image': NEW_IMAGE_DATA
-        }
+        },
+        None
     ),
     (
         _dynamo_event(event_name='REMOVE', old_image=OLD_IMAGE),
@@ -87,9 +91,49 @@ def _dynamo_event(event_name, old_image=None, new_image=None):
             'old_image': OLD_IMAGE_DATA,
             'new_image': None
         },
+        None
+    ),
+
+    # Then we replay exactly the same test events, but this time setting the
+    # view type explicitly.
+    (
+        _dynamo_event(event_name='MODIFY', new_image=NEW_IMAGE),
+        {
+            'event_type': 'MODIFY',
+            'old_image': None,
+            'new_image': NEW_IMAGE_DATA
+        },
+        'FULL_EVENT'
+    ),
+    (
+        _dynamo_event(event_name='REMOVE', old_image=OLD_IMAGE),
+        {
+            'event_type': 'REMOVE',
+            'old_image': OLD_IMAGE_DATA,
+            'new_image': None
+        },
+        'FULL_EVENT'
+    ),
+
+    # And now we play a couple of tests with different view types, to check
+    # they behave correctly.
+    (
+        _dynamo_event(event_name='REMOVE', old_image=OLD_IMAGE),
+        OLD_IMAGE_DATA,
+        'OLD_IMAGE_ONLY'
+    ),
+    (
+        _dynamo_event(event_name='REMOVE', new_image=NEW_IMAGE),
+        NEW_IMAGE_DATA,
+        'NEW_IMAGE_ONLY'
     ),
 ])
-def test_end_to_end_feature_test(queue_url, input_event, expected_message):
+def test_end_to_end_feature_test(
+    queue_url, input_event, expected_message, stream_view_type
+):
+    if stream_view_type is not None:
+        os.environ.update({'STREAM_VIEW_TYPE': stream_view_type})
+
     event = {'Records': [input_event]}
     dynamo_to_sns.main(event=event, context=None)
 
@@ -97,6 +141,16 @@ def test_end_to_end_feature_test(queue_url, input_event, expected_message):
         expected_message=expected_message,
         queue_url=queue_url
     )
+
+
+def test_invalid_stream_view_type_is_error():
+    input_event = _dynamo_event(event_name='REMOVE', old_image=OLD_IMAGE)
+    os.environ.update({'STREAM_VIEW_TYPE': 'NOTAREALSTREAMVIEWTYPE'})
+
+    event = {'Records': [input_event]}
+
+    with pytest.raises(ValueError):
+        dynamo_to_sns.main(event=event, context=None)
 
 
 def _assert_sqs_has_message(expected_message, queue_url):

--- a/shared_infra/dynamo_to_sns/src/test_dynamo_to_sns.py
+++ b/shared_infra/dynamo_to_sns/src/test_dynamo_to_sns.py
@@ -11,39 +11,6 @@ import dynamo_to_sns
 TEST_STREAM_ARN = 'arn:aws:dynamodb:eu-west-1:123456789012:table/table-stream'
 
 
-def _dynamo_event(event_name, old_image=None, new_image=None):
-    event_data = {
-        'eventID': '87cf2ca0f689908d573fb3698a487bb1',
-        'eventName': event_name,
-        'eventVersion': '1.1',
-        'eventSource': 'aws:dynamodb',
-        'awsRegion': 'eu-west-1',
-        'dynamodb': {
-            'ApproximateCreationDateTime': 1505815200.0,
-            'Keys': {
-                'MiroID': {
-                    'S': 'V0000001'
-                },
-                'MiroCollection': {
-                    'S': 'Images-V'
-                }
-            },
-            'OldImage': old_image,
-            'SequenceNumber': '545308300000000005226392296',
-            'SizeBytes': 36,
-            'StreamViewType': 'OLD_IMAGE'
-        },
-        'eventSourceARN': TEST_STREAM_ARN
-    }
-
-    if old_image is not None:
-        event_data['dynamodb']['OldImage'] = old_image
-    if new_image is not None:
-        event_data['dynamodb']['NewImage'] = new_image
-
-    return event_data
-
-
 def test_dynamo_to_sns_fails_gracefully_on_remove_event(sns_sqs):
     sqs_client = boto3.client('sqs')
     topic_arn, queue_url = sns_sqs
@@ -121,6 +88,39 @@ def test_dynamo_to_sns(sns_sqs):
         expected_messages=[expected_image],
         queue_url=queue_url
     )
+
+
+def _dynamo_event(event_name, old_image=None, new_image=None):
+    event_data = {
+        'eventID': '87cf2ca0f689908d573fb3698a487bb1',
+        'eventName': event_name,
+        'eventVersion': '1.1',
+        'eventSource': 'aws:dynamodb',
+        'awsRegion': 'eu-west-1',
+        'dynamodb': {
+            'ApproximateCreationDateTime': 1505815200.0,
+            'Keys': {
+                'MiroID': {
+                    'S': 'V0000001'
+                },
+                'MiroCollection': {
+                    'S': 'Images-V'
+                }
+            },
+            'OldImage': old_image,
+            'SequenceNumber': '545308300000000005226392296',
+            'SizeBytes': 36,
+            'StreamViewType': 'OLD_IMAGE'
+        },
+        'eventSourceARN': TEST_STREAM_ARN
+    }
+
+    if old_image is not None:
+        event_data['dynamodb']['OldImage'] = old_image
+    if new_image is not None:
+        event_data['dynamodb']['NewImage'] = new_image
+
+    return event_data
 
 
 def _assert_sqs_has_messages(expected_messages, queue_url):

--- a/shared_infra/dynamo_to_sns/variables.tf
+++ b/shared_infra/dynamo_to_sns/variables.tf
@@ -7,4 +7,8 @@ variable "batch_size" {
   default = 50
 }
 
+variable "stream_view_type" {
+  default = "FULL_EVENT"
+}
+
 variable "lambda_error_alarm_arn" {}


### PR DESCRIPTION
Spun out as a smaller patch from #1345.

> Give a way for the user to decide what we emit – full events (the current behaviour, and the default), or a filtered version with the old/new image only.
>
> Our transformers can only process the new image; we have filters in front of this stream, but when a pile of Sierra updates arrive all at once, we seem to be hitting concurrency limits in AWS Lambda. This lets us to reduce the flood of SNS notifications.
>
> Plus a bunch of tests and test refactoring.
>
> The idea is that, in the Sierra pipeline at least, we can cut out the filter Lambda.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.
