### PR TITLE
Take account of MARC field 264 when populating the "publishers" field

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraPublishers.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraPublishers.scala
@@ -24,17 +24,22 @@ trait SierraPublishers {
   // https://www.loc.gov/marc/bibliographic/bd264.html
   //
   def getPublishers(bibData: SierraBibData): List[Agent] = {
-    val matchingSubfields = bibData.varFields
-      .filter(_.marcTag.contains("260"))
-      .flatMap {
-        _.subfields
-      }
+    val matchingFields = bibData.varFields
+      .filter { _.marcTag.contains("260") }
+
+    val publisherFields = if (!matchingFields.isEmpty) {
+      matchingFields
+    } else {
+      bibData.varFields
+        .filter { _.marcTag.contains("264") }
+    }
+
+    val matchingSubfields = publisherFields
+      .flatMap { _.subfields }
       .flatten
 
     matchingSubfields
-      .filter {
-        _.tag == "b"
-      }
+      .filter { _.tag == "b" }
       .map { subfield =>
         Agent(
           label = subfield.content,

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraPublishers.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraPublishers.scala
@@ -8,13 +8,21 @@ trait SierraPublishers {
 
   // Populate wwork:publishers.
   //
-  //    For bibliographic records where "260" is populated:
-  //    - "label" comes from MARC field 260 subfield $b.
-  //    - "type" is "Organisation"
+  // We use MARC field "260", if populated, otherwise we use field "264".
   //
-  // Note that subfield $b can occur more than once on a record.
+  // In either case:
+  //  - "label" comes from subfield $b
+  //  - "type" is "Organisation".
   //
-  // http://www.loc.gov/marc/bibliographic/bd260.html
+  // Notes:
+  //  - A bib may have 260, or 264, or neither -- but we would never expect
+  //    it to have both.
+  //  - A bib may have a single 260 field, or multiple 264 fields.
+  //  - Subfield $b may occur more than once on a field.
+  //
+  // https://www.loc.gov/marc/bibliographic/bd260.html
+  // https://www.loc.gov/marc/bibliographic/bd264.html
+  //
   def getPublishers(bibData: SierraBibData): List[Agent] = {
     val matchingSubfields = bibData.varFields
       .filter(_.marcTag.contains("260"))

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraPublishers.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraPublishers.scala
@@ -34,9 +34,7 @@ trait SierraPublishers {
         .filter { _.marcTag.contains("264") }
     }
 
-    val matchingSubfields = publisherFields
-      .flatMap { _.subfields }
-      .flatten
+    val matchingSubfields = publisherFields.flatMap { _.subfields }.flatten
 
     matchingSubfields
       .filter { _.tag == "b" }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraPublishersTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraPublishersTest.scala
@@ -142,7 +142,7 @@ class SierraPublishersTest extends FunSpec with Matchers with SierraData {
             MarcSubfield(tag = "b", content = "Thrilling Tomes"),
             MarcSubfield(tag = "b", content = "Page-Turning Paperbacks")
           )
-        ),
+        )
       ),
       expectedPublisherNames = List(
         "Brilliant Books",


### PR DESCRIPTION
### What is this PR trying to achieve?

Take account of new notes from Silver/Branwen about using field 264 if 260 isn't populated.

Part of #1419.

### Who is this change for?

📖 