### PR TITLE
Populate lettering on Sierra works

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraBibData.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraBibData.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.transformer.source
 case class SierraBibData(
   id: String,
   title: Option[String],
+  lettering: Option[String] = None,
   deleted: Boolean = false,
   suppressed: Boolean = false,
   fixedFields: Map[String, FixedField] = Map(),

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
@@ -14,6 +14,7 @@ class SierraTransformableTransformer
     extends TransformableTransformer[SierraTransformable]
     with SierraIdentifiers
     with SierraDescription
+    with SierraLettering
     with SierraPublishers
     with SierraTitle
     with Logging {
@@ -61,6 +62,7 @@ class SierraTransformableTransformer
               ),
               identifiers = getIdentifiers(sierraBibData),
               description = getDescription(sierraBibData),
+              lettering = getLettering(sierraBibData),
               items = Option(sierraTransformable.itemData)
                 .getOrElse(Map.empty)
                 .values

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLettering.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLettering.scala
@@ -1,0 +1,10 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+import uk.ac.wellcome.transformer.source.SierraBibData
+
+trait SierraLettering {
+
+  def getLettering(bibData: SierraBibData): Option[String] = {
+    Some("foo")
+  }
+}

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLettering.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLettering.scala
@@ -4,7 +4,28 @@ import uk.ac.wellcome.transformer.source.SierraBibData
 
 trait SierraLettering {
 
+  // Populate wwork:lettering.
+  //
+  // We use the prefilled "lettering" field, if there's a MARC field 246
+  // with indicator 16.  Otherwise nothing.
+  //
+  // Notes:
+  //  - If a record is an archive, image or a journal, there are different
+  //    rules (Silver's notes say "look at 749 but not subfield 6").  We don't
+  //    have a way to distinguish these yet, so for now we don't do anything.
+  //    TODO: When we know how to identify these, implement the correct rules
+  //    for lettering.
+  //
   def getLettering(bibData: SierraBibData): Option[String] = {
-    Some("foo")
+    val matchingFields = bibData.varFields
+      .filter { _.marcTag == Some("246") }
+      .filter { _.indicator1 == Some("1") }
+      .filter { _.indicator2 == Some("6") }
+
+    if (matchingFields.isEmpty) {
+      None
+    } else {
+      bibData.lettering
+    }
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -97,6 +97,7 @@ class SierraTransformableTransformerTest
   it("performs a transformation on a work using all varfields") {
     val id = "000"
     val title = "Hi Diddle Dee Dee"
+    val lettering = "An actor's life for me"
 
     val publisherFields = List(
       VarField(
@@ -125,13 +126,24 @@ class SierraTransformableTransformerTest
       )
     )
 
-    val marcFields = publisherFields ++ descriptionFields
+    val letteringFields = List(
+      VarField(
+        fieldTag = "?",
+        marcTag = "246",
+        indicator1 = "1",
+        indicator2 = "6",
+        subfields = List()
+      )
+    )
+
+    val marcFields = publisherFields ++ descriptionFields ++ letteringFields
 
     val data =
       s"""
          |{
          | "id": "$id",
          | "title": "$title",
+         | "lettering": "$lettering",
          | "varFields": ${toJson(marcFields).get}
          |}
         """.stripMargin
@@ -153,7 +165,8 @@ class SierraTransformableTransformerTest
         sourceIdentifier = identifier,
         identifiers = List(identifier),
         description = Some("A delightful description of a dead daisy."),
-        publishers = List(Organisation(label = "Peaceful Poetry"))
+        publishers = List(Organisation(label = "Peaceful Poetry")),
+        lettering = Some(lettering)
       )
     )
   }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLetteringTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLetteringTest.scala
@@ -1,0 +1,111 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.{Agent, Organisation}
+import uk.ac.wellcome.transformer.source.{
+  MarcSubfield,
+  SierraBibData,
+  VarField
+}
+import uk.ac.wellcome.test.utils.SierraData
+
+class SierraLetteringTest extends FunSpec with Matchers with SierraData {
+
+  it("ignores records with the wrong MARC field") {
+    assertFindsCorrectLettering(
+      lettering = Some("An ambiance of accordions"),
+      varFields = List(
+        VarField(
+          fieldTag = "p",
+          marcTag = "260",
+          indicator1 = " ",
+          indicator2 = " ",
+          subfields = List()
+        )
+      ),
+      expectedLettering = None
+    )
+  }
+
+  it("ignores records with the right MARC field but wrong indicator 1") {
+    assertFindsCorrectLettering(
+      lettering = Some("Bellowing bassoons in the basement"),
+      varFields = List(
+        VarField(
+          fieldTag = "p",
+          marcTag = "246",
+          indicator1 = "2",
+          indicator2 = "6",
+          subfields = List()
+        )
+      ),
+      expectedLettering = None
+    )
+  }
+
+  it("ignores records with the right MARC field but wrong indicator 2") {
+    assertFindsCorrectLettering(
+      lettering = Some("Cantering clarinets for a concert"),
+      varFields = List(
+        VarField(
+          fieldTag = "p",
+          marcTag = "246",
+          indicator1 = "1",
+          indicator2 = "7",
+          subfields = List()
+        )
+      ),
+      expectedLettering = None
+    )
+  }
+
+  it("picks up lettering if the correct MARC field is present") {
+    assertFindsCorrectLettering(
+      lettering = Some("Dancing to a drum"),
+      varFields = List(
+        VarField(
+          fieldTag = "p",
+          marcTag = "246",
+          indicator1 = "1",
+          indicator2 = "6",
+          subfields = List()
+        )
+      ),
+      expectedLettering = Some("Dancing to a drum")
+    )
+  }
+
+  it("passes through nothing if the lettering is missing, even if the MARC is correct") {
+    assertFindsCorrectLettering(
+      lettering = None,
+      varFields = List(
+        VarField(
+          fieldTag = "p",
+          marcTag = "246",
+          indicator1 = "1",
+          indicator2 = "6",
+          subfields = List()
+        )
+      ),
+      expectedLettering = None
+    )
+  }
+
+  val transformer = new Object with SierraLettering
+
+  private def assertFindsCorrectLettering(
+    lettering: Option[String],
+    varFields: List[VarField],
+    expectedLettering: Option[String]
+  ) = {
+
+    val bibData = SierraBibData(
+      id = "b1234567",
+      title = Some("A libel of lions"),
+      lettering = lettering,
+      varFields = varFields
+    )
+
+    transformer.getLettering(bibData = bibData) shouldBe expectedLettering
+  }
+}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLetteringTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLetteringTest.scala
@@ -75,7 +75,8 @@ class SierraLetteringTest extends FunSpec with Matchers with SierraData {
     )
   }
 
-  it("passes through nothing if the lettering is missing, even if the MARC is correct") {
+  it(
+    "passes through nothing if the lettering is missing, even if the MARC is correct") {
     assertFindsCorrectLettering(
       lettering = None,
       varFields = List(


### PR DESCRIPTION
### What is this PR trying to achieve?

Implement lettering in the Sierra transformer. It's already exposed in the API; we just need to populate it.

### Who is this change for?

🔠 