### PR TITLE
Use the database version when merging in sierra_items_to_dynamo

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/sqs/SQSWorkerToDynamo.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sqs/SQSWorkerToDynamo.scala
@@ -25,7 +25,7 @@ abstract class SQSWorkerToDynamo[T](
       t <- Future.fromTry(fromJson[T](message.body))
       _ <- store(t).recover {
         case e: ConditionalCheckFailedException =>
-          logger.warn(s"Failed processing $message", e)
+          logger.warn(s"Processing $message failed a Conditional Update", e)
           throw GracefulFailureException(e)
       }
     } yield ()

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMerger.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMerger.scala
@@ -3,12 +3,13 @@ package uk.ac.wellcome.platform.sierra_items_to_dynamo.merger
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 
 object SierraItemRecordMerger {
-  def mergeItems(oldRecord: SierraItemRecord,
-                 newRecord: SierraItemRecord): SierraItemRecord = {
+  def mergeItems(existingRecord: SierraItemRecord,
+                 updatedRecord: SierraItemRecord): SierraItemRecord = {
 
-    if (oldRecord.modifiedDate.isBefore(newRecord.modifiedDate)) {
+    if (existingRecord.modifiedDate.isBefore(updatedRecord.modifiedDate)) {
 
-      newRecord.copy(
+      updatedRecord.copy(
+
         // Let's suppose we have
         //
         //    oldRecord = (linked = {1, 2, 3}, unlinked = {4, 5})
@@ -27,11 +28,11 @@ object SierraItemRecordMerger {
         //      = {1, 2, 5}
         //
         unlinkedBibIds =
-          subList(addList(oldRecord.unlinkedBibIds, oldRecord.bibIds),
-                  newRecord.bibIds)
+          subList(addList(existingRecord.unlinkedBibIds, existingRecord.bibIds),
+                  updatedRecord.bibIds)
       )
     } else {
-      oldRecord
+      existingRecord
     }
   }
 

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMerger.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMerger.scala
@@ -10,6 +10,9 @@ object SierraItemRecordMerger {
 
       updatedRecord.copy(
 
+        // We always carry across the version from the existing record.
+        version = existingRecord.version,
+
         // Let's suppose we have
         //
         //    oldRecord = (linked = {1, 2, 3}, unlinked = {4, 5})

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMerger.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMerger.scala
@@ -9,10 +9,8 @@ object SierraItemRecordMerger {
     if (existingRecord.modifiedDate.isBefore(updatedRecord.modifiedDate)) {
 
       updatedRecord.copy(
-
         // We always carry across the version from the existing record.
         version = existingRecord.version,
-
         // Let's suppose we have
         //
         //    oldRecord = (linked = {1, 2, 3}, unlinked = {4, 5})
@@ -30,9 +28,9 @@ object SierraItemRecordMerger {
         //      = {1, 2, 3, 4, 5} - {3, 4}
         //      = {1, 2, 5}
         //
-        unlinkedBibIds =
-          subList(addList(existingRecord.unlinkedBibIds, existingRecord.bibIds),
-                  updatedRecord.bibIds)
+        unlinkedBibIds = subList(
+          addList(existingRecord.unlinkedBibIds, existingRecord.bibIds),
+          updatedRecord.bibIds)
       )
     } else {
       existingRecord

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserter.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserter.scala
@@ -14,7 +14,7 @@ class DynamoInserter @Inject()(sierraItemRecordDao: SierraItemRecordDao) {
     sierraItemRecordDao.getItem(record.id).flatMap {
       case Some(existingRecord) =>
         val mergedRecord = SierraItemRecordMerger
-          .mergeItems(oldRecord = existingRecord, newRecord = record)
+          .mergeItems(existingRecord = existingRecord, updatedRecord = record)
         if (mergedRecord != existingRecord) {
           sierraItemRecordDao.updateItem(mergedRecord)
         } else {

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.sierra_items_to_dynamo.merger
 
+import java.time.Instant
+
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 import uk.ac.wellcome.utils.JsonUtil._
@@ -74,6 +76,7 @@ class SierraItemRecordMergerTest extends FunSpec with Matchers {
     val existingRecord = sierraItemRecord(
       bibIds = List("1", "2", "3"),
       modifiedDate = "2017-01-01T00:00:00Z",
+      version = 3
     )
     val updatedRecord = sierraItemRecord(
       bibIds = List("1", "2", "3", "4", "5"),
@@ -84,18 +87,29 @@ class SierraItemRecordMergerTest extends FunSpec with Matchers {
 
     mergedRecord shouldBe existingRecord
   }
+  
+  it("carries across the version from the existing record") {
+    val existingRecord = sierraItemRecord(
+      modifiedDate = "2001-01-01T00:00:00Z",
+      version = 10
+    )
+    val updatedRecord = sierraItemRecord(
+      modifiedDate = "2009-09-09T00:00:00Z",
+      version = 2
+    )
 
     val mergedRecord = SierraItemRecordMerger.mergeItems(existingRecord, updatedRecord)
     mergedRecord.version shouldBe existingRecord.version
   }
 
   private def sierraItemRecord(
-    bibIds: List[String],
+    bibIds: List[String] = List(),
     unlinkedBibIds: List[String] = List(),
-    modifiedDate: String = "2001-01-01T01:01:01Z"): SierraItemRecord = {
+    modifiedDate: String = "2001-01-01T01:01:01Z",
+    version: Int = 1): SierraItemRecord = {
     SierraItemRecord(
       id = s"i111",
-      modifiedDate = modifiedDate,
+      modifiedDate = Instant.parse(modifiedDate),
       data = s"""
            |{
            |  "id": "i111",
@@ -104,7 +118,8 @@ class SierraItemRecordMergerTest extends FunSpec with Matchers {
            |  "bibIds": ${toJson(bibIds).get}
            |}""".stripMargin,
       bibIds = bibIds,
-      unlinkedBibIds = unlinkedBibIds
+      unlinkedBibIds = unlinkedBibIds,
+      version = version
     )
   }
 }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
@@ -7,79 +7,86 @@ import uk.ac.wellcome.utils.JsonUtil._
 class SierraItemRecordMergerTest extends FunSpec with Matchers {
 
   it("combines the bibIds in the final result") {
-    val oldRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
+    val existingRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
                                      modifiedDate = "2001-01-01T01:01:01Z")
-    val newRecord = sierraItemRecord(bibIds = List("1", "2", "3", "4", "5"),
+    val updatedRecord = sierraItemRecord(bibIds = List("1", "2", "3", "4", "5"),
                                      modifiedDate = "2002-01-01T01:01:01Z")
 
-    val mergedRecord = SierraItemRecordMerger.mergeItems(oldRecord = oldRecord,
-                                                         newRecord = newRecord)
+    val mergedRecord = SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
+                                                         updatedRecord = updatedRecord)
     mergedRecord.bibIds shouldBe List("1", "2", "3", "4", "5")
     mergedRecord.unlinkedBibIds shouldBe List()
   }
 
   it("records unlinked bibIds") {
-    val oldRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
+    val existingRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
                                      modifiedDate = "2001-01-01T01:01:01Z")
-    val newRecord = sierraItemRecord(bibIds = List("3", "4", "5"),
+    val updatedRecord = sierraItemRecord(bibIds = List("3", "4", "5"),
                                      modifiedDate = "2002-01-01T01:01:01Z")
 
-    val mergedRecord = SierraItemRecordMerger.mergeItems(oldRecord = oldRecord,
-                                                         newRecord = newRecord)
+    val mergedRecord = SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
+                                                         updatedRecord = updatedRecord)
     mergedRecord.bibIds shouldBe List("3", "4", "5")
     mergedRecord.unlinkedBibIds shouldBe List("1", "2")
   }
 
   it("preserves existing unlinked bibIds") {
-    val oldRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
+    val existingRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
                                      unlinkedBibIds = List("4", "5"),
                                      modifiedDate = "2001-01-01T01:01:01Z")
-    val newRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
+    val updatedRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
                                      modifiedDate = "2002-01-01T01:01:01Z")
 
-    val mergedRecord = SierraItemRecordMerger.mergeItems(oldRecord = oldRecord,
-                                                         newRecord = newRecord)
+    val mergedRecord = SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
+                                                         updatedRecord = updatedRecord)
     mergedRecord.unlinkedBibIds shouldBe List("4", "5")
   }
 
   it("does not duplicate unlinked bibIds") {
     // This would be an unusual scenario to arise, but check we handle it anyway!
-    val oldRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
+    val existingRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
                                      unlinkedBibIds = List("3"),
                                      modifiedDate = "2001-01-01T01:01:01Z")
-    val newRecord = sierraItemRecord(bibIds = List("1", "2"),
+    val updatedRecord = sierraItemRecord(bibIds = List("1", "2"),
                                      modifiedDate = "2002-01-01T01:01:01Z")
 
-    val mergedRecord = SierraItemRecordMerger.mergeItems(oldRecord = oldRecord,
-                                                         newRecord = newRecord)
+    val mergedRecord = SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
+                                                         updatedRecord = updatedRecord)
     mergedRecord.bibIds shouldBe List("1", "2")
     mergedRecord.unlinkedBibIds shouldBe List("3")
   }
 
   it("removes an unlinked bibId if it appears on a new record") {
-    val oldRecord =
+    val existingRecord =
       sierraItemRecord(bibIds = List(),
                        unlinkedBibIds = List("1", "2", "3"),
                        modifiedDate = "2001-01-01T01:01:01Z")
-    val newRecord = sierraItemRecord(bibIds = List("1", "2"),
+    val updatedRecord = sierraItemRecord(bibIds = List("1", "2"),
                                      modifiedDate = "2002-01-01T01:01:01Z")
 
-    val mergedRecord = SierraItemRecordMerger.mergeItems(oldRecord = oldRecord,
-                                                         newRecord = newRecord)
+    val mergedRecord = SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
+                                                         updatedRecord = updatedRecord)
     mergedRecord.bibIds shouldBe List("1", "2")
     mergedRecord.unlinkedBibIds shouldBe List("3")
   }
 
-  it(
-    "should return the oldRecord unchanged if the newRecord has an older date") {
-    val oldRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
-                                     modifiedDate = "2017-01-01T00:00:00Z")
-    val newRecord = sierraItemRecord(bibIds = List("1", "2", "3", "4", "5"),
-                                     modifiedDate = "2010-01-01T00:00:00Z")
+  it("should return the existing record unchanged if the update has an older date") {
+    val existingRecord = sierraItemRecord(
+      bibIds = List("1", "2", "3"),
+      modifiedDate = "2017-01-01T00:00:00Z",
+    )
+    val updatedRecord = sierraItemRecord(
+      bibIds = List("1", "2", "3", "4", "5"),
+      modifiedDate = "2010-01-01T00:00:00Z"
+    )
 
-    val mergedRecord = SierraItemRecordMerger.mergeItems(oldRecord, newRecord)
+    val mergedRecord = SierraItemRecordMerger.mergeItems(existingRecord, updatedRecord)
 
-    mergedRecord shouldBe oldRecord
+    mergedRecord shouldBe existingRecord
+  }
+
+    val mergedRecord = SierraItemRecordMerger.mergeItems(existingRecord, updatedRecord)
+    mergedRecord.version shouldBe existingRecord.version
   }
 
   private def sierraItemRecord(

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
@@ -9,51 +9,60 @@ import uk.ac.wellcome.utils.JsonUtil._
 class SierraItemRecordMergerTest extends FunSpec with Matchers {
 
   it("combines the bibIds in the final result") {
-    val existingRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
-                                     modifiedDate = "2001-01-01T01:01:01Z")
-    val updatedRecord = sierraItemRecord(bibIds = List("1", "2", "3", "4", "5"),
-                                     modifiedDate = "2002-01-01T01:01:01Z")
+    val existingRecord =
+      sierraItemRecord(bibIds = List("1", "2", "3"),
+                       modifiedDate = "2001-01-01T01:01:01Z")
+    val updatedRecord =
+      sierraItemRecord(bibIds = List("1", "2", "3", "4", "5"),
+                       modifiedDate = "2002-01-01T01:01:01Z")
 
-    val mergedRecord = SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
-                                                         updatedRecord = updatedRecord)
+    val mergedRecord =
+      SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
+                                        updatedRecord = updatedRecord)
     mergedRecord.bibIds shouldBe List("1", "2", "3", "4", "5")
     mergedRecord.unlinkedBibIds shouldBe List()
   }
 
   it("records unlinked bibIds") {
-    val existingRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
-                                     modifiedDate = "2001-01-01T01:01:01Z")
+    val existingRecord =
+      sierraItemRecord(bibIds = List("1", "2", "3"),
+                       modifiedDate = "2001-01-01T01:01:01Z")
     val updatedRecord = sierraItemRecord(bibIds = List("3", "4", "5"),
-                                     modifiedDate = "2002-01-01T01:01:01Z")
+                                         modifiedDate = "2002-01-01T01:01:01Z")
 
-    val mergedRecord = SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
-                                                         updatedRecord = updatedRecord)
+    val mergedRecord =
+      SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
+                                        updatedRecord = updatedRecord)
     mergedRecord.bibIds shouldBe List("3", "4", "5")
     mergedRecord.unlinkedBibIds shouldBe List("1", "2")
   }
 
   it("preserves existing unlinked bibIds") {
-    val existingRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
-                                     unlinkedBibIds = List("4", "5"),
-                                     modifiedDate = "2001-01-01T01:01:01Z")
+    val existingRecord =
+      sierraItemRecord(bibIds = List("1", "2", "3"),
+                       unlinkedBibIds = List("4", "5"),
+                       modifiedDate = "2001-01-01T01:01:01Z")
     val updatedRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
-                                     modifiedDate = "2002-01-01T01:01:01Z")
+                                         modifiedDate = "2002-01-01T01:01:01Z")
 
-    val mergedRecord = SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
-                                                         updatedRecord = updatedRecord)
+    val mergedRecord =
+      SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
+                                        updatedRecord = updatedRecord)
     mergedRecord.unlinkedBibIds shouldBe List("4", "5")
   }
 
   it("does not duplicate unlinked bibIds") {
     // This would be an unusual scenario to arise, but check we handle it anyway!
-    val existingRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
-                                     unlinkedBibIds = List("3"),
-                                     modifiedDate = "2001-01-01T01:01:01Z")
+    val existingRecord =
+      sierraItemRecord(bibIds = List("1", "2", "3"),
+                       unlinkedBibIds = List("3"),
+                       modifiedDate = "2001-01-01T01:01:01Z")
     val updatedRecord = sierraItemRecord(bibIds = List("1", "2"),
-                                     modifiedDate = "2002-01-01T01:01:01Z")
+                                         modifiedDate = "2002-01-01T01:01:01Z")
 
