### PR TITLE
Rename the bucket that holds our ALB logs

### DIFF
--- a/shared_infra/iam_policy_document.tf
+++ b/shared_infra/iam_policy_document.tf
@@ -77,6 +77,26 @@ data "aws_iam_policy_document" "alb_logs" {
   }
 }
 
+data "aws_iam_policy_document" "s3_alb_logs" {
+  statement {
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${local.alb_logs_bucket_name}/*",
+    ]
+
+    # This is the Account ID for Elastic Load Balancing; not another
+    # AWS account at Wellcome.
+    # See https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html
+    principals {
+      identifiers = ["arn:aws:iam::156460612806:root"]
+      type        = "AWS"
+    }
+  }
+}
+
 data "aws_iam_policy_document" "sqs_readwrite" {
   statement {
     actions = [

--- a/shared_infra/iam_policy_document.tf
+++ b/shared_infra/iam_policy_document.tf
@@ -60,23 +60,6 @@ data "aws_iam_policy_document" "travis_permissions" {
   }
 }
 
-data "aws_iam_policy_document" "alb_logs" {
-  statement {
-    actions = [
-      "s3:PutObject",
-    ]
-
-    resources = [
-      "arn:aws:s3:::wellcomecollection-alb-logs/*",
-    ]
-
-    principals {
-      identifiers = ["arn:aws:iam::156460612806:root"]
-      type        = "AWS"
-    }
-  }
-}
-
 data "aws_iam_policy_document" "s3_alb_logs" {
   statement {
     actions = [

--- a/shared_infra/outputs.tf
+++ b/shared_infra/outputs.tf
@@ -43,7 +43,7 @@ output "ec2_terminating_topic_publish_policy" {
 }
 
 output "bucket_alb_logs_id" {
-  value = "${aws_s3_bucket.alb-logs.id}"
+  value = "${aws_s3_bucket.alb_logs.id}"
 }
 
 output "travis_ci_aws_id" {

--- a/shared_infra/s3.tf
+++ b/shared_infra/s3.tf
@@ -57,6 +57,30 @@ resource "aws_s3_bucket" "alb-logs" {
   }
 }
 
+locals {
+  alb_logs_bucket_name = "wellcomecollection-platform-logs-alb"
+}
+
+resource "aws_s3_bucket" "alb_logs" {
+  bucket = "${local.alb_logs_bucket_name}"
+  acl    = "private"
+
+  policy = "${data.aws_iam_policy_document.s3_alb_logs.json}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  lifecycle_rule {
+    id      = "expire_alb_logs"
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
+}
+
 resource "aws_s3_bucket" "wellcomecollection-images" {
   bucket = "wellcomecollection-images"
   acl    = "private"

--- a/shared_infra/s3.tf
+++ b/shared_infra/s3.tf
@@ -37,26 +37,6 @@ resource "aws_s3_bucket" "infra" {
   }
 }
 
-resource "aws_s3_bucket" "alb-logs" {
-  bucket = "wellcomecollection-alb-logs"
-  acl    = "private"
-
-  policy = "${data.aws_iam_policy_document.alb_logs.json}"
-
-  lifecycle {
-    prevent_destroy = true
-  }
-
-  lifecycle_rule {
-    id      = "expire_alb_logs"
-    enabled = true
-
-    expiration {
-      days = 30
-    }
-  }
-}
-
 locals {
   alb_logs_bucket_name = "wellcomecollection-platform-logs-alb"
 }


### PR DESCRIPTION
This name was less bad, but now it's consistent with CloudFront: **wellcomecollection-platform-logs-alb**. I’m migrating the existing logs to the new bucket (even though they expire after 30 days).

Part of #1511.

### Who is this change for?

📛 