### PR TITLE
Define a clear boundary between display models (Jackson/API) and internal models (Circe/everything else)

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayConcept.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayConcept.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.platform.api.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.models.Concept
+
+@ApiModel(
+  value = "Concept",
+  description = "A broad concept"
+)
+case class DisplayConcept(
+  @ApiModelProperty(
+    dataType = "String"
+  ) label: String
+) {
+  @JsonProperty("type") val ontologyType: String = "Concept"
+}
+
+case object DisplayConcept {
+  def apply(concept: Concept): DisplayConcept = DisplayConcept(
+    label = concept.label
+  )
+}

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayPeriod.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayPeriod.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.platform.api.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.models.Period
+
+@ApiModel(
+  value = "Period",
+  description = "A period of time"
+)
+case class DisplayPeriod(
+  @ApiModelProperty(
+    dataType = "String"
+  ) label: String
+) {
+  @JsonProperty("type") val ontologyType: String = "Period"
+}
+
+case object DisplayPeriod {
+  def apply(period: Period): DisplayPeriod = DisplayPeriod(
+    label = period.label
+  )
+}

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -81,18 +81,12 @@ case object DisplayWork {
       description = work.description,
       lettering = work.lettering,
       createdDate = work.createdDate.map { DisplayPeriod(_) },
-      // Wrapping this in Option to catch null value from Jackson
-      // TODO: Since Jackson no longer does Work decoding, can we drop this?
-      creators = Option(work.creators.map { DisplayAgent(_) } ).getOrElse(Nil),
-      subjects = Option(work.subjects.map { DisplayConcept(_) }).getOrElse(Nil),
-      genres = Option(work.genres.map { DisplayConcept(_) } ).getOrElse(Nil),
+      creators = work.creators.map { DisplayAgent(_) },
+      subjects = work.subjects.map { DisplayConcept(_) },
+      genres = work.genres.map { DisplayConcept(_) } ),
       identifiers =
         if (includes.identifiers)
