### PR TITLE
Move the autoformat command into a separate build stage in Travis, and fail the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,8 @@ jobs:
     # Sierra adapter stack.  This covers multiple Scala apps, so we skip
     # it into separate tasks to avoid running all of them any time there's
     # a change to just one.
-    - env: TASK=sierra_common-test
+    - stage: test
+      env: TASK=sierra_common-test
     - env: TASK=sierra_window_generator-test
     - env: TASK=sierra_reader-test
     - env: TASK=sierra_items_to_dynamo-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,48 +55,54 @@ env:
     #  * PYPI_PASSWORD
     - secure: CgvR1hv+oZBiIhQOfqPaLqYx6tnMa9Fr7DbrziiLK8Iu6t99nB/cgDdPUczvCfyQvSDwnWJbYhXhkAWgmlAjTHfojeAt7FbZY1cgpLVBZfMHw/VGOhFWAjPZzpqW+IJvREVUJ3meubs/ZvxLvquTu0Xv0XXXzv30LaNyFgP94+EWQaZyIuKgY0mjS6fR5+x5TQHucs3e+EBVDmRkYDfa8dHWTLp1z9tP/veUnj7drDApXLMjbg6YsWfOIbJ3MDYLesBvWf5+3I+DRj18EF2AJ6Ls8S9IALHTq+jx0uXttqsJ2A7MqjdW+5FtDgkjwUC2eTjfok/gPKvgplM9emjrwSccMnL/msw09ahlH9X0S6zGFmCrrgyPdI3As9+tOiZQDVR4nOrCk1ALLnCS/0OmEsln2LNv8ZSD8vKCH1tng9AcTo4Ey3LfRXYElKCVIRlT38KWKPZGn5uHVdtD6mBLRnAiHHWd6Ebhj43k6q58oOjpAs0d4K20CMg6B8jUM0JzXfTtENh0eDNjDYdvfHFXUy8nKdt7Tpfnjj8y5E4jVclYfNmHRWys+nE/EvBAyV2w5naC6ve5IeP1s1V9LOIKUQMOKqzynSJwGtRzp5gZValN29CBsl1oDiccIyYmwcTc3iZCAacwbCrb3aB3ilD5CK8XsF2KmPLyAYCoF//HDbg=
 
-  matrix:
-    - TASK=travis-format
+jobs:
+  include:
+    - env: TASK=travis-format
+      stage: format
 
     # (not under active development)
-    # - TASK=nginx-build
+    # - env: TASK=nginx-build
 
     # Sierra adapter stack.  This covers multiple Scala apps, so we skip
     # it into separate tasks to avoid running all of them any time there's
     # a change to just one.
-    - TASK=sierra_common-test
-    - TASK=sierra_window_generator-test
-    - TASK=sierra_reader-test
-    - TASK=sierra_items_to_dynamo-test
-    - TASK=sierra_bib_merger-test
-    - TASK=sierra_item_merger-test
-    - TASK=s3_demultiplexer-test
+    - env: TASK=sierra_common-test
+    - env: TASK=sierra_window_generator-test
+    - env: TASK=sierra_reader-test
+    - env: TASK=sierra_items_to_dynamo-test
+    - env: TASK=sierra_bib_merger-test
+    - env: TASK=sierra_item_merger-test
+    - env: TASK=s3_demultiplexer-test
 
     # Catalogue pipeline stack
-    - TASK=sbt-common-test
-    - TASK=transformer-test
-    - TASK=ingestor-test
-    - TASK=id_minter-test
-    - TASK=reindexer-test
+    - env: TASK=sbt-common-test
+    - env: TASK=transformer-test
+    - env: TASK=ingestor-test
+    - env: TASK=id_minter-test
+    - env: TASK=reindexer-test
 
     # Catalogue API stack
-    - TASK=api-test
+    - env: TASK=api-test
     # (not under active development)
-    # - TASK=api_docs-build
+    # - env: TASK=api_docs-build
 
     # Miro preprocessor stack  (not under active development)
-    # - TASK=miro_preprocessor-test
+    # - env: TASK=miro_preprocessor-test
 
     # Shared infra stack
-    - TASK=shared_infra-test
+    - env: TASK=shared_infra-test
 
     # Loris stack
-    - TASK=loris-build
+    - env: TASK=loris-build
     # (not under active development)
-    # - TASK=cache_cleaner-build
+    # - env: TASK=cache_cleaner-build
 
     # Monitoring stack
-    - TASK=monitoring-test
+    - env: TASK=monitoring-test
+
+stages:
+  - format
+  - test
 
 # This has a Slack API token for posting messages about build failures to
 # our team channel.  It was created by following the "Setup Instructions" at

--- a/.travis/run_autoformat.py
+++ b/.travis/run_autoformat.py
@@ -10,6 +10,7 @@ auto-formatted (yet).
 
 import os
 import subprocess
