### PR TITLE
Provide more useful descriptions in our SNS subjects

### DIFF
--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/services/IdMinterWorkerService.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/services/IdMinterWorkerService.scala
@@ -30,7 +30,7 @@ class IdMinterWorkerService @Inject()(
       workWithCanonicalId <- idEmbedder.embedId(json)
       _ <- writer.writeMessage(
         message = workWithCanonicalId.toString(),
-        subject = "source: IdMinterWorkerService.processMessage"
+        subject = s"source: ${this.getClass.getSimpleName}.processMessage"
       )
     } yield ()
 

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/services/IdMinterWorkerService.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/services/IdMinterWorkerService.scala
@@ -28,8 +28,10 @@ class IdMinterWorkerService @Inject()(
     for {
       json <- Future.fromTry(parseMessageIntoJson(message))
       workWithCanonicalId <- idEmbedder.embedId(json)
-      _ <- writer.writeMessage(workWithCanonicalId.toString(),
-                               Some(snsSubject))
+      _ <- writer.writeMessage(
+        message = workWithCanonicalId.toString(),
+        subject = "source: IdMinterWorkerService.processMessage"
+      )
     } yield ()
 
   private def parseMessageIntoJson(message: SQSMessage): Try[Json] = {

--- a/catalogue_pipeline/reindexer_v2/reindex_job_creator/src/reindex_job_creator.py
+++ b/catalogue_pipeline/reindexer_v2/reindex_job_creator/src/reindex_job_creator.py
@@ -33,5 +33,5 @@ def main(event, _ctxt=None, sns_client=None):
             sns_client=sns_client,
             topic_arn=topic_arn,
             message=message,
-            subject='Reindex job from reindex_job_creator'
+            subject='source: reindex_job_creator.main'
         )

--- a/catalogue_pipeline/reindexer_v2/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexerWorkerService.scala
+++ b/catalogue_pipeline/reindexer_v2/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexerWorkerService.scala
@@ -32,7 +32,7 @@ class ReindexerWorkerService @Inject()(
           _ <- targetService.runReindex(reindexJob = reindexJob)
           message <- Future.fromTry(toJson(CompletedReindexJob(reindexJob)))
           result <- snsWriter.writeMessage(
-            subject = None,
+            subject = "source: ReindexerWorkerService.processMessage",
             message = message
           )
         } yield result

--- a/catalogue_pipeline/reindexer_v2/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexerWorkerService.scala
+++ b/catalogue_pipeline/reindexer_v2/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexerWorkerService.scala
@@ -32,7 +32,7 @@ class ReindexerWorkerService @Inject()(
           _ <- targetService.runReindex(reindexJob = reindexJob)
           message <- Future.fromTry(toJson(CompletedReindexJob(reindexJob)))
           result <- snsWriter.writeMessage(
-            subject = "source: ReindexerWorkerService.processMessage",
+            subject = s"source: ${this.getClass.getSimpleName}.processMessage",
             message = message
           )
         } yield result

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
@@ -97,7 +97,7 @@ class SQSMessageReceiver @Inject()(snsWriter: SNSWriter,
       snsWriter
         .writeMessage(
           message = JsonUtil.toJson(work).get,
-          subject = "source: ${this.getClass.getSimpleName}.publishMessage"
+          subject = s"source: ${this.getClass.getSimpleName}.publishMessage"
         )
         .map(publishAttempt => Some(publishAttempt))
     }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
@@ -95,7 +95,10 @@ class SQSMessageReceiver @Inject()(snsWriter: SNSWriter,
     maybeWork: Option[Work]): Future[Option[PublishAttempt]] =
     maybeWork.fold(Future.successful(None: Option[PublishAttempt])) { work =>
       snsWriter
-        .writeMessage(JsonUtil.toJson(work).get, Some("Foo"))
+        .writeMessage(
+          message = JsonUtil.toJson(work).get,
+          subject = "source: SQSMessageReceiver.publishMessage"
+        )
         .map(publishAttempt => Some(publishAttempt))
     }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
@@ -97,7 +97,7 @@ class SQSMessageReceiver @Inject()(snsWriter: SNSWriter,
       snsWriter
         .writeMessage(
           message = JsonUtil.toJson(work).get,
-          subject = "source: SQSMessageReceiver.publishMessage"
+          subject = "source: ${this.getClass.getSimpleName}.publishMessage"
         )
         .map(publishAttempt => Some(publishAttempt))
     }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -105,7 +105,7 @@ class SQSMessageReceiverTest
 
     whenReady(future) { x =>
       verify(snsWriter, Mockito.never())
-        .writeMessage(anyString, any[Option[String]])
+        .writeMessage(anyString, any[String])
     }
   }
 
