### PR TITLE
Reduce log spam when we hit a ConditionalCheckFailedException

### DIFF
--- a/sierra_adapter/sierra_bibs_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/sink/SierraBibsDynamoSink.scala
+++ b/sierra_adapter/sierra_bibs_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/sink/SierraBibsDynamoSink.scala
@@ -50,7 +50,8 @@ object SierraBibsDynamoSink extends Logging {
         case Right(_) =>
           logger.info(s"Successfully saved ${record.id} to DynamoDB")
         case Left(error: ConditionalCheckFailedException) =>
-          logger.info(s"Conditional check failed saving ${record.id} to DynamoDB")
+          logger.info(
+            s"Conditional check failed saving ${record.id} to DynamoDB")
         case Left(error) =>
           logger.warn(s"Failed saving ${record.id} to DynamoDB", error)
       }

--- a/sierra_adapter/sierra_bibs_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/sink/SierraBibsDynamoSink.scala
+++ b/sierra_adapter/sierra_bibs_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/sink/SierraBibsDynamoSink.scala
@@ -6,6 +6,7 @@ import java.time.{LocalDate, ZoneOffset}
 import akka.Done
 import akka.stream.scaladsl.Sink
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
 import com.gu.scanamo.syntax._
 import com.gu.scanamo.{Scanamo, Table}
 import com.twitter.inject.Logging
@@ -47,9 +48,11 @@ object SierraBibsDynamoSink extends Logging {
         .put(record)
       Scanamo.exec(client)(ops) match {
         case Right(_) =>
-          logger.info(s"${json.noSpaces} saved successfully to DynamoDB")
+          logger.info(s"Successfully saved ${record.id} to DynamoDB")
+        case Left(error: ConditionalCheckFailedException) =>
+          logger.info(s"Conditional check failed saving ${record.id} to DynamoDB")
         case Left(error) =>
-          logger.warn(s"Failed saving ${json.noSpaces} into DynamoDB", error)
+          logger.warn(s"Failed saving ${record.id} to DynamoDB", error)
       }
     })
 

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/dynamo/SierraItemRecordDao.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/dynamo/SierraItemRecordDao.scala
@@ -43,7 +43,8 @@ class SierraItemRecordDao @Inject()(dynamoDbClient: AmazonDynamoDB,
       case Right(_) =>
         debug(s"Successfully saved item ${sierraItemRecord.id} to DynamoDB")
       case Left(error: ConditionalCheckFailedException) =>
-        info(s"Conditional check failed saving ${sierraItemRecord.id} to DynamoDB")
+        info(
+          s"Conditional check failed saving ${sierraItemRecord.id} to DynamoDB")
       case Left(error) =>
         warn(s"Failed saving ${sierraItemRecord.id} to DynamoDB", error)
     }

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/dynamo/SierraItemRecordDao.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/dynamo/SierraItemRecordDao.scala
@@ -41,9 +41,11 @@ class SierraItemRecordDao @Inject()(dynamoDbClient: AmazonDynamoDB,
         )
         .put(sierraItemRecord)) match {
       case Right(_) =>
-        debug(s"Successfully inserted item ${sierraItemRecord.id}")
+        debug(s"Successfully saved item ${sierraItemRecord.id} to DynamoDB")
+      case Left(error: ConditionalCheckFailedException) =>
+        info(s"Conditional check failed saving ${sierraItemRecord.id} to DynamoDB")
       case Left(error) =>
-        warn(s"Failed saving ${sierraItemRecord.id} into DynamoDB", error)
+        warn(s"Failed saving ${sierraItemRecord.id} to DynamoDB", error)
     }
   }
 

