### PR TITLE
Move WorksIndex to ingestor

### DIFF
--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/models/WorksIndex.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/models/WorksIndex.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.elasticsearch.mappings
+package uk.ac.wellcome.platform.ingestor.models
 
 import com.google.inject.Inject
 import com.sksamuel.elastic4s.analyzers._

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/WorksIndexModule.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/WorksIndexModule.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.ingestor.modules
 
 import com.twitter.inject.{Injector, TwitterModule}
-import uk.ac.wellcome.elasticsearch.mappings.WorksIndex
+import uk.ac.wellcome.platform.ingestor.models.WorksIndex
 
 object WorksIndexModule extends TwitterModule {
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -7,6 +7,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, Work}
+import uk.ac.wellcome.platform.ingestor.test.utils.Ingestor
 import uk.ac.wellcome.test.utils.JsonTestUtil
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
@@ -15,7 +16,7 @@ import scala.collection.JavaConversions._
 
 class IngestorFeatureTest
     extends FunSpec
-    with IngestorUtils
+    with Ingestor
     with FeatureTestMixin
     with Matchers
     with JsonTestUtil

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
@@ -4,10 +4,11 @@ import com.sksamuel.elastic4s.ElasticDsl.{deleteIndex, index}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import com.sksamuel.elastic4s.http.ElasticDsl._
+import uk.ac.wellcome.platform.ingestor.test.utils.Ingestor
 
 class IngestorIndexTest
     extends FunSpec
-    with IngestorUtils
+    with Ingestor
     with Matchers
     with ScalaFutures {
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/models/WorksIndexTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/models/WorksIndexTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.elasticsearch.mappings
+package uk.ac.wellcome.platform.ingestor.models
 
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicMapping
@@ -6,7 +6,7 @@ import org.elasticsearch.client.ResponseException
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
 import uk.ac.wellcome.models.{IdentifierSchemes, _}
-import uk.ac.wellcome.test.utils.ElasticSearchLocal
+import uk.ac.wellcome.platform.ingestor.test.utils.ElasticSearchLocal
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -8,8 +8,9 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, Work}
+import uk.ac.wellcome.platform.ingestor.test.utils.IndexedElasticSearchLocal
 import uk.ac.wellcome.sqs.SQSReaderGracefulException
-import uk.ac.wellcome.test.utils.{IndexedElasticSearchLocal, JsonTestUtil}
+import uk.ac.wellcome.test.utils.JsonTestUtil
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
 
