### PR TITLE
Rename the bucket that holds our CloudFront logs

### DIFF
--- a/catalogue_api/terraform/outputs.tf
+++ b/catalogue_api/terraform/outputs.tf
@@ -16,10 +16,6 @@ output "bucket_miro_images_sync_id" {
 
 # Outputs required for Loris
 
-output "cloudfront_logs_domain_name" {
-  value = "${aws_s3_bucket.cloudfront-logs.bucket_domain_name}"
-}
-
 output "vpc_api_id" {
   value = "${module.vpc_api.vpc_id}"
 }

--- a/catalogue_api/terraform/s3.tf
+++ b/catalogue_api/terraform/s3.tf
@@ -22,12 +22,3 @@ resource "aws_s3_bucket" "miro-images-sync" {
     }
   }
 }
-
-resource "aws_s3_bucket" "cloudfront-logs" {
-  bucket = "wellcome-platform-cloudfront-logs"
-  acl    = "private"
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}

--- a/loris/terraform/cloudfront.tf
+++ b/loris/terraform/cloudfront.tf
@@ -54,7 +54,7 @@ resource "aws_cloudfront_distribution" "loris" {
 
   logging_config {
     include_cookies = false
-    bucket          = "${local.cloudfront_logs_domain_name}"
+    bucket          = "${aws_s3_bucket.cloudfront_logs.bucket_domain_name}"
     prefix          = "loris"
   }
 }

--- a/loris/terraform/locals.tf
+++ b/loris/terraform/locals.tf
@@ -2,8 +2,6 @@ locals {
   vpc_api_subnets = "${data.terraform_remote_state.catalogue_api.vpc_api_subnets}"
   vpc_api_id      = "${data.terraform_remote_state.catalogue_api.vpc_api_id}"
 
-  cloudfront_logs_domain_name = "${data.terraform_remote_state.catalogue_api.cloudfront_logs_domain_name}"
-
   bucket_alb_logs_id = "${data.terraform_remote_state.shared_infra.bucket_alb_logs_id}"
 
   ec2_terminating_topic_arn                       = "${data.terraform_remote_state.shared_infra.ec2_terminating_topic_arn}"

--- a/loris/terraform/s3.tf
+++ b/loris/terraform/s3.tf
@@ -11,3 +11,12 @@ resource "aws_s3_bucket" "wellcomecollection-miro-images-public" {
     prevent_destroy = true
   }
 }
+
+resource "aws_s3_bucket" "cloudfront_logs" {
+  bucket = "wellcomecollection-platform-logs-cloudfront"
+  acl    = "private"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}


### PR DESCRIPTION
A first step towards #1511; our CloudFront logs bucket now uses the **wellcomecollection-platform** prefix. Additionally, since it was defined in the API stack but only used by Loris, I moved the definition of the bucket into the Loris stack.

I've applied the change in the Loris stack (create the new bucket, migrate the existing logs) – but not in the API stack (so the old bucket is still around).

We keep our CloudFront logs *forever*. Do we actually want that, or is 30 days (as we do for ALB logs) enough?

### Who is this change for?

📛 