### PR TITLE
DynamoDBClient: remove some unused providers

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/DynamoClientModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/DynamoClientModule.scala
@@ -28,23 +28,6 @@ object DynamoClientModule extends TwitterModule {
     createAwsClient(awsConfig, standardDynamoDBClientBuilder)
   }
 
-  @Singleton
-  @Provides
-  def providesDynamoStreamsClient(
-    awsConfig: AWSConfig): AmazonDynamoDBStreams = {
-    val standardDynamoStreamsClientBuilder = AmazonDynamoDBStreamsClientBuilder
-      .standard()
-    createAwsClient(awsConfig, standardDynamoStreamsClientBuilder)
-  }
-
-  @Singleton
-  @Provides
-  def providesDynamoAsyncClient(awsConfig: AWSConfig): AmazonDynamoDBAsync = {
-    val standardDynamoDbAsyncClientBuilder = AmazonDynamoDBAsyncClientBuilder
-      .standard()
-    createAwsClient(awsConfig, standardDynamoDbAsyncClientBuilder)
-  }
-
   private def createAwsClient[T <: AwsClientBuilder[_, _], J](
     awsConfig: AWSConfig,
     awsClientBuilder: AwsClientBuilder[T, J]): J = {

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/DynamoDBLocalClients.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/DynamoDBLocalClients.scala
@@ -7,9 +7,7 @@ import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.dynamodbv2.{
   AmazonDynamoDB,
-  AmazonDynamoDBClientBuilder,
-  AmazonDynamoDBStreams,
-  AmazonDynamoDBStreamsClientBuilder
+  AmazonDynamoDBClientBuilder
 }
 
 trait DynamoDBLocalClients { this: Suite =>
@@ -32,13 +30,6 @@ trait DynamoDBLocalClients { this: Suite =>
       new BasicAWSCredentials(accessKey, secretKey))
 
   val dynamoDbClient: AmazonDynamoDB = AmazonDynamoDBClientBuilder
-    .standard()
-    .withCredentials(dynamoDBLocalCredentialsProvider)
-    .withEndpointConfiguration(
-      new EndpointConfiguration(dynamoDBEndPoint, "localhost"))
-    .build()
-
-  val streamsClient: AmazonDynamoDBStreams = AmazonDynamoDBStreamsClientBuilder
     .standard()
     .withCredentials(dynamoDBLocalCredentialsProvider)
     .withEndpointConfiguration(

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/modules/SierraBibMergerModule.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/modules/SierraBibMergerModule.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.sierra_bib_merger.modules
 import javax.inject.Singleton
 
 import akka.actor.ActorSystem
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.google.inject.Provides
 import com.twitter.app.Flag
 import com.twitter.inject.{Injector, TwitterModule}


### PR DESCRIPTION
Just a small code cleanup – these clients are never used.