@@ -22,6 +23,9 @@ class WorkIndexerTest
     with MockitoSugar
     with JsonTestUtil
     with IndexedElasticSearchLocal {
+
+  val indexName = "works"
+  val itemType = "work"
 
   val metricsSender: MetricsSender =
     new MetricsSender(namespace = "reindexer-tests", mock[AmazonCloudWatch])

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/ElasticSearchLocal.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/ElasticSearchLocal.scala
@@ -1,18 +1,14 @@
-package uk.ac.wellcome.test.utils
+package uk.ac.wellcome.platform.ingestor.test.utils
 
 import com.sksamuel.elastic4s.http.ElasticDsl._
-import com.sksamuel.elastic4s.ElasticsearchClientUri
 import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.http.index.admin.IndexExistsResponse
-import org.apache.http.auth.{AuthScope, UsernamePasswordCredentials}
 import org.apache.http.HttpHost
-import org.apache.http.impl.client.BasicCredentialsProvider
-import org.apache.http.impl.nio.client.HttpAsyncClientBuilder
 import org.elasticsearch.client.RestClient
-import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback
-import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.concurrent.Eventually
 import org.scalatest.{Matchers, Suite}
 import uk.ac.wellcome.finatra.modules.ElasticCredentials
+import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.Future
@@ -22,12 +18,12 @@ trait ElasticSearchLocal
     with ExtendedPatience
     with Matchers { this: Suite =>
 
-  val restClient = RestClient
+  val restClient: RestClient = RestClient
     .builder(new HttpHost("localhost", 9200, "http"))
     .setHttpClientConfigCallback(new ElasticCredentials("elastic", "changeme"))
     .build()
 
-  val elasticClient = HttpClient.fromRestClient(restClient)
+  val elasticClient: HttpClient = HttpClient.fromRestClient(restClient)
 
   // Elasticsearch takes a while to start up so check that it actually started before running tests
   eventually {

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/IndexedElasticSearchLocal.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/IndexedElasticSearchLocal.scala
@@ -1,21 +1,23 @@
-package uk.ac.wellcome.test.utils
+package uk.ac.wellcome.platform.ingestor.test.utils
 
-import com.sksamuel.elastic4s.http.ElasticDsl._
+import com.sksamuel.elastic4s.http.ElasticDsl.{indexExists, indexInto, search}
 import com.sksamuel.elastic4s.http.index.IndexResponse
 import org.scalatest.{BeforeAndAfterEach, Suite}
-import uk.ac.wellcome.elasticsearch.mappings.WorksIndex
 import uk.ac.wellcome.models.Work
-import uk.ac.wellcome.utils.GlobalExecutionContext.context
+import uk.ac.wellcome.platform.ingestor.models.WorksIndex
 import uk.ac.wellcome.utils.JsonUtil
+import uk.ac.wellcome.utils.GlobalExecutionContext.context
+
+import com.sksamuel.elastic4s.http.ElasticDsl._
 
 import scala.concurrent.Future
 
 trait IndexedElasticSearchLocal
-    extends ElasticSearchLocal
+  extends ElasticSearchLocal
     with BeforeAndAfterEach { this: Suite =>
 
-  val indexName = "works"
-  val itemType = "work"
+  val indexName: String
+  val itemType: String
 
   private def createIndex(index: String) = {
     ensureIndexDeleted(index)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/IndexedElasticSearchLocal.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/IndexedElasticSearchLocal.scala
@@ -13,7 +13,7 @@ import com.sksamuel.elastic4s.http.ElasticDsl._
 import scala.concurrent.Future
 
 trait IndexedElasticSearchLocal
-  extends ElasticSearchLocal
+    extends ElasticSearchLocal
     with BeforeAndAfterEach { this: Suite =>
 
   val indexName: String

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/Ingestor.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/Ingestor.scala
@@ -1,18 +1,20 @@
-package uk.ac.wellcome.platform.ingestor
+package uk.ac.wellcome.platform.ingestor.test.utils
 
 import com.twitter.finatra.http.EmbeddedHttpServer
-import org.scalatest.Suite
-import uk.ac.wellcome.test.utils.{
-  AmazonCloudWatchFlag,
-  IndexedElasticSearchLocal,
-  SQSLocal
-}
+import org.scalatest.{BeforeAndAfterEach, Suite}
+import uk.ac.wellcome.platform.ingestor.Server
+import uk.ac.wellcome.test.utils.{AmazonCloudWatchFlag, SQSLocal}
 
-trait IngestorUtils
+trait Ingestor
     extends IndexedElasticSearchLocal
     with SQSLocal
+    with BeforeAndAfterEach
     with AmazonCloudWatchFlag { this: Suite =>
+
   val ingestorQueueUrl = createQueueAndReturnUrl("test_es_ingestor_queue")
+
+  val indexName = "works"
+  val itemType = "work"
 
   def createServer: EmbeddedHttpServer = {
     new EmbeddedHttpServer(

--- a/common/docker-compose.yml
+++ b/common/docker-compose.yml
@@ -6,12 +6,3 @@ sqs:
   image: s12v/elasticmq
   ports:
     - "9324:9324"
-elasticsearch:
-  image: docker.elastic.co/elasticsearch/elasticsearch:5.4.0
-  ports:
-    - "9200:9200"
-    - "9300:9300"
-  environment:
-    - "http.host=0.0.0.0"
-    - "transport.host=0.0.0.0"
-    - "cluster.name=wellcome"


### PR DESCRIPTION
### What is this PR trying to achieve?

Clarify and make index creation more reliable.

This change starts this process by moving WorksIndex to `ingestor`.

### Who is this change for?

🦀 🔫 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.
