### PR TITLE
Use out of the box circe instant encoder and decoder

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/utils/JsonUtil.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/JsonUtil.scala
@@ -1,34 +1,17 @@
 package uk.ac.wellcome.utils
 
-import java.time.Instant
-
 import cats.syntax.either._
 import com.twitter.inject.Logging
 import io.circe.generic.extras.{AutoDerivation, Configuration}
+import io.circe.java8.time.TimeInstances
 import io.circe.parser.decode
 import io.circe.syntax._
-import io.circe.{Decoder, Encoder, HCursor, Json}
+import io.circe.{Decoder, Encoder}
 import uk.ac.wellcome.exceptions.GracefulFailureException
 
 import scala.util.Try
 
-object JsonUtil extends AutoDerivation with Logging {
-
-  implicit val decodeInstant: Decoder[Instant] = new Decoder[Instant] {
-    final def apply(c: HCursor): Decoder.Result[Instant] = {
-      List(
-        c.as[Long],
-        c.as[Double].map(_.toLong)
-      ).filter(_.isRight)
-        .head
-        .map(i => Instant.ofEpochSecond(i))
-    }
-  }
-
-  implicit val encodeInstant: Encoder[Instant] = new Encoder[Instant] {
-    override def apply(value: Instant): Json =
-      Json.fromInt(value.getEpochSecond.toInt)
-  }
+object JsonUtil extends AutoDerivation with TimeInstances with Logging {
 
   implicit val customConfig: Configuration =
     Configuration.default.withDefaults

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,7 +50,8 @@ object Dependencies {
     "io.circe" %% "circe-generic"% versions.circeVersion,
     "io.circe" %% "circe-generic-extras"% versions.circeVersion,
     "io.circe" %% "circe-parser"% versions.circeVersion,
-    "io.circe" %% "circe-optics" % versions.circeVersion
+    "io.circe" %% "circe-optics" % versions.circeVersion,
+    "io.circe" %% "circe-java8" % versions.circeVersion
   )
 
   val jacksonDependencies = Seq(

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -40,7 +40,6 @@ class WindowManagerTest
 
     val record = SierraRecord(id = "b1794165", data = "{}", modifiedDate = Instant.now())
 
-    println(toJson(List(record)).get)
     s3Client.putObject(
       bucketName,
       s"$prefix/0001.json",

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -1,10 +1,14 @@
 package uk.ac.wellcome.platform.sierra_reader.modules
 
+import java.time.Instant
+
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
+import uk.ac.wellcome.models.transformable.sierra.SierraRecord
 import uk.ac.wellcome.platform.sierra_reader.flow.SierraResourceTypes
 import uk.ac.wellcome.test.utils.{ExtendedPatience, S3Local}
+import uk.ac.wellcome.utils.JsonUtil._
 
 class WindowManagerTest
     extends FunSpec
@@ -33,18 +37,14 @@ class WindowManagerTest
 
     // We pre-populate S3 with files as if they'd come from a prior run of the reader.
     s3Client.putObject(bucketName, s"$prefix/0000.json", "[]")
+
+    val record = SierraRecord(id = "b1794165", data = "{}", modifiedDate = Instant.now())
+
+    println(toJson(List(record)).get)
     s3Client.putObject(
       bucketName,
       s"$prefix/0001.json",
-      """
-        |[
-        |  {
-        |    "id": "b1794165",
-        |    "modifiedDate": 12345678,
-        |    "data": "{}"
-        |  }
-        |]
-      """.stripMargin
+      toJson(List(record)).get
     )
 
     val result = windowManager.getCurrentStatus("[2013,2014]")

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -38,7 +38,8 @@ class WindowManagerTest
     // We pre-populate S3 with files as if they'd come from a prior run of the reader.
     s3Client.putObject(bucketName, s"$prefix/0000.json", "[]")
 
-    val record = SierraRecord(id = "b1794165", data = "{}", modifiedDate = Instant.now())
+    val record =
+      SierraRecord(id = "b1794165", data = "{}", modifiedDate = Instant.now())
 
     s3Client.putObject(
       bucketName,

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -181,7 +181,7 @@ class SierraReaderWorkerServiceTest
         |[
         |  {
         |    "id": "i1794165",
-        |    "modifiedDate": 12345678,
+        |    "modifiedDate": "2013-12-10T17:16:35Z",
         |    "data": "{}"
         |  }
         |]


### PR DESCRIPTION
### What is this PR trying to achieve?
Use built in circe decoders and encoders for java8 types rather than DIY
### Who is this change for?
🐨 🦈 
