### PR TITLE
Adds visibility to Work

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraBibData.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraBibData.scala
@@ -1,0 +1,8 @@
+package uk.ac.wellcome.transformer.source
+
+case class SierraBibData(
+  id: String,
+  title: String,
+  deleted: Boolean,
+  suppressed: Boolean
+)

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraItemData.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraItemData.scala
@@ -1,0 +1,6 @@
+package uk.ac.wellcome.transformer.source
+
+case class SierraItemData(
+  id: String,
+  deleted: Boolean
+)

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
@@ -3,23 +3,51 @@ package uk.ac.wellcome.transformer.transformers
 import com.twitter.inject.Logging
 import uk.ac.wellcome.models._
 import uk.ac.wellcome.models.transformable.SierraTransformable
+import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
+import uk.ac.wellcome.transformer.source.{SierraBibData, SierraItemData}
 import uk.ac.wellcome.utils.JsonUtil
 
-import scala.util.{Success, Try}
+import scala.util.{Failure, Success, Try}
 
-case class SierraBibData(id: String, title: String)
 
 class SierraTransformableTransformer
     extends TransformableTransformer[SierraTransformable]
     with Logging {
+
+  private def extractItemData(itemRecord: SierraItemRecord) = {
+    info(s"Attempting to transform ${itemRecord}")
+
+    JsonUtil
+      .fromJson[SierraItemData](itemRecord.data) match {
+      case Success(sierraItemData) => Some(Item(
+        sourceIdentifier = SourceIdentifier(
+          IdentifierSchemes.sierraSystemNumber,
+          sierraItemData.id
+        ),
+        identifiers = List(
+          SourceIdentifier(
+            identifierScheme = IdentifierSchemes.sierraSystemNumber,
+            sierraItemData.id
+          )
+        ),
+        visible = !sierraItemData.deleted
+      ))
+      case Failure(e) => {
+        error(s"Failed to parse item!", e)
+
+        None
+      }
+    }
+  }
+
   override def transformForType(
     sierraTransformable: SierraTransformable): Try[Option[Work]] = {
     sierraTransformable.maybeBibData
       .map { bibData =>
         info(s"Attempting to transform $bibData")
 
-        JsonUtil.fromJson[SierraBibData](bibData.data).map { sierraBibData =>
-          Some(Work(
+        JsonUtil.fromJson[SierraBibData](bibData.data).map {
+          sierraBibData => Some(Work(
             title = sierraBibData.title,
             sourceIdentifier = SourceIdentifier(
               identifierScheme = IdentifierSchemes.sierraSystemNumber,
@@ -34,24 +62,13 @@ class SierraTransformableTransformer
             items = Option(sierraTransformable.itemData)
               .getOrElse(Map.empty)
               .values
-              .map(record =>
-                Item(
-                  sourceIdentifier = SourceIdentifier(
-                    IdentifierSchemes.sierraSystemNumber,
-                    record.id
-                  ),
-                  identifiers = List(
-                    SourceIdentifier(
-                      IdentifierSchemes.sierraSystemNumber,
-                      record.id
-                    )
-                  )
-              ))
-              .toList
+              .flatMap(extractItemData)
+              .toList,
+            visible = !(sierraBibData.deleted || sierraBibData.suppressed)
           ))
         }
+
       }
       .getOrElse(Success(None))
   }
-
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
@@ -9,7 +9,6 @@ import uk.ac.wellcome.utils.JsonUtil
 
 import scala.util.{Failure, Success, Try}
 
-
 class SierraTransformableTransformer
     extends TransformableTransformer[SierraTransformable]
     with Logging {
@@ -19,19 +18,21 @@ class SierraTransformableTransformer
 
     JsonUtil
       .fromJson[SierraItemData](itemRecord.data) match {
-      case Success(sierraItemData) => Some(Item(
-        sourceIdentifier = SourceIdentifier(
-          IdentifierSchemes.sierraSystemNumber,
-          sierraItemData.id
-        ),
-        identifiers = List(
-          SourceIdentifier(
-            identifierScheme = IdentifierSchemes.sierraSystemNumber,
-            sierraItemData.id
-          )
-        ),
-        visible = !sierraItemData.deleted
-      ))
+      case Success(sierraItemData) =>
+        Some(
+          Item(
+            sourceIdentifier = SourceIdentifier(
+              IdentifierSchemes.sierraSystemNumber,
+              sierraItemData.id
+            ),
+            identifiers = List(
+              SourceIdentifier(
+                identifierScheme = IdentifierSchemes.sierraSystemNumber,
+                sierraItemData.id
+              )
+            ),
+            visible = !sierraItemData.deleted
+          ))
       case Failure(e) => {
         error(s"Failed to parse item!", e)
 
@@ -46,8 +47,8 @@ class SierraTransformableTransformer
       .map { bibData =>
         info(s"Attempting to transform $bibData")
 
-        JsonUtil.fromJson[SierraBibData](bibData.data).map {
-          sierraBibData => Some(Work(
+        JsonUtil.fromJson[SierraBibData](bibData.data).map { sierraBibData =>
+          Some(Work(
             title = sierraBibData.title,
             sourceIdentifier = SourceIdentifier(
               identifierScheme = IdentifierSchemes.sierraSystemNumber,

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -123,4 +123,120 @@ class SierraTransformableTransformerTest
       )
     )
   }
+
+  it("makes deleted works invisible") {
+    val id = "000"
+    val title = "Hi Diddle Dee Dee"
+    val data =
+      s"""
+         |{
+         | "id": "$id",
+         | "title": "$title",
+         | "deleted": true
+         |}
+        """.stripMargin
+
+    val sierraTransformable = SierraTransformable(
+      id = id,
+      maybeBibData =
+        Some(SierraBibRecord(id = id, data = data, modifiedDate = now())))
+
+    val transformedSierraRecord = transformer.transform(sierraTransformable)
+    transformedSierraRecord.isSuccess shouldBe true
+
+    val identifier =
+      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, id)
+
+    transformedSierraRecord.get shouldBe Some(
+      Work(
+        title = title,
+        sourceIdentifier = identifier,
+        identifiers = List(identifier),
+        visible = false
+      )
+    )
+  }
+
+  it("makes supressed works invisible") {
+    val id = "000"
+    val title = "Hi Diddle Dee Dee"
+    val data =
+      s"""
+         |{
+         | "id": "$id",
+         | "title": "$title",
+         | "suppressed": true
+         |}
+        """.stripMargin
+
+    val sierraTransformable = SierraTransformable(
+      id = id,
+      maybeBibData =
+        Some(SierraBibRecord(id = id, data = data, modifiedDate = now())))
+
+    val transformedSierraRecord = transformer.transform(sierraTransformable)
+    transformedSierraRecord.isSuccess shouldBe true
+
+    val identifier =
+      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, id)
+
+    transformedSierraRecord.get shouldBe Some(
+      Work(
+        title = title,
+        sourceIdentifier = identifier,
+        identifiers = List(identifier),
+        visible = false
+      )
+    )
+  }
+
+  it("makes deleted items on a work invisible") {
+    val id = "b5757575"
+    val title = "A morning mixture of molasses and muesli"
+    val data =
+      s"""
+         |{
+         | "id": "$id",
+         | "title": "$title"
+         |}
+        """.stripMargin
+
+    val sierraTransformable = SierraTransformable(
+      id = id,
+      maybeBibData =
+        Some(SierraBibRecord(id = id, data = data, modifiedDate = now())),
+      itemData = Map(
+        "i111" -> sierraItemRecord(id = "i111",
+          title = title,
+          bibIds = List(id)),
+        "i222" -> sierraItemRecord(id = "i222",
+          title = title,
+          deleted = true,
+          bibIds = List(id))
+      )
+    )
+
+    val transformedSierraRecord = transformer.transform(sierraTransformable)
+
+    transformedSierraRecord.isSuccess shouldBe true
+    val work = transformedSierraRecord.get.get
+
+    val sourceIdentifier1 =
+      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, "i111")
+    val sourceIdentifier2 =
+      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, "i222")
+
+    work.items shouldBe List(
+      Item(
+        sourceIdentifier = sourceIdentifier1,
+        identifiers = List(sourceIdentifier1)
+      ),
+      Item(
+        sourceIdentifier = sourceIdentifier2,
+        identifiers = List(sourceIdentifier2),
+        visible = false
+      )
+    )
+  }
+
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -207,12 +207,12 @@ class SierraTransformableTransformerTest
         Some(SierraBibRecord(id = id, data = data, modifiedDate = now())),
       itemData = Map(
         "i111" -> sierraItemRecord(id = "i111",
-          title = title,
-          bibIds = List(id)),
+                                   title = title,
+                                   bibIds = List(id)),
         "i222" -> sierraItemRecord(id = "i222",
-          title = title,
-          deleted = true,
-          bibIds = List(id))
+                                   title = title,
+                                   deleted = true,
+                                   bibIds = List(id))
       )
     )
 

--- a/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
+++ b/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
@@ -63,6 +63,7 @@ class WorksIndex @Inject()(client: HttpClient,
     sourceIdentifier,
     identifiers,
     location(),
+    booleanField("visible"),
     keywordField("type")
   )
 
@@ -70,6 +71,7 @@ class WorksIndex @Inject()(client: HttpClient,
     .dynamic(DynamicMapping.Strict)
     .as(
       keywordField("canonicalId"),
+      booleanField("visible"),
       keywordField("type"),
       sourceIdentifier,
       identifiers,

--- a/common/src/main/scala/uk/ac/wellcome/models/Item.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Item.scala
@@ -6,7 +6,8 @@ case class Item(
   canonicalId: Option[String] = None,
   sourceIdentifier: SourceIdentifier,
   identifiers: List[SourceIdentifier] = Nil,
-  locations: List[Location] = List()
+  locations: List[Location] = List(),
+  visible: Boolean = true
 ) extends Identifiable {
   @JsonProperty("type") val ontologyType: String = "Item"
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -16,7 +16,9 @@ case class Work(title: String,
                 creators: List[Agent] = Nil,
                 genres: List[Concept] = Nil,
                 thumbnail: Option[Location] = None,
-                items: List[Item] = Nil)
+                items: List[Item] = Nil,
+                visible: Boolean = true
+               )
     extends Identifiable {
   @JsonProperty("type") val ontologyType: String = "Work"
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -17,8 +17,7 @@ case class Work(title: String,
                 genres: List[Concept] = Nil,
                 thumbnail: Option[Location] = None,
                 items: List[Item] = Nil,
-                visible: Boolean = true
-               )
+                visible: Boolean = true)
     extends Identifiable {
   @JsonProperty("type") val ontologyType: String = "Work"
 }

--- a/common/src/test/scala/uk/ac/wellcome/models/ItemTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/ItemTest.scala
@@ -32,6 +32,7 @@ class ItemTest extends FunSpec with Matchers with JsonTestUtil {
       |      "type": "Location"
       |    }
       |  ],
+      |  "visible":true,
       |  "type": "Item"
       |}
     """.stripMargin
@@ -61,6 +62,7 @@ class ItemTest extends FunSpec with Matchers with JsonTestUtil {
       |      "type": "Location"
       |    }
       |  ],
+      |  "visible":true,
       |  "type": "Item"
       |}
     """.stripMargin

--- a/common/src/test/scala/uk/ac/wellcome/models/WorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/WorkTest.scala
@@ -78,9 +78,11 @@ class WorkTest extends FunSpec with Matchers with JsonTestUtil {
       |          "type": "Location"
       |        }
       |      ],
+      |      "visible":true,
       |      "type": "Item"
       |    }
       |  ],
+      |  "visible":true,
       |  "type": "Work"
       |}
     """.stripMargin
@@ -148,9 +150,11 @@ class WorkTest extends FunSpec with Matchers with JsonTestUtil {
       |          "type": "Location"
       |        }
       |      ],
+      |      "visible":true,
       |      "type": "Item"
       |    }
       |  ],
+      |  "visible":true,
       |  "type": "Work"
       |}
     """.stripMargin

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/SierraData.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/SierraData.scala
@@ -9,13 +9,15 @@ trait SierraData {
     title: String = "Ingenious imps invent invasive implements",
     modifiedDate: String = "2001-01-01T01:01:01Z",
     bibIds: List[String] = List(),
-    unlinkedBibIds: List[String] = List()
+    unlinkedBibIds: List[String] = List(),
+    deleted:Boolean = false
   ) = SierraItemRecord(
     id = id,
     data = sierraRecordString(
       id = id,
       updatedDate = modifiedDate,
-      title = title
+      title = title,
+      deleted = deleted
     ),
     modifiedDate = modifiedDate,
     bibIds = bibIds,
@@ -25,14 +27,15 @@ trait SierraData {
   def sierraRecordString(
     id: String,
     updatedDate: String,
-    title: String
+    title: String,
+    deleted: Boolean = false
   ) =
     s"""
        |{
        |      "id": "$id",
        |      "updatedDate": "$updatedDate",
        |      "createdDate": "1999-11-01T16:36:51Z",
-       |      "deleted": false,
+       |      "deleted": $deleted,
        |      "suppressed": false,
        |      "lang": {
        |        "code": "ger",

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/SierraData.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/SierraData.scala
@@ -10,7 +10,7 @@ trait SierraData {
     modifiedDate: String = "2001-01-01T01:01:01Z",
     bibIds: List[String] = List(),
     unlinkedBibIds: List[String] = List(),
-    deleted:Boolean = false
+    deleted: Boolean = false
   ) = SierraItemRecord(
     id = id,
     data = sierraRecordString(


### PR DESCRIPTION
### What is this PR trying to achieve?

In order that visibility states as calculated from sierra data can be applied.

- Items are invisible when deleted is true on Sierra items.
- Bibs are invisible when deleted or supressed is true on Sierra bibs.

This PR adds only the status, does not make the change to actually hide records with visible state false.

### Who is this change for?

Folk who want to be able to reflect the hidden status from sierra. 📖 💘 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.

Part of https://github.com/wellcometrust/platform/issues/1283