@@ -155,14 +155,14 @@ class SQSMessageReceiverTest
 
   private def mockSNSWriter = {
     val mockSNS = mock[SNSWriter]
-    when(mockSNS.writeMessage(anyString(), any[Option[String]]))
+    when(mockSNS.writeMessage(anyString(), any[String]))
       .thenReturn(Future { PublishAttempt(Right("1234")) })
     mockSNS
   }
 
   private def mockFailPublishMessage = {
     val mockSNS = mock[SNSWriter]
-    when(mockSNS.writeMessage(anyString(), any[Option[String]]))
+    when(mockSNS.writeMessage(anyString(), any[String]))
       .thenReturn(
         Future.failed(new RuntimeException("Failed publishing message")))
     mockSNS

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -78,7 +78,7 @@ class SQSMessageReceiverTest
       val messages = listMessagesReceivedFromSNS()
       messages should have size 1
       messages.head.message shouldBe JsonUtil.toJson(work).get
-      messages.head.subject shouldBe "Foo"
+      messages.head.subject shouldBe "source: SQSMessageReceiver.publishMessage"
     }
   }
 

--- a/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
@@ -13,7 +13,6 @@ case class PublishAttempt(id: Either[Throwable, String])
 
 class SNSWriter @Inject()(snsClient: AmazonSNS, snsConfig: SNSConfig)
     extends Logging {
-  val defaultSubject = "subject-not-specified"
 
   def writeMessage(message: String, subject: String): Future[PublishAttempt] =
     Future {

--- a/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
@@ -19,7 +19,8 @@ class SNSWriter @Inject()(snsClient: AmazonSNS, snsConfig: SNSConfig)
       blocking {
         info(
           s"about to publish message $message on the SNS topic ${snsConfig.topicArn}")
-        snsClient.publish(toPublishRequest(message = message, subject = subject))
+        snsClient.publish(
+          toPublishRequest(message = message, subject = subject))
       }
     }.map { publishResult =>
         info(s"Published message ${publishResult.getMessageId}")

--- a/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
@@ -15,13 +15,12 @@ class SNSWriter @Inject()(snsClient: AmazonSNS, snsConfig: SNSConfig)
     extends Logging {
   val defaultSubject = "subject-not-specified"
 
-  def writeMessage(message: String,
-                   subject: Option[String]): Future[PublishAttempt] =
+  def writeMessage(message: String, subject: String): Future[PublishAttempt] =
     Future {
       blocking {
         info(
           s"about to publish message $message on the SNS topic ${snsConfig.topicArn}")
-        snsClient.publish(toPublishRequest(message, subject))
+        snsClient.publish(toPublishRequest(message = message, subject = subject))
       }
     }.map { publishResult =>
         info(s"Published message ${publishResult.getMessageId}")
@@ -33,9 +32,6 @@ class SNSWriter @Inject()(snsClient: AmazonSNS, snsConfig: SNSConfig)
           throw e
       }
 
-  private def toPublishRequest(message: String, subject: Option[String]) = {
-    new PublishRequest(snsConfig.topicArn,
-                       message,
-                       subject.getOrElse(defaultSubject))
-  }
+  private def toPublishRequest(message: String, subject) =
+    new PublishRequest(snsConfig.topicArn, message, subject)
 }

--- a/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
@@ -31,6 +31,6 @@ class SNSWriter @Inject()(snsClient: AmazonSNS, snsConfig: SNSConfig)
           throw e
       }
 
-  private def toPublishRequest(message: String, subject) =
+  private def toPublishRequest(message: String, subject: String) =
     new PublishRequest(snsConfig.topicArn, message, subject)
 }

