### PR TITLE
Add permissions to write to CloudWatch

### DIFF
--- a/sierra_adapter/terraform/items_to_dynamo/iam_policy_document.tf
+++ b/sierra_adapter/terraform/items_to_dynamo/iam_policy_document.tf
@@ -9,3 +9,15 @@ data "aws_iam_policy_document" "sierra_table_permissions" {
     ]
   }
 }
+
+data "aws_iam_policy_document" "allow_cloudwatch_push_metrics" {
+  statement {
+    actions = [
+      "cloudwatch:PutMetricData",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/sierra_adapter/terraform/items_to_dynamo/iam_role_policy.tf
+++ b/sierra_adapter/terraform/items_to_dynamo/iam_role_policy.tf
@@ -7,3 +7,8 @@ resource "aws_iam_role_policy" "allow_read_from_windows_q" {
   role   = "${module.sierra_to_dynamo_service.task_role_name}"
   policy = "${module.demultiplexer_queue.read_policy}"
 }
+
+resource "aws_iam_role_policy" "push_cloudwatch_metric" {
+  role   = "${module.sierra_to_dynamo_service.task_role_name}"
+  policy = "${data.aws_iam_policy_document.allow_cloudwatch_push_metrics.json}"
+}

--- a/sierra_adapter/terraform/merger/iam_policy_document.tf
+++ b/sierra_adapter/terraform/merger/iam_policy_document.tf
@@ -13,3 +13,15 @@ data "aws_iam_policy_document" "sierra_merged_table_permissions" {
     ]
   }
 }
+
+data "aws_iam_policy_document" "allow_cloudwatch_push_metrics" {
+  statement {
+    actions = [
+      "cloudwatch:PutMetricData",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/sierra_adapter/terraform/merger/iam_role_policy.tf
+++ b/sierra_adapter/terraform/merger/iam_role_policy.tf
@@ -2,3 +2,8 @@ resource "aws_iam_role_policy" "allow_merged_dynamo_access" {
   role   = "${module.sierra_merger_service.task_role_name}"
   policy = "${data.aws_iam_policy_document.sierra_merged_table_permissions.json}"
 }
+
+resource "aws_iam_role_policy" "push_cloudwatch_metric" {
+  role   = "${module.sierra_merger_service.task_role_name}"
+  policy = "${data.aws_iam_policy_document.allow_cloudwatch_push_metrics.json}"
+}

--- a/sierra_adapter/terraform/sierra_reader/iam_policy_document.tf
+++ b/sierra_adapter/terraform/sierra_reader/iam_policy_document.tf
@@ -27,3 +27,15 @@ data "aws_iam_policy_document" "read_from_windows_q" {
     ]
   }
 }
+
+data "aws_iam_policy_document" "allow_cloudwatch_push_metrics" {
+  statement {
+    actions = [
+      "cloudwatch:PutMetricData",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/sierra_adapter/terraform/sierra_reader/iam_role_policy.tf
+++ b/sierra_adapter/terraform/sierra_reader/iam_role_policy.tf
@@ -7,3 +7,8 @@ resource "aws_iam_role_policy" "allow_read_from_windows_q" {
   role   = "${module.sierra_reader_service.task_role_name}"
   policy = "${data.aws_iam_policy_document.read_from_windows_q.json}"
 }
+
+resource "aws_iam_role_policy" "push_cloudwatch_metric" {
+  role   = "${module.sierra_reader_service.task_role_name}"
+  policy = "${data.aws_iam_policy_document.allow_cloudwatch_push_metrics.json}"
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

Currently some services cannot report stats to CloudWatch as they do not have the correct permissions. This PR adds the necessary permissions.

### Who is this change for?

🍇 🗜 

### Have the following been considered/are they needed?

- [x] Run `terraform apply`.
