### PR TITLE
Rename mergedsierrarecord sierratransformable

### DIFF
--- a/catalogue_pipeline/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
+++ b/catalogue_pipeline/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
@@ -12,7 +12,11 @@ import uk.ac.wellcome.models.Reindex
 import uk.ac.wellcome.models.transformable.CalmTransformable
 import uk.ac.wellcome.platform.reindexer.Server
 import uk.ac.wellcome.platform.reindexer.models.ReindexAttempt
-import uk.ac.wellcome.platform.reindexer.services.{CalmReindexTargetService, ReindexService, ReindexTargetService}
+import uk.ac.wellcome.platform.reindexer.services.{
+  CalmReindexTargetService,
+  ReindexService,
+  ReindexTargetService
+}
 import uk.ac.wellcome.platform.reindexer.locals.DynamoDBLocal
 import uk.ac.wellcome.test.utils.{AmazonCloudWatchFlag, ExtendedPatience}
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/parsers/SierraParser.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/parsers/SierraParser.scala
@@ -1,12 +1,12 @@
 package uk.ac.wellcome.transformer.parsers
 
-import uk.ac.wellcome.models.transformable.{MergedSierraRecord, Transformable}
+import uk.ac.wellcome.models.transformable.{SierraTransformable, Transformable}
 import uk.ac.wellcome.utils.JsonUtil
 
 import scala.util.Try
 