--- a/common/src/test/scala/uk/ac/wellcome/sns/SNSWriterTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sns/SNSWriterTest.scala
@@ -18,30 +18,19 @@ class SNSWriterTest
   it(
     "should send a message with subject to the SNS client and return a publish attempt with the id of the request") {
     val snsWriter = new SNSWriter(snsClient, snsConfig)
-    val message = "someMessage"
-    val subject = "subject"
-    val futurePublishAttempt = snsWriter.writeMessage(message, Some(subject))
+    val message = "sns-writer-test-message"
+    val subject = "sns-writer-test-subject"
+    val futurePublishAttempt = snsWriter.writeMessage(
+      message = message,
+      subject = subject
+    )
 
     whenReady(futurePublishAttempt) { publishAttempt =>
       val messages = listMessagesReceivedFromSNS()
       messages should have size (1)
-      messages.head.message shouldBe "someMessage"
-      messages.head.subject shouldBe "subject"
+      messages.head.message shouldBe message
+      messages.head.subject shouldBe subject
       publishAttempt.id should be(Right(messages.head.messageId))
-    }
-  }
-
-  it(
-    "should send a message with no subject to the SNS client with the default subject") {
-    val snsWriter = new SNSWriter(snsClient, snsConfig)
-    val message = "someMessage"
-
-    val futurePublishAttempt = snsWriter.writeMessage(message, None)
-
-    whenReady(futurePublishAttempt) { _ =>
-      val messages = listMessagesReceivedFromSNS()
-      messages should have size (1)
-      messages.head.subject shouldBe "subject-not-specified"
     }
   }
 
@@ -50,7 +39,7 @@ class SNSWriterTest
       new SNSWriter(snsClient, SNSConfig("not a valid topic"))
 
     val futurePublishAttempt =
-      snsWriter.writeMessage("someMessage", Some("subject"))
+      snsWriter.writeMessage(message = "someMessage", subject = "subject")
 
     whenReady(futurePublishAttempt.failed) { exception =>
       exception.getMessage should not be (empty)

--- a/shared_infra/dynamo_to_sns/src/dynamo_to_sns.py
+++ b/shared_infra/dynamo_to_sns/src/dynamo_to_sns.py
@@ -53,5 +53,6 @@ def main(event, _ctxt=None, sns_client=None):
         publish_sns_message(
             sns_client=sns_client,
             topic_arn=topic_arn,
-            message=message
+            message=message,
+            subject=f'source: dynamo_to_sns ({topic_arn})'
         )

--- a/shared_infra/dynamo_to_sns/src/dynamo_to_sns.py
+++ b/shared_infra/dynamo_to_sns/src/dynamo_to_sns.py
@@ -42,6 +42,7 @@ def main(event, _ctxt=None, sns_client=None):
     print(f'Received event: {event!r}')
 
     topic_arn = os.environ['TOPIC_ARN']
+    topic_name = topic_arn.split(":")[-1]
     stream_view_type = os.environ.get('STREAM_VIEW_TYPE', 'FULL_EVENT')
 
     sns_client = sns_client or boto3.client('sns')
@@ -54,5 +55,5 @@ def main(event, _ctxt=None, sns_client=None):
             sns_client=sns_client,
             topic_arn=topic_arn,
             message=message,
-            subject=f'source: dynamo_to_sns ({topic_arn})'
+            subject=f'source: dynamo_to_sns ({topic_name})'
         )

--- a/sierra_adapter/s3_demultiplexer/src/s3_demultiplexer.py
+++ b/sierra_adapter/s3_demultiplexer/src/s3_demultiplexer.py
@@ -52,5 +52,6 @@ def main(event, _ctxt=None, s3_client=None, sns_client=None):
         sns_utils.publish_sns_message(
             sns_client=sns_client,
             topic_arn=topic_arn,
-            message=r
+            message=r,
+            subject='source: s3_demultiplexer.main'
         )

--- a/sierra_adapter/sierra_window_generator/src/sierra_window_generator.py
+++ b/sierra_adapter/sierra_window_generator/src/sierra_window_generator.py
@@ -42,5 +42,6 @@ def main(event=None, _ctxt=None, sns_client=None):
     publish_sns_message(
         sns_client=sns_client,
         topic_arn=topic_arn,
-        message=message
+        message=message,
+        subject='source: sierra_window_generator.main'
     )


### PR DESCRIPTION
We have an SQS message on the transformer DLQ with

```
  "Subject" : "default-subject",
  "Message" : "null",
```

and it's really not obvious where it came from!

This patch modifies the subject in our SNS writers to provide slightly more helpful descriptions, so hopefully we'll be able to trace this sort of message in future!