### PR TITLE
Fix scaling on sierra adapter dynamo tables

### DIFF
--- a/sierra_adapter/terraform/dynamo.tf
+++ b/sierra_adapter/terraform/dynamo.tf
@@ -21,15 +21,10 @@ resource "aws_dynamodb_table" "sierradata_table" {
   }
 }
 
-data "aws_iam_role" "DynamoDBAutoscaleRole" {
-  name = "DynamoDBAutoscaleRole"
-}
-
 resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
   max_capacity       = 100
   min_capacity       = 1
   resource_id        = "table/${aws_dynamodb_table.sierradata_table.name}"
-  role_arn           = "${data.aws_iam_role.DynamoDBAutoscaleRole.arn}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 }
@@ -54,7 +49,6 @@ resource "aws_appautoscaling_target" "dynamodb_table_write_target" {
   max_capacity       = 100
   min_capacity       = 1
   resource_id        = "table/${aws_dynamodb_table.sierradata_table.name}"
-  role_arn           = "${data.aws_iam_role.DynamoDBAutoscaleRole.arn}"
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
   service_namespace  = "dynamodb"
 }

--- a/sierra_adapter/terraform/items_to_dynamo/dynamo.tf
+++ b/sierra_adapter/terraform/items_to_dynamo/dynamo.tf
@@ -20,3 +20,51 @@ resource "aws_dynamodb_table" "sierra_table" {
     ]
   }
 }
+
+resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
+  max_capacity       = 100
+  min_capacity       = 1
+  resource_id        = "table/${aws_dynamodb_table.sierra_table.name}"
+  scalable_dimension = "dynamodb:table:ReadCapacityUnits"
+  service_namespace  = "dynamodb"
+}
+
+resource "aws_appautoscaling_policy" "dynamodb_table_read_policy" {
+  name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.dynamodb_table_read_target.resource_id}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = "${aws_appautoscaling_target.dynamodb_table_read_target.resource_id}"
+  scalable_dimension = "${aws_appautoscaling_target.dynamodb_table_read_target.scalable_dimension}"
+  service_namespace  = "${aws_appautoscaling_target.dynamodb_table_read_target.service_namespace}"
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "DynamoDBReadCapacityUtilization"
+    }
+
+    target_value = 70
+  }
+}
+
+resource "aws_appautoscaling_target" "dynamodb_table_write_target" {
+  max_capacity       = 100
+  min_capacity       = 1
+  resource_id        = "table/${aws_dynamodb_table.sierra_table.name}"
+  scalable_dimension = "dynamodb:table:WriteCapacityUnits"
+  service_namespace  = "dynamodb"
+}
+
+resource "aws_appautoscaling_policy" "dynamodb_table_write_policy" {
+  name               = "DynamoDBWriteCapacityUtilization:${aws_appautoscaling_target.dynamodb_table_write_target.resource_id}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = "${aws_appautoscaling_target.dynamodb_table_write_target.resource_id}"
+  scalable_dimension = "${aws_appautoscaling_target.dynamodb_table_write_target.scalable_dimension}"
+  service_namespace  = "${aws_appautoscaling_target.dynamodb_table_write_target.service_namespace}"
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "DynamoDBWriteCapacityUtilization"
+    }
+
+    target_value = 70
+  }
+}

--- a/sierra_adapter/terraform/provider.tf
+++ b/sierra_adapter/terraform/provider.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.3.1"
+  version = "1.7.0"
 }
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
### What is this PR trying to achieve?

Allow scaling to work reliably for sierra adapter dynamo tables.

### Who is this change for?

🐐 

### Have the following been considered/are they needed?

- [X] Deployed new versions
- [X] Run `terraform apply`.
