### PR TITLE
Transformable: inherit from Sourced, not Versioned/Reindexable

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/dynamo/VersionedDao.scala
+++ b/common/src/main/scala/uk/ac/wellcome/dynamo/VersionedDao.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.models.aws.DynamoConfig
 import uk.ac.wellcome.models.{
   VersionUpdater,
   Versioned,
-  VersionedDynamoFormatWrapper
+  SourcedDynamoFormatWrapper
 }
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
@@ -21,7 +21,7 @@ class VersionedDao @Inject()(
 ) extends Logging {
 
   private def putRecord[T <: Versioned](record: T)(
-    implicit evidence: VersionedDynamoFormatWrapper[T],
+    implicit evidence: SourcedDynamoFormatWrapper[T],
     versionUpdater: VersionUpdater[T]) = {
     implicit val dynamoFormat = evidence.enrichedDynamoFormat
     val newVersion = record.version + 1
@@ -35,7 +35,7 @@ class VersionedDao @Inject()(
   }
 
   def updateRecord[T <: Versioned](record: T)(
-    implicit evidence: VersionedDynamoFormatWrapper[T],
+    implicit evidence: SourcedDynamoFormatWrapper[T],
     versionUpdater: VersionUpdater[T]): Future[Unit] = Future {
     info(s"Attempting to update Dynamo record: ${record.id}")
 

--- a/common/src/main/scala/uk/ac/wellcome/dynamo/VersionedDao.scala
+++ b/common/src/main/scala/uk/ac/wellcome/dynamo/VersionedDao.scala
@@ -21,7 +21,7 @@ class VersionedDao @Inject()(
   dynamoConfig: DynamoConfig
 ) extends Logging {
 
-  private def putRecord[T <: Versioned](record: T)(
+  private def putRecord[T <: Versioned with Sourced](record: T)(
     implicit evidence: SourcedDynamoFormatWrapper[T],
     versionUpdater: VersionUpdater[T]) = {
     implicit val dynamoFormat = evidence.enrichedDynamoFormat

--- a/common/src/main/scala/uk/ac/wellcome/dynamo/VersionedDao.scala
+++ b/common/src/main/scala/uk/ac/wellcome/dynamo/VersionedDao.scala
@@ -9,6 +9,7 @@ import uk.ac.wellcome.models.aws.DynamoConfig
 import uk.ac.wellcome.models.{
   VersionUpdater,
   Versioned,
+  Sourced,
   SourcedDynamoFormatWrapper
 }
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -34,7 +35,7 @@ class VersionedDao @Inject()(
       .put(versionUpdater.updateVersion(record, newVersion))
   }
 
-  def updateRecord[T <: Versioned](record: T)(
+  def updateRecord[T <: Versioned with Sourced](record: T)(
     implicit evidence: SourcedDynamoFormatWrapper[T],
     versionUpdater: VersionUpdater[T]): Future[Unit] = Future {
     info(s"Attempting to update Dynamo record: ${record.id}")
@@ -50,7 +51,7 @@ class VersionedDao @Inject()(
     }
   }
 
-  def getRecord[T <: Versioned](id: String)(
+  def getRecord[T <: Versioned with Sourced](id: String)(
     implicit evidence: DynamoFormat[T]): Future[Option[T]] = Future {
     val table = Table[T](dynamoConfig.table)
 

--- a/common/src/main/scala/uk/ac/wellcome/models/Sourced.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Sourced.scala
@@ -1,0 +1,30 @@
+package uk.ac.wellcome.models
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import com.gu.scanamo.DynamoFormat
+import com.gu.scanamo.error.DynamoReadError
+
+trait Sourced {
+  val sourceId: String
+  val sourceName: String
+  val id: String = Sourced.id(sourceName, sourceId)
+}
+
+object Sourced {
+  implicit def toSourcedDynamoFormatWrapper[T <: Sourced](
+    implicit dynamoFormat: DynamoFormat[T]): SourcedDynamoFormatWrapper[T] =
+    new SourcedDynamoFormatWrapper[T](dynamoFormat)
+
+  def id(sourceName: String, sourceId: String) = s"$sourceName/$sourceId"
+}
+
+class SourcedDynamoFormatWrapper[T <: Sourced](
+  dynamoFormat: DynamoFormat[T]) {
+  val enrichedDynamoFormat = new DynamoFormat[T] {
+    override def read(av: AttributeValue): Either[DynamoReadError, T] =
+      dynamoFormat.read(av)
+
+    override def write(t: T): AttributeValue =
+      dynamoFormat.write(t).addMEntry("id", new AttributeValue(t.id))
+  }
+}

--- a/common/src/main/scala/uk/ac/wellcome/models/Sourced.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Sourced.scala
@@ -18,8 +18,7 @@ object Sourced {
   def id(sourceName: String, sourceId: String) = s"$sourceName/$sourceId"
 }
 
-class SourcedDynamoFormatWrapper[T <: Sourced](
-  dynamoFormat: DynamoFormat[T]) {
+class SourcedDynamoFormatWrapper[T <: Sourced](dynamoFormat: DynamoFormat[T]) {
   val enrichedDynamoFormat = new DynamoFormat[T] {
     override def read(av: AttributeValue): Either[DynamoReadError, T] =
       dynamoFormat.read(av)

--- a/common/src/main/scala/uk/ac/wellcome/models/Versioned.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Versioned.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.models
 
-trait Versioned extends Sourced {
+trait Versioned {
   val version: Int
 }
 

--- a/common/src/main/scala/uk/ac/wellcome/models/Versioned.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Versioned.scala
@@ -1,36 +1,7 @@
 package uk.ac.wellcome.models
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
-import com.gu.scanamo.DynamoFormat
-import com.gu.scanamo.error.DynamoReadError
-
-trait Sourced {
-  val sourceId: String
-  val sourceName: String
-}
-
 trait Versioned extends Sourced {
   val version: Int
-  val id: String = Versioned.id(sourceName, sourceId)
-}
-
-object Versioned {
-  implicit def toVersionedDynamoFormatWrapper[T <: Versioned](
-    implicit dynamoFormat: DynamoFormat[T]): VersionedDynamoFormatWrapper[T] =
-    new VersionedDynamoFormatWrapper[T](dynamoFormat)
-
-  def id(sourceName: String, sourceId: String) = s"$sourceName/$sourceId"
-}
-
-class VersionedDynamoFormatWrapper[T <: Versioned](
-  dynamoFormat: DynamoFormat[T]) {
-  val enrichedDynamoFormat = new DynamoFormat[T] {
-    override def read(av: AttributeValue): Either[DynamoReadError, T] =
-      dynamoFormat.read(av)
-
-    override def write(t: T): AttributeValue =
-      dynamoFormat.write(t).addMEntry("id", new AttributeValue(t.id))
-  }
 }
 
 trait VersionUpdater[T <: Versioned] {

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
@@ -6,10 +6,10 @@ import uk.ac.wellcome.models.transformable.sierra.{
 }
 import io.circe.Decoder
 import cats.syntax.functor._
-import uk.ac.wellcome.models.Versioned
+import uk.ac.wellcome.models.Sourced
 import uk.ac.wellcome.utils.JsonUtil._
 
-sealed trait Transformable extends Versioned
+sealed trait Transformable extends Sourced
 
 case class CalmTransformable(
   sourceId: String,
@@ -17,12 +17,8 @@ case class CalmTransformable(
   AltRefNo: String,
   RefNo: String,
   data: String,
-  reindexShard: String = "default",
-  reindexVersion: Int = 0,
-  version: Int = 0,
   sourceName: String = "calm"
 ) extends Transformable
-    with Reindexable
 
 case class CalmTransformableData(
   AccessStatus: Array[String]
@@ -31,12 +27,8 @@ case class CalmTransformableData(
 case class MiroTransformable(sourceId: String,
                              sourceName: String = "miro",
                              MiroCollection: String,
-                             data: String,
-                             reindexShard: String = "default",
-                             reindexVersion: Int = 0,
-                             version: Int = 1)
+                             data: String)
     extends Transformable
-    with Reindexable
 
 /** Represents a row in the DynamoDB database of "merged" Sierra records;
   * that is, records that contain data for both bibs and
@@ -53,13 +45,11 @@ case class MiroTransformable(sourceId: String,
   *
   */
 case class SierraTransformable(
-  version: Int = 0,
   sourceId: String,
   sourceName: String = "sierra",
   maybeBibData: Option[SierraBibRecord] = None,
   itemData: Map[String, SierraItemRecord] = Map[String, SierraItemRecord]()
 ) extends Transformable
-    with Versioned
 
 object SierraTransformable {
   def apply(sourceId: String, bibData: String): SierraTransformable = {
@@ -75,11 +65,4 @@ object SierraTransformable {
             itemRecord: SierraItemRecord): SierraTransformable =
     SierraTransformable(sourceId = sourceId,
                         itemData = Map(itemRecord.id -> itemRecord))
-
-  def apply(bibRecord: SierraBibRecord, version: Int): SierraTransformable =
-    SierraTransformable(
-      sourceId = bibRecord.id,
-      maybeBibData = Some(bibRecord),
-      version = version
-    )
 }

--- a/common/src/main/scala/uk/ac/wellcome/storage/VersionedHybridStore.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/VersionedHybridStore.scala
@@ -67,15 +67,14 @@ class VersionedHybridStore @Inject()(
         putObject(
           id = id,
           sourcedObject = ifNotExisting,
-          f = key => HybridRecord(
-
-            // If this record doesn't exist already, then we can start it
-            // at version 0 and not worry about a newer version elsewhere.
-            version = 0,
-
-            sourceId = ifNotExisting.sourceId,
-            sourceName = ifNotExisting.sourceName,
-            s3key = key
+          f = key =>
+            HybridRecord(
+              // If this record doesn't exist already, then we can start it
+              // at version 0 and not worry about a newer version elsewhere.
+              version = 0,
+              sourceId = ifNotExisting.sourceId,
+              sourceName = ifNotExisting.sourceName,
+              s3key = key
           )
         )
     }

--- a/common/src/main/scala/uk/ac/wellcome/storage/VersionedHybridStore.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/VersionedHybridStore.scala
@@ -23,6 +23,7 @@ case class HybridRecord(
   reindexShard: String = "default",
   reindexVersion: Int = 0
 ) extends Reindexable
+    with Sourced
     with Versioned
 
 class VersionedHybridStore @Inject()(

--- a/common/src/main/scala/uk/ac/wellcome/storage/VersionedHybridStore.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/VersionedHybridStore.scala
@@ -7,7 +7,8 @@ import uk.ac.wellcome.models.transformable.Reindexable
 import uk.ac.wellcome.models.{
   VersionUpdater,
   Versioned,
-  VersionedDynamoFormatWrapper
+  Sourced,
+  SourcedDynamoFormatWrapper
 }
 import uk.ac.wellcome.s3.SourcedObjectStore
 
@@ -36,19 +37,18 @@ class VersionedHybridStore @Inject()(
     }
   }
 
-  private case class VersionedHybridObject[T <: Versioned](
+  private case class VersionedHybridObject[T <: Sourced](
     hybridRecord: HybridRecord,
     s3Object: T
   )
 
-  def updateRecord[T <: Versioned](sourceName: String, sourceId: String)(
+  def updateRecord[T <: Sourced](sourceName: String, sourceId: String)(
     ifNotExisting: => T)(ifExisting: T => T)(
-    implicit evidence: VersionedDynamoFormatWrapper[T],
-    versionUpdater: VersionUpdater[T],
+    implicit evidence: SourcedDynamoFormatWrapper[T],
     decoder: Decoder[T],
     encoder: Encoder[T]
   ): Future[Unit] = {
-    val id = Versioned.id(sourceName, sourceId)
+    val id = Sourced.id(sourceName, sourceId)
 
     getObject[T](id).flatMap {
       case Some(VersionedHybridObject(hybridRecord, s3Record)) =>
@@ -63,25 +63,30 @@ class VersionedHybridStore @Inject()(
         }
 
       case None =>
-        putObject(id,
-                  ifNotExisting,
-                  key =>
-                    HybridRecord(
-                      version = ifNotExisting.version,
-                      sourceId = ifNotExisting.sourceId,
-                      sourceName = ifNotExisting.sourceName,
-                      s3key = key
-                  ))
+        putObject(
+          id = id,
+          sourcedObject = ifNotExisting,
+          f = key => HybridRecord(
+
+            // If this record doesn't exist already, then we can start it
+            // at version 0 and not worry about a newer version elsewhere.
+            version = 0,
+
+            sourceId = ifNotExisting.sourceId,
+            sourceName = ifNotExisting.sourceName,
+            s3key = key
+          )
+        )
     }
   }
 
-  def getRecord[T <: Versioned](id: String)(
+  def getRecord[T <: Sourced](id: String)(
     implicit decoder: Decoder[T]): Future[Option[T]] =
     getObject[T](id).map { maybeObject =>
       maybeObject.map(_.s3Object)
     }
 
-  private def getObject[T <: Versioned](id: String)(
+  private def getObject[T <: Sourced](id: String)(
     implicit decoder: Decoder[T]): Future[Option[VersionedHybridObject[T]]] = {
 
     val dynamoRecord: Future[Option[HybridRecord]] =
@@ -97,22 +102,16 @@ class VersionedHybridStore @Inject()(
     }
   }
 
-  private def putObject[T <: Versioned](id: String,
-                                        versionedObject: T,
-                                        f: (String) => HybridRecord)(
-    implicit encoder: Encoder[T],
-    versionUpdater: VersionUpdater[T]
+  private def putObject[T <: Sourced](id: String,
+                                      sourcedObject: T,
+                                      f: (String) => HybridRecord)(
+    implicit encoder: Encoder[T]
   ) = {
-    if (versionedObject.id != id)
+    if (sourcedObject.id != id)
       throw new IllegalArgumentException(
         "ID provided does not match ID in record.")
 
-    // The versioned DAO automatically increments the version on any new
-    // records.  The sourcedObjectStore doesn't, so we bump it here to be
-    // consistent.
-    val futureKey = sourcedObjectStore.put(
-      versionUpdater.updateVersion(versionedObject,
-                                   newVersion = versionedObject.version + 1))
+    val futureKey = sourcedObjectStore.put(sourcedObject)
 
     futureKey.flatMap { key =>
       versionedDao.updateRecord(f(key))

--- a/common/src/test/scala/uk/ac/wellcome/dynamo/VersionedDaoTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/dynamo/VersionedDaoTest.scala
@@ -22,7 +22,7 @@ case class TestVersioned(sourceId: String,
                          sourceName: String,
                          somethingElse: String,
                          version: Int)
-    extends Versioned
+    extends Versioned with Sourced
 
 class VersionedDaoTest
     extends FunSpec

--- a/common/src/test/scala/uk/ac/wellcome/dynamo/VersionedDaoTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/dynamo/VersionedDaoTest.scala
@@ -22,7 +22,8 @@ case class TestVersioned(sourceId: String,
                          sourceName: String,
                          somethingElse: String,
                          version: Int)
-    extends Versioned with Sourced
+    extends Versioned
+    with Sourced
 
 class VersionedDaoTest
     extends FunSpec

--- a/common/src/test/scala/uk/ac/wellcome/dynamo/VersionedDaoTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/dynamo/VersionedDaoTest.scala
@@ -15,7 +15,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.locals.DynamoDBLocal
 import uk.ac.wellcome.models.aws.DynamoConfig
-import uk.ac.wellcome.models.{VersionUpdater, Versioned}
+import uk.ac.wellcome.models.{Sourced, VersionUpdater, Versioned}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
 case class TestVersioned(sourceId: String,
@@ -46,8 +46,8 @@ class VersionedDaoTest
   val versionedDao =
     new VersionedDao(dynamoDbClient, DynamoConfig(tableName))
 
-  private val enrichedDynamoFormat: DynamoFormat[TestVersioned] = Versioned
-    .toVersionedDynamoFormatWrapper[TestVersioned]
+  private val enrichedDynamoFormat: DynamoFormat[TestVersioned] = Sourced
+    .toSourcedDynamoFormatWrapper[TestVersioned]
     .enrichedDynamoFormat
 
   describe("get a record") {

--- a/common/src/test/scala/uk/ac/wellcome/locals/DynamoDBLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/locals/DynamoDBLocal.scala
@@ -5,12 +5,12 @@ import com.gu.scanamo.{DynamoFormat, Scanamo}
 import com.gu.scanamo.query.UniqueKey
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterEach, Matchers, Suite}
-import uk.ac.wellcome.models.Versioned
+import uk.ac.wellcome.models.{Sourced, Versioned}
 import uk.ac.wellcome.test.utils.{DynamoDBLocalClients, ExtendedPatience}
 
 import scala.collection.JavaConversions._
 
-trait DynamoDBLocal[T <: Versioned]
+trait DynamoDBLocal[T <: Versioned with Sourced]
     extends BeforeAndAfterEach
     with DynamoDBLocalClients
     with Eventually

--- a/common/src/test/scala/uk/ac/wellcome/models/SierraTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/SierraTransformableTest.scala
@@ -18,21 +18,6 @@ class SierraTransformableTest extends FunSpec with Matchers with SierraData {
     mergedRecord.maybeBibData.get shouldEqual bibRecord
   }
 
-  it("should allow creation from a SierraBibRecord and a version") {
-    val bibRecord = sierraBibRecord(id = "202")
-    val version = 10
-    val mergedRecord = SierraTransformable(
-      bibRecord = bibRecord,
-      version = version
-    )
-    mergedRecord.version shouldEqual version
-  }
-
-  it("should be at version 0 when first created") {
-    val record = SierraTransformable(sourceId = "555")
-    record.version shouldEqual 0
-  }
-
   def sierraBibRecord(
     id: String = "111",
     title: String = "Two toucans touching a towel",

--- a/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreLocal.scala
@@ -5,7 +5,7 @@ import com.gu.scanamo.syntax._
 import org.scalatest.Suite
 import uk.ac.wellcome.dynamo.VersionedDao
 import uk.ac.wellcome.locals.DynamoDBLocal
-import uk.ac.wellcome.models.Versioned
+import uk.ac.wellcome.models.Sourced
 import uk.ac.wellcome.models.aws.DynamoConfig
 import uk.ac.wellcome.s3.SourcedObjectStore
 import uk.ac.wellcome.test.utils.{ExtendedPatience, JsonTestUtil, S3Local}
@@ -28,17 +28,14 @@ trait VersionedHybridStoreLocal
                                     ))
   )
 
-  def assertHybridRecordIsStoredCorrectly[T <: Versioned with Sourced](
-    record: T,
-    expectedJson: String
-  ) = {
+  def assertHybridRecordIsStoredCorrectly(record: Sourced,
+                                          expectedJson: String) = {
     val dynamoRecord = Scanamo
       .get[HybridRecord](dynamoDbClient)(tableName)('id -> record.id)
       .get
     dynamoRecord.isRight shouldBe true
     val hybridRecord = dynamoRecord.right.get
 
-    hybridRecord.version shouldBe record.version
     hybridRecord.sourceId shouldBe record.sourceId
     hybridRecord.sourceName shouldBe record.sourceName
 

--- a/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreLocal.scala
@@ -28,8 +28,10 @@ trait VersionedHybridStoreLocal
                                     ))
   )
 
-  def assertHybridRecordIsStoredCorrectly(record: Versioned,
-                                          expectedJson: String) = {
+  def assertHybridRecordIsStoredCorrectly[T <: Versioned with Sourced](
+    record: T,
+    expectedJson: String
+  ) = {
     val dynamoRecord = Scanamo
       .get[HybridRecord](dynamoDbClient)(tableName)('id -> record.id)
       .get

--- a/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
@@ -8,7 +8,6 @@ import uk.ac.wellcome.utils.GlobalExecutionContext._
 import uk.ac.wellcome.utils.JsonUtil._
 
 case class ExampleRecord(
-  version: Int,
   sourceId: String,
   sourceName: String,
   content: String

--- a/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
@@ -12,7 +12,8 @@ case class ExampleRecord(
   sourceId: String,
   sourceName: String,
   content: String
-) extends Versioned with Sourced
+) extends Versioned
+    with Sourced
 
 class VersionedHybridStoreTest
     extends FunSpec

--- a/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.storage
 import com.gu.scanamo.DynamoFormat
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.{VersionUpdater, Versioned}
+import uk.ac.wellcome.models.{Sourced, VersionUpdater, Versioned}
 import uk.ac.wellcome.utils.GlobalExecutionContext._
 import uk.ac.wellcome.utils.JsonUtil._
 
@@ -12,7 +12,7 @@ case class ExampleRecord(
   sourceId: String,
   sourceName: String,
   content: String
-) extends Versioned
+) extends Versioned with Sourced
 
 class VersionedHybridStoreTest
     extends FunSpec

--- a/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
@@ -73,7 +73,6 @@ class VersionedHybridStoreTest
 
   it("updates DynamoDB and S3 if it sees a new version of a record") {
     val record = ExampleRecord(
-      version = 2,
       sourceId = "2222",
       sourceName = "Test2222",
       content = "Two teal turtles in Tenerife"

--- a/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
@@ -159,9 +159,9 @@ class VersionedHybridStoreTest
       content = "Five fishing flinging flint"
     )
 
-    val future = hybridStore.updateRecord(
-      sourceName = record.sourceName,
-      sourceId = "not_the_same_id")(record)(identity)
+    val future =
+      hybridStore.updateRecord(sourceName = record.sourceName,
+                               sourceId = "not_the_same_id")(record)(identity)
 
     whenReady(future.failed) { e: Throwable =>
       e shouldBe a[IllegalArgumentException]

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
@@ -14,7 +14,7 @@ import uk.ac.wellcome.dynamo.VersionedDao
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.DynamoConfig
-import uk.ac.wellcome.models.{VersionUpdater, VersionedDynamoFormatWrapper}
+import uk.ac.wellcome.models.{VersionUpdater, SourcedDynamoFormatWrapper}
 import uk.ac.wellcome.platform.reindex_worker.models.{
   ReindexJob,
   ScanamoQueryStream
@@ -70,7 +70,7 @@ class ReindexService @Inject()(dynamoDBClient: AmazonDynamoDB,
     hybridRecord: HybridRecord,
     desiredVersion: Int
   )(
-    implicit evidence: VersionedDynamoFormatWrapper[HybridRecord],
+    implicit evidence: SourcedDynamoFormatWrapper[HybridRecord],
     versionUpdater: VersionUpdater[HybridRecord]
   ): Future[Unit] = {
     // TODO: what if desiredVersion < reindexVersion?
@@ -85,7 +85,7 @@ class ReindexService @Inject()(dynamoDBClient: AmazonDynamoDB,
   def updateQueryResults(desiredVersion: Int)(
     resultGroup: List[ScanamoQueryResult]
   )(
-    implicit evidence: VersionedDynamoFormatWrapper[HybridRecord],
+    implicit evidence: SourcedDynamoFormatWrapper[HybridRecord],
     versionUpdater: VersionUpdater[HybridRecord]
   ): Future[Boolean] = {
 

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
@@ -5,7 +5,7 @@ import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.locals.DynamoDBLocal
-import uk.ac.wellcome.models.Versioned
+import uk.ac.wellcome.models.Sourced
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.platform.reindex_worker.models.{
   CompletedReindexJob,
@@ -31,7 +31,7 @@ class ReindexerFeatureTest
   override lazy val evidence: DynamoFormat[HybridRecord] =
     DynamoFormat[HybridRecord]
 
-  private val enrichedDynamoFormat: DynamoFormat[HybridRecord] = Versioned
+  private val enrichedDynamoFormat: DynamoFormat[HybridRecord] = Sourced
     .toSourcedDynamoFormatWrapper[HybridRecord]
     .enrichedDynamoFormat
 

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
@@ -32,7 +32,7 @@ class ReindexerFeatureTest
     DynamoFormat[HybridRecord]
 
   private val enrichedDynamoFormat: DynamoFormat[HybridRecord] = Versioned
-    .toVersionedDynamoFormatWrapper[HybridRecord]
+    .toSourcedDynamoFormatWrapper[HybridRecord]
     .enrichedDynamoFormat
 
   val queueUrl = createQueueAndReturnUrl("reindexer-feature-test-q")

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/models/ScanamoQueryStreamTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/models/ScanamoQueryStreamTest.scala
@@ -13,7 +13,7 @@ import scala.collection.mutable.ListBuffer
 import com.gu.scanamo.syntax._
 import shapeless.{HList, LabelledGeneric, Witness}
 import uk.ac.wellcome.locals.DynamoDBLocal
-import uk.ac.wellcome.models.{Versioned, VersionedDynamoFormatWrapper}
+import uk.ac.wellcome.models.{Versioned, SourcedDynamoFormatWrapper}
 import uk.ac.wellcome.storage.HybridRecord
 import scala.collection.JavaConverters._
 import scala.collection.JavaConversions._
@@ -33,7 +33,7 @@ class ScanamoQueryStreamTest
     DynamoFormat[HybridRecord]
 
   private val enrichedDynamoFormat: DynamoFormat[HybridRecord] = Versioned
-    .toVersionedDynamoFormatWrapper[HybridRecord]
+    .toSourcedDynamoFormatWrapper[HybridRecord]
     .enrichedDynamoFormat
 
   it("should run a given function for each batch from the query provided") {
@@ -95,7 +95,7 @@ class ScanamoQueryStreamTest
   }
 
   def calculateRecordSize[R <: HList](hybridRecord: HybridRecord)(
-    implicit versionedDynamoFormatWrapper: VersionedDynamoFormatWrapper[
+    implicit versionedDynamoFormatWrapper: SourcedDynamoFormatWrapper[
       HybridRecord]): Int = {
     val attributeValue =
       versionedDynamoFormatWrapper.enrichedDynamoFormat.write(hybridRecord)

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/models/ScanamoQueryStreamTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/models/ScanamoQueryStreamTest.scala
@@ -13,7 +13,7 @@ import scala.collection.mutable.ListBuffer
 import com.gu.scanamo.syntax._
 import shapeless.{HList, LabelledGeneric, Witness}
 import uk.ac.wellcome.locals.DynamoDBLocal
-import uk.ac.wellcome.models.{Versioned, SourcedDynamoFormatWrapper}
+import uk.ac.wellcome.models.{Sourced, SourcedDynamoFormatWrapper}
 import uk.ac.wellcome.storage.HybridRecord
 import scala.collection.JavaConverters._
 import scala.collection.JavaConversions._
@@ -32,7 +32,7 @@ class ScanamoQueryStreamTest
   override lazy val evidence: DynamoFormat[HybridRecord] =
     DynamoFormat[HybridRecord]
 
-  private val enrichedDynamoFormat: DynamoFormat[HybridRecord] = Versioned
+  private val enrichedDynamoFormat: DynamoFormat[HybridRecord] = Sourced
     .toSourcedDynamoFormatWrapper[HybridRecord]
     .enrichedDynamoFormat
 

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
@@ -34,7 +34,7 @@ class ReindexServiceTest
     DynamoFormat[HybridRecord]
 
   private val enrichedDynamoFormat: DynamoFormat[HybridRecord] = Versioned
-    .toVersionedDynamoFormatWrapper[HybridRecord]
+    .toSourcedDynamoFormatWrapper[HybridRecord]
     .enrichedDynamoFormat
 
   it("only updates records with a lower than desired reindexVersion") {

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.dynamo.VersionedDao
 import uk.ac.wellcome.locals.DynamoDBLocal
 import uk.ac.wellcome.metrics.MetricsSender
-import uk.ac.wellcome.models.Versioned
+import uk.ac.wellcome.models.Sourced
 import uk.ac.wellcome.models.aws.DynamoConfig
 import uk.ac.wellcome.platform.reindex_worker.models.ReindexJob
 import uk.ac.wellcome.storage.HybridRecord
@@ -33,7 +33,7 @@ class ReindexServiceTest
   override lazy val evidence: DynamoFormat[HybridRecord] =
     DynamoFormat[HybridRecord]
 
-  private val enrichedDynamoFormat: DynamoFormat[HybridRecord] = Versioned
+  private val enrichedDynamoFormat: DynamoFormat[HybridRecord] = Sourced
     .toSourcedDynamoFormatWrapper[HybridRecord]
     .enrichedDynamoFormat
 

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
@@ -5,7 +5,6 @@ import com.twitter.inject.Logging
 import io.circe.Decoder
 import io.circe.generic.extras.semiauto.deriveDecoder
 import uk.ac.wellcome.metrics.MetricsSender
-import uk.ac.wellcome.models.VersionUpdater
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord
 import uk.ac.wellcome.platform.sierra_bib_merger.merger.BibMerger
@@ -21,14 +20,6 @@ class SierraBibMergerUpdaterService @Inject()(
   versionedHybridStore: VersionedHybridStore,
   metrics: MetricsSender
 ) extends Logging {
-
-  implicit val sierraTransformableUpdater =
-    new VersionUpdater[SierraTransformable] {
-      override def updateVersion(sierraTransformable: SierraTransformable,
-                                 newVersion: Int): SierraTransformable = {
-        sierraTransformable.copy(version = newVersion)
-      }
-    }
 
   def update(bibRecord: SierraBibRecord): Future[Unit] = {
     versionedHybridStore.updateRecord("sierra", bibRecord.id)(

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -188,7 +188,8 @@ class SierraBibMergerFeatureTest
       modifiedDate = "2006-06-06T06:06:06Z"
     )
 
-    val expectedSierraTransformable = SierraTransformable(bibRecord = newBibRecord)
+    val expectedSierraTransformable =
+      SierraTransformable(bibRecord = newBibRecord)
 
     val oldTitle = "A small selection of sad shellfish"
     val oldUpdatedDate = "2001-01-01T01:01:01Z"

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -18,7 +18,6 @@ import uk.ac.wellcome.test.utils.{
   SQSLocal
 }
 
-import uk.ac.wellcome.models.VersionUpdater
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord
 
@@ -40,14 +39,6 @@ class SierraBibMergerFeatureTest
 
   implicit val system = ActorSystem()
   implicit val executionContext = system.dispatcher
-
-  implicit val sierraTransformableUpdater =
-    new VersionUpdater[SierraTransformable] {
-      override def updateVersion(sierraTransformable: SierraTransformable,
-                                 newVersion: Int): SierraTransformable = {
-        sierraTransformable.copy(version = newVersion)
-      }
-    }
 
   override lazy val tableName = "sierra-bib-merger-feature-test-table"
   override lazy val bucketName = "sierra-bib-merger-feature-test-bucket"

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -101,8 +101,7 @@ class SierraBibMergerFeatureTest
 
     sendBibRecordToSQS(record)
 
-    val expectedSierraTransformable =
-      SierraTransformable(bibRecord = record, version = 1)
+    val expectedSierraTransformable = SierraTransformable(bibRecord = record)
 
     assertStored(expectedSierraTransformable)
   }
@@ -119,8 +118,7 @@ class SierraBibMergerFeatureTest
       modifiedDate = "2001-01-01T01:01:01Z"
     )
     sendBibRecordToSQS(record1)
-    val expectedSierraTransformable1 =
-      SierraTransformable(bibRecord = record1, version = 1)
+    val expectedSierraTransformable1 = SierraTransformable(bibRecord = record1)
 
     val id2 = "2000002"
     val record2 = SierraBibRecord(
@@ -133,8 +131,7 @@ class SierraBibMergerFeatureTest
       modifiedDate = "2002-02-02T02:02:02Z"
     )
     sendBibRecordToSQS(record2)
-    val expectedSierraTransformable2 =
-      SierraTransformable(bibRecord = record2, version = 1)
+    val expectedSierraTransformable2 = SierraTransformable(bibRecord = record2)
 
     assertStored(expectedSierraTransformable1)
     assertStored(expectedSierraTransformable2)
@@ -174,8 +171,7 @@ class SierraBibMergerFeatureTest
         sendBibRecordToSQS(record)
       }
 
-    val expectedSierraTransformable =
-      SierraTransformable(bibRecord = record, version = 2)
+    val expectedSierraTransformable = SierraTransformable(bibRecord = record)
 
     assertStored(expectedSierraTransformable)
   }
@@ -192,8 +188,7 @@ class SierraBibMergerFeatureTest
       modifiedDate = "2006-06-06T06:06:06Z"
     )
 
-    val expectedSierraTransformable =
-      SierraTransformable(bibRecord = newBibRecord, version = 1)
+    val expectedSierraTransformable = SierraTransformable(bibRecord = newBibRecord)
 
     val oldTitle = "A small selection of sad shellfish"
     val oldUpdatedDate = "2001-01-01T01:01:01Z"
@@ -220,7 +215,7 @@ class SierraBibMergerFeatureTest
     // enough time for this update to have gone through (if it was going to).
     Thread.sleep(5000)
 
-    assertStored(expectedSierraTransformable.copy(version = 2))
+    assertStored(expectedSierraTransformable)
   }
 
   it("stores a bib from SQS if the ID already exists but no bibData") {
@@ -247,8 +242,7 @@ class SierraBibMergerFeatureTest
       sendBibRecordToSQS(record)
     }
 
-    val expectedSierraTransformable =
-      SierraTransformable(bibRecord = record, version = 2)
+    val expectedSierraTransformable = SierraTransformable(bibRecord = record)
 
     assertStored(expectedSierraTransformable)
   }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMergerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMergerTest.scala
@@ -25,13 +25,6 @@ class BibMergerTest extends FunSpec with Matchers {
       caught.getMessage shouldEqual "Non-matching bib ids 333 != 444"
     }
 
-    it("should never increment the version when mergeBibRecord is called") {
-      val record = sierraBibRecord(id = "666")
-      val originalRecord = SierraTransformable(sourceId = "666", version = 10)
-      val newRecord = BibMerger.mergeBibRecord(originalRecord, record)
-      newRecord.version shouldEqual 10
-    }
-
     it(
       "should return the unmerged record when merging bib records with stale data") {
       val record = sierraBibRecord(

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
@@ -5,7 +5,6 @@ import com.twitter.inject.Logging
 import io.circe.generic.extras.semiauto.deriveDecoder
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
-import uk.ac.wellcome.models.VersionUpdater
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 import uk.ac.wellcome.platform.sierra_item_merger.links.ItemLinker
@@ -23,14 +22,6 @@ class SierraItemMergerUpdaterService @Inject()(
   versionedHybridStore: VersionedHybridStore,
   metrics: MetricsSender
 ) extends Logging {
-
-  implicit val sierraTransformableUpdater =
-    new VersionUpdater[SierraTransformable] {
-      override def updateVersion(sierraTransformable: SierraTransformable,
-                                 newVersion: Int): SierraTransformable = {
-        sierraTransformable.copy(version = newVersion)
-      }
-    }
 
   def update(itemRecord: SierraItemRecord): Future[Unit] = {
     val mergeUpdateFutures = itemRecord.bibIds.map { bibId =>

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
@@ -40,8 +40,7 @@ class SierraItemMergerFeatureTest
 
     val expectedSierraTransformable = SierraTransformable(
       sourceId = bibId,
-      itemData = Map(id -> record),
-      version = 1
+      itemData = Map(id -> record)
     )
 
     eventually {
@@ -80,14 +79,12 @@ class SierraItemMergerFeatureTest
     eventually {
       val expectedSierraTransformable1 = SierraTransformable(
         sourceId = bibId1,
-        itemData = Map(id1 -> record1),
-        version = 1
+        itemData = Map(id1 -> record1)
       )
 
       val expectedSierraTransformable2 = SierraTransformable(
         sourceId = bibId2,
-        itemData = Map(id2 -> record2),
-        version = 1
+        itemData = Map(id2 -> record2)
       )
 
       val futureRecord1 = hybridStore.getRecord[SierraTransformable](

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -48,8 +48,7 @@ class SierraItemMergerUpdaterServiceTest
                             maybeBibData = None,
                             itemData = Map(
                               newItemRecord.id -> newItemRecord
-                            ),
-                            version = 1)
+                            ))
 
       val futureRecord1 = hybridStore.getRecord[SierraTransformable](
         expectedSierraTransformable.id)
@@ -127,8 +126,7 @@ class SierraItemMergerUpdaterServiceTest
           SierraTransformable(
             sourceId = bibIdNotExisting,
             maybeBibData = None,
-            itemData = Map(itemRecord.id -> itemRecord),
-            version = 1
+            itemData = Map(itemRecord.id -> itemRecord)
           )
 
         val futureRecord1 = hybridStore.getRecord[SierraTransformable](
@@ -141,8 +139,7 @@ class SierraItemMergerUpdaterServiceTest
           itemData = Map(
             itemId -> itemRecord,
             "i888" -> otherItem
-          ),
-          version = 2
+          )
         )
 
         val futureRecord2 = hybridStore.getRecord[SierraTransformable](
@@ -151,12 +148,10 @@ class SierraItemMergerUpdaterServiceTest
           record.get shouldBe expectedUpdatedSierraTransformable
         }
 
-        val expectedUnchangedSierraTranformable = newRecord.copy(version = 1)
-
         val futureRecord3 = hybridStore.getRecord[SierraTransformable](
-          expectedUnchangedSierraTranformable.id)
+          newRecord.id)
         whenReady(futureRecord3) { record =>
-          record.get shouldBe expectedUnchangedSierraTranformable
+          record.get shouldBe newRecord
         }
       }
     }
@@ -189,10 +184,7 @@ class SierraItemMergerUpdaterServiceTest
 
       whenReady(sierraUpdaterService.update(newItemRecord)) { _ =>
         val expectedSierraRecord = oldRecord.copy(
-          itemData = Map(
-            id -> newItemRecord
-          ),
-          version = 2
+          itemData = Map(id -> newItemRecord)
         )
 
         val futureRecord3 =
@@ -257,13 +249,11 @@ class SierraItemMergerUpdaterServiceTest
     whenReady(eventualUnits.flatMap(_ =>
       sierraUpdaterService.update(unlinkItemRecord))) { _ =>
       val expectedSierraRecord1 = sierraTransformable1.copy(
-        itemData = Map.empty,
-        version = 2
+        itemData = Map.empty
       )
 
       val expectedSierraRecord2 = sierraTransformable2.copy(
-        itemData = expectedItemData,
-        version = 2
+        itemData = expectedItemData
       )
 
       val futureRecord1 =
@@ -329,15 +319,13 @@ class SierraItemMergerUpdaterServiceTest
     whenReady(Future.sequence(List(f1, f2))) { _ =>
       whenReady(sierraUpdaterService.update(unlinkItemRecord)) { _ =>
         val expectedSierraRecord1 = sierraTransformable1.copy(
-          itemData = Map.empty,
-          version = 2
+          itemData = Map.empty
         )
 
         // In this situation the item was already linked to sierraTransformable2
         // but the modified date is updated in line with the item update
         val expectedSierraRecord2 = sierraTransformable2.copy(
-          itemData = expectedItemData,
-          version = 2
+          itemData = expectedItemData
         )
 
         val futureRecord1 =
@@ -401,14 +389,11 @@ class SierraItemMergerUpdaterServiceTest
 
     whenReady(Future.sequence(List(f1, f2))) { _ =>
       whenReady(sierraUpdaterService.update(unlinkItemRecord)) { _ =>
-        // In this situation the item will _not_ be unlinked from the original record
-        // but will be linked to the new record (as this is the first time we've seen
-        // the link so it is valid for that bib.
-        val expectedSierraRecord1 = sierraTransformable1.copy(
-          version = 1
-        )
+        // In this situation the item will _not_ be unlinked from the original
+        // record but will be linked to the new record (as this is the first
+        // time we've seen the link so it is valid for that bib.
+        val expectedSierraRecord1 = sierraTransformable1
         val expectedSierraRecord2 = sierraTransformable2.copy(
-          version = 2,
           itemData = expectedItemData
         )
 
@@ -456,7 +441,7 @@ class SierraItemMergerUpdaterServiceTest
         val futureRecord1 =
           hybridStore.getRecord[SierraTransformable](sierraRecord.id)
         whenReady(futureRecord1) { record =>
-          record.get shouldBe sierraRecord.copy(version = 1)
+          record.get shouldBe sierraRecord
         }
       }
     }
@@ -485,8 +470,7 @@ class SierraItemMergerUpdaterServiceTest
           sourceId = bibId,
           itemData = Map(
             itemRecord.id -> itemRecord
-          ),
-          version = 2
+          )
         )
 
         val futureRecord1 =

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -148,8 +148,8 @@ class SierraItemMergerUpdaterServiceTest
           record.get shouldBe expectedUpdatedSierraTransformable
         }
 
-        val futureRecord3 = hybridStore.getRecord[SierraTransformable](
-          newRecord.id)
+        val futureRecord3 =
+          hybridStore.getRecord[SierraTransformable](newRecord.id)
         whenReady(futureRecord3) { record =>
           record.get shouldBe newRecord
         }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/utils/SierraItemMergerTestUtil.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/utils/SierraItemMergerTestUtil.scala
@@ -4,7 +4,6 @@ import io.circe.generic.extras.semiauto.deriveDecoder
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, Suite}
-import uk.ac.wellcome.models.VersionUpdater
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
@@ -22,14 +21,6 @@ trait SierraItemMergerTestUtil
     with VersionedHybridStoreLocal { this: Suite =>
 
   val queueUrl = createQueueAndReturnUrl("test_item_merger")
-
-  implicit val sierraTransformableUpdater =
-    new VersionUpdater[SierraTransformable] {
-      override def updateVersion(sierraTransformable: SierraTransformable,
-                                 newVersion: Int): SierraTransformable = {
-        sierraTransformable.copy(version = newVersion)
-      }
-    }
 
   override lazy val tableName = "sierra-item-merger-feature-test-table"
   override lazy val bucketName = "sierra-item-merger-feature-test-bucket"


### PR DESCRIPTION
This lets us delete several fields on this model that we weren’t using.

Along the way, I had to clean up the Sourced/Versioned models, as there were several things defined on Versioned that really belong on Sourced.

I’m still working on fixing the problems caused by the Sourced/Versioned changes.

Resolves #1562.

### Who is this change for?

☘️