+import sys
 
 from tooling import changed_files, git, make
 
@@ -55,6 +56,8 @@ if __name__ == '__main__':
         git('add', '--verbose', '--all')
         git('commit', '-m', 'Apply auto-formatting rules')
         git('push', 'ssh-origin', 'HEAD:%s' % branch)
+
+        sys.exit(1)
     else:
         print('*** There were no changes from auto-formatting', flush=True)
 

--- a/.travis/test_tooling.py
+++ b/.travis/test_tooling.py
@@ -15,6 +15,8 @@ import tooling
 
     ('sierra_adapter/common/main.scala', 'sierra_adapter-test', True),
     ('sierra_adapter/common/main.scala', 'loris-test', False),
+    ('sierra_adapter/common/main.scala', 's3_demultiplexer-test', False),
+    ('sierra_adapter/common/main.scala', 'sierra_window_generator-test', False),
     ('sierra_adapter/common/main.scala', 'unknown-task', True),
 ])
 def test_affects_test(path, task, expected_result):

--- a/.travis/tooling.py
+++ b/.travis/tooling.py
@@ -100,8 +100,15 @@ def affects_tests(path, task):
     # sierra_adapter directory.  If we're definitely in a project which
     # has nothing to do with Sierra, we can ignore changes in this dir.
     sierra_free_tasks = (
-        'loris', 'id_minter', 'ingestor', 'reindexer', 'transformer',
-        'api', 'monitoring', 'shared_infra', 'nginx'
+        'loris',
+        'id_minter',
+        'ingestor',
+        'reindexer',
+        'transformer',
+        'api',
+        'monitoring',
+        'shared_infra',
+        'nginx',
     )
     if (
         task.startswith(sierra_free_tasks) and
@@ -109,6 +116,21 @@ def affects_tests(path, task):
     ):
         print(
             "~~~ Ignoring %s; sierra_adapter changes don't affect %s tests" %
+            (path, task))
+        return False
+
+    # Within the sierra_adapter stack, there's an sbt common lib.  If we're
+    # in a Sierra project that doesn't use sbt, we can ignore that too.
+    sbt_common_free_tasks = (
+        's3_demultiplexer',
+        'sierra_window_generator',
+    )
+    if (
+        task.startswith(sbt_common_free_tasks) and
+        path.startswith('sierra_adapter/common/')
+    ):
+        print(
+            "~~~ Ignoring %s; sierra-common changes don't affect %s tests" %
             (path, task))
         return False
 
@@ -125,29 +147,6 @@ def affects_tests(path, task):
     if task.startswith(sbt_free_tasks) and path.startswith('common/'):
         print(
             "~~~ Ignoring %s; sbt-common changes don't affect %s tests" %
-            (path, task))
-        return False
-
-    # The Makefile at the top of the sierra_adapter directory is often
-    # changed, but isn't exclusively owned by any one task.  If this a task
-    # which _definitely isn't_ affected by this file, we can skip tests.
-    not_sierra_adapter = (
-        'loris',
-        'id_minter',
-        'ingestor',
-        'reindexer',
-        'transformer',
-        'api',
-        'monitoring',
-        'shared_infra',
-        'nginx',
-    )
-    if (
-        task.startswith(not_sierra_adapter) and
-        path == 'sierra_adapter/Makefile'
-    ):
-        print(
-            "~~~ Ignoring %s; sierra_adapter changes don't affect %s" %
             (path, task))
         return False
 

--- a/.travis/tooling.py
+++ b/.travis/tooling.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 
 import subprocess
+import sys
 
 
 # Root of the Git repository
@@ -226,7 +227,9 @@ def make(task, dry_run=False):
     else:
         command = ['make', task]
     print('*** Running %r' % command, flush=True)
-    subprocess.check_call(command)
+    rc = subprocess.call(command)
+    if rc != 0:
+        sys.exit(rc)
 
 
 def git(*args):

--- a/sierra_adapter/terraform/terraform.tf
+++ b/sierra_adapter/terraform/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.9"
 
   backend "s3" {
-    bucket = "platform-infra"
+    bucket         = "platform-infra"
     key            = "terraform/sierra_adapter.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"

--- a/sierra_adapter/terraform/terraform.tf
+++ b/sierra_adapter/terraform/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.9"
 
   backend "s3" {
-    bucket         = "platform-infra"
+    bucket = "platform-infra"
     key            = "terraform/sierra_adapter.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"


### PR DESCRIPTION
### What is this PR trying to achieve?

Reduce build churn. When Travis pushes an autoformat commit, it should fail the build stage and cancel the other jobs. No but really this time.

See https://docs.travis-ci.com/user/build-stages

### Who is this change for?

🍶 