### PR TITLE
Add a script for managing reindexes

### DIFF
--- a/catalogue_pipeline/reindexer_v2/manage_reindex.py
+++ b/catalogue_pipeline/reindexer_v2/manage_reindex.py
@@ -34,8 +34,8 @@ import tqdm
 #  2. The whole process is idempotent, so it's enough to bump the capacity
 #     and re-run the prefix.
 #
-# FWIW, I was able to create >5000 shards with WriteCapacity=1 on a test table,
-# so this may be a theoretical concern!
+# FWIW, I was able to create >5000 shards with WriteCapacity=1 and autoscaling
+# on a test table, so this may be a theoretical concern!
 
 def _update_shard(client, table_name, shard):
     client.update_item(

--- a/catalogue_pipeline/reindexer_v2/manage_reindex.py
+++ b/catalogue_pipeline/reindexer_v2/manage_reindex.py
@@ -71,8 +71,8 @@ def create_shards(prefix, desired_version, count, table_name):
     # we choose simplicity over speed.
     #
     # If you're finding this script to be too slow, this is where to start.
-    for shard in shards:
-        print(f'Processing shard {shard.shardId}')
+    for shard in new_shards:
+        print(f'Processing shard {shard["shardId"]}')
         _update_shard(client=client, table_name=table_name, shard=shard)
 
 

--- a/catalogue_pipeline/reindexer_v2/manage_reindex.py
+++ b/catalogue_pipeline/reindexer_v2/manage_reindex.py
@@ -85,7 +85,7 @@ def create_shards(prefix, desired_version, count, table_name):
 if __name__ == '__main__':
     args = docopt.docopt(__doc__)
 
-    default_table_name = 'AlexTest'
+    default_table_name = 'ReindexShardTracker'
 
     if args['update-shards']:
         prefix = args['--prefix']

--- a/catalogue_pipeline/reindexer_v2/manage_reindex.py
+++ b/catalogue_pipeline/reindexer_v2/manage_reindex.py
@@ -4,6 +4,7 @@
 Create/update reindex shards in the reindex shard tracker table.
 
 Usage: manage_reindex.py create-shards --prefix=<PREFIX> --count=<COUNT> [--table=<TABLE>]
+       manage_reindex.py -h | --help
 
 Actions:
   create-shards         Create a new set of shards in the reindex shard tracker
@@ -13,6 +14,7 @@ Options:
   --prefix=<PREFIX>     Name of the reindex shard prefix, e.g. sierra, miro
   --count=<COUNT>       How many shards to create in the table
   --table=<TABLE>       Name of the reindex shard tracker DynamoDB table
+  -h --help             Print this help message
 
 """
 

--- a/catalogue_pipeline/reindexer_v2/manage_reindex.py
+++ b/catalogue_pipeline/reindexer_v2/manage_reindex.py
@@ -22,11 +22,17 @@ Options:
 import time
 
 import boto3
+from botocore.exceptions import ClientError
 import docopt
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import (
+    retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+)
 
 
-@retry(stop=stop_after_attempt(5), wait=wait_exponential(multiplier=1, max=10))
+@retry(
+    retry=retry_if_exception_type(ClientError),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential(multiplier=1, max=10))
 def _update_shard(client, table_name, shard):
     client.update_item(
         TableName=table_name,

--- a/catalogue_pipeline/reindexer_v2/manage_reindex.py
+++ b/catalogue_pipeline/reindexer_v2/manage_reindex.py
@@ -19,8 +19,6 @@ Options:
 
 """
 
-import time
-
 import boto3
 import docopt
 import tqdm

--- a/catalogue_pipeline/reindexer_v2/manage_reindex.py
+++ b/catalogue_pipeline/reindexer_v2/manage_reindex.py
@@ -1,16 +1,36 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8
 """
-Create/update reindex shards in the ReindexShardTracker table.
+Create/update reindex shards in the reindex shard tracker table.
 
-Usage: manage_reindex.py create-shards --prefix=<PREFIX> --count=<COUNT>
+Usage: manage_reindex.py create-shards --prefix=<PREFIX> --count=<COUNT> [--table=<TABLE>]
 
 Actions:
-  create-shards         Create a new set of shards in the ReindexShardTracker
+  create-shards         Create a new set of shards in the reindex shard tracker
                         table with requestedVersion = currentVersion = 1
 
 Options:
   --prefix=<PREFIX>     Name of the reindex shard prefix, e.g. sierra, miro
   --count=<COUNT>       How many shards to create in the table
+  --table=<TABLE>       Name of the reindex shard tracker DynamoDB table
 
 """
+
+import docopt
+
+
+def create_shards(prefix, count, table_name):
+    """Create new shards in the table."""
+
+
+if __name__ == '__main__':
+    args = docopt.docopt(__doc__)
+
+    default_table_name = 'AlexTest'
+
+    if args['create-shards']:
+        prefix = args['--prefix']
+        count = int(args['--count'])
+        table_name = args['--table'] or default_table_name
+
+        create_shards(prefix=prefix, count=count, table_name=table_name)

--- a/catalogue_pipeline/reindexer_v2/manage_reindex.py
+++ b/catalogue_pipeline/reindexer_v2/manage_reindex.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8
+"""
+Create/update reindex shards in the ReindexShardTracker table.
+
+Usage: manage_reindex.py create-shards --prefix=<PREFIX> --count=<COUNT>
+
+Actions:
+  create-shards         Create a new set of shards in the ReindexShardTracker
+                        table with requestedVersion = currentVersion = 1
+
+Options:
+  --prefix=<PREFIX>     Name of the reindex shard prefix, e.g. sierra, miro
+  --count=<COUNT>       How many shards to create in the table
+
+"""


### PR DESCRIPTION
Add a script that allows us to manage the ReindexShardTrackerTable. In particular, it can:

* Create a new set of shards at desiredVersion = 1
* Update an existing set of shards with a new desiredVersion