### PR TITLE
Reduce the verbosity of our logs

### DIFF
--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -29,7 +29,7 @@ class WorkIndexer @Inject()(
     metricsSender.timeAndCount[IndexResponse](
       "ingestor-index-work",
       () => {
-        info(s"Indexing work $work")
+        info(s"Indexing work ${work.id}")
 
         elasticClient
           .execute {
@@ -37,7 +37,7 @@ class WorkIndexer @Inject()(
           }
           .recover {
             case e: Throwable =>
-              error(s"Error indexing work $work into Elasticsearch", e)
+              error(s"Error indexing work ${work.id} into Elasticsearch", e)
               throw e
           }
       }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
@@ -35,7 +35,7 @@ class SQSMessageReceiver @Inject()(snsWriter: SNSWriter,
     extends Logging {
 
   def receiveMessage(message: SQSMessage): Future[Unit] = {
-    info(s"Starting to process message $message")
+    debug(s"Starting to process message $message")
     metricsSender.timeAndCount(
       "ingest-time",
       () => {
@@ -51,7 +51,7 @@ class SQSMessageReceiver @Inject()(snsWriter: SNSWriter,
         futurePublishAttempt
           .recover {
             case e: ParsingFailure =>
-              info("Recoverable failure extracting workfrom record", e)
+              info("Recoverable failure parsing HybridRecord from message", e)
               throw GracefulFailureException(e)
           }
           .map(_ => ())
@@ -74,7 +74,7 @@ class SQSMessageReceiver @Inject()(snsWriter: SNSWriter,
     transformable: Transformable): Try[Option[Work]] = {
     val transformableTransformer = chooseTransformer(transformable)
     transformableTransformer.transform(transformable) map { transformed =>
-      info(s"Transformed record $transformed")
+      debug(s"Transformed record to $transformed")
       transformed
     } recover {
       case e: Throwable =>

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
@@ -21,7 +21,7 @@ class SierraTransformableTransformer
     with Logging {
 
   private def extractItemData(itemRecord: SierraItemRecord) = {
-    info(s"Attempting to transform $itemRecord")
+    info(s"Attempting to transform ${itemRecord.id}")
 
     fromJson[SierraItemData](itemRecord.data) match {
       case Success(sierraItemData) =>
@@ -52,7 +52,7 @@ class SierraTransformableTransformer
   ): Try[Option[Work]] = {
     sierraTransformable.maybeBibData
       .map { bibData =>
-        info(s"Attempting to transform $bibData")
+        info(s"Attempting to transform ${bibData.id}")
 
         fromJson[SierraBibData](bibData.data).map { sierraBibData =>
           Some(

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
@@ -29,7 +29,7 @@ object SierraRecordWrapperFlow extends Logging {
     resourceType: SierraResourceTypes.Value): SierraRecord = {
     val json = addIDPrefix(json = unprefixedJson,
                            resourceType: SierraResourceTypes.Value)
-    logger.info(s"Creating record from ${json.noSpaces}")
+    logger.debug(s"Creating record from ${json.noSpaces}")
     val maybeUpdatedDate = root.updatedDate.string.getOption(json)
     maybeUpdatedDate match {
       case Some(updatedDate) =>


### PR DESCRIPTION
Move a couple of very chatty (and mostly unnecessary) logs to DEBUG, and log IDs rather than full records in other places. This should reduce our CloudWatch costs somewhat.

### Have the following been considered/are they needed?

💸 