### PR TITLE
catalogue_api: Delete the miro-data bucket

### DIFF
--- a/catalogue_api/terraform/s3.tf
+++ b/catalogue_api/terraform/s3.tf
@@ -1,12 +1,3 @@
-resource "aws_s3_bucket" "miro-data" {
-  bucket = "miro-data"
-  acl    = "private"
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
 resource "aws_s3_bucket" "miro-images-sync" {
   bucket = "miro-images-sync"
   acl    = "private"


### PR DESCRIPTION
Everything in it has been copied elsewhere, and it doesn't fit the new naming scheme.  Also, why is it in this stack?! See: https://wellcome.slack.com/archives/C3TQSF63C/p1518795233000630

I've emptied and deleted the bucket manually, after double-checking it's been synced elsewhere. This just removes it from our Terraform management.

Part of #1511.

### What is this PR trying to achieve?

📛