### PR TITLE
Include the branch name in “terraform apply” notifications in Slack

### DIFF
--- a/assets/Makefile
+++ b/assets/Makefile
@@ -8,7 +8,7 @@ ECS_TASKS 	=
 LAMBDAS 	=
 
 TF_NAME 	= assets
-TF_PATH 	= $(ROOT)/assets/terraform
+TF_PATH 	= assets/terraform
 
 # Not technically public facing, but we want double-approval on
 # changes here!

--- a/catalogue_api/Makefile
+++ b/catalogue_api/Makefile
@@ -8,7 +8,7 @@ ECS_TASKS   = update_api_docs
 LAMBDAS     =
 
 TF_NAME     = catalogue_api
-TF_PATH     = $(ROOT)/$(STACK_ROOT)/terraform
+TF_PATH     = $(STACK_ROOT)/terraform
 TF_IS_PUBLIC_FACING = true
 
 $(val $(call stack_setup))

--- a/catalogue_pipeline/Makefile
+++ b/catalogue_pipeline/Makefile
@@ -8,7 +8,7 @@ ECS_TASKS 	=
 LAMBDAS 	=
 
 TF_NAME 	= catalogue_pipeline
-TF_PATH 	= $(ROOT)/catalogue_pipeline/terraform
+TF_PATH 	= catalogue_pipeline/terraform
 
 TF_IS_PUBLIC_FACING = false
 

--- a/functions.Makefile
+++ b/functions.Makefile
@@ -19,7 +19,8 @@ endif
 define terraform_plan
 	make uptodate-git
 	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(1):/data \
+		--volume $(ROOT):/data \
+		--workdir /data/$(1) \
 		--env OP=plan \
 		--env GET_PLATFORM_TFVARS=true \
 		--env IS_PUBLIC_FACING=$(2) \
@@ -35,7 +36,8 @@ endef
 define terraform_apply
 	make uptodate-git
 	$(ROOT)/builds/docker_run.py --aws -- \
-		--volume $(1):/data \
+		--volume $(ROOT):/data \
+		--workdir /data/$(1) \
 		--env OP=apply \
 		wellcome/terraform_wrapper:latest
 endef

--- a/loris/Makefile
+++ b/loris/Makefile
@@ -8,7 +8,7 @@ ECS_TASKS 	= loris cache_cleaner
 LAMBDAS 	=
 
 TF_NAME 	= loris
-TF_PATH 	= $(ROOT)/loris/terraform
+TF_PATH 	= loris/terraform
 TF_IS_PUBLIC_FACING = true
 
 $(val $(call stack_setup))

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -8,7 +8,7 @@ ECS_TASKS   = slack_budget_bot
 LAMBDAS     = post_to_slack terraform_tracker
 
 TF_NAME     = monitoring
-TF_PATH     = $(ROOT)/$(STACK_ROOT)
+TF_PATH     = $(STACK_ROOT)
 TF_IS_PUBLIC_FACING = false
 
 $(val $(call stack_setup))

--- a/monitoring/terraform_tracker/src/terraform_tracker.py
+++ b/monitoring/terraform_tracker/src/terraform_tracker.py
@@ -57,16 +57,27 @@ def main(event, context):
     if stack.endswith('.tfstate'):
         stack = stack[:-len('.tfstate')]
 
+    message = f'{username} has run "terraform apply" in the {stack} stack.'
+
+    try:
+        git_branch = data['git_branch']
+        git_commit = data['git_commit']
+    except KeyError:
+        # The user is running an older version of the Terraform Docker image
+        # which doesn't provide Git information.
+        pass
+    else:
+        message += f'\nGit branch: {git_branch} ({git_commit[:7]}).'
+
     slack_data = {
         'username': 'terraform-tracker',
         'icon_emoji': ':terraform:',
         'attachments': [{
             'color': '#5C4EE5',
-            'fields': [{
-                'value': f'{username} has run "terraform apply" in the {stack} stack.'
-            }, {
-                'value': display_url
-            }]
+            'fields': [
+                {'value': message},
+                {'value': display_url}
+            ]
         }]
     }
 

--- a/shared_infra/Makefile
+++ b/shared_infra/Makefile
@@ -13,7 +13,7 @@ LAMBDAS     = drain_ecs_container_instance \
               update_ecs_service_size
 
 TF_NAME     = shared_infra
-TF_PATH     = $(ROOT)/$(STACK_ROOT)
+TF_PATH     = $(STACK_ROOT)
 TF_IS_PUBLIC_FACING = false
 
 $(val $(call stack_setup))

--- a/sierra_adapter/Makefile
+++ b/sierra_adapter/Makefile
@@ -11,7 +11,7 @@ ECS_TASKS   =
 LAMBDAS     = s3_demultiplexer sierra_window_generator
 
 TF_NAME     = sierra_adapter
-TF_PATH     = $(ROOT)/$(STACK_ROOT)/terraform
+TF_PATH     = $(STACK_ROOT)/terraform
 TF_IS_PUBLIC_FACING = false
 
 $(val $(call stack_setup))


### PR DESCRIPTION
Better visibility into what’s being deployed – especially relevant when it’s not master. Example output:

![screen shot 2018-02-19 at 15 13 10](https://user-images.githubusercontent.com/301220/36384560-9c15cfca-1587-11e8-9fbb-29a778b1880f.png)

This change is already deployed.

Resolves #1560.