### PR TITLE
catalogue_pipeline: disable the ALB alarms

### DIFF
--- a/catalogue_pipeline/terraform/service_id_minter.tf
+++ b/catalogue_pipeline/terraform/service_id_minter.tf
@@ -31,4 +31,6 @@ module "id_minter" {
   alb_listener_http_arn      = "${module.catalogue_pipeline_cluster.alb_listener_http_arn}"
   alb_server_error_alarm_arn = "${local.alb_server_error_alarm_arn}"
   alb_client_error_alarm_arn = "${local.alb_client_error_alarm_arn}"
+
+  enable_alb_alarm = false
 }

--- a/catalogue_pipeline/terraform/service_ingestor.tf
+++ b/catalogue_pipeline/terraform/service_ingestor.tf
@@ -43,4 +43,6 @@ module "ingestor" {
   alb_listener_http_arn      = "${module.catalogue_pipeline_cluster.alb_listener_http_arn}"
   alb_server_error_alarm_arn = "${local.alb_server_error_alarm_arn}"
   alb_client_error_alarm_arn = "${local.alb_client_error_alarm_arn}"
+
+  enable_alb_alarm = false
 }

--- a/catalogue_pipeline/terraform/service_reindexer.tf
+++ b/catalogue_pipeline/terraform/service_reindexer.tf
@@ -27,6 +27,8 @@ module "reindexer" {
   alb_listener_http_arn      = "${module.catalogue_pipeline_cluster.alb_listener_http_arn}"
   alb_server_error_alarm_arn = "${local.alb_server_error_alarm_arn}"
   alb_client_error_alarm_arn = "${local.alb_client_error_alarm_arn}"
+
+  enable_alb_alarm = false
 }
 
 # Role policies for the reindexer

--- a/catalogue_pipeline/terraform/service_transformer.tf
+++ b/catalogue_pipeline/terraform/service_transformer.tf
@@ -28,6 +28,8 @@ module "transformer" {
   alb_listener_http_arn      = "${module.catalogue_pipeline_cluster.alb_listener_http_arn}"
   alb_server_error_alarm_arn = "${local.alb_server_error_alarm_arn}"
   alb_client_error_alarm_arn = "${local.alb_client_error_alarm_arn}"
+
+  enable_alb_alarm = false
 }
 
 module "transformer_dynamo_to_sns" {


### PR DESCRIPTION
They've been spamming Slack incessantly since we turned them on (the alarms, not the services), and since everything stays running we haven't done anything to fix them -- it seems to be a side-effect of autoscaling.

Since they don't tell us anything useful and we're not going to "fix" the services, let's turn off the alarms to reduce noise.

I'm trying to deploy this patch over on-train Wi-Fi.

### Who is this change for?

🚨 

A Slack channel with high signal-to-noise ratio.

---

This change is deployed in prod.