### PR TITLE
SQSReaderGracefulException -> GracefulFailureException

### DIFF
--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -15,7 +15,7 @@ import scala.concurrent.Future
 import io.circe.generic.extras.auto._
 import uk.ac.wellcome.circe._
 import io.circe.parser._
-import uk.ac.wellcome.sqs.SQSReaderGracefulException
+import uk.ac.wellcome.exceptions.GracefulFailureException
 
 import scala.util.Try
 
@@ -36,7 +36,7 @@ class WorkIndexer @Inject()(
           .fromTry(Try {
             decode[Work](document) match {
               case Right(work) => work
-              case Left(error) => throw SQSReaderGracefulException(error)
+              case Left(error) => throw GracefulFailureException(error)
             }
           })
           .flatMap(item => {

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -6,9 +6,9 @@ import com.sksamuel.elastic4s.http.ElasticDsl._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, Work}
-import uk.ac.wellcome.sqs.SQSReaderGracefulException
 import uk.ac.wellcome.test.utils.{IndexedElasticSearchLocal, JsonTestUtil}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
@@ -106,7 +106,7 @@ class WorkIndexerTest
     val future = workIndexer.indexWork("a document")
 
     whenReady(future.failed) { exception =>
-      exception shouldBe a[SQSReaderGracefulException]
+      exception shouldBe a[GracefulFailureException]
     }
   }
 
@@ -115,7 +115,7 @@ class WorkIndexerTest
     val future = workIndexer.indexWork("null")
 
     whenReady(future.failed) { exception =>
-      exception shouldBe a[SQSReaderGracefulException]
+      exception shouldBe a[GracefulFailureException]
     }
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
@@ -1,12 +1,12 @@
 package uk.ac.wellcome.transformer.receive
 
 import com.twitter.inject.Logging
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.models.Work
 import uk.ac.wellcome.models.transformable.Transformable
 import uk.ac.wellcome.sns.{PublishAttempt, SNSWriter}
-import uk.ac.wellcome.sqs.SQSReaderGracefulException
 import uk.ac.wellcome.transformer.parsers.TransformableParser
 import uk.ac.wellcome.transformer.transformers.TransformableTransformer
 import uk.ac.wellcome.utils.JsonUtil
@@ -37,7 +37,7 @@ class SQSMessageReceiver(
         triedWork match {
           case Success(Some(work)) => publishMessage(work).map(_ => ())
           case Success(None) => Future.successful()
-          case Failure(SQSReaderGracefulException(e)) =>
+          case Failure(GracefulFailureException(e)) =>
             info("Recoverable failure extracting workfrom record", e)
             Future.successful(PublishAttempt(Left(e)))
           case Failure(e) =>

--- a/common/src/main/scala/uk/ac/wellcome/exceptions/GracefulFailureException.scala
+++ b/common/src/main/scala/uk/ac/wellcome/exceptions/GracefulFailureException.scala
@@ -1,0 +1,4 @@
+package uk.ac.wellcome.exceptions
+
+case class GracefulFailureException(e: Throwable)
+    extends Exception(e.getMessage)

--- a/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
@@ -1,7 +1,11 @@
 package uk.ac.wellcome.sqs
 
 import com.amazonaws.services.sqs.AmazonSQS
-import com.amazonaws.services.sqs.model.{DeleteMessageRequest, Message, ReceiveMessageRequest}
+import com.amazonaws.services.sqs.model.{
+  DeleteMessageRequest,
+  Message,
+  ReceiveMessageRequest
+}
 import com.google.inject.Inject
 import com.twitter.inject.Logging
 import uk.ac.wellcome.exceptions.GracefulFailureException
@@ -10,8 +14,6 @@ import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.collection.JavaConversions._
 import scala.concurrent.{Future, blocking}
-
-
 
 class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
     extends Logging {

--- a/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
@@ -1,21 +1,17 @@
 package uk.ac.wellcome.sqs
 
 import com.amazonaws.services.sqs.AmazonSQS
-import com.amazonaws.services.sqs.model.{
-  DeleteMessageRequest,
-  Message,
-  ReceiveMessageRequest
-}
+import com.amazonaws.services.sqs.model.{DeleteMessageRequest, Message, ReceiveMessageRequest}
 import com.google.inject.Inject
 import com.twitter.inject.Logging
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.aws.SQSConfig
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.collection.JavaConversions._
 import scala.concurrent.{Future, blocking}
 
-case class SQSReaderGracefulException(e: Throwable)
-    extends Exception(e.getMessage)
+
 
 class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
     extends Logging {
@@ -69,7 +65,7 @@ class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
         })
         .flatMap(_ => deleteMessage(message))
         .recover {
-          case e: SQSReaderGracefulException =>
+          case e: GracefulFailureException =>
             warn(s"An error occurred while processing the message $message", e)
             ()
           case e: Throwable =>

--- a/common/src/main/scala/uk/ac/wellcome/sqs/SQSWorker.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sqs/SQSWorker.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.sqs
 import akka.actor.ActorSystem
 import com.amazonaws.services.sqs.model.Message
 import com.fasterxml.jackson.core.JsonParseException
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -43,7 +44,7 @@ abstract class SQSWorker(sqsReader: SQSReader,
     JsonUtil.fromJson[SQSMessage](sqsMessage.getBody).recover {
       case e: Exception =>
         warn("Invalid message structure (not via SNS?)", e)
-        throw SQSReaderGracefulException(e)
+        throw GracefulFailureException(e)
     }
 
   override def terminalFailureHook(): Unit =

--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
@@ -3,13 +3,13 @@ package uk.ac.wellcome.sqs
 import com.amazonaws.services.sqs.model.Message
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.aws.SQSConfig
 import uk.ac.wellcome.test.utils.SQSLocal
 
 import scala.collection.JavaConversions._
 import scala.concurrent.Future
 import scala.concurrent.duration._
-
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 class SQSReaderTest
@@ -132,7 +132,7 @@ class SQSReaderTest
     val futureMessages = sqsReader.retrieveAndDeleteMessages { message =>
       if (message.getBody == failingMessage)
         Future {
-          throw SQSReaderGracefulException(
+          throw GracefulFailureException(
             new RuntimeException(s"$failingMessage is not valid"))
         } else
         Future.successful(message)

--- a/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/services/WindowExtractor.scala
+++ b/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/services/WindowExtractor.scala
@@ -7,7 +7,7 @@ import com.twitter.inject.Logging
 import io.circe.Json
 import io.circe.optics.JsonPath.root
 import io.circe.parser.parse
-import uk.ac.wellcome.sqs.SQSReaderGracefulException
+import uk.ac.wellcome.exceptions.GracefulFailureException
 
 import scala.util.Try
 
@@ -31,7 +31,7 @@ object WindowExtractor extends Logging {
       .recover {
         case e: Exception =>
           warn(s"Error parsing $jsonString", e)
-          throw SQSReaderGracefulException(e)
+          throw GracefulFailureException(e)
       }
 
   private def extractField(field: String, json: Json) = {

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/services/WindowExtractorTest.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/services/WindowExtractorTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.sierra_adapter.services
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.sqs.SQSReaderGracefulException
+import uk.ac.wellcome.exceptions.GracefulFailureException
 
 class WindowExtractorTest extends FunSpec with Matchers {
 
@@ -30,7 +30,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor
       .extractWindow(jsonString)
       .failed
-      .get shouldBe a[SQSReaderGracefulException]
+      .get shouldBe a[GracefulFailureException]
   }
 
   it(
@@ -45,7 +45,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor
       .extractWindow(jsonString)
       .failed
-      .get shouldBe a[SQSReaderGracefulException]
+      .get shouldBe a[GracefulFailureException]
   }
 
   it(
@@ -60,7 +60,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor
       .extractWindow(jsonString)
       .failed
-      .get shouldBe a[SQSReaderGracefulException]
+      .get shouldBe a[GracefulFailureException]
   }
 
   it(
@@ -75,7 +75,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor
       .extractWindow(jsonString)
       .failed
-      .get shouldBe a[SQSReaderGracefulException]
+      .get shouldBe a[GracefulFailureException]
   }
 
   it(
@@ -89,7 +89,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor
       .extractWindow(jsonString)
       .failed
-      .get shouldBe a[SQSReaderGracefulException]
+      .get shouldBe a[GracefulFailureException]
   }
 
   it(
@@ -103,7 +103,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor
       .extractWindow(jsonString)
       .failed
-      .get shouldBe a[SQSReaderGracefulException]
+      .get shouldBe a[GracefulFailureException]
   }
 
   it(
@@ -118,7 +118,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor
       .extractWindow(jsonString)
       .failed
-      .get shouldBe a[SQSReaderGracefulException]
+      .get shouldBe a[GracefulFailureException]
   }
 
   it(
@@ -133,6 +133,6 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor
       .extractWindow(jsonString)
       .failed
-      .get shouldBe a[SQSReaderGracefulException]
+      .get shouldBe a[GracefulFailureException]
   }
 }

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerService.scala
@@ -7,12 +7,10 @@ import io.circe.generic.extras.auto._
 import io.circe.parser.decode
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.sqs.{SQSReader, SQSReaderGracefulException, SQSWorker}
+import uk.ac.wellcome.sqs.{SQSReader, SQSWorker}
 import uk.ac.wellcome.circe._
-import uk.ac.wellcome.models.transformable.sierra.{
-  SierraBibRecord,
-  SierraRecord
-}
+import uk.ac.wellcome.exceptions.GracefulFailureException
+import uk.ac.wellcome.models.transformable.sierra.{SierraBibRecord, SierraRecord}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -32,7 +30,7 @@ class SierraBibMergerWorkerService @Inject()(
       case Left(e) =>
         Future {
           logger.warn(s"Failed processing $message", e)
-          throw SQSReaderGracefulException(e)
+          throw GracefulFailureException(e)
         }
     }
 }

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerService.scala
@@ -10,7 +10,10 @@ import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.sqs.{SQSReader, SQSWorker}
 import uk.ac.wellcome.circe._
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.models.transformable.sierra.{SierraBibRecord, SierraRecord}
+import uk.ac.wellcome.models.transformable.sierra.{
+  SierraBibRecord,
+  SierraRecord
+}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -4,10 +4,11 @@ import akka.actor.ActorSystem
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.sierra_adapter.dynamo.SierraTransformableDao
-import uk.ac.wellcome.sqs.{SQSReader, SQSReaderGracefulException}
+import uk.ac.wellcome.sqs.SQSReader
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
 class SierraBibMergerWorkerServiceTest
@@ -38,7 +39,7 @@ class SierraBibMergerWorkerServiceTest
                  timestamp = ""))
 
     whenReady(future.failed) { ex =>
-      ex shouldBe a[SQSReaderGracefulException]
+      ex shouldBe a[GracefulFailureException]
     }
 
   }

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
@@ -2,13 +2,13 @@ package uk.ac.wellcome.platform.sierra_item_merger.services
 
 import com.google.inject.Inject
 import com.twitter.inject.Logging
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 import uk.ac.wellcome.platform.sierra_item_merger.links.ItemLinker
 import uk.ac.wellcome.platform.sierra_item_merger.links.ItemUnlinker
 import uk.ac.wellcome.sierra_adapter.dynamo.SierraTransformableDao
-import uk.ac.wellcome.sqs.SQSReaderGracefulException
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -52,7 +52,7 @@ class SierraItemMergerUpdaterService @Inject()(
           // assume we're too early and put the message back
           case None =>
             Future.failed(
-              SQSReaderGracefulException(
+              GracefulFailureException(
                 new RuntimeException(
                   s"Missing Bib record to unlink: $unlinkedBibId.")
               ))

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerWorkerService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerWorkerService.scala
@@ -7,8 +7,9 @@ import io.circe.generic.extras.auto._
 import io.circe.parser._
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.sqs.{SQSReader, SQSReaderGracefulException, SQSWorker}
+import uk.ac.wellcome.sqs.{SQSReader, SQSWorker}
 import uk.ac.wellcome.circe._
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -29,7 +30,7 @@ class SierraItemMergerWorkerService @Inject()(
       case Left(e) =>
         Future {
           logger.warn(s"Failed processing $message", e)
-          throw SQSReaderGracefulException(e)
+          throw GracefulFailureException(e)
         }
     }
 }

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerService.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerService.scala
@@ -6,9 +6,10 @@ import io.circe.parser.decode
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.models.transformable.sierra.SierraRecord
-import uk.ac.wellcome.sqs.{SQSReader, SQSReaderGracefulException, SQSWorker}
+import uk.ac.wellcome.sqs.{SQSReader, SQSWorker}
 import uk.ac.wellcome.circe._
 import io.circe.generic.auto._
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.utils.GlobalExecutionContext._
 
 import scala.concurrent.Future
@@ -27,7 +28,7 @@ class SierraItemsToDynamoWorkerService @Inject()(
       case Left(e) =>
         Future {
           logger.warn(s"Failed processing $message", e)
-          throw SQSReaderGracefulException(e)
+          throw GracefulFailureException(e)
         }
     }
 }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -12,15 +12,11 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSpec, Matchers}
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.{DynamoConfig, SQSConfig, SQSMessage}
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.locals.SierraItemsToDynamoDBLocal
-import uk.ac.wellcome.sqs.{SQSReader, SQSReaderGracefulException}
+import uk.ac.wellcome.sqs.SQSReader
 import uk.ac.wellcome.test.utils.{ExtendedPatience, SQSLocal}
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.dynamo._
-import uk.ac.wellcome.models.transformable.sierra.{
-  SierraBibRecord,
-  SierraItemRecord,
-  SierraRecord
-}
+import uk.ac.wellcome.models.transformable.sierra.{SierraBibRecord, SierraItemRecord, SierraRecord}
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.dynamo.SierraItemRecordDao
 import io.circe.generic.auto._
 import io.circe.syntax._
@@ -28,6 +24,7 @@ import com.gu.scanamo.syntax._
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import uk.ac.wellcome.circe._
+import uk.ac.wellcome.exceptions.GracefulFailureException
 
 import scala.concurrent.duration._
 
@@ -118,7 +115,7 @@ class SierraItemsToDynamoWorkerServiceTest
     val sqsMessage =
       SQSMessage(Some("subject"), message, "topic", "messageType", "timestamp")
     whenReady(worker.get.processMessage(sqsMessage).failed) { ex =>
-      ex shouldBe a[SQSReaderGracefulException]
+      ex shouldBe a[GracefulFailureException]
     }
 
   }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -16,7 +16,11 @@ import uk.ac.wellcome.sqs.SQSReader
 import uk.ac.wellcome.test.utils.{ExtendedPatience, SQSLocal}
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.dynamo._
-import uk.ac.wellcome.models.transformable.sierra.{SierraBibRecord, SierraItemRecord, SierraRecord}
+import uk.ac.wellcome.models.transformable.sierra.{
+  SierraBibRecord,
+  SierraItemRecord,
+  SierraRecord
+}
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.dynamo.SierraItemRecordDao
 import io.circe.generic.auto._
 import io.circe.syntax._

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
@@ -9,8 +9,8 @@ import io.circe.generic.auto._
 import io.circe.parser.decode
 import uk.ac.wellcome.platform.sierra_reader.flow.SierraResourceTypes
 import uk.ac.wellcome.circe._
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.transformable.sierra.SierraRecord
-import uk.ac.wellcome.sqs.SQSReaderGracefulException
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.collection.JavaConversions._
@@ -47,7 +47,7 @@ class WindowManager @Inject()(
         val offset = key match {
           case embeddedIndexMatch(index) => index.toInt
           case _ =>
-            throw SQSReaderGracefulException(
+            throw GracefulFailureException(
               new RuntimeException(s"Unable to determine offset in $key"))
         }
 
@@ -57,7 +57,7 @@ class WindowManager @Inject()(
         val lastId = records match {
           case Right(r) =>
             r.map { _.id }.sorted.lastOption
-          case Left(err) => throw SQSReaderGracefulException(err)
+          case Left(err) => throw GracefulFailureException(err)
         }
 
         info(s"Found latest ID in S3: $lastId")
@@ -71,7 +71,7 @@ class WindowManager @Inject()(
             WindowStatus(id = Some(newId), offset = offset + 1)
           })
           .getOrElse(
-            throw SQSReaderGracefulException(
+            throw GracefulFailureException(
               new RuntimeException("Json did not contain an id"))
           )
       }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -2,8 +2,8 @@ package uk.ac.wellcome.platform.sierra_reader.modules
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.platform.sierra_reader.flow.SierraResourceTypes
-import uk.ac.wellcome.sqs.SQSReaderGracefulException
 import uk.ac.wellcome.test.utils.{ExtendedPatience, S3Local}
 
 class WindowManagerTest
@@ -62,7 +62,7 @@ class WindowManagerTest
     val result = windowManager.getCurrentStatus("[2013,2014]")
 
     whenReady(result.failed) {
-      _ shouldBe a[SQSReaderGracefulException]
+      _ shouldBe a[GracefulFailureException]
     }
   }
 
@@ -74,7 +74,7 @@ class WindowManagerTest
     val result = windowManager.getCurrentStatus("[2013,2014]")
 
     whenReady(result.failed) {
-      _ shouldBe a[SQSReaderGracefulException]
+      _ shouldBe a[GracefulFailureException]
     }
   }
 
@@ -85,7 +85,7 @@ class WindowManagerTest
     val result = windowManager.getCurrentStatus("[2013,2014]")
 
     whenReady(result.failed) {
-      _ shouldBe a[SQSReaderGracefulException]
+      _ shouldBe a[GracefulFailureException]
     }
   }
 }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSpec, Matchers}
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.{SQSConfig, SQSMessage}
-import uk.ac.wellcome.sqs.{SQSReader, SQSReaderGracefulException}
+import uk.ac.wellcome.sqs.SQSReader
 import uk.ac.wellcome.test.utils.{ExtendedPatience, S3Local, SQSLocal}
 import uk.ac.wellcome.utils.JsonUtil
 