--- a/sierra_adapter/terraform/pipeline/services.tf
+++ b/sierra_adapter/terraform/pipeline/services.tf
@@ -13,10 +13,10 @@ module "sierra_to_dynamo_service" {
 
     dynamo_table_name = "${aws_dynamodb_table.sierra_table.id}"
 
-    sierra_api_url       = "${var.sierra_api_url}"
-    sierra_oauth_key     = "${var.sierra_oauth_key}"
-    sierra_oauth_secret  = "${var.sierra_oauth_secret}"
-    sierra_fields        = "${var.sierra_fields}"
+    sierra_api_url      = "${var.sierra_api_url}"
+    sierra_oauth_key    = "${var.sierra_oauth_key}"
+    sierra_oauth_secret = "${var.sierra_oauth_secret}"
+    sierra_fields       = "${var.sierra_fields}"
   }
 
   env_vars_length = 7


### PR DESCRIPTION
Whenever we throw a ConditionalCheckFailedException in the sierra_to_dynamo apps, we get a long traceback in the logs:

```
14:41:34.895 [ForkJoinPool-1-worker-29] WARN  u.a.w.p.s.dynamo.SierraItemRecordDao - Failed saving i111 into DynamoDB
com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException: The conditional request failed (Service: AmazonDynamoDBv2; Status Code: 400; Error Code: ConditionalCheckFailedException; Request ID: 204e708f-a000-4525-954c-b2e6cb85d26b)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1579)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1249)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1030)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:742)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:716)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:699)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:667)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:649)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:513)
	at com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient.doInvoke(AmazonDynamoDBClient.java:1974)
	at com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient.invoke(AmazonDynamoDBClient.java:1950)
	at com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient.putItem(AmazonDynamoDBClient.java:1331)
	at com.gu.scanamo.ops.ScanamoInterpreters$$anon$1$$anonfun$apply$4.apply(ScanamoInterpreters.scala:36)
	at com.gu.scanamo.ops.ScanamoInterpreters$$anon$1$$anonfun$apply$4.apply(ScanamoInterpreters.scala:36)
	at cats.syntax.CatchOnlyPartiallyApplied.apply(either.scala:294)
	at com.gu.scanamo.ops.ScanamoInterpreters$$anon$1.apply(ScanamoInterpreters.scala:35)
	at com.gu.scanamo.ops.ScanamoInterpreters$$anon$1.apply(ScanamoInterpreters.scala:30)
	at cats.free.Free$$anonfun$foldMap$1.apply(Free.scala:126)
	at cats.free.Free$$anonfun$foldMap$1.apply(Free.scala:124)
	at cats.package$$anon$1.tailRecM(package.scala:36)
	at cats.free.Free.foldMap(Free.scala:124)
	at com.gu.scanamo.Scanamo$.exec(Scanamo.scala:17)
	at uk.ac.wellcome.platform.sierra_items_to_dynamo.dynamo.SierraItemRecordDao$$anonfun$updateItem$1.apply$mcV$sp(SierraItemRecordDao.scala:36)
	at uk.ac.wellcome.platform.sierra_items_to_dynamo.dynamo.SierraItemRecordDao$$anonfun$updateItem$1.apply(SierraItemRecordDao.scala:36)
	at uk.ac.wellcome.platform.sierra_items_to_dynamo.dynamo.SierraItemRecordDao$$anonfun$updateItem$1.apply(SierraItemRecordDao.scala:36)
	at scala.concurrent.impl.Future$PromiseCompletingRunnable.liftedTree1$1(Future.scala:24)
	at scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:24)
	at scala.concurrent.impl.ExecutionContextImpl$AdaptedForkJoinTask.exec(ExecutionContextImpl.scala:121)
	at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```

But this is a benign error!

This patch gives a different log for this error only, so it’s easier to distinguish genuine errors when reading the logs. It also makes it faster to skim logs of a service that’s working correctly.

Now you get a single line log:

```
14:38:44.775 [default-akka.actor.default-dispatcher-7] INFO  u.a.w.p.s.sink.SierraBibsDynamoSink$ - Conditional check failed saving {"id":"b200002","updatedDate":"2001-01-01T00:00:01Z","comment":"I am an old record"} to DynamoDB
```