### PR TITLE
Don’t run the full test suite on every push to master

### DIFF
--- a/.travis/should_run_tests.py
+++ b/.travis/should_run_tests.py
@@ -12,11 +12,11 @@ def should_run_tests(task, travis_event_type):
     We skip doing the publish/deploy step when running a build on master that
     doesn't have any relevant changes since the last deploy.
     """
-    if travis_event_type == 'push':
-        print('*** We always run tests on master!')
+    if travis_event_type == 'cron':
+        print('*** We always run tests in cron!')
         return True
 
-    assert travis_event_type == 'pull_request'
+    assert travis_event_type in ('pull_request', 'push')
 
     return make_decision(
         changed_files=changed_files('HEAD', 'master'),

--- a/builds/docker_run.py
+++ b/builds/docker_run.py
@@ -15,6 +15,7 @@ Arguments after the two flags are passed directly to ``docker run``.
 import argparse
 import os
 import subprocess
+import sys
 
 from tooling import ROOT
 
@@ -99,4 +100,7 @@ if __name__ == '__main__':
         additional_args = additional_args[1:]
     cmd += additional_args
 
-    subprocess.check_call(cmd)
+    print('*** Running %r' % ' '.join(cmd))
+    rc = subprocess.call(cmd)
+    if rc != 0:
+        sys.exit(rc)


### PR DESCRIPTION
This is pulling what is hopefully big piece of low-hanging fruit from our Travis build times, without compromising too much on test coverage.

Our current policy is:

- PRs only run tests if they’re relevant
- Pushes to master run the full test suite, only publish if they’re relevant

This means we burn ~25m of build time for every push to master, even if it’s a one-character change to the README. This is patently silly.

This patch modifies master to only run tests if they’re relevant, so we should save a bunch of build time on master. Then I’ll enable nightly builds which run the full test suite – once a day, and outside office hours – so we still have the complete test suite running semi-regularly.