### PR TITLE
Forward *all* requests to Loris

### DIFF
--- a/loris/terraform/services.tf
+++ b/loris/terraform/services.tf
@@ -8,7 +8,7 @@ module "loris" {
   listener_https_arn = "${module.loris_alb.listener_https_arn}"
   listener_http_arn  = "${module.loris_alb.listener_http_arn}"
 
-  path_pattern     = "/image*"
+  path_pattern     = "/*"
   healthcheck_path = "/image/"
 
   cpu    = 3960


### PR DESCRIPTION
Previously requests to / or /robots.txt would 503, because the ALB had
nowhere to send them.  That meant Googlebot would assume the site was
missing, and refuse to crawl anything.  This should fix it.

More details: https://plus.google.com/+PierreFar/posts/Gas8vjZ5fmB

[skip ci]

### Who is this change for?

⛳️ 🐐 

### Have the following been considered/are they needed?

- [x] Run `terraform apply`.
