### PR TITLE
Ensure that worker services always return a failed future

### DIFF
--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -24,6 +24,8 @@ class IngestorWorkerService @Inject()(
     fromJson[Work](message.body) match {
       case Success(work) =>
         identifiedWorkIndexer.indexWork(work = work).map(_ => ())
-      case Failure(err) => throw GracefulFailureException(err)
+      case Failure(err) => Future {
+        throw GracefulFailureException(err)
+      }
     }
 }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -20,11 +20,10 @@ class IngestorWorkerService @Inject()(
   metrics: MetricsSender
 ) extends SQSWorker(reader, system, metrics) {
 
-  override def processMessage(message: SQSMessage): Future[Unit] = Future {
+  override def processMessage(message: SQSMessage): Future[Unit] =
     fromJson[Work](message.body) match {
       case Success(work) =>
         identifiedWorkIndexer.indexWork(work = work).map(_ => ())
       case Failure(err) => throw GracefulFailureException(err)
     }
-  }
 }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -24,8 +24,9 @@ class IngestorWorkerService @Inject()(
     fromJson[Work](message.body) match {
       case Success(work) =>
         identifiedWorkIndexer.indexWork(work = work).map(_ => ())
-      case Failure(err) => Future {
-        throw GracefulFailureException(err)
-      }
+      case Failure(err) =>
+        Future {
+          throw GracefulFailureException(err)
+        }
     }
 }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -24,9 +24,6 @@ class IngestorWorkerService @Inject()(
     fromJson[Work](message.body) match {
       case Success(work) =>
         identifiedWorkIndexer.indexWork(work = work).map(_ => ())
-      case Failure(err) =>
-        Future {
-          throw GracefulFailureException(err)
-        }
+      case Failure(err) => Future.failed(new GracefulFailureException(err))
     }
 }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -73,10 +73,12 @@ class IngestorWorkerServiceTest
   it("returns a failed Future if indexing into Elasticsearch fails") {
     val brokenRestClient: RestClient = RestClient
       .builder(new HttpHost("localhost", 9800, "http"))
-      .setHttpClientConfigCallback(new ElasticCredentials("elastic", "badpassword"))
+      .setHttpClientConfigCallback(
+        new ElasticCredentials("elastic", "badpassword"))
       .build()
 
-    val brokenElasticClient: HttpClient = HttpClient.fromRestClient(brokenRestClient)
+    val brokenElasticClient: HttpClient =
+      HttpClient.fromRestClient(brokenRestClient)
 
     val brokenWorkIndexer = new WorkIndexer(
       esIndex = indexName,

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -74,7 +74,7 @@ class IngestorWorkerServiceTest
     val brokenRestClient: RestClient = RestClient
       .builder(new HttpHost("localhost", 9800, "http"))
       .setHttpClientConfigCallback(
-        new ElasticCredentials("elastic", "badpassword"))
+        new ElasticCredentials("elastic", "changeme"))
       .build()
 
     val brokenElasticClient: HttpClient =
@@ -103,9 +103,11 @@ class IngestorWorkerServiceTest
     val sqsMessage = messageFromString(toJson(work).get)
     val future = service.processMessage(sqsMessage)
 
+    // The exact exception isn't so important -- we just care that it's
+    // *not* a GracefulFailureException, as problems with Elasticsearch
+    // should trigger the TryBackoff behaviour.
     whenReady(future.failed) { result =>
       result shouldBe a[ConnectException]
-      result.getMessage should include("Connection refused")
     }
   }
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -64,16 +64,6 @@ class IngestorWorkerServiceTest
     }
   }
 
