### PR TITLE
Don't store metadata about progress in SourceData

### DIFF
--- a/catalogue_pipeline/reindexer_v2/resharder/src/resharder.py
+++ b/catalogue_pipeline/reindexer_v2/resharder/src/resharder.py
@@ -23,10 +23,6 @@ def main(event, _ctxt=None, s3_client=None, dynamodb_client=None):
             print("no NewImage key in dynamo update event, skipping")
             continue
 
-        if row.get('resharded'):
-            print(f'{row["sourceId"]} has already been resharded')
-            continue
-
         old_key = row['s3key']
 
         shard = row['sourceId'][::-1][:2]
@@ -46,7 +42,7 @@ def main(event, _ctxt=None, s3_client=None, dynamodb_client=None):
         dynamodb_client.update_item(
             TableName=table_name,
             Key={'id': {'S': row['id']}},
-            UpdateExpression='SET version = :newVersion, resharded = :true, s3key = :newKey',
+            UpdateExpression='SET version = :newVersion, s3key = :newKey',
             ConditionExpression='version < :newVersion',
             ExpressionAttributeValues={
                 ':newVersion': {'N': str(version + 1)},

--- a/catalogue_pipeline/reindexer_v2/resharder/src/test_resharder.py
+++ b/catalogue_pipeline/reindexer_v2/resharder/src/test_resharder.py
@@ -8,30 +8,6 @@ import pytest
 from resharder import main
 
 
-def test_ignores_already_resharded_row(
-    dynamodb_client, source_data_table, s3_client, source_bucket
-):
-    item = _dynamodb_item(
-        id='sierra/b1111111',
-        s3key='sierra/b1111111.json',
-        resharded=True
-    )
-    dynamodb_client.put_item(TableName=source_data_table, Item=item)
-
-    event = _wrap(item)
-
-    main(event=event, dynamodb_client=dynamodb_client, s3_client=s3_client)
-
-    time.sleep(1)
-
-    item = dynamodb_client.get_item(
-        TableName=source_data_table,
-        Key={'id': {'S': 'sierra/b1111111'}}
-    )
-
-    assert item['Item']['version']['N'] == '1'
-
-
 def test_updates_old_row(
     dynamodb_client, source_data_table, s3_client, source_bucket_name, source_bucket
 ):
@@ -57,7 +33,6 @@ def test_updates_old_row(
         Key={'id': {'S': 'sierra/b2222223'}}
     )
 
-    assert item['Item']['resharded']['BOOL'] is True
     assert item['Item']['version']['N'] == '2'
     assert item['Item']['s3key']['S'] == 'sierra/32/b2222223/abc.json'
 
@@ -171,9 +146,6 @@ def _dynamodb_item(id, s3key, resharded=None, version=1):
         'version': {'N': str(version)},
         's3key': {'S': s3key},
     }
-
-    if resharded is not None:
-        data['resharded'] = {'BOOL': resharded}
 
     return data
 


### PR DESCRIPTION
### What is this PR trying to achieve?

We would prefer not to store metadata about s3 reshard progress in the `SourceData` table as this can be determined downstream.

### Who is this change for?

🍖 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
