### PR TITLE
terraform: move all the tfstate files into the new bucket

### DIFF
--- a/assets/terraform/terraform.tf
+++ b/assets/terraform/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.11"
 
   backend "s3" {
-    bucket         = "platform-infra"
+    bucket         = "wellcomecollection-platform-infra"
     key            = "terraform/assets.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"

--- a/catalogue_api/terraform/terraform.tf
+++ b/catalogue_api/terraform/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.9"
 
   backend "s3" {
-    bucket         = "platform-infra"
+    bucket         = "wellcomecollection-platform-infra"
     key            = "terraform/catalogue_api.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
@@ -13,7 +13,7 @@ data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 
   config {
-    bucket = "platform-infra"
+    bucket = "wellcomecollection-platform-infra"
     key    = "terraform/shared_infra.tfstate"
     region = "eu-west-1"
   }

--- a/catalogue_pipeline/terraform/terraform.tf
+++ b/catalogue_pipeline/terraform/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.9"
 
   backend "s3" {
-    bucket         = "platform-infra"
+    bucket         = "wellcomecollection-platform-infra"
     key            = "terraform/catalogue_pipeline.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
@@ -13,7 +13,7 @@ data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 
   config {
-    bucket = "platform-infra"
+    bucket = "wellcomecollection-platform-infra"
     key    = "terraform/shared_infra.tfstate"
     region = "eu-west-1"
   }

--- a/loris/terraform/terraform.tf
+++ b/loris/terraform/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.9"
 
   backend "s3" {
-    bucket         = "platform-infra"
+    bucket         = "wellcomecollection-platform-infra"
     key            = "terraform/loris.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
@@ -13,7 +13,7 @@ data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 
   config {
-    bucket = "platform-infra"
+    bucket = "wellcomecollection-platform-infra"
     key    = "terraform/shared_infra.tfstate"
     region = "eu-west-1"
   }
@@ -23,7 +23,7 @@ data "terraform_remote_state" "catalogue_api" {
   backend = "s3"
 
   config {
-    bucket = "platform-infra"
+    bucket = "wellcomecollection-platform-infra"
     key    = "terraform/catalogue_api.tfstate"
     region = "eu-west-1"
   }

--- a/monitoring/terraform.tf
+++ b/monitoring/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.10"
 
   backend "s3" {
-    bucket         = "platform-infra"
+    bucket         = "wellcomecollection-platform-infra"
     key            = "terraform/monitoring.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
@@ -13,7 +13,7 @@ data "terraform_remote_state" "catalogue_pipeline" {
   backend = "s3"
 
   config {
-    bucket = "platform-infra"
+    bucket = "wellcomecollection-platform-infra"
     key    = "terraform/catalogue_pipeline.tfstate"
     region = "eu-west-1"
   }
@@ -23,7 +23,7 @@ data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 
   config {
-    bucket = "platform-infra"
+    bucket = "wellcomecollection-platform-infra"
     key    = "terraform/shared_infra.tfstate"
     region = "eu-west-1"
   }

--- a/reindexer/terraform/terraform.tf
+++ b/reindexer/terraform/terraform.tf
@@ -13,7 +13,7 @@ data "terraform_remote_state" "catalogue_pipeline" {
   backend = "s3"
 
   config {
-    bucket = "platform-infra"
+    bucket = "wellcomecollection-platform-infra"
     key    = "terraform/catalogue_pipeline.tfstate"
     region = "eu-west-1"
   }
@@ -23,7 +23,7 @@ data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 
   config {
-    bucket = "platform-infra"
+    bucket = "wellcomecollection-platform-infra"
     key    = "terraform/shared_infra.tfstate"
     region = "eu-west-1"
   }

--- a/shared_infra/terraform.tf
+++ b/shared_infra/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.9"
 
   backend "s3" {
-    bucket         = "platform-infra"
+    bucket         = "wellcomecollection-platform-infra"
     key            = "terraform/shared_infra.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"

--- a/sierra_adapter/terraform/terraform.tf
+++ b/sierra_adapter/terraform/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.9"
 
   backend "s3" {
-    bucket         = "platform-infra"
+    bucket         = "wellcomecollection-platform-infra"
     key            = "terraform/sierra_adapter.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
@@ -13,7 +13,7 @@ data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 
   config {
-    bucket = "platform-infra"
+    bucket = "wellcomecollection-platform-infra"
     key    = "terraform/shared_infra.tfstate"
     region = "eu-west-1"
   }
@@ -23,7 +23,7 @@ data "terraform_remote_state" "catalogue_pipeline" {
   backend = "s3"
 
   config {
-    bucket = "platform-infra"
+    bucket = "wellcomecollection-platform-infra"
     key    = "terraform/catalogue_pipeline.tfstate"
     region = "eu-west-1"
   }


### PR DESCRIPTION
Part of #1544, all our .tfstate files now live in the renamed infra bucket, and I’ve moved the old files over.

This PR is for visibility more than tests – I’ll merge immediately so we don't have issues with mixed state.