### PR TITLE
Add metrics to message processing

### DIFF
--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerTest.scala
@@ -1,37 +1,83 @@
 package uk.ac.wellcome.sqs
 
 import akka.actor.ActorSystem
-import org.mockito.Matchers.{anyDouble, anyString}
+import org.mockito.Matchers.{any, anyDouble, anyString, contains}
 import org.mockito.Mockito
-import org.mockito.Mockito.{never, verify}
+import org.mockito.Mockito.{never, times, verify, when}
 import org.scalatest.FunSpec
+import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.{SQSConfig, SQSMessage}
 import uk.ac.wellcome.test.utils.SQSLocal
+import uk.ac.wellcome.utils.JsonUtil
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.collection.JavaConversions._
 
-class SQSWorkerTest extends FunSpec with SQSLocal with MockitoSugar {
+import uk.ac.wellcome.utils.GlobalExecutionContext.context
+
+class SQSWorkerTest
+  extends FunSpec
+    with SQSLocal
+    with MockitoSugar
+    with Eventually {
 
   val queueUrl = createQueueAndReturnUrl("worker-test-queue")
+
   private val metricsSender: MetricsSender = mock[MetricsSender]
+
+  when(
+    metricsSender.timeAndCount[Unit](
+      anyString(),
+      any[() => Future[Unit]].apply
+    )
+  ).thenReturn(
+    Future.successful()
+  )
+
   sqsClient.setQueueAttributes(queueUrl, Map("VisibilityTimeout" -> "0"))
 
-  val worker = new SQSWorker(
+  class TestWorker extends SQSWorker(
     new SQSReader(sqsClient, SQSConfig(queueUrl, 1.second, 1)),
     ActorSystem(),
     metricsSender) {
     override lazy val totalWait = 1.second
 
     override def processMessage(message: SQSMessage): Future[Unit] =
-      Future.successful(())
+      Future.successful()
   }
 
-  it(
-    "should not fail the TryBackoff run if it's unable to parse a message into SQSMessage") {
+  val worker = new TestWorker()
+
+  it("processes messages") {
+    worker.runSQSWorker()
+
+    val testMessage = SQSMessage(
+      subject = Some("subject"),
+      messageType = "messageType",
+      topic = "topic",
+      body = "body",
+      timestamp = "timestamp"
+    )
+
+    val testMessageJson = JsonUtil.toJson(testMessage).get
+
+    sqsClient.sendMessage(queueUrl, testMessageJson)
+
+    eventually {
+        verify(
+          metricsSender,
+          times(1)
+        ).timeAndCount(
+          contains("TestWorker_ProcessMessage"),
+          any[() => Future[Unit]]()
+        )
+    }
+  }
+
+  it("does not fail the TryBackoff run when unable to parse a message") {
     worker.runSQSWorker()
     sqsClient.sendMessage(queueUrl, "this is not valid Json")
 

--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerTest.scala
@@ -19,7 +19,7 @@ import scala.collection.JavaConversions._
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 class SQSWorkerTest
-  extends FunSpec
+    extends FunSpec
     with SQSLocal
     with MockitoSugar
     with Eventually {
@@ -39,10 +39,11 @@ class SQSWorkerTest
 
   sqsClient.setQueueAttributes(queueUrl, Map("VisibilityTimeout" -> "0"))
 
-  class TestWorker extends SQSWorker(
-    new SQSReader(sqsClient, SQSConfig(queueUrl, 1.second, 1)),
-    ActorSystem(),
-    metricsSender) {
+  class TestWorker
+      extends SQSWorker(
+        new SQSReader(sqsClient, SQSConfig(queueUrl, 1.second, 1)),
+        ActorSystem(),
+        metricsSender) {
     override lazy val totalWait = 1.second
 
     override def processMessage(message: SQSMessage): Future[Unit] =
@@ -67,13 +68,13 @@ class SQSWorkerTest
     sqsClient.sendMessage(queueUrl, testMessageJson)
 
     eventually {
-        verify(
-          metricsSender,
-          times(1)
-        ).timeAndCount(
-          contains("TestWorker_ProcessMessage"),
-          any[() => Future[Unit]]()
-        )
+      verify(
+        metricsSender,
+        times(1)
+      ).timeAndCount(
+        contains("TestWorker_ProcessMessage"),
+        any[() => Future[Unit]]()
+      )
     }
   }
 

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -16,7 +16,11 @@ import uk.ac.wellcome.sqs.{SQSReader, SQSReaderGracefulException}
 import uk.ac.wellcome.test.utils.{ExtendedPatience, SQSLocal}
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.dynamo._
-import uk.ac.wellcome.models.transformable.sierra.{SierraBibRecord, SierraItemRecord, SierraRecord}
+import uk.ac.wellcome.models.transformable.sierra.{
+  SierraBibRecord,
+  SierraItemRecord,
+  SierraRecord
+}
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.dynamo.SierraItemRecordDao
 import io.circe.generic.auto._
 import io.circe.syntax._


### PR DESCRIPTION
### What is this PR trying to achieve?

Better visibility of timings and success/failure of message processing apps.

This should add metrics to all apps using the `SQSWorker`!

### Who is this change for?

🗺 👑 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.
