### PR TITLE
Give our Terraform state files a consistent naming scheme

### DIFF
--- a/catalogue_api/terraform/terraform.tf
+++ b/catalogue_api/terraform/terraform.tf
@@ -3,7 +3,7 @@ terraform {
 
   backend "s3" {
     bucket         = "platform-infra"
-    key            = "platform.tfstate"
+    key            = "terraform/catalogue_api.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
   }
@@ -14,7 +14,7 @@ data "terraform_remote_state" "shared_infra" {
 
   config {
     bucket = "platform-infra"
-    key    = "platform-lambda.tfstate"
+    key    = "terraform/shared_infra.tfstate"
     region = "eu-west-1"
   }
 }

--- a/catalogue_pipeline/terraform/terraform.tf
+++ b/catalogue_pipeline/terraform/terraform.tf
@@ -3,7 +3,7 @@ terraform {
 
   backend "s3" {
     bucket         = "platform-infra"
-    key            = "platform-pipeline.tfstate"
+    key            = "terraform/catalogue_pipeline.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
   }
@@ -14,7 +14,7 @@ data "terraform_remote_state" "shared_infra" {
 
   config {
     bucket = "platform-infra"
-    key    = "platform-lambda.tfstate"
+    key    = "terraform/shared_infra.tfstate"
     region = "eu-west-1"
   }
 }

--- a/loris/terraform/terraform.tf
+++ b/loris/terraform/terraform.tf
@@ -14,7 +14,7 @@ data "terraform_remote_state" "shared_infra" {
 
   config {
     bucket = "platform-infra"
-    key    = "platform-lambda.tfstate"
+    key    = "terraform/shared_infra.tfstate"
     region = "eu-west-1"
   }
 }
@@ -24,7 +24,7 @@ data "terraform_remote_state" "catalogue_api" {
 
   config {
     bucket = "platform-infra"
-    key    = "platform.tfstate"
+    key    = "terraform/catalogue_api.tfstate"
     region = "eu-west-1"
   }
 }

--- a/miro_preprocessor/terraform.tf
+++ b/miro_preprocessor/terraform.tf
@@ -3,7 +3,7 @@ terraform {
 
   backend "s3" {
     bucket         = "platform-infra"
-    key            = "platform-miro_preprocessor.tfstate"
+    key            = "terraform/miro_preprocessor.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
   }
@@ -14,7 +14,7 @@ data "terraform_remote_state" "catalogue_pipeline" {
 
   config {
     bucket = "platform-infra"
-    key    = "platform-pipeline.tfstate"
+    key    = "terraform/catalogue_pipeline.tfstate"
     region = "eu-west-1"
   }
 }
@@ -24,7 +24,7 @@ data "terraform_remote_state" "catalogue_api" {
 
   config {
     bucket = "platform-infra"
-    key    = "platform.tfstate"
+    key    = "terraform/catalogue_api.tfstate"
     region = "eu-west-1"
   }
 }
@@ -34,7 +34,7 @@ data "terraform_remote_state" "loris" {
 
   config {
     bucket = "platform-infra"
-    key    = "platform-loris.tfstate"
+    key    = "terraform/loris.tfstate"
     region = "eu-west-1"
   }
 }
@@ -44,7 +44,7 @@ data "terraform_remote_state" "shared_infra" {
 
   config {
     bucket = "platform-infra"
-    key    = "platform-lambda.tfstate"
+    key    = "terraform/shared_infra.tfstate"
     region = "eu-west-1"
   }
 }

--- a/monitoring/terraform.tf
+++ b/monitoring/terraform.tf
@@ -14,7 +14,7 @@ data "terraform_remote_state" "catalogue_pipeline" {
 
   config {
     bucket = "platform-infra"
-    key    = "platform-pipeline.tfstate"
+    key    = "terraform/catalogue_pipeline.tfstate"
     region = "eu-west-1"
   }
 }
@@ -24,7 +24,7 @@ data "terraform_remote_state" "shared_infra" {
 
   config {
     bucket = "platform-infra"
-    key    = "platform-lambda.tfstate"
+    key    = "terraform/shared_infra.tfstate"
     region = "eu-west-1"
   }
 }

--- a/shared_infra/terraform.tf
+++ b/shared_infra/terraform.tf
@@ -3,7 +3,7 @@ terraform {
 
   backend "s3" {
     bucket         = "platform-infra"
-    key            = "platform-lambda.tfstate"
+    key            = "terraform/shared_infra.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
   }

--- a/sierra_adapter/terraform/terraform.tf
+++ b/sierra_adapter/terraform/terraform.tf
@@ -14,7 +14,7 @@ data "terraform_remote_state" "shared_infra" {
 
   config {
     bucket = "platform-infra"
-    key    = "platform-lambda.tfstate"
+    key    = "terraform/shared_infra.tfstate"
     region = "eu-west-1"
   }
 }
@@ -24,7 +24,7 @@ data "terraform_remote_state" "catalogue_pipeline" {
 
   config {
     bucket = "platform-infra"
-    key    = "platform-pipeline.tfstate"
+    key    = "terraform/catalogue_pipeline.tfstate"
     region = "eu-west-1"
   }
 }


### PR DESCRIPTION
In the spirit of the bucket renaming, I’m doing a bit of tidying in platform-infra to make things more consistent.

I’ll merge this as soon as CI passes so state doesn’t get out of sync; this PR is for visibility and testing.

### What is this PR trying to achieve?

📛