-          // If there aren't any identifiers on the work JSON, Jackson puts a
-          // nil here.  Wrapping it in an Option casts it into a None or Some
-          // as appropriate, and avoids throwing a NullPointerError when
-          // we map over the value.
-          Option[List[SourceIdentifier]](work.identifiers) match {
+          work.identifiers match {
             case Some(identifiers) =>
               Some(identifiers.map(DisplayIdentifier(_)))
             case None => Some(List())
@@ -103,7 +97,7 @@ case object DisplayWork {
         else None,
       items =
         if (includes.items)
-          Option[List[Item]](work.items) match {
+          work.items match {
             case Some(items) =>
               Some(items.map(DisplayItem(_, includes.identifiers)))
             case None => Some(List())

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -86,25 +86,18 @@ case object DisplayWork {
       genres = work.genres.map { DisplayConcept(_) },
       identifiers =
         if (includes.identifiers)
-          work.identifiers match {
-            case Some(identifiers) =>
-              Some(identifiers.map(DisplayIdentifier(_)))
-            case None => Some(List())
-          } else None,
+          Some(work.identifiers.map { DisplayIdentifier(_) })
+        else None,
       thumbnail =
         if (includes.thumbnail)
-          work.thumbnail.map(DisplayLocation(_))
+          work.thumbnail.map { DisplayLocation(_) }
         else None,
       items =
         if (includes.items)
-          work.items match {
-            case Some(items) =>
-              Some(items.map(DisplayItem(_, includes.identifiers)))
-            case None => Some(List())
-          } else None,
+          Some(work.items.map { DisplayItem(_, includes.identifiers) })
+        else None,
       publishers = work.publishers.map(DisplayAgent(_)),
-      visible = work.visible
-    )
+      visible = work.visible    )
   }
 
   def apply(work: Work): DisplayWork =

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -83,7 +83,7 @@ case object DisplayWork {
       createdDate = work.createdDate.map { DisplayPeriod(_) },
       creators = work.creators.map { DisplayAgent(_) },
       subjects = work.subjects.map { DisplayConcept(_) },
-      genres = work.genres.map { DisplayConcept(_) } ),
+      genres = work.genres.map { DisplayConcept(_) },
       identifiers =
         if (includes.identifiers)
           work.identifiers match {

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.{JsonIgnoreProperties, JsonProperty}
 import com.sksamuel.elastic4s.http.search.SearchHit
 import com.sksamuel.elastic4s.http.get.GetResponse
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models._
+import uk.ac.wellcome.models.{Item, SourceIdentifier, Work}
 import uk.ac.wellcome.utils.JsonUtil._
 
 @JsonIgnoreProperties(Array("visible"))
@@ -29,24 +29,30 @@ case class DisplayWork(
     value = "Recording written text on a (usually visual) work.") lettering: Option[
     String] = None,
   @ApiModelProperty(
-    dataType = "uk.ac.wellcome.models.Period",
+    dataType = "uk.ac.wellcome.platform.api.models.DisplayPeriod",
     value =
       "Relates the creation of a work to a date, when the date of creation does not cover a range.") createdDate: Option[
-    Period] = None,
-  @ApiModelProperty(value =
-    "Relates a work to its author, compiler, editor, artist or other entity responsible for its coming into existence in the form that it has.") creators: List[
-    Agent] = List(),
+    DisplayPeriod] = None,
+  @ApiModelProperty(
+    dataType = "List[uk.ac.wellcome.platform.api.models.DisplayAgent]",
+    value =
+      "Relates a work to its author, compiler, editor, artist or other entity responsible for its coming into existence in the form that it has.") creators: List[
+    DisplayAgent] = List(),
   @ApiModelProperty(
     dataType = "List[uk.ac.wellcome.platform.api.models.DisplayIdentifier]",
     value =
       "Relates the item to a unique system-generated identifier that governs interaction between systems and is regarded as canonical within the Wellcome data ecosystem."
   ) identifiers: Option[List[DisplayIdentifier]] = None,
-  @ApiModelProperty(value =
-    "Relates a work to the general thesaurus-based concept that describes the work's content.") subjects: List[
-    Concept] = List(),
-  @ApiModelProperty(value =
-    "Relates a work to the genre that describes the work's content.") genres: List[
-    Concept] = List(),
+  @ApiModelProperty(
+    dataType = "uk.ac.wellcome.platform.api.models.DisplayConcept",
+    value =
+      "Relates a work to the general thesaurus-based concept that describes the work's content.") subjects: List[
+    DisplayConcept] = List(),
+  @ApiModelProperty(
+    dataType = "uk.ac.wellcome.platform.api.models.DisplayConcept",
+    value =
+      "Relates a work to the genre that describes the work's content.") genres: List[
+    DisplayConcept] = List(),
   @ApiModelProperty(
     dataType = "uk.ac.wellcome.platform.api.models.DisplayLocation",
     value =
@@ -74,11 +80,12 @@ case object DisplayWork {
       title = work.title.get,
       description = work.description,
       lettering = work.lettering,
-      createdDate = work.createdDate,
+      createdDate = work.createdDate.map { DisplayPeriod(_) },
       // Wrapping this in Option to catch null value from Jackson
-      creators = Option(work.creators).getOrElse(Nil),
-      subjects = Option(work.subjects).getOrElse(Nil),
-      genres = Option(work.genres).getOrElse(Nil),
+      // TODO: Since Jackson no longer does Work decoding, can we drop this?
+      creators = Option(work.creators.map { DisplayAgent(_) } ).getOrElse(Nil),
+      subjects = Option(work.subjects.map { DisplayConcept(_) }).getOrElse(Nil),
+      genres = Option(work.genres.map { DisplayConcept(_) } ).getOrElse(Nil),
       identifiers =
         if (includes.identifiers)
           // If there aren't any identifiers on the work JSON, Jackson puts a

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -31,13 +31,13 @@ case class DisplayWork(
   @ApiModelProperty(
     dataType = "uk.ac.wellcome.platform.api.models.DisplayPeriod",
     value =
-      "Relates the creation of a work to a date, when the date of creation does not cover a range.") createdDate: Option[
-    DisplayPeriod] = None,
+      "Relates the creation of a work to a date, when the date of creation does not cover a range."
+  ) createdDate: Option[DisplayPeriod] = None,
   @ApiModelProperty(
     dataType = "List[uk.ac.wellcome.platform.api.models.DisplayAgent]",
     value =
-      "Relates a work to its author, compiler, editor, artist or other entity responsible for its coming into existence in the form that it has.") creators: List[
-    DisplayAgent] = List(),
+      "Relates a work to its author, compiler, editor, artist or other entity responsible for its coming into existence in the form that it has."
+  ) creators: List[DisplayAgent] = List(),
   @ApiModelProperty(
     dataType = "List[uk.ac.wellcome.platform.api.models.DisplayIdentifier]",
     value =
@@ -46,12 +46,11 @@ case class DisplayWork(
   @ApiModelProperty(
     dataType = "uk.ac.wellcome.platform.api.models.DisplayConcept",
     value =
-      "Relates a work to the general thesaurus-based concept that describes the work's content.") subjects: List[
-    DisplayConcept] = List(),
+      "Relates a work to the general thesaurus-based concept that describes the work's content."
+  ) subjects: List[DisplayConcept] = List(),
   @ApiModelProperty(
     dataType = "uk.ac.wellcome.platform.api.models.DisplayConcept",
-    value =
-      "Relates a work to the genre that describes the work's content.") genres: List[
+    value = "Relates a work to the genre that describes the work's content.") genres: List[
     DisplayConcept] = List(),
   @ApiModelProperty(
     dataType = "uk.ac.wellcome.platform.api.models.DisplayLocation",
@@ -90,14 +89,16 @@ case object DisplayWork {
         else None,
       thumbnail =
         if (includes.thumbnail)
-          work.thumbnail.map { DisplayLocation(_) }
-        else None,
+          work.thumbnail.map { DisplayLocation(_) } else None,
       items =
         if (includes.items)
-          Some(work.items.map { DisplayItem(_, includesIdentifiers = includes.identifiers) })
+          Some(work.items.map {
+            DisplayItem(_, includesIdentifiers = includes.identifiers)
+          })
         else None,
       publishers = work.publishers.map(DisplayAgent(_)),
-      visible = work.visible    )
+      visible = work.visible
+    )
   }
 
   def apply(work: Work): DisplayWork =

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -94,7 +94,7 @@ case object DisplayWork {
         else None,
       items =
         if (includes.items)
-          Some(work.items.map { DisplayItem(_, includes.identifiers) })
+          Some(work.items.map { DisplayItem(_, includesIdentifiers = includes.identifiers) })
         else None,
       publishers = work.publishers.map(DisplayAgent(_)),
       visible = work.visible    )

--- a/common/src/main/scala/uk/ac/wellcome/models/Agent.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Agent.scala
@@ -1,17 +1,16 @@
 package uk.ac.wellcome.models
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
 sealed trait AbstractAgent {
   val label: String
-  @JsonProperty("type") val ontologyType: String
+  val ontologyType: String
 }
 
-case class Agent(label: String,
-                 @JsonProperty("type") ontologyType: String = "Agent")
-    extends AbstractAgent
+case class Agent(
+  label: String,
+  ontologyType: String = "Agent"
+) extends AbstractAgent
 
 case class Organisation(
   label: String,
-  @JsonProperty("type") ontologyType: String = "Organisation"
+  ontologyType: String = "Organisation"
 ) extends AbstractAgent

--- a/common/src/main/scala/uk/ac/wellcome/models/Concept.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Concept.scala
@@ -1,8 +1,6 @@
 package uk.ac.wellcome.models
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
 case class Concept(
   label: String,
-  @JsonProperty("type") ontologyType: String = "Concept"
+  ontologyType: String = "Concept"
 )

--- a/common/src/main/scala/uk/ac/wellcome/models/Error.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Error.scala
@@ -1,14 +1,12 @@
 package uk.ac.wellcome.models
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
 case class Error(
   errorType: String,
   httpStatus: Option[Int] = None,
   label: String,
   description: Option[String] = None
 ) {
-  @JsonProperty("type") val ontologyType: String = "Error"
+  val ontologyType: String = "Error"
 }
 
 case object Error {

--- a/common/src/main/scala/uk/ac/wellcome/models/Item.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Item.scala
@@ -1,12 +1,10 @@
 package uk.ac.wellcome.models
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
 case class Item(
   canonicalId: Option[String] = None,
   sourceIdentifier: SourceIdentifier,
   identifiers: List[SourceIdentifier] = Nil,
   locations: List[Location] = List(),
   visible: Boolean = true,
-  @JsonProperty("type") ontologyType: String = "Item"
+  ontologyType: String = "Item"
 ) extends Identifiable

--- a/common/src/main/scala/uk/ac/wellcome/models/License.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/License.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.models
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.{
@@ -17,7 +16,7 @@ sealed trait License {
   val licenseType: String
   val label: String
   val url: String
-  @JsonProperty("type") val ontologyType: String = "License"
+  val ontologyType: String = "License"
 }
 
 object License extends Logging {
@@ -52,8 +51,8 @@ object License extends Logging {
   }
 }
 
+// TODO: Do we need this?
 class LicenseDeserialiser extends JsonDeserializer[License] with Logging {
-
   override def deserialize(p: JsonParser,
                            ctxt: DeserializationContext): License = {
     val node: JsonNode = p.getCodec.readTree(p)

--- a/common/src/main/scala/uk/ac/wellcome/models/License.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/License.scala
@@ -1,17 +1,9 @@
 package uk.ac.wellcome.models
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.{
-  DeserializationContext,
-  JsonDeserializer,
-  JsonNode
-}
 import com.twitter.inject.Logging
 import io.circe.{Decoder, Encoder, Json}
 import cats.syntax.either._
 
-@JsonDeserialize(using = classOf[LicenseDeserialiser])
 sealed trait License {
   val licenseType: String
   val label: String
@@ -48,16 +40,6 @@ object License extends Logging {
         error(errorMessage)
         throw new Exception(errorMessage)
     }
-  }
-}
-
-// TODO: Do we need this?
-class LicenseDeserialiser extends JsonDeserializer[License] with Logging {
-  override def deserialize(p: JsonParser,
-                           ctxt: DeserializationContext): License = {
-    val node: JsonNode = p.getCodec.readTree(p)
-    val licenseType = node.get("licenseType").asText
-    License.createLicense(licenseType)
   }
 }
 

--- a/common/src/main/scala/uk/ac/wellcome/models/Location.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Location.scala
@@ -1,7 +1,5 @@
 package uk.ac.wellcome.models
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
 sealed trait Location {
   val locationType: String
 }
@@ -11,11 +9,11 @@ case class DigitalLocation(
   license: License,
   locationType: String,
   credit: Option[String] = None,
-  @JsonProperty("type") ontologyType: String = "DigitalLocation"
+  ontologyType: String = "DigitalLocation"
 ) extends Location
 
 case class PhysicalLocation(
   locationType: String,
   label: String,
-  @JsonProperty("type") ontologyType: String = "PhysicalLocation"
+  ontologyType: String = "PhysicalLocation"
 ) extends Location

--- a/common/src/main/scala/uk/ac/wellcome/models/Period.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Period.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.models
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
-case class Period(label: String,
-                  @JsonProperty("type") ontologyType: String = "Period")
+case class Period(
+  label: String,
+  ontologyType: String = "Period"
+)

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -1,9 +1,7 @@
 package uk.ac.wellcome.models
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.sksamuel.elastic4s.Indexable
 import uk.ac.wellcome.utils.JsonUtil._
-import uk.ac.wellcome.utils.JsonUtil.toJson
 
 /** A representation of a work in our ontology */
 case class Work(title: Option[String],
@@ -20,7 +18,7 @@ case class Work(title: Option[String],
                 items: List[Item] = Nil,
                 publishers: List[AbstractAgent] = Nil,
                 visible: Boolean = true,
-                @JsonProperty("type") ontologyType: String = "Work")
+                ontologyType: String = "Work")
     extends Identifiable
 
 case object Work extends Indexable[Work] {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,6 @@ object Dependencies {
     val elastic4s = "5.4.1"
     val scanamo = "1.0.0-M3"
     val jacksonYamlVersion = "2.8.8"
-    val jacksonJSR310Version = "2.8.9"
     val circeVersion = "0.9.0"
     val scalaCheckVersion = "1.13.4"
     val scalaCheckShapelessVersion = "1.1.6"


### PR DESCRIPTION
Follows up from #1463.

We now have separate display and internal models, where previously our DisplayWork was previously a weird hybrid of the two. This means that:

* Only Circe does encoding/decoding of our internal models
* Only Jackson does encoding of our display models

So we can simplify the internal models, and delete a bunch of code.

### What is this PR trying to achieve?

⚽️