### PR TITLE
Allow complete_reindex lambda to handle missing version

### DIFF
--- a/catalogue_pipeline/reindexer_v2/complete_reindex/src/test_complete_reindex.py
+++ b/catalogue_pipeline/reindexer_v2/complete_reindex/src/test_complete_reindex.py
@@ -143,7 +143,6 @@ def test_request_reindex_throws_conditional_update_exception(reindex_shard_track
             'shardId': shard_id,
             'currentVersion': 1,
             'desiredVersion': 3,
-            'version': 0,
         }
     )
 
@@ -157,7 +156,7 @@ def test_request_reindex_throws_conditional_update_exception(reindex_shard_track
             'shardId': shard_id,
             'currentVersion': 2,
             'desiredVersion': 2,
-            'version': 1,
+            'version': 2,
         }
     )
 


### PR DESCRIPTION
### What is this PR trying to achieve?

Allow complete_reindex lambda to handle missing version!

### Who is this change for?

📴 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.