@@ -20,6 +20,7 @@ import org.mockito.Matchers.{any, anyString}
 import org.mockito.Mockito.when
 import uk.ac.wellcome.platform.sierra_reader.flow.SierraResourceTypes
 import uk.ac.wellcome.circe._
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.transformable.sierra.SierraRecord
 import uk.ac.wellcome.platform.sierra_reader.modules.WindowManager
 
@@ -244,7 +245,7 @@ class SierraReaderWorkerServiceTest
     val sqsMessage =
       SQSMessage(Some("subject"), message, "topic", "messageType", "timestamp")
     whenReady(worker.get.processMessage(sqsMessage).failed) { ex =>
-      ex shouldBe a[SQSReaderGracefulException]
+      ex shouldBe a[GracefulFailureException]
     }
 
   }
@@ -268,7 +269,7 @@ class SierraReaderWorkerServiceTest
       SQSMessage(Some("subject"), message, "topic", "messageType", "timestamp")
 
     whenReady(worker.get.processMessage(sqsMessage).failed) { ex =>
-      ex shouldNot be(a[SQSReaderGracefulException])
+      ex shouldNot be(a[GracefulFailureException])
     }
   }
 


### PR DESCRIPTION
### What is this PR trying to achieve?

Decouples the GracefulFailureException from SQSReader so it can be used elsewhere.

### Who is this change for?

🌁 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.
