### PR TITLE
Move the identifiers code into its own trait

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
@@ -12,6 +12,7 @@ import scala.util.{Failure, Success, Try}
 
 class SierraTransformableTransformer
     extends TransformableTransformer[SierraTransformable]
+    with SierraIdentifiers
     with SierraPublishers
     with SierraTitle
     with Logging {
@@ -59,12 +60,7 @@ class SierraTransformableTransformer
               identifierScheme = IdentifierSchemes.sierraSystemNumber,
               sierraBibData.id
             ),
-            identifiers = List(
-              SourceIdentifier(
-                identifierScheme = IdentifierSchemes.sierraSystemNumber,
-                sierraBibData.id
-              )
-            ),
+            identifiers = getIdentifiers(sierraBibData),
             items = Option(sierraTransformable.itemData)
               .getOrElse(Map.empty)
               .values

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraIdentifiers.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraIdentifiers.scala
@@ -1,0 +1,22 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier}
+
+import uk.ac.wellcome.transformer.source.SierraBibData
+
+trait SierraIdentifiers {
+
+  // Populate wwork:identifiers.
+  //
+  //    We populate with "identifierScheme": "sierra-system-number" for the
+  //    main ID on the original bib.  Adding other identifiers is out-of-scope
+  //    for now.
+  //
+  def getIdentifiers(bibData: SierraBibData): List[SourceIdentifier] =
+    List(
+      SourceIdentifier(
+        identifierScheme = IdentifierSchemes.sierraSystemNumber,
+        value = bibData.id
+      )
+    )
+}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraIdentifiersTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraIdentifiersTest.scala
@@ -1,0 +1,38 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier}
+import uk.ac.wellcome.transformer.source.SierraBibData
+import uk.ac.wellcome.test.utils.SierraData
+
+class SierraIdentifiersTest extends FunSpec with Matchers with SierraData {
+
+  it("passes through the main identifier from the bib record") {
+    assertIdentifiersAreCorrect(
+      bibDataId = "b1782863",
+      expectedIdentifiers = List(
+        SourceIdentifier(
+          identifierScheme = IdentifierSchemes.sierraSystemNumber,
+          value = "b1782863"
+        )
+      )
+    )
+  }
+
+  val transformer = new Object with SierraIdentifiers
+
+  private def assertIdentifiersAreCorrect(
+    bibDataId: String,
+    expectedIdentifiers: List[SourceIdentifier]
+  ) = {
+
+    val bibData = SierraBibData(
+      id = bibDataId,
+      title = "An imprint of insects on the inside of an igloo",
+      deleted = false,
+      suppressed = false
+    )
+
+    transformer.getIdentifiers(bibData = bibData) shouldBe expectedIdentifiers
+  }
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

Better code organisation in the Sierra transformer.

### Who is this change for?

🦈 