-  it(
-    "should not return a NullPointerException if the document is the string null") {
-    val sqsMessage = messageFromString("<xml><item> ??? Not JSON!!")
-    val future = service.processMessage(sqsMessage)
-
-    whenReady(future.failed) { exception =>
-      exception shouldBe a[GracefulFailureException]
-    }
-  }
-
   private def messageFromString(body: String): SQSMessage =
     SQSMessage(
       subject = Some("inserting-identified-work-test"),

--- a/common/src/main/scala/uk/ac/wellcome/sqs/SQSWorkerToDynamo.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sqs/SQSWorkerToDynamo.scala
@@ -20,7 +20,7 @@ abstract class SQSWorkerToDynamo[T](
   implicit val decoder: Decoder[T]
   def store(t: T): Future[Unit]
 
-  override def processMessage(message: SQSMessage): Future[Unit] = {
+  override def processMessage(message: SQSMessage): Future[Unit] =
     for {
       t <- Future.fromTry(fromJson[T](message.body))
       _ <- store(t).recover {
@@ -29,5 +29,4 @@ abstract class SQSWorkerToDynamo[T](
           throw GracefulFailureException(e)
       }
     } yield ()
-  }
 }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/modules/ReindexerWorkerModule.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/modules/ReindexerWorkerModule.scala
@@ -2,12 +2,12 @@ package uk.ac.wellcome.platform.reindex_worker.modules
 
 import akka.actor.ActorSystem
 import com.twitter.inject.{Injector, TwitterModule}
-import uk.ac.wellcome.platform.reindex_worker.services.ReindexerWorkerService
+import uk.ac.wellcome.platform.reindex_worker.services.ReindexWorkerService
 
 object ReindexerWorkerModule extends TwitterModule {
 
   override def singletonStartup(injector: Injector) {
-    val workerService = injector.instance[ReindexerWorkerService]
+    val workerService = injector.instance[ReindexWorkerService]
 
     workerService.runSQSWorker()
 
@@ -18,7 +18,7 @@ object ReindexerWorkerModule extends TwitterModule {
     info("Terminating SQS worker")
 
     val system = injector.instance[ActorSystem]
-    val workerService = injector.instance[ReindexerWorkerService]
+    val workerService = injector.instance[ReindexWorkerService]
 
     workerService.cancelRun()
     system.terminate()

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
@@ -67,7 +67,8 @@ class ReindexService @Inject()(dynamoDBClient: AmazonDynamoDB,
       }
 
     val futureOutdatedRecords: Future[List[HybridRecord]] = futureResults.map {
-      results => results.map { extractHybridRecord(_) }
+      results =>
+        results.map { extractHybridRecord(_) }
     }
 
     // Then we PUT all the records.  It might be more efficient to do a
@@ -79,7 +80,8 @@ class ReindexService @Inject()(dynamoDBClient: AmazonDynamoDB,
     }
   }
 
-  private def extractHybridRecord(scanamoResult: Either[DynamoReadError, HybridRecord]): HybridRecord =
+  private def extractHybridRecord(
+    scanamoResult: Either[DynamoReadError, HybridRecord]): HybridRecord =
     scanamoResult match {
       case Left(err: DynamoReadError) => {
         warn(s"Failed to read Dynamo records: $err")
@@ -90,7 +92,8 @@ class ReindexService @Inject()(dynamoDBClient: AmazonDynamoDB,
       case Right(r: HybridRecord) => r
     }
 
-  private def updateIndividualRecord(record: HybridRecord, desiredVersion: Int): Future[Unit] = {
+  private def updateIndividualRecord(record: HybridRecord,
+                                     desiredVersion: Int): Future[Unit] = {
     val updatedRecord = record.copy(reindexVersion = desiredVersion)
     versionedDao.updateRecord[HybridRecord](updatedRecord)
   }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
@@ -85,9 +85,7 @@ class ReindexService @Inject()(dynamoDBClient: AmazonDynamoDB,
       val results = outdatedRecords.map { hybridRecord =>
         val updatedRecord =
           hybridRecord.copy(reindexVersion = reindexJob.desiredVersion)
-        versionedDao.updateRecord[HybridRecord](updatedRecord)(
-          evidence = evidence,
-          versionUpdater = versionUpdater)
+        versionedDao.updateRecord[HybridRecord](updatedRecord)
       }
       Future.sequence(results)
     }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerService.scala
@@ -39,9 +39,6 @@ class ReindexWorkerService @Inject()(
         result.recover { case err => throw GracefulFailureException(err) }
       }
 
-      case Failure(err) =>
-        Future {
-          throw GracefulFailureException(err)
-        }
+      case Failure(err) => Future.failed(new GracefulFailureException(err))
     }
 }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerService.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.reindex_worker.services
 
 import akka.actor.ActorSystem
 import com.google.inject.Inject
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.platform.reindex_worker.models.{
@@ -15,7 +14,6 @@ import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.Future
-import scala.util.{Failure, Success}
 
 class ReindexWorkerService @Inject()(
   targetService: ReindexService,
@@ -26,19 +24,13 @@ class ReindexWorkerService @Inject()(
 ) extends SQSWorker(reader, system, metrics) {
 
   override def processMessage(message: SQSMessage): Future[Unit] =
-    fromJson[ReindexJob](message.body) match {
-      case Success(reindexJob) => {
-        val result = for {
-          _ <- targetService.runReindex(reindexJob = reindexJob)
-          message <- Future.fromTry(toJson(CompletedReindexJob(reindexJob)))
-          result <- snsWriter.writeMessage(
-            subject = s"source: ${this.getClass.getSimpleName}.processMessage",
-            message = message
-          )
-        } yield ()
-        result.recover { case err => throw GracefulFailureException(err) }
-      }
-
-      case Failure(err) => Future.failed(new GracefulFailureException(err))
-    }
+    for {
+      reindexJob <- Future.fromTry(fromJson[ReindexJob](message.body))
+      _ <- targetService.runReindex(reindexJob = reindexJob)
+      message <- Future.fromTry(toJson(CompletedReindexJob(reindexJob)))
+      _ <- snsWriter.writeMessage(
+        subject = s"source: ${this.getClass.getSimpleName}.processMessage",
+        message = message
+      )
+    } yield ()
 }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerService.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.utils.JsonUtil._
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
-class ReindexerWorkerService @Inject()(
+class ReindexWorkerService @Inject()(
   targetService: ReindexService,
   reader: SQSReader,
   snsWriter: SNSWriter,

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerService.scala
@@ -39,6 +39,8 @@ class ReindexWorkerService @Inject()(
         result.recover { case err => throw GracefulFailureException(err) }
       }
 
-      case Failure(err) => throw GracefulFailureException(err)
+      case Failure(err) => Future {
+        throw GracefulFailureException(err)
+      }
     }
 }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerService.scala
@@ -39,8 +39,9 @@ class ReindexWorkerService @Inject()(
         result.recover { case err => throw GracefulFailureException(err) }
       }
 
-      case Failure(err) => Future {
-        throw GracefulFailureException(err)
-      }
+      case Failure(err) =>
+        Future {
+          throw GracefulFailureException(err)
+        }
     }
 }


### PR DESCRIPTION
Previously any error inside the `for` comprehension in these two WorkerServices would be lost, and we'd exit the `processMessage()` prematurely.

Now we should always return a Future or a failed Future as appropriate, and retry messages as necessary.

Hopefully this will (finally!) get the reindexer working – part of #1509.