-    val mergedRecord = SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
-                                                         updatedRecord = updatedRecord)
+    val mergedRecord =
+      SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
+                                        updatedRecord = updatedRecord)
     mergedRecord.bibIds shouldBe List("1", "2")
     mergedRecord.unlinkedBibIds shouldBe List("3")
   }
@@ -64,15 +73,17 @@ class SierraItemRecordMergerTest extends FunSpec with Matchers {
                        unlinkedBibIds = List("1", "2", "3"),
                        modifiedDate = "2001-01-01T01:01:01Z")
     val updatedRecord = sierraItemRecord(bibIds = List("1", "2"),
-                                     modifiedDate = "2002-01-01T01:01:01Z")
+                                         modifiedDate = "2002-01-01T01:01:01Z")
 
-    val mergedRecord = SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
-                                                         updatedRecord = updatedRecord)
+    val mergedRecord =
+      SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
+                                        updatedRecord = updatedRecord)
     mergedRecord.bibIds shouldBe List("1", "2")
     mergedRecord.unlinkedBibIds shouldBe List("3")
   }
 
-  it("should return the existing record unchanged if the update has an older date") {
+  it(
+    "should return the existing record unchanged if the update has an older date") {
     val existingRecord = sierraItemRecord(
       bibIds = List("1", "2", "3"),
       modifiedDate = "2017-01-01T00:00:00Z",
@@ -83,11 +94,12 @@ class SierraItemRecordMergerTest extends FunSpec with Matchers {
       modifiedDate = "2010-01-01T00:00:00Z"
     )
 
-    val mergedRecord = SierraItemRecordMerger.mergeItems(existingRecord, updatedRecord)
+    val mergedRecord =
+      SierraItemRecordMerger.mergeItems(existingRecord, updatedRecord)
 
     mergedRecord shouldBe existingRecord
   }
-  
+
   it("carries across the version from the existing record") {
     val existingRecord = sierraItemRecord(
       modifiedDate = "2001-01-01T00:00:00Z",
@@ -98,15 +110,15 @@ class SierraItemRecordMergerTest extends FunSpec with Matchers {
       version = 2
     )
 
-    val mergedRecord = SierraItemRecordMerger.mergeItems(existingRecord, updatedRecord)
+    val mergedRecord =
+      SierraItemRecordMerger.mergeItems(existingRecord, updatedRecord)
     mergedRecord.version shouldBe existingRecord.version
   }
 
-  private def sierraItemRecord(
-    bibIds: List[String] = List(),
-    unlinkedBibIds: List[String] = List(),
-    modifiedDate: String = "2001-01-01T01:01:01Z",
-    version: Int = 1): SierraItemRecord = {
+  private def sierraItemRecord(bibIds: List[String] = List(),
+                               unlinkedBibIds: List[String] = List(),
+                               modifiedDate: String = "2001-01-01T01:01:01Z",
+                               version: Int = 1): SierraItemRecord = {
     SierraItemRecord(
       id = s"i111",
       modifiedDate = Instant.parse(modifiedDate),

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.sierra_items_to_dynamo.services
 
+import java.time.Instant
+
 import com.gu.scanamo.Scanamo
 import com.gu.scanamo.syntax._
 import io.circe.parser.parse
@@ -99,10 +101,11 @@ class DynamoInserterTest
 
     val oldRecord = SierraItemRecord(
       id = s"i$id",
-      modifiedDate = oldUpdatedDate,
+      modifiedDate = Instant.parse(oldUpdatedDate),
       data =
         s"""{"id": "i$id", "updatedDate": "$oldUpdatedDate", "comment": "Legacy line of lamentable leopards", "bibIds": ["b1556974"]}""",
-      bibIds = List("b1556974")
+      bibIds = List("b1556974"),
+      version = 1
     )
     Scanamo.put(dynamoDbClient)(tableName)(oldRecord)
 
@@ -124,7 +127,7 @@ class DynamoInserterTest
 
     whenReady(futureUnit) { _ =>
       Scanamo.get[SierraItemRecord](dynamoDbClient)(tableName)('id -> s"i$id") shouldBe Some(
-        Right(newRecord.copy(version = 1)))
+        Right(newRecord.copy(version = 2)))
     }
   }
 

--- a/sierra_adapter/terraform/sierra_reader/queues.tf
+++ b/sierra_adapter/terraform/sierra_reader/queues.tf
@@ -1,9 +1,13 @@
 module "windows_queue" {
-  source      = "git::https://github.com/wellcometrust/terraform.git//sqs?ref=v1.1.0"
+  source      = "git::https://github.com/wellcometrust/terraform.git//sqs?ref=v6.4.0"
   queue_name  = "sierra_${var.resource_type}_windows"
   aws_region  = "${var.aws_region}"
   account_id  = "${var.account_id}"
   topic_names = ["${var.windows_topic_name}"]
+
+  # Ensure that messages are spread around -- if we get a timeout from the
+  # Sierra API, we don't retry _too_ quickly.
+  visibility_timeout_seconds = 90
 
   alarm_topic_arn = "${var.dlq_alarm_arn}"
 }


### PR DESCRIPTION
This fixes a bug that prevents sierra_items_to_dynamo from updating a record that's been stored once in DynamoDB.

I did this change with Alice; it will be deployed ahead of tonight's run but may not get merged tonight.

PR is more for discussion/visibility than for review.