-class SierraParser extends TransformableParser[MergedSierraRecord] {
+class SierraParser extends TransformableParser[SierraTransformable] {
   override def readFromRecord(
     transformableAsJson: String): Try[Transformable] =
-    JsonUtil.fromJson[MergedSierraRecord](transformableAsJson)
+    JsonUtil.fromJson[SierraTransformable](transformableAsJson)
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/CalmTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/CalmTransformableTransformer.scala
@@ -1,6 +1,10 @@
 package uk.ac.wellcome.transformer.transformers
 
-import uk.ac.wellcome.models.transformable.{CalmTransformable, CalmTransformableData, Transformable}
+import uk.ac.wellcome.models.transformable.{
+  CalmTransformable,
+  CalmTransformableData,
+  Transformable
+}
 import uk.ac.wellcome.models._
 import uk.ac.wellcome.utils.JsonUtil
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.transformer.transformers
 
 import uk.ac.wellcome.models._
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
+import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.utils.JsonUtil
 
 import scala.util.{Success, Try}
@@ -9,9 +9,9 @@ import scala.util.{Success, Try}
 case class SierraBibData(id: String, title: String)
 
 class SierraTransformableTransformer
-    extends TransformableTransformer[MergedSierraRecord] {
+    extends TransformableTransformer[SierraTransformable] {
   override def transformForType(
-    sierraTransformable: MergedSierraRecord): Try[Option[Work]] =
+    sierraTransformable: SierraTransformable): Try[Option[Work]] =
     sierraTransformable.maybeBibData
       .map { bibData =>
         JsonUtil.fromJson[SierraBibData](bibData.data).map { sierraBibData =>

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/parsers/SierraParserTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/parsers/SierraParserTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.transformer.parsers
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.transformable.{MergedSierraRecord, Transformable}
+import uk.ac.wellcome.models.transformable.{SierraTransformable, Transformable}
 import uk.ac.wellcome.transformer.utils.TransformableSQSMessageUtils
 import uk.ac.wellcome.utils.JsonUtil
 
@@ -21,9 +21,9 @@ class SierraParserTest
       sierraParser.extractTransformable(sqsMessage)
 
     triedSierraTransformable.isSuccess shouldBe true
-    triedSierraTransformable.get shouldBe a[MergedSierraRecord]
+    triedSierraTransformable.get shouldBe a[SierraTransformable]
     val actualRecord =
-      triedSierraTransformable.get.asInstanceOf[MergedSierraRecord]
+      triedSierraTransformable.get.asInstanceOf[SierraTransformable]
     actualRecord.id shouldEqual id
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -5,7 +5,10 @@ import java.time.Instant.now
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models._
 import uk.ac.wellcome.models.transformable.SierraTransformable
-import uk.ac.wellcome.models.transformable.sierra.{SierraBibRecord, SierraItemRecord}
+import uk.ac.wellcome.models.transformable.sierra.{
+  SierraBibRecord,
+  SierraItemRecord
+}
 
 class SierraTransformableTransformerTest extends FunSpec with Matchers {
   val transformer = new SierraTransformableTransformer

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -4,8 +4,8 @@ import java.time.Instant.now
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models._
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
-import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord
+import uk.ac.wellcome.models.transformable.SierraTransformable
+import uk.ac.wellcome.models.transformable.sierra.{SierraBibRecord, SierraItemRecord}
 
 class SierraTransformableTransformerTest extends FunSpec with Matchers {
   val transformer = new SierraTransformableTransformer
@@ -21,7 +21,7 @@ class SierraTransformableTransformerTest extends FunSpec with Matchers {
          |}
         """.stripMargin
 
-    val mergedSierraRecord = MergedSierraRecord(
+    val sierraTransformable = SierraTransformable(
       id = id,
       maybeBibData =
         Some(SierraBibRecord(id = id, data = data, modifiedDate = now())),
@@ -35,7 +35,7 @@ class SierraTransformableTransformerTest extends FunSpec with Matchers {
       )
     )
 
-    val transformedSierraRecord = transformer.transform(mergedSierraRecord)
+    val transformedSierraRecord = transformer.transform(sierraTransformable)
 
     transformedSierraRecord.isSuccess shouldBe true
     val work = transformedSierraRecord.get.get
@@ -58,10 +58,10 @@ class SierraTransformableTransformerTest extends FunSpec with Matchers {
   }
 
   it("should not perform a transformation without bibData") {
-    val mergedSierraRecord =
-      MergedSierraRecord(id = "000", maybeBibData = None)
+    val sierraTransformable =
+      SierraTransformable(id = "000", maybeBibData = None)
 
-    val transformedSierraRecord = transformer.transform(mergedSierraRecord)
+    val transformedSierraRecord = transformer.transform(sierraTransformable)
     transformedSierraRecord.isSuccess shouldBe true
 
     transformedSierraRecord.get shouldBe None
@@ -69,7 +69,7 @@ class SierraTransformableTransformerTest extends FunSpec with Matchers {
 
   it(
     "should not perform a transformation without bibData, even if some itemData is present") {
-    val mergedSierraRecord = MergedSierraRecord(
+    val sierraTransformable = SierraTransformable(
       id = "b111",
       maybeBibData = None,
       itemData = Map(
@@ -81,7 +81,7 @@ class SierraTransformableTransformerTest extends FunSpec with Matchers {
         ))
     )
 
-    val transformedSierraRecord = transformer.transform(mergedSierraRecord)
+    val transformedSierraRecord = transformer.transform(sierraTransformable)
     transformedSierraRecord.isSuccess shouldBe true
     transformedSierraRecord.get shouldBe None
   }
@@ -97,12 +97,12 @@ class SierraTransformableTransformerTest extends FunSpec with Matchers {
          |}
         """.stripMargin
 
-    val mergedSierraRecord = MergedSierraRecord(
+    val sierraTransformable = SierraTransformable(
       id = id,
       maybeBibData =
         Some(SierraBibRecord(id = id, data = data, modifiedDate = now())))
 
-    val transformedSierraRecord = transformer.transform(mergedSierraRecord)
+    val transformedSierraRecord = transformer.transform(sierraTransformable)
     transformedSierraRecord.isSuccess shouldBe true
 
     val identifier =

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformableSQSMessageUtils.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformableSQSMessageUtils.scala
@@ -3,10 +3,16 @@ package uk.ac.wellcome.transformer.utils
 import java.time.Instant
 
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.models.transformable.{CalmTransformable, SierraTransformable}
+import uk.ac.wellcome.models.transformable.{
+  CalmTransformable,
+  SierraTransformable
+}
 import uk.ac.wellcome.models.transformable.miro.MiroTransformable
 import uk.ac.wellcome.models.SierraItemRecord
-import uk.ac.wellcome.models.transformable.sierra.{SierraBibRecord, SierraItemRecord}
+import uk.ac.wellcome.models.transformable.sierra.{
+  SierraBibRecord,
+  SierraItemRecord
+}
 import uk.ac.wellcome.utils.JsonUtil
 
 trait TransformableSQSMessageUtils {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformableSQSMessageUtils.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformableSQSMessageUtils.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.transformer.utils
 import java.time.Instant
 
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.models.transformable.{CalmTransformable, MergedSierraRecord}
+import uk.ac.wellcome.models.transformable.{CalmTransformable, SierraTransformable}
 import uk.ac.wellcome.models.transformable.miro.MiroTransformable
 import uk.ac.wellcome.models.SierraItemRecord
 import uk.ac.wellcome.models.transformable.sierra.{SierraBibRecord, SierraItemRecord}
@@ -23,13 +23,13 @@ trait TransformableSQSMessageUtils {
   }
 
   def createValidEmptySierraBibSQSMessage(id: String): SQSMessage = {
-    val mergedSierraRecord = MergedSierraRecord(
+    val sierraTransformable = SierraTransformable(
       id = id,
       maybeBibData = None,
       itemData = Map[String, SierraItemRecord]()
     )
 
-    sqsMessage(JsonUtil.toJson(mergedSierraRecord).get)
+    sqsMessage(JsonUtil.toJson(sierraTransformable).get)
   }
 
   def createValidSierraBibSQSMessage(id: String,
@@ -43,13 +43,13 @@ trait TransformableSQSMessageUtils {
          |}
       """.stripMargin
 
-    val mergedSierraRecord = MergedSierraRecord(
+    val sierraTransformable = SierraTransformable(
       id = id,
       maybeBibData = Some(SierraBibRecord(id, data, lastModifiedDate)),
       itemData = Map[String, SierraItemRecord]()
     )
 
-    sqsMessage(JsonUtil.toJson(mergedSierraRecord).get)
+    sqsMessage(JsonUtil.toJson(sierraTransformable).get)
   }
 
   def createValidMiroSQSMessage(data: String): SQSMessage = {

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/Reindexable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/Reindexable.scala
@@ -17,11 +17,10 @@ case class HashKey(keyName: String, keyValue: String)
 case class RangeKey[T](keyName: String, keyValue: T)
 case class ItemIdentifier[T](hashKey: HashKey, rangeKey: RangeKey[T])
 
-
 case class ReindexItem[T](id: ItemIdentifier[T],
                           ReindexShard: String,
                           ReindexVersion: Int)
-  extends Reindexable[T] {
+    extends Reindexable[T] {
 
   def hashKey = Symbol(id.hashKey.keyName) -> id.hashKey.keyValue
   def rangeKey = Symbol(id.rangeKey.keyName) -> id.rangeKey.keyValue

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
@@ -59,7 +59,7 @@ case class MiroTransformable(MiroID: String,
   *     value at any time is unimportant, but it should only ever increase.
   *
   */
-case class MergedSierraRecord(
+case class SierraTransformable(
                                id: String,
                                maybeBibData: Option[SierraBibRecord] = None,
                                itemData: Map[String, SierraItemRecord] = Map[String, SierraItemRecord](),
@@ -67,20 +67,20 @@ case class MergedSierraRecord(
                              ) extends Transformable
 
 
-object MergedSierraRecord {
-  def apply(id: String, bibData: String): MergedSierraRecord = {
+object SierraTransformable {
+  def apply(id: String, bibData: String): SierraTransformable = {
     val bibRecord = JsonUtil.fromJson[SierraBibRecord](bibData).get
-    MergedSierraRecord(id = id, maybeBibData = Some(bibRecord))
+    SierraTransformable(id = id, maybeBibData = Some(bibRecord))
   }
 
-  def apply(bibRecord: SierraBibRecord): MergedSierraRecord =
-    MergedSierraRecord(id = bibRecord.id, maybeBibData = Some(bibRecord))
+  def apply(bibRecord: SierraBibRecord): SierraTransformable =
+    SierraTransformable(id = bibRecord.id, maybeBibData = Some(bibRecord))
 
-  def apply(id: String, itemRecord: SierraItemRecord): MergedSierraRecord =
-    MergedSierraRecord(id = id, itemData = Map(itemRecord.id -> itemRecord))
+  def apply(id: String, itemRecord: SierraItemRecord): SierraTransformable =
+    SierraTransformable(id = id, itemData = Map(itemRecord.id -> itemRecord))
 
-  def apply(bibRecord: SierraBibRecord, version: Int): MergedSierraRecord =
-    MergedSierraRecord(
+  def apply(bibRecord: SierraBibRecord, version: Int): SierraTransformable =
+    SierraTransformable(
       id = bibRecord.id,
       maybeBibData = Some(bibRecord),
       version = version

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
@@ -1,6 +1,9 @@
 package uk.ac.wellcome.models.transformable
 
-import uk.ac.wellcome.models.transformable.sierra.{SierraBibRecord, SierraItemRecord}
+import uk.ac.wellcome.models.transformable.sierra.{
+  SierraBibRecord,
+  SierraItemRecord
+}
 import uk.ac.wellcome.models.{SierraItemRecord, Work}
 import uk.ac.wellcome.utils.JsonUtil
 
@@ -9,20 +12,20 @@ import scala.util.Try
 sealed trait Transformable
 
 case class CalmTransformableData(
-                                  AccessStatus: Array[String]
-                                ) extends Transformable
+  AccessStatus: Array[String]
+) extends Transformable
 
 //TODO add some tests around transformation
 case class CalmTransformable(
-                              RecordID: String,
-                              RecordType: String,
-                              AltRefNo: String,
-                              RefNo: String,
-                              data: String,
-                              ReindexShard: String = "default",
-                              ReindexVersion: Int = 0
-                            ) extends Transformable
-  with Reindexable[String] {
+  RecordID: String,
+  RecordType: String,
+  AltRefNo: String,
+  RefNo: String,
+  data: String,
+  ReindexShard: String = "default",
+  ReindexVersion: Int = 0
+) extends Transformable
+    with Reindexable[String] {
 
   val id: ItemIdentifier[String] = ItemIdentifier(
     HashKey("RecordID", RecordID),
@@ -36,7 +39,7 @@ case class MiroTransformable(MiroID: String,
                              data: String,
                              ReindexShard: String = "default",
                              ReindexVersion: Int = 0)
-  extends Transformable
+    extends Transformable
     with Reindexable[String] {
 
   val id: ItemIdentifier[String] = ItemIdentifier(
@@ -60,12 +63,11 @@ case class MiroTransformable(MiroID: String,
   *
   */
 case class SierraTransformable(
-                               id: String,
-                               maybeBibData: Option[SierraBibRecord] = None,
-                               itemData: Map[String, SierraItemRecord] = Map[String, SierraItemRecord](),
-                               version: Int = 0
-                             ) extends Transformable
-
+  id: String,
+  maybeBibData: Option[SierraBibRecord] = None,
+  itemData: Map[String, SierraItemRecord] = Map[String, SierraItemRecord](),
+  version: Int = 0
+) extends Transformable
 
 object SierraTransformable {
   def apply(id: String, bibData: String): SierraTransformable = {

--- a/common/src/test/scala/uk/ac/wellcome/models/SierraTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/SierraTransformableTest.scala
@@ -4,18 +4,19 @@ import java.time.Instant
 import java.time.Instant._
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
+import uk.ac.wellcome.models.transformable.SierraTransformable
+import uk.ac.wellcome.models.transformable.sierra.{SierraBibRecord, SierraItemRecord}
 import uk.ac.wellcome.utils.JsonUtil
 
-class MergedSierraRecordTest extends FunSpec with Matchers {
+class SierraTransformableTest extends FunSpec with Matchers {
 
-  it("should allow creation of MergedSierraRecord with no data") {
-    MergedSierraRecord(id = "111")
+  it("should allow creation of SierraTransformable with no data") {
+    SierraTransformable(id = "111")
   }
 
   it("should allow creation from only a SierraBibRecord") {
     val bibRecord = sierraBibRecord(id = "101")
-    val mergedRecord = MergedSierraRecord(bibRecord = bibRecord)
+    val mergedRecord = SierraTransformable(bibRecord = bibRecord)
     mergedRecord.id shouldEqual bibRecord.id
     mergedRecord.maybeBibData.get shouldEqual bibRecord
   }
@@ -23,7 +24,7 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
   it("should allow creation from a SierraBibRecord and a version") {
     val bibRecord = sierraBibRecord(id = "202")
     val version = 10
-    val mergedRecord = MergedSierraRecord(
+    val mergedRecord = SierraTransformable(
       bibRecord = bibRecord,
       version = version
     )
@@ -31,7 +32,7 @@ class MergedSierraRecordTest extends FunSpec with Matchers {
   }
 
   it("should be at version 0 when first created") {
-    val record = MergedSierraRecord(id = "555")
+    val record = SierraTransformable(id = "555")
     record.version shouldEqual 0
   }
 

--- a/common/src/test/scala/uk/ac/wellcome/models/SierraTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/SierraTransformableTest.scala
@@ -5,7 +5,10 @@ import java.time.Instant._
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.transformable.SierraTransformable
-import uk.ac.wellcome.models.transformable.sierra.{SierraBibRecord, SierraItemRecord}
+import uk.ac.wellcome.models.transformable.sierra.{
+  SierraBibRecord,
+  SierraItemRecord
+}
 import uk.ac.wellcome.utils.JsonUtil
 
 class SierraTransformableTest extends FunSpec with Matchers {

--- a/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/dynamo/SierraTransformableDao.scala
+++ b/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/dynamo/SierraTransformableDao.scala
@@ -1,19 +1,19 @@
-package uk.ac.wellcome.platform.sierra_adapter.dynamo
+package uk.ac.wellcome.sierra_adapter.dynamo
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.google.inject.Inject
-import com.gu.scanamo.{Scanamo, Table}
 import com.gu.scanamo.ops.ScanamoOps
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.{Scanamo, Table}
 import com.twitter.inject.Logging
 import uk.ac.wellcome.dynamo._
 import uk.ac.wellcome.models.aws.DynamoConfig
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
-
-import scala.concurrent.Future
+import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
-class MergedSierraRecordDao @Inject()(
+import scala.concurrent.Future
+
+class SierraTransformableDao @Inject()(
   dynamoDbClient: AmazonDynamoDB,
   dynamoConfigs: Map[String, DynamoConfig]
 ) extends Logging {
@@ -23,16 +23,16 @@ class MergedSierraRecordDao @Inject()(
   private val dynamoConfig = dynamoConfigs.getOrElse(
     tableConfigId,
     throw new RuntimeException(
-      s"MergedSierraRecordDao ($tableConfigId) dynamo config not available!"
+      s"SierraTransformableDao ($tableConfigId) dynamo config not available!"
     )
   )
 
-  private val table = Table[MergedSierraRecord](dynamoConfig.table)
+  private val table = Table[SierraTransformable](dynamoConfig.table)
 
   private def scanamoExec[T](op: ScanamoOps[T]) =
     Scanamo.exec(dynamoDbClient)(op)
 
-  private def putRecord(record: MergedSierraRecord) = {
+  private def putRecord(record: SierraTransformable) = {
     val newVersion = record.version + 1
 
     table
@@ -43,7 +43,7 @@ class MergedSierraRecordDao @Inject()(
       .put(record.copy(version = newVersion))
   }
 
-  def updateRecord(record: MergedSierraRecord): Future[Unit] = Future {
+  def updateRecord(record: SierraTransformable): Future[Unit] = Future {
     debug(s"About to update record $record")
     scanamoExec(putRecord(record)) match {
       case Left(err) =>
@@ -53,7 +53,7 @@ class MergedSierraRecordDao @Inject()(
     }
   }
 
-  def getRecord(id: String): Future[Option[MergedSierraRecord]] = Future {
+  def getRecord(id: String): Future[Option[SierraTransformable]] = Future {
     scanamoExec(table.get('id -> id)) match {
       case Some(Right(record)) => Some(record)
       case Some(Left(scanamoError)) =>

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/dynamo/SierraTransformableDaoTest.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/dynamo/SierraTransformableDaoTest.scala
@@ -1,7 +1,11 @@
 package uk.ac.wellcome.sierra_adapter.dynamo
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.amazonaws.services.dynamodbv2.model.{ConditionalCheckFailedException, GetItemRequest, PutItemRequest}
+import com.amazonaws.services.dynamodbv2.model.{
+  ConditionalCheckFailedException,
+  GetItemRequest,
+  PutItemRequest
+}
 import com.gu.scanamo.Scanamo
 import com.gu.scanamo.syntax._
 import org.mockito.Matchers.any
@@ -21,15 +25,15 @@ class SierraTransformableDaoTest extends FunSpec with SierraTestUtils {
 
   val sierraTransformableDao =
     new SierraTransformableDao(dynamoDbClient,
-                              Map("merger" -> DynamoConfig(tableName)))
+                               Map("merger" -> DynamoConfig(tableName)))
 
   describe("get a merged sierra record") {
     it(
       "should return a future of merged sierra record if it exists in  DynamoDB") {
       val sierraTransformable = SierraTransformable(id = "b1111",
-                                                  maybeBibData = None,
-                                                  itemData = Map(),
-                                                  version = 1)
+                                                    maybeBibData = None,
+                                                    itemData = Map(),
+                                                    version = 1)
 
       Scanamo.put(dynamoDbClient)(tableName)(sierraTransformable)
 
@@ -42,9 +46,9 @@ class SierraTransformableDaoTest extends FunSpec with SierraTestUtils {
     it(
       "should return a future of None if the record does not exist in DynamoDB") {
       val sierraTransformable = SierraTransformable(id = "b1111",
-                                                  maybeBibData = None,
-                                                  itemData = Map(),
-                                                  version = 1)
+                                                    maybeBibData = None,
+                                                    itemData = Map(),
+                                                    version = 1)
 
       Scanamo.put(dynamoDbClient)(tableName)(sierraTransformable)
 
@@ -62,7 +66,7 @@ class SierraTransformableDaoTest extends FunSpec with SierraTestUtils {
 
       val sierraTransformableDaoMockedDynamoClient =
         new SierraTransformableDao(dynamoDbClient,
-                                  Map("merger" -> DynamoConfig(tableName)))
+                                   Map("merger" -> DynamoConfig(tableName)))
 
       val future =
         sierraTransformableDaoMockedDynamoClient.getRecord("b88888")
@@ -89,17 +93,19 @@ class SierraTransformableDaoTest extends FunSpec with SierraTestUtils {
 
       val expectedSierraRecord = sierraTransformable.copy(version = 1)
 
-      whenReady(sierraTransformableDao.updateRecord(sierraTransformable)) { _ =>
-        dynamoQueryEqualsValue('id -> id)(expectedValue = expectedSierraRecord)
+      whenReady(sierraTransformableDao.updateRecord(sierraTransformable)) {
+        _ =>
+          dynamoQueryEqualsValue('id -> id)(
+            expectedValue = expectedSierraRecord)
       }
     }
 
     it("updates an existing record if the update has a higher version") {
       val id = "b1111"
       val sierraTransformable = SierraTransformable(id = id,
-                                                  maybeBibData = None,
-                                                  itemData = Map(),
-                                                  version = 1)
+                                                    maybeBibData = None,
+                                                    itemData = Map(),
+                                                    version = 1)
       val newerSierraTransformable = sierraTransformable.copy(version = 2)
 
       Scanamo.put(dynamoDbClient)(tableName)(sierraTransformable)
@@ -117,35 +123,37 @@ class SierraTransformableDaoTest extends FunSpec with SierraTestUtils {
     it("updates a record if it already exists and has the same version") {
       val id = "b1111"
       val sierraTransformable = SierraTransformable(id = id,
-                                                  maybeBibData = None,
-                                                  itemData = Map(),
-                                                  version = 1)
+                                                    maybeBibData = None,
+                                                    itemData = Map(),
+                                                    version = 1)
 
       Scanamo.put(dynamoDbClient)(tableName)(sierraTransformable)
 
-      whenReady(sierraTransformableDao.updateRecord(sierraTransformable)) { _ =>
-        Scanamo
-          .get[SierraTransformable](dynamoDbClient)(tableName)('id -> id)
-          .get shouldBe Right(
-          sierraTransformable.copy(version = 2)
-        )
+      whenReady(sierraTransformableDao.updateRecord(sierraTransformable)) {
+        _ =>
+          Scanamo
+            .get[SierraTransformable](dynamoDbClient)(tableName)('id -> id)
+            .get shouldBe Right(
+            sierraTransformable.copy(version = 2)
+          )
       }
     }
 
     it("does not update an existing record if the update has a lower version") {
       val id = "b1111"
       val sierraTransformable = SierraTransformable(id = id,
-                                                  maybeBibData = None,
-                                                  itemData = Map(),
-                                                  version = 1)
+                                                    maybeBibData = None,
+                                                    itemData = Map(),
+                                                    version = 1)
       val newerSierraTransformable = SierraTransformable(id = id,
-                                                       maybeBibData = None,
-                                                       itemData = Map(),
-                                                       version = 2)
+                                                         maybeBibData = None,
+                                                         itemData = Map(),
+                                                         version = 2)
 
       Scanamo.put(dynamoDbClient)(tableName)(newerSierraTransformable)
 
-      whenReady(sierraTransformableDao.updateRecord(sierraTransformable).failed) {
+      whenReady(
+        sierraTransformableDao.updateRecord(sierraTransformable).failed) {
         ex =>
           ex shouldBe a[ConditionalCheckFailedException]
 
@@ -165,12 +173,12 @@ class SierraTransformableDaoTest extends FunSpec with SierraTestUtils {
 
       val failingDao =
         new SierraTransformableDao(dynamoDbClient,
-                                  Map("merger" -> DynamoConfig(tableName)))
+                                   Map("merger" -> DynamoConfig(tableName)))
 
       val sierraTransformable = SierraTransformable(id = "b1111",
-                                                  maybeBibData = None,
-                                                  itemData = Map(),
-                                                  version = 1)
+                                                    maybeBibData = None,
+                                                    itemData = Map(),
+                                                    version = 1)
 
       whenReady(failingDao.updateRecord(sierraTransformable).failed) { ex =>
         ex shouldBe expectedException

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/dynamo/SierraTransformableDaoTest.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/dynamo/SierraTransformableDaoTest.scala
@@ -10,46 +10,45 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.aws.DynamoConfig
-import uk.ac.wellcome.platform.sierra_adapter.dynamo.MergedSierraRecordDao
 import uk.ac.wellcome.sierra_adapter.locals.DynamoDBLocal
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.sierra_adapter.utils.SierraTestUtils
 import uk.ac.wellcome.dynamo._
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
+import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 
-class MergedSierraRecordDaoTest extends FunSpec with SierraTestUtils {
+class SierraTransformableDaoTest extends FunSpec with SierraTestUtils {
 
-  val mergedSierraRecordDao =
-    new MergedSierraRecordDao(dynamoDbClient,
+  val sierraTransformableDao =
+    new SierraTransformableDao(dynamoDbClient,
                               Map("merger" -> DynamoConfig(tableName)))
 
   describe("get a merged sierra record") {
     it(
       "should return a future of merged sierra record if it exists in  DynamoDB") {
-      val mergedSierraRecord = MergedSierraRecord(id = "b1111",
+      val sierraTransformable = SierraTransformable(id = "b1111",
                                                   maybeBibData = None,
                                                   itemData = Map(),
                                                   version = 1)
 
-      Scanamo.put(dynamoDbClient)(tableName)(mergedSierraRecord)
+      Scanamo.put(dynamoDbClient)(tableName)(sierraTransformable)
 
-      whenReady(mergedSierraRecordDao.getRecord(mergedSierraRecord.id)) {
+      whenReady(sierraTransformableDao.getRecord(sierraTransformable.id)) {
         record =>
-          record shouldBe Some(mergedSierraRecord)
+          record shouldBe Some(sierraTransformable)
       }
     }
 
     it(
       "should return a future of None if the record does not exist in DynamoDB") {
-      val mergedSierraRecord = MergedSierraRecord(id = "b1111",
+      val sierraTransformable = SierraTransformable(id = "b1111",
                                                   maybeBibData = None,
                                                   itemData = Map(),
                                                   version = 1)
 
-      Scanamo.put(dynamoDbClient)(tableName)(mergedSierraRecord)
+      Scanamo.put(dynamoDbClient)(tableName)(sierraTransformable)
 
-      whenReady(mergedSierraRecordDao.getRecord("b88888")) { record =>
+      whenReady(sierraTransformableDao.getRecord("b88888")) { record =>
         record shouldBe None
       }
     }
@@ -61,12 +60,12 @@ class MergedSierraRecordDaoTest extends FunSpec with SierraTestUtils {
       when(dynamoDbClient.getItem(any[GetItemRequest]))
         .thenThrow(expectedException)
 
-      val mergedSierraRecordDaoMockedDynamoClient =
-        new MergedSierraRecordDao(dynamoDbClient,
+      val sierraTransformableDaoMockedDynamoClient =
+        new SierraTransformableDao(dynamoDbClient,
                                   Map("merger" -> DynamoConfig(tableName)))
 
       val future =
-        mergedSierraRecordDaoMockedDynamoClient.getRecord("b88888")
+        sierraTransformableDaoMockedDynamoClient.getRecord("b88888")
 
       whenReady(future.failed) { ex =>
         ex shouldBe expectedException
@@ -77,7 +76,7 @@ class MergedSierraRecordDaoTest extends FunSpec with SierraTestUtils {
   describe("update a merged sierra record") {
     it("inserts a new record if it doesn't already exist") {
       val id = "b1111"
-      val mergedSierraRecord = MergedSierraRecord(
+      val sierraTransformable = SierraTransformable(
         id = id,
         maybeBibData = None,
         itemData = Map(
@@ -88,72 +87,72 @@ class MergedSierraRecordDaoTest extends FunSpec with SierraTestUtils {
         version = 0
       )
 
-      val expectedSierraRecord = mergedSierraRecord.copy(version = 1)
+      val expectedSierraRecord = sierraTransformable.copy(version = 1)
 
-      whenReady(mergedSierraRecordDao.updateRecord(mergedSierraRecord)) { _ =>
+      whenReady(sierraTransformableDao.updateRecord(sierraTransformable)) { _ =>
         dynamoQueryEqualsValue('id -> id)(expectedValue = expectedSierraRecord)
       }
     }
 
     it("updates an existing record if the update has a higher version") {
       val id = "b1111"
-      val mergedSierraRecord = MergedSierraRecord(id = id,
+      val sierraTransformable = SierraTransformable(id = id,
                                                   maybeBibData = None,
                                                   itemData = Map(),
                                                   version = 1)
-      val newerMergedSierraRecord = mergedSierraRecord.copy(version = 2)
+      val newerSierraTransformable = sierraTransformable.copy(version = 2)
 
-      Scanamo.put(dynamoDbClient)(tableName)(mergedSierraRecord)
+      Scanamo.put(dynamoDbClient)(tableName)(sierraTransformable)
 
-      whenReady(mergedSierraRecordDao.updateRecord(newerMergedSierraRecord)) {
+      whenReady(sierraTransformableDao.updateRecord(newerSierraTransformable)) {
         _ =>
           Scanamo
-            .get[MergedSierraRecord](dynamoDbClient)(tableName)('id -> id)
+            .get[SierraTransformable](dynamoDbClient)(tableName)('id -> id)
             .get shouldBe Right(
-            newerMergedSierraRecord.copy(version = 3)
+            newerSierraTransformable.copy(version = 3)
           )
       }
     }
 
     it("updates a record if it already exists and has the same version") {
       val id = "b1111"
-      val mergedSierraRecord = MergedSierraRecord(id = id,
+      val sierraTransformable = SierraTransformable(id = id,
                                                   maybeBibData = None,
                                                   itemData = Map(),
                                                   version = 1)
 
-      Scanamo.put(dynamoDbClient)(tableName)(mergedSierraRecord)
+      Scanamo.put(dynamoDbClient)(tableName)(sierraTransformable)
 
-      whenReady(mergedSierraRecordDao.updateRecord(mergedSierraRecord)) { _ =>
+      whenReady(sierraTransformableDao.updateRecord(sierraTransformable)) { _ =>
         Scanamo
-          .get[MergedSierraRecord](dynamoDbClient)(tableName)('id -> id)
+          .get[SierraTransformable](dynamoDbClient)(tableName)('id -> id)
           .get shouldBe Right(
-          mergedSierraRecord.copy(version = 2)
+          sierraTransformable.copy(version = 2)
         )
       }
     }
 
     it("does not update an existing record if the update has a lower version") {
       val id = "b1111"
-      val mergedSierraRecord = MergedSierraRecord(id = id,
+      val sierraTransformable = SierraTransformable(id = id,
                                                   maybeBibData = None,
                                                   itemData = Map(),
                                                   version = 1)
-      val newerMergedSierraRecord = MergedSierraRecord(id = id,
+      val newerSierraTransformable = SierraTransformable(id = id,
                                                        maybeBibData = None,
                                                        itemData = Map(),
                                                        version = 2)
 
-      Scanamo.put(dynamoDbClient)(tableName)(newerMergedSierraRecord)
+      Scanamo.put(dynamoDbClient)(tableName)(newerSierraTransformable)
 
-      whenReady(mergedSierraRecordDao.updateRecord(mergedSierraRecord).failed) {
+      whenReady(sierraTransformableDao.updateRecord(sierraTransformable).failed) {
         ex =>
           ex shouldBe a[ConditionalCheckFailedException]
 
           Scanamo
-            .get[MergedSierraRecord](dynamoDbClient)(tableName)('id -> id)
+            .get[SierraTransformable](dynamoDbClient)(tableName)('id -> id)
             .get shouldBe Right(
-            newerMergedSierraRecord
+            newerSierraTransformable
           )
       }
     }
@@ -165,15 +164,15 @@ class MergedSierraRecordDaoTest extends FunSpec with SierraTestUtils {
         .thenThrow(expectedException)
 
       val failingDao =
-        new MergedSierraRecordDao(dynamoDbClient,
+        new SierraTransformableDao(dynamoDbClient,
                                   Map("merger" -> DynamoConfig(tableName)))
 
-      val mergedSierraRecord = MergedSierraRecord(id = "b1111",
+      val sierraTransformable = SierraTransformable(id = "b1111",
                                                   maybeBibData = None,
                                                   itemData = Map(),
                                                   version = 1)
 
-      whenReady(failingDao.updateRecord(mergedSierraRecord).failed) { ex =>
+      whenReady(failingDao.updateRecord(sierraTransformable).failed) { ex =>
         ex shouldBe expectedException
       }
     }

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/locals/DynamoDBLocal.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/locals/DynamoDBLocal.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.dynamodbv2.model._
 import com.gu.scanamo.Scanamo
 import org.scalatest.{BeforeAndAfterEach, Suite}
 import uk.ac.wellcome.dynamo._
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
+import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.test.utils.DynamoDBLocalClients
 
 import scala.collection.JavaConversions._
@@ -24,7 +24,7 @@ trait DynamoDBLocal extends BeforeAndAfterEach with DynamoDBLocalClients {
   }
 
   private def clearTable =
-    Scanamo.scan[MergedSierraRecord](dynamoDbClient)(tableName).map {
+    Scanamo.scan[SierraTransformable](dynamoDbClient)(tableName).map {
       case Right(item) =>
         dynamoDbClient.deleteItem(
           tableName,

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMerger.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMerger.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.sierra_bib_merger.merger
 
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
+import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord
 
 object BibMerger {
@@ -8,23 +8,23 @@ object BibMerger {
   /** Return the most up-to-date combination of the merged record and the
     * bib record we've just received.
     */
-  def mergeBibRecord(mergedSierraRecord: MergedSierraRecord,
-                     sierraBibRecord: SierraBibRecord): MergedSierraRecord = {
-    if (sierraBibRecord.id != mergedSierraRecord.id) {
+  def mergeBibRecord(sierraTransformable: SierraTransformable,
+                     sierraBibRecord: SierraBibRecord): SierraTransformable = {
+    if (sierraBibRecord.id != sierraTransformable.id) {
       throw new RuntimeException(
-        s"Non-matching bib ids ${sierraBibRecord.id} != ${mergedSierraRecord.id}")
+        s"Non-matching bib ids ${sierraBibRecord.id} != ${sierraTransformable.id}")
     }
 
-    val isNewerData = mergedSierraRecord.maybeBibData match {
+    val isNewerData = sierraTransformable.maybeBibData match {
       case Some(bibData) =>
         sierraBibRecord.modifiedDate.isAfter(bibData.modifiedDate)
       case None => true
     }
 
     if (isNewerData) {
-      mergedSierraRecord.copy(maybeBibData = Some(sierraBibRecord))
+      sierraTransformable.copy(maybeBibData = Some(sierraBibRecord))
     } else {
-      mergedSierraRecord
+      sierraTransformable
     }
   }
 

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
@@ -3,33 +3,33 @@ package uk.ac.wellcome.platform.sierra_bib_merger.services
 import com.google.inject.Inject
 import com.twitter.inject.Logging
 import uk.ac.wellcome.metrics.MetricsSender
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
+import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord
-import uk.ac.wellcome.platform.sierra_adapter.dynamo.MergedSierraRecordDao
 import uk.ac.wellcome.platform.sierra_bib_merger.merger.BibMerger
+import uk.ac.wellcome.sierra_adapter.dynamo.SierraTransformableDao
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class SierraBibMergerUpdaterService @Inject()(
-  mergedSierraRecordDao: MergedSierraRecordDao,
-  metrics: MetricsSender
+                                               sierraTransformableDao: SierraTransformableDao,
+                                               metrics: MetricsSender
 ) extends Logging {
 
   def update(bibRecord: SierraBibRecord): Future[Unit] = {
 
-    mergedSierraRecordDao
+    sierraTransformableDao
       .getRecord(bibRecord.id)
       .flatMap {
-        case Some(existingMergedSierraRecord) =>
+        case Some(existingSierraTransformable) =>
           val mergedRecord =
-            BibMerger.mergeBibRecord(existingMergedSierraRecord, bibRecord)
-          if (mergedRecord != existingMergedSierraRecord)
-            mergedSierraRecordDao.updateRecord(mergedRecord)
+            BibMerger.mergeBibRecord(existingSierraTransformable, bibRecord)
+          if (mergedRecord != existingSierraTransformable)
+            sierraTransformableDao.updateRecord(mergedRecord)
           else Future.successful(())
         case None =>
-          mergedSierraRecordDao.updateRecord(
-            MergedSierraRecord(bibRecord)
+          sierraTransformableDao.updateRecord(
+            SierraTransformable(bibRecord)
           )
       }
 

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
@@ -12,8 +12,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class SierraBibMergerUpdaterService @Inject()(
-                                               sierraTransformableDao: SierraTransformableDao,
-                                               metrics: MetricsSender
+  sierraTransformableDao: SierraTransformableDao,
+  metrics: MetricsSender
 ) extends Logging {
 
   def update(bibRecord: SierraBibRecord): Future[Unit] = {

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.test.utils.{AmazonCloudWatchFlag, SQSLocal}
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.sierra_adapter.utils.SierraTestUtils
 import uk.ac.wellcome.dynamo._
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
+import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord
 
 class SierraBibMergerFeatureTest
@@ -80,11 +80,11 @@ class SierraBibMergerFeatureTest
       modifiedDate = "2001-01-01T01:01:01Z"
     )
     sendBibRecordToSQS(record)
-    val expectedMergedSierraRecord =
-      MergedSierraRecord(bibRecord = record, version = 1)
+    val expectedSierraTransformable =
+      SierraTransformable(bibRecord = record, version = 1)
 
     dynamoQueryEqualsValue('id -> id)(
-      expectedValue = expectedMergedSierraRecord)
+      expectedValue = expectedSierraTransformable)
   }
 
   it("should put multiple bibs from SQS into DynamoDB") {
@@ -99,8 +99,8 @@ class SierraBibMergerFeatureTest
       modifiedDate = "2001-01-01T01:01:01Z"
     )
     sendBibRecordToSQS(record1)
-    val expectedMergedSierraRecord1 =
-      MergedSierraRecord(bibRecord = record1, version = 1)
+    val expectedSierraTransformable1 =
+      SierraTransformable(bibRecord = record1, version = 1)
 
     val id2 = "2000002"
     val record2 = SierraBibRecord(
@@ -113,13 +113,13 @@ class SierraBibMergerFeatureTest
       modifiedDate = "2002-02-02T02:02:02Z"
     )
     sendBibRecordToSQS(record2)
-    val expectedMergedSierraRecord2 =
-      MergedSierraRecord(bibRecord = record2, version = 1)
+    val expectedSierraTransformable2 =
+      SierraTransformable(bibRecord = record2, version = 1)
 
     dynamoQueryEqualsValue('id -> id1)(
-      expectedValue = expectedMergedSierraRecord1)
+      expectedValue = expectedSierraTransformable1)
     dynamoQueryEqualsValue('id -> id2)(
-      expectedValue = expectedMergedSierraRecord2)
+      expectedValue = expectedSierraTransformable2)
   }
 
   it("should update a bib in DynamoDB if a newer version is sent to SQS") {
@@ -133,7 +133,7 @@ class SierraBibMergerFeatureTest
       ),
       modifiedDate = "2003-03-03T03:03:03Z"
     )
-    val oldRecord = MergedSierraRecord(bibRecord = oldBibRecord, version = 1)
+    val oldRecord = SierraTransformable(bibRecord = oldBibRecord, version = 1)
     Scanamo.put(dynamoDbClient)(tableName)(oldRecord)
 
     val newTitle = "A number of new narwhals near Newmarket"
@@ -150,7 +150,7 @@ class SierraBibMergerFeatureTest
     sendBibRecordToSQS(record)
 
     val expectedSierraRecord =
-      MergedSierraRecord(bibRecord = record, version = 2)
+      SierraTransformable(bibRecord = record, version = 2)
     dynamoQueryEqualsValue('id -> id)(expectedValue = expectedSierraRecord)
   }
 
@@ -165,9 +165,9 @@ class SierraBibMergerFeatureTest
       ),
       modifiedDate = "2006-06-06T06:06:06Z"
     )
-    val newRecord = MergedSierraRecord(bibRecord = newBibRecord)
+    val newRecord = SierraTransformable(bibRecord = newBibRecord)
     Scanamo.put(dynamoDbClient)(tableName)(newRecord)
-    val expectedSierraRecord = MergedSierraRecord(bibRecord = newBibRecord)
+    val expectedSierraRecord = SierraTransformable(bibRecord = newBibRecord)
 
     val oldTitle = "A small selection of sad shellfish"
     val oldUpdatedDate = "2001-01-01T01:01:01Z"
@@ -191,7 +191,7 @@ class SierraBibMergerFeatureTest
 
   it("should put a bib from SQS into DynamoDB if the ID exists but no bibData") {
     val id = "7000007"
-    val newRecord = MergedSierraRecord(id = id, version = 1)
+    val newRecord = SierraTransformable(id = id, version = 1)
     Scanamo.put(dynamoDbClient)(tableName)(newRecord)
 
     val title = "Inside an inquisitive igloo of ice imps"
@@ -208,7 +208,7 @@ class SierraBibMergerFeatureTest
 
     sendBibRecordToSQS(record)
     val expectedSierraRecord =
-      MergedSierraRecord(bibRecord = record, version = 2)
+      SierraTransformable(bibRecord = record, version = 2)
 
     dynamoQueryEqualsValue('id -> id)(expectedValue = expectedSierraRecord)
   }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMergerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMergerTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.sierra_bib_merger.merger
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
+import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord
 
 class BibMergerTest extends FunSpec with Matchers {
@@ -9,7 +9,7 @@ class BibMergerTest extends FunSpec with Matchers {
   describe("merging with a SierraBibRecord") {
     it("should merge data from a bibRecord when empty") {
       val record = sierraBibRecord(id = "222")
-      val originalRecord = MergedSierraRecord(id = "222")
+      val originalRecord = SierraTransformable(id = "222")
 
       val newRecord = BibMerger.mergeBibRecord(originalRecord, record)
       newRecord.maybeBibData.get shouldEqual record
@@ -17,7 +17,7 @@ class BibMergerTest extends FunSpec with Matchers {
 
     it("should only merge bib records with matching ids") {
       val record = sierraBibRecord(id = "333")
-      val originalRecord = MergedSierraRecord(id = "444")
+      val originalRecord = SierraTransformable(id = "444")
 
       val caught = intercept[RuntimeException] {
         BibMerger.mergeBibRecord(originalRecord, record)
@@ -27,7 +27,7 @@ class BibMergerTest extends FunSpec with Matchers {
 
     it("should never increment the version when mergeBibRecord is called") {
       val record = sierraBibRecord(id = "666")
-      val originalRecord = MergedSierraRecord(id = "666", version = 10)
+      val originalRecord = SierraTransformable(id = "666", version = 10)
       val newRecord = BibMerger.mergeBibRecord(originalRecord, record)
       newRecord.version shouldEqual 10
     }
@@ -40,7 +40,7 @@ class BibMergerTest extends FunSpec with Matchers {
         modifiedDate = "2001-01-01T01:01:01Z"
       )
 
-      val mergedSierraRecord = MergedSierraRecord(
+      val sierraTransformable = SierraTransformable(
         id = "777",
         maybeBibData = Some(
           sierraBibRecord(
@@ -51,8 +51,8 @@ class BibMergerTest extends FunSpec with Matchers {
         )
       )
 
-      val result = BibMerger.mergeBibRecord(mergedSierraRecord, record)
-      result shouldBe mergedSierraRecord
+      val result = BibMerger.mergeBibRecord(sierraTransformable, record)
+      result shouldBe sierraTransformable
     }
 
     it("should update bibData when merging bib records with newer data") {
@@ -62,7 +62,7 @@ class BibMergerTest extends FunSpec with Matchers {
         modifiedDate = "2011-11-11T11:11:11Z"
       )
 
-      val mergedSierraRecord = MergedSierraRecord(
+      val sierraTransformable = SierraTransformable(
         id = "888",
         maybeBibData = Some(
           sierraBibRecord(
@@ -73,7 +73,7 @@ class BibMergerTest extends FunSpec with Matchers {
         )
       )
 
-      val result = BibMerger.mergeBibRecord(mergedSierraRecord, record)
+      val result = BibMerger.mergeBibRecord(sierraTransformable, record)
       result.maybeBibData.get shouldBe record
     }
   }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.platform.sierra_adapter.dynamo.MergedSierraRecordDao
+import uk.ac.wellcome.sierra_adapter.dynamo.SierraTransformableDao
 import uk.ac.wellcome.sqs.{SQSReader, SQSReaderGracefulException}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
@@ -23,7 +23,7 @@ class SierraBibMergerWorkerServiceTest
     val sqsReader = mock[SQSReader]
     val metricsSender = mock[MetricsSender]
     val mergerUpdaterService =
-      new SierraBibMergerUpdaterService(mock[MergedSierraRecordDao],
+      new SierraBibMergerUpdaterService(mock[SierraTransformableDao],
                                         metricsSender)
     val worker = new SierraBibMergerWorkerService(sqsReader,
                                                   ActorSystem(),

--- a/sierra_adapter/sierra_bibs_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/SierraBibsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_bibs_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_bibs_to_dynamo/SierraBibsToDynamoFeatureTest.scala
@@ -6,7 +6,11 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.platform.sierra_bibs_to_dynamo.locals.SierraBibsToDynamoDBLocal
 import uk.ac.wellcome.dynamo._
-import uk.ac.wellcome.test.utils.{AmazonCloudWatchFlag, ExtendedPatience, SQSLocal}
+import uk.ac.wellcome.test.utils.{
+  AmazonCloudWatchFlag,
+  ExtendedPatience,
+  SQSLocal
+}
 import uk.ac.wellcome.utils.JsonUtil
 import com.gu.scanamo.Scanamo
 import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemLinker.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemLinker.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.sierra_item_merger.links
 
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
+import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 
 object ItemLinker {
@@ -10,11 +10,11 @@ object ItemLinker {
     *
     * Returns the merged record.
     */
-  def linkItemRecord(mergedSierraRecord: MergedSierraRecord,
-                     itemRecord: SierraItemRecord): MergedSierraRecord = {
-    if (!itemRecord.bibIds.contains(mergedSierraRecord.id)) {
+  def linkItemRecord(sierraTransformable: SierraTransformable,
+                     itemRecord: SierraItemRecord): SierraTransformable = {
+    if (!itemRecord.bibIds.contains(sierraTransformable.id)) {
       throw new RuntimeException(
-        s"Non-matching bib id ${mergedSierraRecord.id} in item bib ${itemRecord.bibIds}")
+        s"Non-matching bib id ${sierraTransformable.id} in item bib ${itemRecord.bibIds}")
     }
 
     // We can decide whether to insert the new data in two steps:
@@ -25,17 +25,17 @@ object ItemLinker {
     //    just received?  If the existing data is older, we need to merge the
     //    new record.
     //
-    val isNewerData = mergedSierraRecord.itemData.get(itemRecord.id) match {
+    val isNewerData = sierraTransformable.itemData.get(itemRecord.id) match {
       case Some(existing) =>
         itemRecord.modifiedDate.isAfter(existing.modifiedDate)
       case None => true
     }
 
     if (isNewerData) {
-      val itemData = mergedSierraRecord.itemData + (itemRecord.id -> itemRecord)
-      mergedSierraRecord.copy(itemData = itemData)
+      val itemData = sierraTransformable.itemData + (itemRecord.id -> itemRecord)
+      sierraTransformable.copy(itemData = itemData)
     } else {
-      mergedSierraRecord
+      sierraTransformable
     }
   }
 }

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinker.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinker.scala
@@ -1,18 +1,18 @@
 package uk.ac.wellcome.platform.sierra_item_merger.links
 
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
+import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 
 object ItemUnlinker {
 
-  def unlinkItemRecord(mergedSierraRecord: MergedSierraRecord,
-                       itemRecord: SierraItemRecord): MergedSierraRecord = {
-    if (!itemRecord.unlinkedBibIds.contains(mergedSierraRecord.id)) {
+  def unlinkItemRecord(sierraTransformable: SierraTransformable,
+                       itemRecord: SierraItemRecord): SierraTransformable = {
+    if (!itemRecord.unlinkedBibIds.contains(sierraTransformable.id)) {
       throw new RuntimeException(
-        s"Non-matching bib id ${mergedSierraRecord.id} in item unlink bibs ${itemRecord.unlinkedBibIds}")
+        s"Non-matching bib id ${sierraTransformable.id} in item unlink bibs ${itemRecord.unlinkedBibIds}")
     }
 
-    val itemData: Map[String, SierraItemRecord] = mergedSierraRecord.itemData
+    val itemData: Map[String, SierraItemRecord] = sierraTransformable.itemData
       .filterNot {
         case (id, currentItemRecord) => {
           val matchesCurrentItemRecord = id == itemRecord.id
@@ -25,6 +25,6 @@ object ItemUnlinker {
         }
       }
 
-    mergedSierraRecord.copy(itemData = itemData)
+    sierraTransformable.copy(itemData = itemData)
   }
 }

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
@@ -3,49 +3,49 @@ package uk.ac.wellcome.platform.sierra_item_merger.services
 import com.google.inject.Inject
 import com.twitter.inject.Logging
 import uk.ac.wellcome.metrics.MetricsSender
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
+import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
-import uk.ac.wellcome.platform.sierra_adapter.dynamo.MergedSierraRecordDao
 import uk.ac.wellcome.platform.sierra_item_merger.links.ItemLinker
 import uk.ac.wellcome.platform.sierra_item_merger.links.ItemUnlinker
+import uk.ac.wellcome.sierra_adapter.dynamo.SierraTransformableDao
 import uk.ac.wellcome.sqs.SQSReaderGracefulException
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class SierraItemMergerUpdaterService @Inject()(
-  mergedSierraRecordDao: MergedSierraRecordDao,
-  metrics: MetricsSender
+                                                sierraTransformableDao: SierraTransformableDao,
+                                                metrics: MetricsSender
 ) extends Logging {
 
   def update(itemRecord: SierraItemRecord): Future[Unit] = {
 
     val mergeUpdateFutures = itemRecord.bibIds.map { bibId =>
-      mergedSierraRecordDao
+      sierraTransformableDao
         .getRecord(bibId)
         .flatMap {
-          case Some(existingMergedSierraRecord) =>
+          case Some(existingSierraTransformable) =>
             val mergedRecord =
-              ItemLinker.linkItemRecord(existingMergedSierraRecord, itemRecord)
-            if (mergedRecord != existingMergedSierraRecord)
-              mergedSierraRecordDao.updateRecord(mergedRecord)
+              ItemLinker.linkItemRecord(existingSierraTransformable, itemRecord)
+            if (mergedRecord != existingSierraTransformable)
+              sierraTransformableDao.updateRecord(mergedRecord)
             else Future.successful(())
           case None =>
-            mergedSierraRecordDao.updateRecord(
-              MergedSierraRecord(bibId,
+            sierraTransformableDao.updateRecord(
+              SierraTransformable(bibId,
                                  itemData = Map(itemRecord.id -> itemRecord)))
         }
     }
 
     val unlinkUpdateFutures = itemRecord.unlinkedBibIds.map { unlinkedBibId =>
-      mergedSierraRecordDao
+      sierraTransformableDao
         .getRecord(unlinkedBibId)
         .flatMap {
           case Some(record) =>
             val mergedRecord =
               ItemUnlinker.unlinkItemRecord(record, itemRecord)
             if (mergedRecord != record)
-              mergedSierraRecordDao.updateRecord(mergedRecord)
+              sierraTransformableDao.updateRecord(mergedRecord)
             else Future.successful(())
           // In the case we cannot find the bib record
           // assume we're too early and put the message back

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
@@ -14,8 +14,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class SierraItemMergerUpdaterService @Inject()(
-                                                sierraTransformableDao: SierraTransformableDao,
-                                                metrics: MetricsSender
+  sierraTransformableDao: SierraTransformableDao,
+  metrics: MetricsSender
 ) extends Logging {
 
   def update(itemRecord: SierraItemRecord): Future[Unit] = {
@@ -26,14 +26,15 @@ class SierraItemMergerUpdaterService @Inject()(
         .flatMap {
           case Some(existingSierraTransformable) =>
             val mergedRecord =
-              ItemLinker.linkItemRecord(existingSierraTransformable, itemRecord)
+              ItemLinker.linkItemRecord(existingSierraTransformable,
+                                        itemRecord)
             if (mergedRecord != existingSierraTransformable)
               sierraTransformableDao.updateRecord(mergedRecord)
             else Future.successful(())
           case None =>
             sierraTransformableDao.updateRecord(
               SierraTransformable(bibId,
-                                 itemData = Map(itemRecord.id -> itemRecord)))
+                                  itemData = Map(itemRecord.id -> itemRecord)))
         }
     }
 

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.platform.sierra_item_merger.utils.SierraItemMergerTestUtil
 import uk.ac.wellcome.test.utils.AmazonCloudWatchFlag
 import uk.ac.wellcome.dynamo._
 import com.gu.scanamo.syntax._
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
+import uk.ac.wellcome.models.transformable.SierraTransformable
 
 class SierraItemMergerFeatureTest
     extends FunSpec
@@ -36,7 +36,7 @@ class SierraItemMergerFeatureTest
 
     sendItemRecordToSQS(record)
 
-    val expectedMergedSierraRecord = MergedSierraRecord(
+    val expectedSierraTransformable = SierraTransformable(
       id = bibId,
       itemData = Map(id -> record),
       version = 1
@@ -44,7 +44,7 @@ class SierraItemMergerFeatureTest
 
     eventually {
       dynamoQueryEqualsValue('id -> bibId)(
-        expectedValue = expectedMergedSierraRecord)
+        expectedValue = expectedSierraTransformable)
     }
   }
 
@@ -74,23 +74,23 @@ class SierraItemMergerFeatureTest
 
     eventually {
 
-      val expectedMergedSierraRecord1 = MergedSierraRecord(
+      val expectedSierraTransformable1 = SierraTransformable(
         id = bibId1,
         itemData = Map(id1 -> record1),
         version = 1
       )
 
-      val expectedMergedSierraRecord2 = MergedSierraRecord(
+      val expectedSierraTransformable2 = SierraTransformable(
         id = bibId2,
         itemData = Map(id2 -> record2),
         version = 1
       )
 
       dynamoQueryEqualsValue('id -> bibId1)(
-        expectedValue = expectedMergedSierraRecord1)
+        expectedValue = expectedSierraTransformable1)
 
       dynamoQueryEqualsValue('id -> bibId2)(
-        expectedValue = expectedMergedSierraRecord2)
+        expectedValue = expectedSierraTransformable2)
 
     }
   }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemLinkerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemLinkerTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.sierra_item_merger.links
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
+import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 
 class ItemLinkerTest extends FunSpec with Matchers {
@@ -14,15 +14,15 @@ class ItemLinkerTest extends FunSpec with Matchers {
       bibIds = List("b888")
     )
 
-    val mergedSierraRecord = MergedSierraRecord(id = "b888")
-    val result = ItemLinker.linkItemRecord(mergedSierraRecord, record)
+    val sierraTransformable = SierraTransformable(id = "b888")
+    val result = ItemLinker.linkItemRecord(sierraTransformable, record)
 
     result.itemData(record.id) shouldBe record
   }
 
   it("should update itemData when merging item records with newer data") {
     val itemId = "i999"
-    val mergedSierraRecord = MergedSierraRecord(
+    val sierraTransformable = SierraTransformable(
       id = "b999",
       itemData = Map(
         itemId -> sierraItemRecord(
@@ -39,15 +39,15 @@ class ItemLinkerTest extends FunSpec with Matchers {
       modifiedDate = "2010-10-10T10:10:10Z",
       bibIds = List("b999")
     )
-    val result = ItemLinker.linkItemRecord(mergedSierraRecord, newerRecord)
+    val result = ItemLinker.linkItemRecord(sierraTransformable, newerRecord)
 
-    result shouldBe mergedSierraRecord.copy(
+    result shouldBe sierraTransformable.copy(
       itemData = Map(itemId -> newerRecord))
   }
 
   it("should return itself when merging item records with stale data") {
     val itemId = "i111"
-    val mergedSierraRecord = MergedSierraRecord(
+    val sierraTransformable = SierraTransformable(
       id = "b111",
       itemData = Map(
         itemId -> sierraItemRecord(
@@ -64,8 +64,8 @@ class ItemLinkerTest extends FunSpec with Matchers {
       modifiedDate = "2000-01-01T01:01:01Z",
       bibIds = List("b111")
     )
-    val result = ItemLinker.linkItemRecord(mergedSierraRecord, oldRecord)
-    result shouldBe mergedSierraRecord
+    val result = ItemLinker.linkItemRecord(sierraTransformable, oldRecord)
+    result shouldBe sierraTransformable
   }
 
   it("should support adding multiple items to a merged record") {
@@ -82,8 +82,8 @@ class ItemLinkerTest extends FunSpec with Matchers {
       bibIds = List("b121")
     )
 
-    val mergedSierraRecord = MergedSierraRecord(id = "b121")
-    val result1 = ItemLinker.linkItemRecord(mergedSierraRecord, record1)
+    val sierraTransformable = SierraTransformable(id = "b121")
+    val result1 = ItemLinker.linkItemRecord(sierraTransformable, record1)
     val result2 = ItemLinker.linkItemRecord(result1, record2)
 
     result1.itemData(record1.id) shouldBe record1
@@ -102,10 +102,10 @@ class ItemLinkerTest extends FunSpec with Matchers {
       unlinkedBibIds = List()
     )
 
-    val mergedSierraRecord = MergedSierraRecord(id = bibId)
+    val sierraTransformable = SierraTransformable(id = bibId)
 
     val caught = intercept[RuntimeException] {
-      ItemLinker.linkItemRecord(mergedSierraRecord, record)
+      ItemLinker.linkItemRecord(sierraTransformable, record)
     }
 
     caught.getMessage shouldEqual "Non-matching bib id 444 in item bib List(666)"

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinkerTests.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinkerTests.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.sierra_item_merger.links
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
+import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 
 class ItemUnlinkerTests extends FunSpec with Matchers {
@@ -23,16 +23,16 @@ class ItemUnlinkerTests extends FunSpec with Matchers {
       unlinkedBibIds = List(bibId)
     )
 
-    val mergedSierraRecord = MergedSierraRecord(
+    val sierraTransformable = SierraTransformable(
       id = bibId,
       itemData = Map(record.id -> record)
     )
 
-    val expectedMergedSierraRecord = mergedSierraRecord.copy(
+    val expectedSierraTransformable = sierraTransformable.copy(
       itemData = Map.empty
     )
 
-    ItemUnlinker.unlinkItemRecord(mergedSierraRecord, unlinkedItemRecord) shouldBe expectedMergedSierraRecord
+    ItemUnlinker.unlinkItemRecord(sierraTransformable, unlinkedItemRecord) shouldBe expectedSierraTransformable
   }
 
   it(
@@ -55,14 +55,14 @@ class ItemUnlinkerTests extends FunSpec with Matchers {
       unlinkedBibIds = List(bibId)
     )
 
-    val mergedSierraRecord = MergedSierraRecord(
+    val sierraTransformable = SierraTransformable(
       id = bibId,
       itemData = Map(record.id -> record)
     )
 
-    val expectedMergedSierraRecord = mergedSierraRecord
+    val expectedSierraTransformable = sierraTransformable
 
-    ItemUnlinker.unlinkItemRecord(mergedSierraRecord, previouslyUnlinkedRecord) shouldBe expectedMergedSierraRecord
+    ItemUnlinker.unlinkItemRecord(sierraTransformable, previouslyUnlinkedRecord) shouldBe expectedSierraTransformable
   }
 
   it(
@@ -86,14 +86,14 @@ class ItemUnlinkerTests extends FunSpec with Matchers {
       unlinkedBibIds = List(bibId)
     )
 
-    val mergedSierraRecord = MergedSierraRecord(
+    val sierraTransformable = SierraTransformable(
       id = bibId,
       itemData = Map(record.id -> record)
     )
 
-    val expectedMergedSierraRecord = mergedSierraRecord
+    val expectedSierraTransformable = sierraTransformable
 
-    ItemUnlinker.unlinkItemRecord(mergedSierraRecord, outOfDateUnlinkedRecord) shouldBe expectedMergedSierraRecord
+    ItemUnlinker.unlinkItemRecord(sierraTransformable, outOfDateUnlinkedRecord) shouldBe expectedSierraTransformable
   }
 
   it("should only unlink item records with matching bib IDs") {
@@ -116,13 +116,13 @@ class ItemUnlinkerTests extends FunSpec with Matchers {
       unlinkedBibIds = List(unrelatedBibId)
     )
 
-    val mergedSierraRecord = MergedSierraRecord(
+    val sierraTransformable = SierraTransformable(
       id = bibId,
       itemData = Map(record.id -> record)
     )
 
     val caught = intercept[RuntimeException] {
-      ItemUnlinker.unlinkItemRecord(mergedSierraRecord, unrelatedItemRecord)
+      ItemUnlinker.unlinkItemRecord(sierraTransformable, unrelatedItemRecord)
     }
 
     caught.getMessage shouldEqual "Non-matching bib id 222 in item unlink bibs List(846)"

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinkerTests.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinkerTests.scala
@@ -62,7 +62,9 @@ class ItemUnlinkerTests extends FunSpec with Matchers {
 
     val expectedSierraTransformable = sierraTransformable
 
-    ItemUnlinker.unlinkItemRecord(sierraTransformable, previouslyUnlinkedRecord) shouldBe expectedSierraTransformable
+    ItemUnlinker.unlinkItemRecord(
+      sierraTransformable,
+      previouslyUnlinkedRecord) shouldBe expectedSierraTransformable
   }
 
   it(

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -37,11 +37,11 @@ class SierraItemMergerUpdaterServiceTest
     whenReady(sierraUpdaterService.update(newItemRecord)) { _ =>
       val expectedSierraTransformable =
         SierraTransformable(id = bibId,
-                           maybeBibData = None,
-                           itemData = Map(
-                             newItemRecord.id -> newItemRecord
-                           ),
-                           version = 1)
+                            maybeBibData = None,
+                            itemData = Map(
+                              newItemRecord.id -> newItemRecord
+                            ),
+                            version = 1)
 
       dynamoQueryEqualsValue('id -> bibId)(
         expectedValue = expectedSierraTransformable)

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -8,18 +8,18 @@ import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.DynamoConfig
 import uk.ac.wellcome.platform.sierra_item_merger.utils.SierraItemMergerTestUtil
 import uk.ac.wellcome.dynamo._
-import uk.ac.wellcome.platform.sierra_adapter.dynamo.MergedSierraRecordDao
 
 import scala.concurrent.Future
 import com.gu.scanamo.syntax._
-import uk.ac.wellcome.models.transformable.MergedSierraRecord
+import uk.ac.wellcome.models.transformable.SierraTransformable
+import uk.ac.wellcome.sierra_adapter.dynamo.SierraTransformableDao
 
 class SierraItemMergerUpdaterServiceTest
     extends FunSpec
     with SierraItemMergerTestUtil {
 
   val sierraUpdaterService = new SierraItemMergerUpdaterService(
-    mergedSierraRecordDao = new MergedSierraRecordDao(
+    sierraTransformableDao = new SierraTransformableDao(
       dynamoConfigs = Map("merger" -> DynamoConfig(tableName)),
       dynamoDbClient = dynamoDbClient
     ),
@@ -35,8 +35,8 @@ class SierraItemMergerUpdaterServiceTest
     )
 
     whenReady(sierraUpdaterService.update(newItemRecord)) { _ =>
-      val expectedMergedSierraRecord =
-        MergedSierraRecord(id = bibId,
+      val expectedSierraTransformable =
+        SierraTransformable(id = bibId,
                            maybeBibData = None,
                            itemData = Map(
                              newItemRecord.id -> newItemRecord
@@ -44,7 +44,7 @@ class SierraItemMergerUpdaterServiceTest
                            version = 1)
 
       dynamoQueryEqualsValue('id -> bibId)(
-        expectedValue = expectedMergedSierraRecord)
+        expectedValue = expectedSierraTransformable)
     }
   }
 
@@ -73,7 +73,7 @@ class SierraItemMergerUpdaterServiceTest
       bibIds = bibIds
     )
 
-    val oldRecord = MergedSierraRecord(
+    val oldRecord = SierraTransformable(
       id = bibIdWithOldData,
       itemData = Map(
         itemId -> sierraItemRecord(
@@ -94,7 +94,7 @@ class SierraItemMergerUpdaterServiceTest
       bibIds = bibIds
     )
 
-    val newRecord = MergedSierraRecord(
+    val newRecord = SierraTransformable(
       id = bibIdWithNewerData,
       itemData = Map(
         itemId -> sierraItemRecord(
@@ -111,7 +111,7 @@ class SierraItemMergerUpdaterServiceTest
 
     whenReady(sierraUpdaterService.update(itemRecord)) { _ =>
       val expectedNewSierraRecord =
-        MergedSierraRecord(
+        SierraTransformable(
           id = bibIdNotExisting,
           maybeBibData = None,
           itemData = Map(itemRecord.id -> itemRecord),
@@ -143,7 +143,7 @@ class SierraItemMergerUpdaterServiceTest
     val id = "i3000003"
     val bibId = "b3000003"
 
-    val oldRecord = MergedSierraRecord(
+    val oldRecord = SierraTransformable(
       id = bibId,
       itemData = Map(
         id -> sierraItemRecord(
@@ -192,20 +192,20 @@ class SierraItemMergerUpdaterServiceTest
       itemRecord.id -> itemRecord
     )
 
-    val mergedSierraRecord1 = MergedSierraRecord(
+    val sierraTransformable1 = SierraTransformable(
       id = bibId1,
       itemData = itemData,
       version = 1
     )
 
-    val mergedSierraRecord2 = MergedSierraRecord(
+    val sierraTransformable2 = SierraTransformable(
       id = bibId2,
       itemData = Map.empty,
       version = 1
     )
 
-    Scanamo.put(dynamoDbClient)(tableName)(mergedSierraRecord1)
-    Scanamo.put(dynamoDbClient)(tableName)(mergedSierraRecord2)
+    Scanamo.put(dynamoDbClient)(tableName)(sierraTransformable1)
+    Scanamo.put(dynamoDbClient)(tableName)(sierraTransformable2)
 
     val unlinkItemRecord = itemRecord.copy(
       bibIds = List(bibId2),
@@ -222,12 +222,12 @@ class SierraItemMergerUpdaterServiceTest
     )
 
     whenReady(sierraUpdaterService.update(unlinkItemRecord)) { _ =>
-      val expectedSierraRecord1 = mergedSierraRecord1.copy(
+      val expectedSierraRecord1 = sierraTransformable1.copy(
         itemData = Map.empty,
         version = 2
       )
 
-      val expectedSierraRecord2 = mergedSierraRecord2.copy(
+      val expectedSierraRecord2 = sierraTransformable2.copy(
         itemData = expectedItemData,
         version = 2
       )
@@ -255,20 +255,20 @@ class SierraItemMergerUpdaterServiceTest
       itemRecord.id -> itemRecord
     )
 
-    val mergedSierraRecord1 = MergedSierraRecord(
+    val sierraTransformable1 = SierraTransformable(
       id = bibId1,
       itemData = itemData,
       version = 1
     )
 
-    val mergedSierraRecord2 = MergedSierraRecord(
+    val sierraTransformable2 = SierraTransformable(
       id = bibId2,
       itemData = itemData,
       version = 1
     )
 
-    Scanamo.put(dynamoDbClient)(tableName)(mergedSierraRecord1)
-    Scanamo.put(dynamoDbClient)(tableName)(mergedSierraRecord2)
+    Scanamo.put(dynamoDbClient)(tableName)(sierraTransformable1)
+    Scanamo.put(dynamoDbClient)(tableName)(sierraTransformable2)
 
     val unlinkItemRecord = itemRecord.copy(
       bibIds = List(bibId2),
@@ -281,14 +281,14 @@ class SierraItemMergerUpdaterServiceTest
     )
 
     whenReady(sierraUpdaterService.update(unlinkItemRecord)) { _ =>
-      val expectedSierraRecord1 = mergedSierraRecord1.copy(
+      val expectedSierraRecord1 = sierraTransformable1.copy(
         itemData = Map.empty,
         version = 2
       )
 
-      // In this situation the item was already linked to mergedSierraRecord2
+      // In this situation the item was already linked to sierraTransformable2
       // but the modified date is updated in line with the item update
-      val expectedSierraRecord2 = mergedSierraRecord2.copy(
+      val expectedSierraRecord2 = sierraTransformable2.copy(
         itemData = expectedItemData,
         version = 2
       )
@@ -315,20 +315,20 @@ class SierraItemMergerUpdaterServiceTest
       itemRecord.id -> itemRecord
     )
 
-    val mergedSierraRecord1 = MergedSierraRecord(
+    val sierraTransformable1 = SierraTransformable(
       id = bibId1,
       itemData = itemData,
       version = 1
     )
 
-    val mergedSierraRecord2 = MergedSierraRecord(
+    val sierraTransformable2 = SierraTransformable(
       id = bibId2,
       itemData = Map.empty,
       version = 1
     )
 
-    Scanamo.put(dynamoDbClient)(tableName)(mergedSierraRecord1)
-    Scanamo.put(dynamoDbClient)(tableName)(mergedSierraRecord2)
+    Scanamo.put(dynamoDbClient)(tableName)(sierraTransformable1)
+    Scanamo.put(dynamoDbClient)(tableName)(sierraTransformable2)
 
     val unlinkItemRecord = itemRecord.copy(
       bibIds = List(bibId2),
@@ -348,8 +348,8 @@ class SierraItemMergerUpdaterServiceTest
       // In this situation the item will _not_ be unlinked from the original record
       // but will be linked to the new record (as this is the first time we've seen
       // the link so it is valid for that bib.
-      val expectedSierraRecord1 = mergedSierraRecord1
-      val expectedSierraRecord2 = mergedSierraRecord2.copy(
+      val expectedSierraRecord1 = sierraTransformable1
+      val expectedSierraRecord2 = sierraTransformable2.copy(
         version = 2,
         itemData = expectedItemData
       )
@@ -365,7 +365,7 @@ class SierraItemMergerUpdaterServiceTest
     val id = "i6000006"
     val bibId = "b6000006"
 
-    val newRecord = MergedSierraRecord(
+    val newRecord = SierraTransformable(
       id = bibId,
       itemData = Map(
         id -> sierraItemRecord(
@@ -392,7 +392,7 @@ class SierraItemMergerUpdaterServiceTest
   it("adds an item to the record if the bibId exists but has no itemData") {
     val bibId = "b7000007"
 
-    val newRecord = MergedSierraRecord(
+    val newRecord = SierraTransformable(
       id = bibId,
       version = 1
     )
@@ -406,7 +406,7 @@ class SierraItemMergerUpdaterServiceTest
     )
 
     whenReady(sierraUpdaterService.update(itemRecord)) { _ =>
-      val expectedSierraRecord = MergedSierraRecord(
+      val expectedSierraRecord = SierraTransformable(
         id = bibId,
         itemData = Map(
           itemRecord.id -> itemRecord
@@ -420,10 +420,10 @@ class SierraItemMergerUpdaterServiceTest
   }
 
   it("returns a failed future if getting and item from the dao fails") {
-    val failingDao = mock[MergedSierraRecordDao]
+    val failingDao = mock[SierraTransformableDao]
 
     val failingUpdaterService = new SierraItemMergerUpdaterService(
-      mergedSierraRecordDao = failingDao,
+      sierraTransformableDao = failingDao,
       mock[MetricsSender]
     )
 
@@ -444,7 +444,7 @@ class SierraItemMergerUpdaterServiceTest
   }
 
   it("returns a failed future if putting an item fails") {
-    val failingDao = mock[MergedSierraRecordDao]
+    val failingDao = mock[SierraTransformableDao]
     val failingUpdaterService = new SierraItemMergerUpdaterService(
       failingDao,
       mock[MetricsSender]
@@ -453,12 +453,12 @@ class SierraItemMergerUpdaterServiceTest
     val expectedException = new RuntimeException("BOOOM!")
 
     val bibId = "b242"
-    val newRecord = MergedSierraRecord(id = bibId, version = 1)
+    val newRecord = SierraTransformable(id = bibId, version = 1)
 
     when(failingDao.getRecord(any[String]))
       .thenReturn(Future.successful(Some(newRecord)))
 
-    when(failingDao.updateRecord(any[MergedSierraRecord]))
+    when(failingDao.updateRecord(any[SierraTransformable]))
       .thenReturn(Future.failed(expectedException))
 
     val itemRecord = sierraItemRecord(

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/dynamo/SierraItemRecordDao.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/dynamo/SierraItemRecordDao.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.sierra_items_to_dynamo.dynamo
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.amazonaws.services.dynamodbv2.model.{ConditionalCheckFailedException, PutItemResult}
+import com.amazonaws.services.dynamodbv2.model.{
+  ConditionalCheckFailedException,
+  PutItemResult
+}
 import com.google.inject.Inject
 import com.gu.scanamo.syntax._
 import com.gu.scanamo.{Scanamo, Table}

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/dynamo/SierraItemRecordDao.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/dynamo/SierraItemRecordDao.scala
@@ -23,7 +23,7 @@ class SierraItemRecordDao @Inject()(dynamoDbClient: AmazonDynamoDB,
   private val dynamoConfig = dynamoConfigs.getOrElse(
     tableConfigId,
     throw new RuntimeException(
-      s"MergedSierraRecordDao ($tableConfigId) dynamo config not available!"
+      s"SierraTransformableDao ($tableConfigId) dynamo config not available!"
     )
   )
 

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
@@ -6,7 +6,11 @@ import com.twitter.inject.server.FeatureTestMixin
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.locals.SierraItemsToDynamoDBLocal
-import uk.ac.wellcome.test.utils.{AmazonCloudWatchFlag, ExtendedPatience, SQSLocal}
+import uk.ac.wellcome.test.utils.{
+  AmazonCloudWatchFlag,
+  ExtendedPatience,
+  SQSLocal
+}
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.dynamo._
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord


### PR DESCRIPTION
### What is this PR trying to achieve?

Common pattern for transformable names.

### Who is this change for?

🐙 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.

Depends: https://github.com/wellcometrust/platform/pull/1357
