### PR TITLE
Remove some old Loris nginx config

### DIFF
--- a/nginx/loris.nginx.conf
+++ b/nginx/loris.nginx.conf
@@ -31,25 +31,6 @@ http {
 
     add_header Cache-Control "max-age=31536000;";
 
-    # A while back, the Collection site started serving all content through
-    # Loris, but requesting JPG format.  This breaks when you request a
-    # transparent PNG, because it falls over trying to fill in the transparent
-    # regions, which triggers a 500 alarm in Slack.
-    #
-    # But those URLs don't exist any more, right?
-    #
-    # Nope, Bingbot keeps requesting them.  So this is meant to shut it up,
-    # eventually we'll remove these, but 410s should tell it to go away.
-    location /image/wordpress:2016/12/victoria_and_albert_christmas_tree.png/full/320,/0/default.jpg {
-      return 410;
-    }
-    location /image/wordpress:2016/04/viral-nova.png/full/320,/0/default.jpg {
-      return 410;
-    }
-    location /image/wordpress:2016/08/jelly-bean.png/full/30,/0/default.jpg {
-      return 410;
-    }
-
     # Requests for iiif.wellcomecollection.org/image should be forwarded to our IIIF Image API, Loris
     #
     # Wellcome Collection V images are currenly hosted in an s3 bucket and


### PR DESCRIPTION
This deletes some old Loris nginx config, for two reasons:

1. It doesn’t actually work.
2. It was meant to shut up Bingbot requesting old PNGs as JPEGs and causing alarms in Slack. It seems to have gone away of its own accord, so we don’t need this fix (working or otherwise!).