### PR TITLE
Refactor the internal interfaces of the ingestor

### DIFF
--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -22,7 +22,8 @@ class IngestorWorkerService @Inject()(
 
   override def processMessage(message: SQSMessage): Future[Unit] = Future {
     fromJson[Work](message.body) match {
-      case Success(work) => identifiedWorkIndexer.indexWork(work = work).map(_ => ())
+      case Success(work) =>
+        identifiedWorkIndexer.indexWork(work = work).map(_ => ())
       case Failure(err) => throw GracefulFailureException(err)
     }
   }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -21,9 +21,10 @@ class IngestorWorkerService @Inject()(
   metrics: MetricsSender
 ) extends SQSWorker(reader, system, metrics) {
 
-  override def processMessage(message: SQSMessage): Future[Unit] =
+  override def processMessage(message: SQSMessage): Future[Unit] = Future {
     decode[Work](message.body) match {
       case Right(work) => identifiedWorkIndexer.indexWork(work = work).map(_ => ())
       case Left(error) => throw GracefulFailureException(error)
     }
+  }
 }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -2,9 +2,7 @@ package uk.ac.wellcome.platform.ingestor.services
 
 import akka.actor.ActorSystem
 import com.google.inject.Inject
-import io.circe.generic.extras.auto._
-import io.circe.parser._
-import uk.ac.wellcome.circe._
+import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.Work
@@ -13,6 +11,7 @@ import uk.ac.wellcome.sqs.{SQSReader, SQSWorker}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.Future
+import scala.util.{Failure, Success}
 
 class IngestorWorkerService @Inject()(
   identifiedWorkIndexer: WorkIndexer,
@@ -22,9 +21,9 @@ class IngestorWorkerService @Inject()(
 ) extends SQSWorker(reader, system, metrics) {
 
   override def processMessage(message: SQSMessage): Future[Unit] = Future {
-    decode[Work](message.body) match {
-      case Right(work) => identifiedWorkIndexer.indexWork(work = work).map(_ => ())
-      case Left(error) => throw GracefulFailureException(error)
+    fromJson[Work](message.body) match {
+      case Success(work) => identifiedWorkIndexer.indexWork(work = work).map(_ => ())
+      case Failure(err) => throw GracefulFailureException(err)
     }
   }
 }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -29,13 +29,15 @@ class WorkIndexer @Inject()(
       "ingestor-index-work",
       () => {
         info("Indexing work $work")
-        elasticClient.execute {
-          indexInto(esIndex / esType).id(work.id).doc(work)
-        }.recover {
-          case e: Throwable =>
-            error(s"Error indexing work $work into Elasticsearch", e)
-            throw e
-        }
+        elasticClient
+          .execute {
+            indexInto(esIndex / esType).id(work.id).doc(work)
+          }
+          .recover {
+            case e: Throwable =>
+              error(s"Error indexing work $work into Elasticsearch", e)
+              throw e
+          }
       }
     )
   }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -24,6 +24,10 @@ class WorkIndexer @Inject()(
 ) extends Logging {
 
   def indexWork(work: Work): Future[IndexResponse] = {
+
+    // This is required for elastic4s, not Circe
+    implicit val jsonMapper = Work
+
     metricsSender.timeAndCount[IndexResponse](
       "ingestor-index-work",
       () => {

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -24,11 +24,10 @@ class WorkIndexer @Inject()(
 ) extends Logging {
 
   def indexWork(work: Work): Future[IndexResponse] = {
-    implicit val jsonMapper = Work
     metricsSender.timeAndCount[IndexResponse](
       "ingestor-index-work",
       () => {
-        info("Indexing work $work")
+        info(s"Indexing work $work")
         elasticClient
           .execute {
             indexInto(esIndex / esType).id(work.id).doc(work)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -26,8 +26,7 @@ class IngestorFeatureTest
   override val server: EmbeddedHttpServer = createServer
 
   // Setting 1 second timeout for tests, so that test don't have to wait too long to test message deletion
-  sqsClient.setQueueAttributes(ingestorQueueUrl,
-                               Map("VisibilityTimeout" -> "1"))
+  sqsClient.setQueueAttributes(queueUrl, Map("VisibilityTimeout" -> "1"))
 
   it("reads an identified work from the queue and ingests it") {
     val sourceIdentifier =
@@ -45,7 +44,7 @@ class IngestorFeatureTest
       .get
 
     sqsClient.sendMessage(
-      ingestorQueueUrl,
+      queueUrl,
       JsonUtil
         .toJson(
           SQSMessage(
@@ -88,7 +87,7 @@ class IngestorFeatureTest
       .get
 
     sqsClient.sendMessage(
-      ingestorQueueUrl,
+      queueUrl,
       invalidMessage
     )
 
@@ -102,7 +101,7 @@ class IngestorFeatureTest
     eventually {
       sqsClient
         .getQueueAttributes(
-          ingestorQueueUrl,
+          queueUrl,
           List("ApproximateNumberOfMessagesNotVisible")
         )
         .getAttributes

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.platform.ingestor.test.utils.Ingestor
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.sqs.SQSReader
 import uk.ac.wellcome.test.utils.JsonTestUtil
-import uk.ac.wellcome.utils.JsonUtil
+import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.duration._
@@ -45,7 +45,7 @@ class IngestorWorkerServiceTest
       title = "A monstrous monolith of moss"
     )
 
-    val sqsMessage = messageFromString(JsonUtil.toJson(work).get)
+    val sqsMessage = messageFromString(toJson(work).get)
     service.processMessage(sqsMessage)
 
     eventually {

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -8,7 +8,8 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.{SQSConfig, SQSMessage}
 import uk.ac.wellcome.platform.ingestor.test.utils.Ingestor
-import uk.ac.wellcome.sqs.{SQSReader, SQSReaderGracefulException}
+import uk.ac.wellcome.exceptions.GracefulFailureException
+import uk.ac.wellcome.sqs.SQSReader
 import uk.ac.wellcome.test.utils.JsonTestUtil
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -57,7 +58,7 @@ class IngestorWorkerServiceTest
     val future = service.processMessage(sqsMessage)
 
     whenReady(future.failed) { exception =>
-      exception shouldBe a[SQSReaderGracefulException]
+      exception shouldBe a[GracefulFailureException]
     }
   }
 
@@ -67,7 +68,7 @@ class IngestorWorkerServiceTest
     val future = service.processMessage(sqsMessage)
 
     whenReady(future.failed) { exception =>
-      exception shouldBe a[SQSReaderGracefulException]
+      exception shouldBe a[GracefulFailureException]
     }
   }
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -1,17 +1,14 @@
 package uk.ac.wellcome.platform.ingestor.services
 
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
-import com.sksamuel.elastic4s.http.ElasticDsl._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
-import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, Work}
-import uk.ac.wellcome.test.utils.{IndexedElasticSearchLocal, JsonTestUtil}
+import uk.ac.wellcome.platform.ingestor.test.utils.Ingestor
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
-import uk.ac.wellcome.utils.JsonUtil
 
 import scala.concurrent.Future
 
@@ -20,11 +17,7 @@ class WorkIndexerTest
     with ScalaFutures
     with Matchers
     with MockitoSugar
-    with JsonTestUtil
-    with IndexedElasticSearchLocal {
-
-  val indexName = "works"
-  val itemType = "work"
+    with Ingestor {
 
   val metricsSender: MetricsSender =
     new MetricsSender(namespace = "reindexer-tests", mock[AmazonCloudWatch])
@@ -52,49 +45,5 @@ class WorkIndexerTest
     whenReady(future) { _ =>
       assertElasticsearchEventuallyHasWork(work)
     }
-  }
-
-  private def assertElasticsearchEventuallyHasWork(work: Work) = {
-    val workJson = JsonUtil.toJson(work).get
-
-    whenReady(future.failed) { exception =>
-      exception shouldBe a[GracefulFailureException]
-    }
-  }
-
-  it(
-    "should not return a NullPointerException if the document is the string null") {
-    val future = workIndexer.indexWork("null")
-
-    whenReady(future.failed) { exception =>
-      exception shouldBe a[GracefulFailureException]
-    }
-  }
-
-  private def assertElasticsearchEventuallyHasWork(workJson: String) = {
-    eventually {
-      val hits = elasticClient
-        .execute(search(s"$indexName/$itemType").matchAllQuery().limit(100))
-        .map { _.hits.hits }
-        .await
-
-      hits should have size 1
-
-      assertJsonStringsAreEqual(hits.head.sourceAsString, workJson)
-    }
-  }
-
-  private def createWork(canonicalId: String, sourceId: String, title: String): Work = {
-    val sourceIdentifier = SourceIdentifier(
-      IdentifierSchemes.miroImageNumber,
-      sourceId
-    )
-
-    Work(
-      canonicalId = Some(canonicalId),
-      sourceIdentifier = sourceIdentifier,
-      identifiers = List(sourceIdentifier),
-      title = title
-    )
   }
 }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/Ingestor.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/Ingestor.scala
@@ -5,7 +5,12 @@ import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.{BeforeAndAfterEach, Suite}
 import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, Work}
 import uk.ac.wellcome.platform.ingestor.Server
-import uk.ac.wellcome.test.utils.{AmazonCloudWatchFlag, IndexedElasticSearchLocal, JsonTestUtil, SQSLocal}
+import uk.ac.wellcome.test.utils.{
+  AmazonCloudWatchFlag,
+  IndexedElasticSearchLocal,
+  JsonTestUtil,
+  SQSLocal
+}
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
@@ -14,7 +19,7 @@ trait Ingestor
     with SQSLocal
     with BeforeAndAfterEach
     with AmazonCloudWatchFlag
-      with JsonTestUtil { this: Suite =>
+    with JsonTestUtil { this: Suite =>
 
   val queueUrl = createQueueAndReturnUrl("test_es_ingestor_queue")
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/Ingestor.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/Ingestor.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.test.utils.{
   JsonTestUtil,
   SQSLocal
 }
-import uk.ac.wellcome.utils.JsonUtil
+import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 trait Ingestor
@@ -43,7 +43,7 @@ trait Ingestor
   }
 
   def assertElasticsearchEventuallyHasWork(work: Work) = {
-    val workJson = JsonUtil.toJson(work).get
+    val workJson = toJson(work).get
 
     eventually {
       val hits = elasticClient

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/Ingestor.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/Ingestor.scala
@@ -1,21 +1,22 @@
 package uk.ac.wellcome.platform.ingestor.test.utils
 
+import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.{BeforeAndAfterEach, Suite}
+import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, Work}
 import uk.ac.wellcome.platform.ingestor.Server
-import uk.ac.wellcome.test.utils.{
-  AmazonCloudWatchFlag,
-  IndexedElasticSearchLocal,
-  SQSLocal
-}
+import uk.ac.wellcome.test.utils.{AmazonCloudWatchFlag, IndexedElasticSearchLocal, JsonTestUtil, SQSLocal}
+import uk.ac.wellcome.utils.JsonUtil
+import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 trait Ingestor
     extends IndexedElasticSearchLocal
     with SQSLocal
     with BeforeAndAfterEach
-    with AmazonCloudWatchFlag { this: Suite =>
+    with AmazonCloudWatchFlag
+      with JsonTestUtil { this: Suite =>
 
-  val ingestorQueueUrl = createQueueAndReturnUrl("test_es_ingestor_queue")
+  val queueUrl = createQueueAndReturnUrl("test_es_ingestor_queue")
 
   val indexName = "works"
   val itemType = "work"
@@ -25,7 +26,7 @@ trait Ingestor
       new Server(),
       flags = Map(
         "aws.region" -> "eu-west-1",
-        "aws.sqs.queue.url" -> ingestorQueueUrl,
+        "aws.sqs.queue.url" -> queueUrl,
         "aws.sqs.waitTime" -> "1",
         "es.host" -> "localhost",
         "es.port" -> "9200",
@@ -33,6 +34,35 @@ trait Ingestor
         "es.index" -> indexName,
         "es.type" -> itemType
       ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag
+    )
+  }
+
+  def assertElasticsearchEventuallyHasWork(work: Work) = {
+    val workJson = JsonUtil.toJson(work).get
+
+    eventually {
+      val hits = elasticClient
+        .execute(search(s"$indexName/$itemType").matchAllQuery().limit(100))
+        .map { _.hits.hits }
+        .await
+
+      hits should have size 1
+
+      assertJsonStringsAreEqual(hits.head.sourceAsString, workJson)
+    }
+  }
+
+  def createWork(canonicalId: String, sourceId: String, title: String): Work = {
+    val sourceIdentifier = SourceIdentifier(
+      IdentifierSchemes.miroImageNumber,
+      sourceId
+    )
+
+    Work(
+      canonicalId = Some(canonicalId),
+      sourceIdentifier = sourceIdentifier,
+      identifiers = List(sourceIdentifier),
+      title = title
     )
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
@@ -117,7 +117,7 @@ class SQSReaderTest
   }
 
   it(
-    "should return a successful future but not delete the message if processing a message fails with SQSReaderGracefulException") {
+    "should return a successful future but not delete the message if processing a message fails with GracefulFailureException") {
     val sqsConfig =
       SQSConfig(queueUrl, waitTime = 20 seconds, maxMessages = 10)
 

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/services/WindowExtractorTest.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/services/WindowExtractorTest.scala
@@ -19,7 +19,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
   }
 
   it(
-    "should return a SQSReaderGracefulException if start is not a valid iso datetime") {
+    "should return a GracefulFailureException if start is not a valid iso datetime") {
     val jsonString =
       s"""
          |{
@@ -34,7 +34,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
   }
 
   it(
-    "should return a SQSReaderGracefulException if start is a datetime but does not have a timezone") {
+    "should return a GracefulFailureException if start is a datetime but does not have a timezone") {
     val jsonString =
       s"""
          |{
@@ -49,7 +49,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
   }
 
   it(
-    "should return a SQSReaderGracefulException if end is not a valid iso datetime") {
+    "should return a GracefulFailureException if end is not a valid iso datetime") {
     val jsonString =
       s"""
          |{
@@ -64,7 +64,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
   }
 
   it(
-    "should return a SQSReaderGracefulException if end is a datetime but does not have a timezone") {
+    "should return a GracefulFailureException if end is a datetime but does not have a timezone") {
     val jsonString =
       s"""
          |{
@@ -79,7 +79,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
   }
 
   it(
-    "should return a SQSReaderGracefulException if there is not a start datetime") {
+    "should return a GracefulFailureException if there is not a start datetime") {
     val jsonString =
       s"""
          |{
@@ -93,7 +93,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
   }
 
   it(
-    "should return a SQSReaderGracefulException if there is not an end datetime") {
+    "should return a GracefulFailureException if there is not an end datetime") {
     val jsonString =
       s"""
          |{
@@ -107,7 +107,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
   }
 
   it(
-    "should return a SQSReaderGracefulException if the start time is after the end time") {
+    "should return a GracefulFailureException if the start time is after the end time") {
     val jsonString =
       s"""
          |{
@@ -122,7 +122,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
   }
 
   it(
-    "should return a SQSReaderGracefulException if the start time is equal to the end time") {
+    "should return a GracefulFailureException if the start time is equal to the end time") {
     val jsonString =
       s"""
          |{

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -19,7 +19,7 @@ class SierraBibMergerWorkerServiceTest
     with ExtendedPatience {
 
   it(
-    "throws a SQSReaderGracefulException if the message on the queue does not represent a SierraRecord") {
+    "throws a GracefulFailureException if the message on the queue does not represent a SierraRecord") {
 
     val sqsReader = mock[SQSReader]
     val metricsSender = mock[MetricsSender]

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -103,7 +103,7 @@ class SierraItemsToDynamoWorkerServiceTest
     }
   }
 
-  it("returns a SQSReaderGracefulException if it receives an invalid message") {
+  it("returns a GracefulFailureException if it receives an invalid message") {
     worker = createSierraWorkerService(fields = "")
 
     val message =

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -228,7 +228,7 @@ class SierraReaderWorkerServiceTest
     fromJson[List[SierraRecord]](getContentFromS3(bucketName, key)).get
 
   it(
-    "returns a SQSReaderGracefulException if it receives a message that doesn't contain start or end values") {
+    "returns a GracefulFailureException if it receives a message that doesn't contain start or end values") {
     worker = createSierraReaderWorkerService(fields = "")
 
     val message =
@@ -247,7 +247,7 @@ class SierraReaderWorkerServiceTest
   }
 
   it(
-    "does not return a SQSReaderGracefulException if it cannot reach the Sierra API") {
+    "does not return a GracefulFailureException if it cannot reach the Sierra API") {
     worker = createSierraReaderWorkerService(
       fields = "",
       apiUrl = "http://localhost:5050"


### PR DESCRIPTION
### What is this PR trying to achieve?

Now the workIndexer takes a Work, rather than a JSON string – handling any JSON decoding errors is deferred to the IngestorWorkerService.

### Who is this change for?

Work on #1283. We'll be adding more logic to the workIndexer internals, and serialising the SQS message is really out-of-scope for this particular service.

🌵 🍥 