### PR TITLE
Split Work into Unidentifiedwork and IdentifiedWork

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayItem.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayItem.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.api.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.{Item, Location, SourceIdentifier}
+import uk.ac.wellcome.models.{IdentifiedItem, Location, SourceIdentifier}
 
 @ApiModel(
   value = "Item",
@@ -28,7 +28,7 @@ case class DisplayItem(
 }
 
 object DisplayItem {
-  def apply(item: Item, includesIdentifiers: Boolean): DisplayItem = {
+  def apply(item: IdentifiedItem, includesIdentifiers: Boolean): DisplayItem = {
     DisplayItem(
       id = item.canonicalId,
       identifiers =

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayItem.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayItem.scala
@@ -30,7 +30,7 @@ case class DisplayItem(
 object DisplayItem {
   def apply(item: Item, includesIdentifiers: Boolean): DisplayItem = {
     DisplayItem(
-      id = item.id,
+      id = item.canonicalId,
       identifiers =
         if (includesIdentifiers)
           // If there aren't any identifiers on the item JSON, Jackson puts a

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.{JsonIgnoreProperties, JsonProperty}
 import com.sksamuel.elastic4s.http.search.SearchHit
 import com.sksamuel.elastic4s.http.get.GetResponse
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.{Item, SourceIdentifier, Work}
+import uk.ac.wellcome.models.{Item, SourceIdentifier, IdentifiedWork}
 import uk.ac.wellcome.utils.JsonUtil._
 
 @JsonIgnoreProperties(Array("visible"))
@@ -73,9 +73,9 @@ case class DisplayWork(
 
 case object DisplayWork {
 
-  def apply(work: Work, includes: WorksIncludes): DisplayWork = {
+  def apply(work: IdentifiedWork, includes: WorksIncludes): DisplayWork = {
     DisplayWork(
-      id = work.id,
+      id = work.canonicalId,
       title = work.title.get,
       description = work.description,
       lettering = work.lettering,
@@ -101,7 +101,7 @@ case object DisplayWork {
     )
   }
 
-  def apply(work: Work): DisplayWork =
+  def apply(work: IdentifiedWork): DisplayWork =
     DisplayWork(work = work, includes = WorksIncludes())
 
   def apply(hit: SearchHit): DisplayWork =
@@ -116,7 +116,7 @@ case object DisplayWork {
   }
 
   private def jsonToDisplayWork(document: String, includes: WorksIncludes) = {
-    fromJson[Work](document) match {
+    fromJson[IdentifiedWork](document) match {
       case Success(work) => DisplayWork(work = work, includes = includes)
       case Failure(e) =>
         throw new RuntimeException(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -5,11 +5,11 @@ import com.twitter.finagle.http.{Response, Status}
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.server.FeatureTestMixin
 import org.scalatest.FunSpec
-import uk.ac.wellcome.models.Work
+import uk.ac.wellcome.models.IdentifiedWork
 
 class ApiSwaggerTest extends FunSpec with FeatureTestMixin {
 
-  implicit val jsonMapper = Work
+  implicit val jsonMapper = IdentifiedWork
   override val server =
     new EmbeddedHttpServer(
       new Server,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
@@ -38,14 +38,14 @@ trait WorksUtil {
          sourceIdentifier = sourceIdentifier,
          version = 1,
          identifiers = List(sourceIdentifier),
-         canonicalId = Some(canonicalId))
+         canonicalId = canonicalId)
 
   def workWith(canonicalId: String, title: String, visible: Boolean): IdentifiedWork =
     IdentifiedWork(title = Some(title),
          sourceIdentifier = sourceIdentifier,
          version = 1,
          identifiers = List(sourceIdentifier),
-         canonicalId = Some(canonicalId),
+         canonicalId = canonicalId,
          visible = visible)
 
   def workWith(
@@ -58,7 +58,7 @@ trait WorksUtil {
          sourceIdentifier = sourceIdentifier,
          version = 1,
          identifiers = identifiers,
-         canonicalId = Some(canonicalId),
+         canonicalId = canonicalId,
          items = items)
 
   def identifiedWorkWith(
@@ -73,7 +73,7 @@ trait WorksUtil {
       identifiers = List(
         SourceIdentifier(IdentifierSchemes.miroImageNumber, "5678")
       ),
-      canonicalId = Some(canonicalId),
+      canonicalId = canonicalId,
       thumbnail = Some(thumbnail)
     )
 
@@ -90,7 +90,7 @@ trait WorksUtil {
       sourceIdentifier = sourceIdentifier,
       version = 1,
       identifiers = List(sourceIdentifier),
-      canonicalId = Some(canonicalId),
+      canonicalId = canonicalId,
       description = Some(description),
       lettering = Some(lettering),
       createdDate = Some(createdDate),
@@ -122,7 +122,7 @@ trait WorksUtil {
     identifier: SourceIdentifier,
     location: Location
   ): Item = Item(
-    canonicalId = Some(canonicalId),
+    canonicalId = canonicalId,
     sourceIdentifier = identifier,
     identifiers = List(identifier),
     locations = List(location)

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
@@ -52,7 +52,7 @@ trait WorksUtil {
     canonicalId: String,
     title: String,
     identifiers: List[SourceIdentifier] = List(),
-    items: List[Item] = List()
+    items: List[IdentifiedItem] = List()
   ): IdentifiedWork =
     IdentifiedWork(title = Some(title),
          sourceIdentifier = sourceIdentifier,
@@ -83,7 +83,7 @@ trait WorksUtil {
                lettering: String,
                createdDate: Period,
                creator: Agent,
-               items: List[Item],
+               items: List[IdentifiedItem],
                visible: Boolean): IdentifiedWork =
     IdentifiedWork(
       title = Some(title),
@@ -99,7 +99,7 @@ trait WorksUtil {
       visible = visible
     )
 
-  def defaultItem: Item = {
+  def defaultItem: IdentifiedItem = {
     itemWith(
       "item-canonical-id",
       defaultSourceIdentifier,
@@ -121,7 +121,7 @@ trait WorksUtil {
     canonicalId: String,
     identifier: SourceIdentifier,
     location: Location
-  ): Item = Item(
+  ): IdentifiedItem = IdentifiedItem(
     canonicalId = canonicalId,
     sourceIdentifier = identifier,
     identifiers = List(identifier),

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
@@ -35,18 +35,20 @@ trait WorksUtil {
 
   def workWith(canonicalId: String, title: String): IdentifiedWork =
     IdentifiedWork(title = Some(title),
-         sourceIdentifier = sourceIdentifier,
-         version = 1,
-         identifiers = List(sourceIdentifier),
-         canonicalId = canonicalId)
+                   sourceIdentifier = sourceIdentifier,
+                   version = 1,
+                   identifiers = List(sourceIdentifier),
+                   canonicalId = canonicalId)
 
-  def workWith(canonicalId: String, title: String, visible: Boolean): IdentifiedWork =
+  def workWith(canonicalId: String,
+               title: String,
+               visible: Boolean): IdentifiedWork =
     IdentifiedWork(title = Some(title),
-         sourceIdentifier = sourceIdentifier,
-         version = 1,
-         identifiers = List(sourceIdentifier),
-         canonicalId = canonicalId,
-         visible = visible)
+                   sourceIdentifier = sourceIdentifier,
+                   version = 1,
+                   identifiers = List(sourceIdentifier),
+                   canonicalId = canonicalId,
+                   visible = visible)
 
   def workWith(
     canonicalId: String,
@@ -55,11 +57,11 @@ trait WorksUtil {
     items: List[IdentifiedItem] = List()
   ): IdentifiedWork =
     IdentifiedWork(title = Some(title),
-         sourceIdentifier = sourceIdentifier,
-         version = 1,
-         identifiers = identifiers,
-         canonicalId = canonicalId,
-         items = items)
+                   sourceIdentifier = sourceIdentifier,
+                   version = 1,
+                   identifiers = identifiers,
+                   canonicalId = canonicalId,
+                   items = items)
 
   def identifiedWorkWith(
     canonicalId: String,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
@@ -19,7 +19,7 @@ trait WorksUtil {
 
   def createWorks(count: Int,
                   start: Int = 1,
-                  visible: Boolean = true): Seq[Work] =
+                  visible: Boolean = true): Seq[IdentifiedWork] =
     (start to count).map(
       (idx: Int) =>
         workWith(
@@ -33,15 +33,15 @@ trait WorksUtil {
           visible = visible
       ))
 
-  def workWith(canonicalId: String, title: String): Work =
-    Work(title = Some(title),
+  def workWith(canonicalId: String, title: String): IdentifiedWork =
+    IdentifiedWork(title = Some(title),
          sourceIdentifier = sourceIdentifier,
          version = 1,
          identifiers = List(sourceIdentifier),
          canonicalId = Some(canonicalId))
 
-  def workWith(canonicalId: String, title: String, visible: Boolean): Work =
-    Work(title = Some(title),
+  def workWith(canonicalId: String, title: String, visible: Boolean): IdentifiedWork =
+    IdentifiedWork(title = Some(title),
          sourceIdentifier = sourceIdentifier,
          version = 1,
          identifiers = List(sourceIdentifier),
@@ -53,8 +53,8 @@ trait WorksUtil {
     title: String,
     identifiers: List[SourceIdentifier] = List(),
     items: List[Item] = List()
-  ): Work =
-    Work(title = Some(title),
+  ): IdentifiedWork =
+    IdentifiedWork(title = Some(title),
          sourceIdentifier = sourceIdentifier,
          version = 1,
          identifiers = identifiers,
@@ -65,8 +65,8 @@ trait WorksUtil {
     canonicalId: String,
     title: String,
     thumbnail: Location
-  ): Work =
-    Work(
+  ): IdentifiedWork =
+    IdentifiedWork(
       title = Some(title),
       sourceIdentifier = sourceIdentifier,
       version = 1,
@@ -84,8 +84,8 @@ trait WorksUtil {
                createdDate: Period,
                creator: Agent,
                items: List[Item],
-               visible: Boolean): Work =
-    Work(
+               visible: Boolean): IdentifiedWork =
+    IdentifiedWork(
       title = Some(title),
       sourceIdentifier = sourceIdentifier,
       version = 1,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayItemTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayItemTest.scala
@@ -24,7 +24,7 @@ class DisplayItemTest extends FunSpec with Matchers {
 
   it("should read an Item as a DisplayItem correctly") {
     val item = Item(
-      canonicalId = Some("foo"),
+      canonicalId = "foo",
       sourceIdentifier = identifier,
       identifiers = List(identifier),
       locations = List(location)

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayItemTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayItemTest.scala
@@ -23,7 +23,7 @@ class DisplayItemTest extends FunSpec with Matchers {
   )
 
   it("should read an Item as a DisplayItem correctly") {
-    val item = Item(
+    val item = IdentifiedItem(
       canonicalId = "foo",
       sourceIdentifier = identifier,
       identifiers = List(identifier),
@@ -35,14 +35,14 @@ class DisplayItemTest extends FunSpec with Matchers {
       includesIdentifiers = true
     )
 
-    displayItem.id shouldBe item.id
+    displayItem.id shouldBe item.canonicalId
     displayItem.locations shouldBe List(DisplayLocation(location))
     displayItem.identifiers shouldBe Some(List(DisplayIdentifier(identifier)))
     displayItem.ontologyType shouldBe "Item"
   }
 
   it("correctly parses an Item without any identifiers") {
-    val item = fromJson[Item]("""
+    val item = fromJson[IdentifiedItem]("""
         {
           "canonicalId": "b71876a",
           "sourceIdentifier": {
@@ -63,7 +63,7 @@ class DisplayItemTest extends FunSpec with Matchers {
   }
 
   it("correctly parses an Item without any locations") {
-    val item = fromJson[Item]("""
+    val item = fromJson[IdentifiedItem]("""
         {
           "canonicalId": "mr953zsh",
           "sourceIdentifier": {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayItemTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayItemTest.scala
@@ -42,7 +42,8 @@ class DisplayItemTest extends FunSpec with Matchers {
   }
 
   it("correctly parses an Item without any identifiers") {
-    val item = fromJson[IdentifiedItem]("""
+    val item =
+      fromJson[IdentifiedItem]("""
         {
           "canonicalId": "b71876a",
           "sourceIdentifier": {
@@ -63,7 +64,8 @@ class DisplayItemTest extends FunSpec with Matchers {
   }
 
   it("correctly parses an Item without any locations") {
-    val item = fromJson[IdentifiedItem]("""
+    val item =
+      fromJson[IdentifiedItem]("""
         {
           "canonicalId": "mr953zsh",
           "sourceIdentifier": {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayWorkTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayWorkTest.scala
@@ -51,11 +51,12 @@ class DisplayWorkTest extends FunSpec with Matchers {
   )
 
   it("correctly parses a work without any identifiers") {
-    val work = IdentifiedWork(title = Some("An irascible iguana invites impudence"),
-                    sourceIdentifier = sourceIdentifier,
-                    version = 1,
-                    identifiers = Nil,
-                    canonicalId = "xtsx8hwk")
+    val work = IdentifiedWork(title =
+                                Some("An irascible iguana invites impudence"),
+                              sourceIdentifier = sourceIdentifier,
+                              version = 1,
+                              identifiers = Nil,
+                              canonicalId = "xtsx8hwk")
 
     val displayWork = DisplayWork(
       work = work,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayWorkTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayWorkTest.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.models._
 class DisplayWorkTest extends FunSpec with Matchers {
 
   it("correctly parses a Work without any items") {
-    val work = Work(
+    val work = IdentifiedWork(
       title = Some("An irritating imp is immune from items"),
       sourceIdentifier = sourceIdentifier,
       version = 1,
@@ -28,7 +28,7 @@ class DisplayWorkTest extends FunSpec with Matchers {
       identifiers = List(sourceIdentifier),
       locations = List()
     )
-    val work = Work(
+    val work = IdentifiedWork(
       title = Some("Inside an irate igloo"),
       sourceIdentifier = sourceIdentifier,
       version = 1,
@@ -51,7 +51,7 @@ class DisplayWorkTest extends FunSpec with Matchers {
   )
 
   it("correctly parses a work without any identifiers") {
-    val work = Work(title = Some("An irascible iguana invites impudence"),
+    val work = IdentifiedWork(title = Some("An irascible iguana invites impudence"),
                     sourceIdentifier = sourceIdentifier,
                     version = 1,
                     identifiers = Nil,
@@ -66,7 +66,7 @@ class DisplayWorkTest extends FunSpec with Matchers {
 
   describe("publishers") {
     it("parses a work without any publishers") {
-      val work = Work(
+      val work = IdentifiedWork(
         title = Some("A goading giraffe is galling"),
         sourceIdentifier = sourceIdentifier,
         version = 1,
@@ -80,7 +80,7 @@ class DisplayWorkTest extends FunSpec with Matchers {
     }
 
     it("parses a work with agent publishers") {
-      val work = Work(
+      val work = IdentifiedWork(
         title = Some("A hammerhead hamster is harrowing"),
         sourceIdentifier = sourceIdentifier,
         version = 1,
@@ -100,7 +100,7 @@ class DisplayWorkTest extends FunSpec with Matchers {
     }
 
     it("parses a work with agents and organisations as publishers") {
-      val work = Work(
+      val work = IdentifiedWork(
         title = Some("Jumping over jackals in Japan"),
         sourceIdentifier = sourceIdentifier,
         version = 1,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayWorkTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayWorkTest.scala
@@ -11,7 +11,7 @@ class DisplayWorkTest extends FunSpec with Matchers {
       sourceIdentifier = sourceIdentifier,
       version = 1,
       identifiers = List(sourceIdentifier),
-      canonicalId = Some("abcdef12")
+      canonicalId = "abcdef12"
     )
 
     val displayWork = DisplayWork(
@@ -22,7 +22,7 @@ class DisplayWorkTest extends FunSpec with Matchers {
   }
 
   it("correctly parses items on a work") {
-    val item = Item(
+    val item = IdentifiedItem(
       canonicalId = "c3a599u5",
       sourceIdentifier = sourceIdentifier,
       identifiers = List(sourceIdentifier),
@@ -42,7 +42,7 @@ class DisplayWorkTest extends FunSpec with Matchers {
       includes = WorksIncludes(items = true)
     )
     val displayItem = displayWork.items.get.head
-    displayItem.id shouldBe item.canonicalId.get
+    displayItem.id shouldBe item.canonicalId
   }
 
   val sourceIdentifier = SourceIdentifier(
@@ -55,7 +55,7 @@ class DisplayWorkTest extends FunSpec with Matchers {
                     sourceIdentifier = sourceIdentifier,
                     version = 1,
                     identifiers = Nil,
-                    canonicalId = Some("xtsx8hwk"))
+                    canonicalId = "xtsx8hwk")
 
     val displayWork = DisplayWork(
       work = work,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayWorkTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayWorkTest.scala
@@ -23,7 +23,7 @@ class DisplayWorkTest extends FunSpec with Matchers {
 
   it("correctly parses items on a work") {
     val item = Item(
-      canonicalId = Some("c3a599u5"),
+      canonicalId = "c3a599u5",
       sourceIdentifier = sourceIdentifier,
       identifiers = List(sourceIdentifier),
       locations = List()
@@ -33,7 +33,7 @@ class DisplayWorkTest extends FunSpec with Matchers {
       sourceIdentifier = sourceIdentifier,
       version = 1,
       identifiers = List(sourceIdentifier),
-      canonicalId = Some("b4heraz7"),
+      canonicalId = "b4heraz7",
       items = List(item)
     )
 
@@ -71,7 +71,7 @@ class DisplayWorkTest extends FunSpec with Matchers {
         sourceIdentifier = sourceIdentifier,
         version = 1,
         identifiers = Nil,
-        canonicalId = Some("gsfmhw7v"),
+        canonicalId = "gsfmhw7v",
         publishers = List()
       )
 
@@ -85,7 +85,7 @@ class DisplayWorkTest extends FunSpec with Matchers {
         sourceIdentifier = sourceIdentifier,
         version = 1,
         identifiers = Nil,
-        canonicalId = Some("hz2hrba9"),
+        canonicalId = "hz2hrba9",
         publishers = List(
           Agent("Henry Hare"),
           Agent("Harriet Heron")
@@ -105,7 +105,7 @@ class DisplayWorkTest extends FunSpec with Matchers {
         sourceIdentifier = sourceIdentifier,
         version = 1,
         identifiers = Nil,
-        canonicalId = Some("j7tw9jv3"),
+        canonicalId = "j7tw9jv3",
         publishers = List(
           Agent("Janet Jackson"),
           Organisation("Juniper Journals")

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.api.services
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.Work
+import uk.ac.wellcome.models.IdentifiedWork
 import uk.ac.wellcome.platform.api.WorksUtil
 import uk.ac.wellcome.platform.api.models.{DisplayWork, WorksIncludes}
 import uk.ac.wellcome.test.utils.IndexedElasticSearchLocal
@@ -121,7 +121,7 @@ class ElasticsearchServiceTest
   }
 
   private def toDisplayWorks(
-    works: Seq[Work],
+    works: Seq[IdentifiedWork],
     worksIncludes: WorksIncludes = WorksIncludes()): List[DisplayWork] =
     works.map(DisplayWork(_, worksIncludes)).sortBy(_.id).toList
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -41,8 +41,8 @@ class ElasticsearchServiceTest
     )
     whenReady(sortedSearchResultByCanonicalId) { result =>
       val works = result.hits.hits.map { DisplayWork(_) }
-      works.head shouldBe DisplayWork(work3.id, work3.title.get)
-      works.last shouldBe DisplayWork(work1.id, work1.title.get)
+      works.head shouldBe DisplayWork(work3.canonicalId, work3.title.get)
+      works.last shouldBe DisplayWork(work1.canonicalId, work1.title.get)
     }
 
     // TODO: canonicalID is the only user-defined field that we can sort on.

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -80,7 +80,8 @@ class WorksServiceTest
     val searchForDodo = worksService.searchWorks("dodo")
     whenReady(searchForDodo) { works =>
       works.results should have size 1
-      works.results.head shouldBe DisplayWork(workDodo.canonicalId, workDodo.title.get)
+      works.results.head shouldBe DisplayWork(workDodo.canonicalId,
+                                              workDodo.title.get)
     }
   }
 
@@ -167,7 +168,8 @@ class WorksServiceTest
 
     whenReady(searchForEmu) { works =>
       works.results should have size 1
-      works.results.head shouldBe DisplayWork(workEmu.canonicalId, workEmu.title.get)
+      works.results.head shouldBe DisplayWork(workEmu.canonicalId,
+                                              workEmu.title.get)
     }
   }
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -39,9 +39,9 @@ class WorksServiceTest
 
     displayWorksFuture map { displayWork =>
       displayWork.results should have size 2
-      displayWork.results.head shouldBe DisplayWork(works(0).id,
+      displayWork.results.head shouldBe DisplayWork(works(0).canonicalId,
                                                     works(0).title.get)
-      displayWork.results.tail.head shouldBe DisplayWork(works(1).id,
+      displayWork.results.tail.head shouldBe DisplayWork(works(1).canonicalId,
                                                          works(1).title.get)
     }
   }
@@ -51,7 +51,7 @@ class WorksServiceTest
 
     insertIntoElasticSearch(works: _*)
 
-    val recordsFuture = worksService.findWorkById(works.head.id)
+    val recordsFuture = worksService.findWorkById(works.head.canonicalId)
 
     whenReady(recordsFuture) { records =>
       records.isDefined shouldBe true
@@ -80,7 +80,7 @@ class WorksServiceTest
     val searchForDodo = worksService.searchWorks("dodo")
     whenReady(searchForDodo) { works =>
       works.results should have size 1
-      works.results.head shouldBe DisplayWork(workDodo.id, workDodo.title.get)
+      works.results.head shouldBe DisplayWork(workDodo.canonicalId, workDodo.title.get)
     }
   }
 
@@ -167,7 +167,7 @@ class WorksServiceTest
 
     whenReady(searchForEmu) { works =>
       works.results should have size 1
-      works.results.head shouldBe DisplayWork(workEmu.id, workEmu.title.get)
+      works.results.head shouldBe DisplayWork(workEmu.canonicalId, workEmu.title.get)
     }
   }
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
@@ -22,7 +22,7 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |  "results": [
                           |   {
                           |     "type": "Work",
-                          |     "id": "${works(0).id}",
+                          |     "id": "${works(0).canonicalId}",
                           |     "title": "${works(0).title.get}",
                           |     "description": "${works(0).description.get}",
                           |     "lettering": "${works(0).lettering.get}",
@@ -35,7 +35,7 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |   },
                           |   {
                           |     "type": "Work",
-                          |     "id": "${works(1).id}",
+                          |     "id": "${works(1).canonicalId}",
                           |     "title": "${works(1).title.get}",
                           |     "description": "${works(1).description.get}",
                           |     "lettering": "${works(1).lettering.get}",
@@ -48,7 +48,7 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |   },
                           |   {
                           |     "type": "Work",
-                          |     "id": "${works(2).id}",
+                          |     "id": "${works(2).canonicalId}",
                           |     "title": "${works(2).title.get}",
                           |     "description": "${works(2).description.get}",
                           |     "lettering": "${works(2).lettering.get}",
@@ -118,13 +118,13 @@ class ApiWorksTest extends ApiWorksTestBase {
 
     eventually {
       server.httpGet(
-        path = s"/$apiPrefix/works/${work.canonicalId.get}?includes=items",
+        path = s"/$apiPrefix/works/${work.canonicalId}?includes=items",
         andExpect = Status.Ok,
         withJsonBody = s"""
                           |{
                           | "@context": "https://localhost:8888/$apiPrefix/context.json",
                           | "type": "Work",
-                          | "id": "${work.canonicalId.get}",
+                          | "id": "${work.canonicalId}",
                           | "title": "${work.title.get}",
                           | "creators": [ ],
                           | "items": [ ${items(work.items)} ],
@@ -148,13 +148,13 @@ class ApiWorksTest extends ApiWorksTestBase {
 
     eventually {
       server.httpGet(
-        path = s"/$apiPrefix/works/${work.canonicalId.get}?includes=items",
+        path = s"/$apiPrefix/works/${work.canonicalId}?includes=items",
         andExpect = Status.Ok,
         withJsonBody = s"""
                           |{
                           | "@context": "https://localhost:8888/$apiPrefix/context.json",
                           | "type": "Work",
-                          | "id": "${work.canonicalId.get}",
+                          | "id": "${work.canonicalId}",
                           | "title": "${work.title.get}",
                           | "creators": [ ],
                           | "items": [ ],
@@ -174,13 +174,13 @@ class ApiWorksTest extends ApiWorksTestBase {
       credit = Some("Wellcome Collection"),
       license = License_CCBY
     )
-    val item = Item(
+    val item = IdentifiedItem(
       canonicalId = "chu27a8",
       sourceIdentifier = sourceIdentifier,
       identifiers = List(),
       locations = List(location)
     )
-    val workWithCopyright = Work(title = Some("A scarf on a squirrel"),
+    val workWithCopyright = IdentifiedWork(title = Some("A scarf on a squirrel"),
                                  sourceIdentifier = sourceIdentifier,
                                  version = 1,
                                  canonicalId = "yxh928a",
@@ -197,7 +197,7 @@ class ApiWorksTest extends ApiWorksTestBase {
           |  "results": [
           |   {
           |     "type": "Work",
-          |     "id": "${workWithCopyright.id}",
+          |     "id": "${workWithCopyright.canonicalId}",
           |     "title": "${workWithCopyright.title.get}",
           |     "creators": [ ],
           |     "subjects": [ ],
@@ -205,7 +205,7 @@ class ApiWorksTest extends ApiWorksTestBase {
           |     "publishers": [ ],
           |     "items": [
           |       {
-          |         "id": "${item.canonicalId.get}",
+          |         "id": "${item.canonicalId}",
           |         "type": "${item.ontologyType}",
           |         "locations": [
           |           {
@@ -245,7 +245,7 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |  "results": [
                           |   {
                           |     "type": "Work",
-                          |     "id": "${works(1).id}",
+                          |     "id": "${works(1).canonicalId}",
                           |     "title": "${works(1).title.get}",
                           |     "description": "${works(1).description.get}",
                           |     "lettering": "${works(1).lettering.get}",
@@ -274,7 +274,7 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |  "results": [
                           |   {
                           |     "type": "Work",
-                          |     "id": "${works(0).id}",
+                          |     "id": "${works(0).canonicalId}",
                           |     "title": "${works(0).title.get}",
                           |     "description": "${works(0).description.get}",
                           |     "lettering": "${works(0).lettering.get}",
@@ -303,7 +303,7 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |  "results": [
                           |   {
                           |     "type": "Work",
-                          |     "id": "${works(2).id}",
+                          |     "id": "${works(2).canonicalId}",
                           |     "title": "${works(2).title.get}",
                           |     "description": "${works(2).description.get}",
                           |     "lettering": "${works(2).lettering.get}",
@@ -450,7 +450,7 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |  "results": [
                           |   {
                           |     "type": "Work",
-                          |     "id": "${work1.id}",
+                          |     "id": "${work1.canonicalId}",
                           |     "title": "${work1.title.get}",
                           |     "creators": [],
                           |     "subjects": [ ],
@@ -464,7 +464,7 @@ class ApiWorksTest extends ApiWorksTestBase {
   }
 
   it("should include subject information in API responses") {
-    val workWithSubjects = Work(
+    val workWithSubjects = IdentifiedWork(
       title = Some("A seal selling seaweed sandwiches in Scotland"),
       sourceIdentifier = sourceIdentifier,
       version = 1,
@@ -484,7 +484,7 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |  "results": [
                           |   {
                           |     "type": "Work",
-                          |     "id": "${workWithSubjects.id}",
+                          |     "id": "${workWithSubjects.canonicalId}",
                           |     "title": "${workWithSubjects.title.get}",
                           |     "creators": [],
                           |     "subjects": [ ${concepts(
@@ -499,7 +499,7 @@ class ApiWorksTest extends ApiWorksTestBase {
   }
 
   it("should include genre information in API responses") {
-    val workWithSubjects = Work(
+    val workWithSubjects = IdentifiedWork(
       title = Some("A guppy in a greenhouse"),
       sourceIdentifier = sourceIdentifier,
       version = 1,
@@ -519,7 +519,7 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |  "results": [
                           |   {
                           |     "type": "Work",
-                          |     "id": "${workWithSubjects.id}",
+                          |     "id": "${workWithSubjects.canonicalId}",
                           |     "title": "${workWithSubjects.title.get}",
                           |     "creators": [],
                           |     "subjects": [ ],
@@ -568,7 +568,7 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |  "results": [
                           |   {
                           |     "type": "Work",
-                          |     "id": "${work1.id}",
+                          |     "id": "${work1.canonicalId}",
                           |     "title": "${work1.title.get}",
                           |     "creators": [ ],
                           |     "identifiers": [ ${identifier(identifier1)} ],
@@ -578,7 +578,7 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |   },
                           |   {
                           |     "type": "Work",
-                          |     "id": "${work2.id}",
+                          |     "id": "${work2.canonicalId}",
                           |     "title": "${work2.title.get}",
                           |     "creators": [ ],
                           |     "identifiers": [ ${identifier(identifier2)} ],
@@ -608,13 +608,13 @@ class ApiWorksTest extends ApiWorksTestBase {
 
     eventually {
       server.httpGet(
-        path = s"/$apiPrefix/works/${work.id}?includes=identifiers",
+        path = s"/$apiPrefix/works/${work.canonicalId}?includes=identifiers",
         andExpect = Status.Ok,
         withJsonBody = s"""
                           |{
                           | "@context": "https://localhost:8888/$apiPrefix/context.json",
                           | "type": "Work",
-                          | "id": "${work.id}",
+                          | "id": "${work.canonicalId}",
                           | "title": "${work.title.get}",
                           | "creators": [ ],
                           | "identifiers": [ ${identifier(srcIdentifier)} ],
@@ -638,13 +638,13 @@ class ApiWorksTest extends ApiWorksTestBase {
 
     eventually {
       server.httpGet(
-        path = s"/$apiPrefix/works/${work.id}?includes=identifiers",
+        path = s"/$apiPrefix/works/${work.canonicalId}?includes=identifiers",
         andExpect = Status.Ok,
         withJsonBody = s"""
                           |{
                           | "@context": "https://localhost:8888/$apiPrefix/context.json",
                           | "type": "Work",
-                          | "id": "${work.id}",
+                          | "id": "${work.canonicalId}",
                           | "title": "${work.title.get}",
                           | "creators": [ ],
                           | "identifiers": [ ],
@@ -673,13 +673,13 @@ class ApiWorksTest extends ApiWorksTestBase {
 
     eventually {
       server.httpGet(
-        path = s"/$apiPrefix/works/${work.id}",
+        path = s"/$apiPrefix/works/${work.canonicalId}",
         andExpect = Status.Ok,
         withJsonBody = s"""
                           |{
                           | "@context": "https://localhost:8888/$apiPrefix/context.json",
                           | "type": "Work",
-                          | "id": "${work.id}",
+                          | "id": "${work.canonicalId}",
                           | "title": "${work.title.get}",
                           | "creators": [ ],
                           | "subjects": [ ],
@@ -692,13 +692,13 @@ class ApiWorksTest extends ApiWorksTestBase {
 
     eventually {
       server.httpGet(
-        path = s"/$apiPrefix/works/${work_alt.id}?_index=alt_records",
+        path = s"/$apiPrefix/works/${work_alt.canonicalId}?_index=alt_records",
         andExpect = Status.Ok,
         withJsonBody = s"""
                           |{
                           | "@context": "https://localhost:8888/$apiPrefix/context.json",
                           | "type": "Work",
-                          | "id": "${work_alt.id}",
+                          | "id": "${work_alt.canonicalId}",
                           | "title": "${work_alt.title.get}",
                           | "creators": [ ],
                           | "subjects": [ ],
@@ -734,7 +734,7 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |  "results": [
                           |   {
                           |     "type": "Work",
-                          |     "id": "${work.id}",
+                          |     "id": "${work.canonicalId}",
                           |     "title": "${work.title.get}",
                           |     "creators": [ ],
                           |     "subjects": [ ],
@@ -757,7 +757,7 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |  "results": [
                           |   {
                           |     "type": "Work",
-                          |     "id": "${work_alt.id}",
+                          |     "id": "${work_alt.canonicalId}",
                           |     "title": "${work_alt.title.get}",
                           |     "creators": [ ],
                           |     "subjects": [ ],
@@ -839,7 +839,7 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |  "results": [
                           |   {
                           |     "type": "Work",
-                          |     "id": "${work.id}",
+                          |     "id": "${work.canonicalId}",
                           |     "title": "${work.title.get}",
                           |     "creators": [ ],
                           |     "subjects": [ ],
@@ -876,7 +876,7 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |  "results": [
                           |   {
                           |     "type": "Work",
-                          |     "id": "${work.id}",
+                          |     "id": "${work.canonicalId}",
                           |     "title": "${work.title.get}",
                           |     "creators": [ ],
                           |     "subjects": [ ],

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
@@ -175,7 +175,7 @@ class ApiWorksTest extends ApiWorksTestBase {
       license = License_CCBY
     )
     val item = Item(
-      canonicalId = Some("chu27a8"),
+      canonicalId = "chu27a8",
       sourceIdentifier = sourceIdentifier,
       identifiers = List(),
       locations = List(location)
@@ -183,7 +183,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     val workWithCopyright = Work(title = Some("A scarf on a squirrel"),
                                  sourceIdentifier = sourceIdentifier,
                                  version = 1,
-                                 canonicalId = Some("yxh928a"),
+                                 canonicalId = "yxh928a",
                                  items = List(item))
     insertIntoElasticSearch(workWithCopyright)
 
@@ -469,7 +469,7 @@ class ApiWorksTest extends ApiWorksTestBase {
       sourceIdentifier = sourceIdentifier,
       version = 1,
       identifiers = List(),
-      canonicalId = Some("test_subject1"),
+      canonicalId = "test_subject1",
       subjects = List(Concept("fish"), Concept("gardening"))
     )
     insertIntoElasticSearch(workWithSubjects)
@@ -504,7 +504,7 @@ class ApiWorksTest extends ApiWorksTestBase {
       sourceIdentifier = sourceIdentifier,
       version = 1,
       identifiers = List(),
-      canonicalId = Some("test_subject1"),
+      canonicalId = "test_subject1",
       genres = List(Concept("woodwork"), Concept("etching"))
     )
     insertIntoElasticSearch(workWithSubjects)

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
@@ -180,11 +180,12 @@ class ApiWorksTest extends ApiWorksTestBase {
       identifiers = List(),
       locations = List(location)
     )
-    val workWithCopyright = IdentifiedWork(title = Some("A scarf on a squirrel"),
-                                 sourceIdentifier = sourceIdentifier,
-                                 version = 1,
-                                 canonicalId = "yxh928a",
-                                 items = List(item))
+    val workWithCopyright = IdentifiedWork(title =
+                                             Some("A scarf on a squirrel"),
+                                           sourceIdentifier = sourceIdentifier,
+                                           version = 1,
+                                           canonicalId = "yxh928a",
+                                           items = List(item))
     insertIntoElasticSearch(workWithCopyright)
 
     eventually {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -17,7 +17,7 @@ class ApiWorksTestBase
   val indexName = "works"
   val itemType = "work"
 
-  implicit val jsonMapper = Work
+  implicit val jsonMapper = IdentifiedWork
   override val server =
     new EmbeddedHttpServer(
       new Server,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -42,11 +42,11 @@ class ApiWorksTestBase
     |  "results": []
     |}""".stripMargin
 
-  def items(its: List[Item]) =
+  def items(its: List[IdentifiedItem]) =
     its
       .map { it =>
         s"""{
-          "id": "${it.canonicalId.get}",
+          "id": "${it.canonicalId}",
           "type": "${it.ontologyType}",
           "locations": [
             ${locations(it.locations)}

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestInvisible.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.api.works
 
 import com.twitter.finagle.http.Status
-import uk.ac.wellcome.models.Work
+import uk.ac.wellcome.models.IdentifiedWork
 
 class ApiWorksTestInvisible extends ApiWorksTestBase {
 
@@ -34,7 +34,7 @@ class ApiWorksTestInvisible extends ApiWorksTestBase {
     // Then we index two ordinary works into Elasticsearch.
     val works = createWorks(2)
 
-    val worksToIndex: Seq[Work] = Seq[Work](deletedWork) ++ works
+    val worksToIndex = Seq[IdentifiedWork](deletedWork) ++ works
     insertIntoElasticSearch(worksToIndex: _*)
 
     eventually {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestInvisible.scala
@@ -16,7 +16,7 @@ class ApiWorksTestInvisible extends ApiWorksTestBase {
 
     eventually {
       server.httpGet(
-        path = s"/$apiPrefix/works/${work.canonicalId.get}",
+        path = s"/$apiPrefix/works/${work.canonicalId}",
         andExpect = Status.Gone,
         withJsonBody = gone
       )
@@ -47,7 +47,7 @@ class ApiWorksTestInvisible extends ApiWorksTestBase {
           |  "results": [
           |   {
           |     "type": "Work",
-          |     "id": "${works(0).id}",
+          |     "id": "${works(0).canonicalId}",
           |     "title": "${works(0).title.get}",
           |     "description": "${works(0).description.get}",
           |     "lettering": "${works(0).lettering.get}",
@@ -59,7 +59,7 @@ class ApiWorksTestInvisible extends ApiWorksTestBase {
           |   },
           |   {
           |     "type": "Work",
-          |     "id": "${works(1).id}",
+          |     "id": "${works(1).canonicalId}",
           |     "title": "${works(1).title.get}",
           |     "description": "${works(1).description.get}",
           |     "lettering": "${works(1).lettering.get}",
@@ -98,7 +98,7 @@ class ApiWorksTestInvisible extends ApiWorksTestBase {
           |  "results": [
           |   {
           |     "type": "Work",
-          |     "id": "${work.id}",
+          |     "id": "${work.canonicalId}",
           |     "title": "${work.title.get}",
           |     "creators": [],
           |     "subjects": [ ],

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/LocationsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/LocationsTest.scala
@@ -14,7 +14,7 @@ class LocationsTest extends ApiWorksTestBase {
       version = 1,
       title = Some("A zoo of zebras doing zumba"),
       items = List(
-        Item(canonicalId = "mhberjwy7",
+        IdentifiedItem(canonicalId = "mhberjwy7",
              sourceIdentifier = sourceIdentifier,
              locations = List(physicalLocation)))
     )
@@ -23,13 +23,13 @@ class LocationsTest extends ApiWorksTestBase {
 
     eventually {
       server.httpGet(
-        path = s"/$apiPrefix/works/${work.canonicalId.get}?includes=items",
+        path = s"/$apiPrefix/works/${work.canonicalId}?includes=items",
         andExpect = Status.Ok,
         withJsonBody = s"""
                           |{
                           | "@context": "https://localhost:8888/$apiPrefix/context.json",
                           | "type": "Work",
-                          | "id": "${work.canonicalId.get}",
+                          | "id": "${work.canonicalId}",
                           | "title": "${work.title.get}",
                           | "creators": [ ],
                           | "items": [ ${items(work.items)} ],

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/LocationsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/LocationsTest.scala
@@ -15,8 +15,8 @@ class LocationsTest extends ApiWorksTestBase {
       title = Some("A zoo of zebras doing zumba"),
       items = List(
         IdentifiedItem(canonicalId = "mhberjwy7",
-             sourceIdentifier = sourceIdentifier,
-             locations = List(physicalLocation)))
+                       sourceIdentifier = sourceIdentifier,
+                       locations = List(physicalLocation)))
     )
 
     insertIntoElasticSearch(work)

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/LocationsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/LocationsTest.scala
@@ -8,7 +8,7 @@ class LocationsTest extends ApiWorksTestBase {
     val physicalLocation: Location =
       PhysicalLocation(locationType = "smeg",
                        label = "a stack of slick slimes")
-    val work = Work(
+    val work = IdentifiedWork(
       canonicalId = Some("zm9q6c6h"),
       sourceIdentifier = sourceIdentifier,
       version = 1,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/LocationsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/LocationsTest.scala
@@ -9,12 +9,12 @@ class LocationsTest extends ApiWorksTestBase {
       PhysicalLocation(locationType = "smeg",
                        label = "a stack of slick slimes")
     val work = IdentifiedWork(
-      canonicalId = Some("zm9q6c6h"),
+      canonicalId = "zm9q6c6h",
       sourceIdentifier = sourceIdentifier,
       version = 1,
       title = Some("A zoo of zebras doing zumba"),
       items = List(
-        Item(canonicalId = Some("mhberjwy7"),
+        Item(canonicalId = "mhberjwy7",
              sourceIdentifier = sourceIdentifier,
              locations = List(physicalLocation)))
     )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/PublishersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/PublishersTest.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.models.{Agent, Organisation, Work}
 class PublishersTest extends ApiWorksTestBase {
 
   it("includes an empty publishers field if the work has no publishers") {
-    val work = Work(
+    val work = IdentifiedWork(
       canonicalId = Some("zm9q6c6h"),
       sourceIdentifier = sourceIdentifier,
       version = 1,
@@ -41,7 +41,7 @@ class PublishersTest extends ApiWorksTestBase {
   }
 
   it("includes the publishers field for agent publishers") {
-    val work = Work(
+    val work = IdentifiedWork(
       canonicalId = Some("patkj4ds"),
       sourceIdentifier = sourceIdentifier,
       version = 1,
@@ -88,7 +88,7 @@ class PublishersTest extends ApiWorksTestBase {
   }
 
   it("includes the publishers field with a mixture of agents/organisations") {
-    val work = Work(
+    val work = IdentifiedWork(
       canonicalId = Some("v9w6cz66"),
       sourceIdentifier = sourceIdentifier,
       version = 1,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/PublishersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/PublishersTest.scala
@@ -7,7 +7,7 @@ class PublishersTest extends ApiWorksTestBase {
 
   it("includes an empty publishers field if the work has no publishers") {
     val work = IdentifiedWork(
-      canonicalId = Some("zm9q6c6h"),
+      canonicalId = "zm9q6c6h",
       sourceIdentifier = sourceIdentifier,
       version = 1,
       title = Some("A zoo of zebras doing zumba"),
@@ -42,7 +42,7 @@ class PublishersTest extends ApiWorksTestBase {
 
   it("includes the publishers field for agent publishers") {
     val work = IdentifiedWork(
-      canonicalId = Some("patkj4ds"),
+      canonicalId = "patkj4ds",
       sourceIdentifier = sourceIdentifier,
       version = 1,
       title = Some("A party of purple panthers in Paris"),
@@ -89,7 +89,7 @@ class PublishersTest extends ApiWorksTestBase {
 
   it("includes the publishers field with a mixture of agents/organisations") {
     val work = IdentifiedWork(
-      canonicalId = Some("v9w6cz66"),
+      canonicalId = "v9w6cz66",
       sourceIdentifier = sourceIdentifier,
       version = 1,
       title = Some("Vultures vying for victory"),

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/PublishersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/PublishersTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.api.works
 
 import com.twitter.finagle.http.Status
-import uk.ac.wellcome.models.{Agent, Organisation, Work}
+import uk.ac.wellcome.models.{Agent, IdentifiedWork, Organisation}
 
 class PublishersTest extends ApiWorksTestBase {
 
@@ -26,7 +26,7 @@ class PublishersTest extends ApiWorksTestBase {
           |  "results": [
           |    {
           |      "type": "Work",
-          |      "id": "${work.id}",
+          |      "id": "${work}",
           |      "title": "${work.title.get}",
           |      "creators": [ ],
           |      "subjects": [ ],
@@ -64,7 +64,7 @@ class PublishersTest extends ApiWorksTestBase {
           |  "results": [
           |    {
           |      "type": "Work",
-          |      "id": "${work.id}",
+          |      "id": "${work}",
           |      "title": "${work.title.get}",
           |      "creators": [ ],
           |      "subjects": [ ],
@@ -111,7 +111,7 @@ class PublishersTest extends ApiWorksTestBase {
           |  "results": [
           |    {
           |      "type": "Work",
-          |      "id": "${work.id}",
+          |      "id": "${work.canonicalId}",
           |      "title": "${work.title.get}",
           |      "creators": [ ],
           |      "subjects": [ ],

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/PublishersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/PublishersTest.scala
@@ -26,7 +26,7 @@ class PublishersTest extends ApiWorksTestBase {
           |  "results": [
           |    {
           |      "type": "Work",
-          |      "id": "${work}",
+          |      "id": "${work.canonicalId}",
           |      "title": "${work.title.get}",
           |      "creators": [ ],
           |      "subjects": [ ],
@@ -64,7 +64,7 @@ class PublishersTest extends ApiWorksTestBase {
           |  "results": [
           |    {
           |      "type": "Work",
-          |      "id": "${work}",
+          |      "id": "${work.canonicalId}",
           |      "title": "${work.title.get}",
           |      "creators": [ ],
           |      "subjects": [ ],

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -35,9 +35,9 @@ class IdMinterFeatureTest
       SourceIdentifier(IdentifierSchemes.miroImageNumber, miroID)
 
     val work = UnidentifiedWork(title = Some(title),
-                    sourceIdentifier = identifier,
-                    version = 1,
-                    identifiers = List(identifier))
+                                sourceIdentifier = identifier,
+                                version = 1,
+                                identifiers = List(identifier))
 
     val sqsMessage = SQSMessage(
       Some("subject"),

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -34,7 +34,7 @@ class IdMinterFeatureTest
     val identifier =
       SourceIdentifier(IdentifierSchemes.miroImageNumber, miroID)
 
-    val work = Work(title = Some(title),
+    val work = UnidentifiedWork(title = Some(title),
                     sourceIdentifier = identifier,
                     version = 1,
                     identifiers = List(identifier))
@@ -53,7 +53,7 @@ class IdMinterFeatureTest
     )
 
     def getWorksFromMessages(messages: Seq[MessageInfo]) =
-      messages.map(m => fromJson[Work](m.message).get)
+      messages.map(m => fromJson[IdentifiedWork](m.message).get)
 
     sendMessage
 

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -169,7 +169,7 @@ class IdEmbedderTests
     )
 
     whenReady(eventualWork) { json =>
-      val work = fromJson[UnidentifiedWork](json.toString()).get
+      val work = fromJson[IdentifiedWork](json.toString()).get
 
       val actualItem1 = work.items.head
       val actualItem2 = work.items.tail.head

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -47,8 +47,8 @@ class IdEmbedderTests
     )
 
     val originalWork = UnidentifiedWork(title = Some("crap"),
-                            sourceIdentifier = identifier,
-                            version = 1)
+                                        sourceIdentifier = identifier,
+                                        version = 1)
 
     val newCanonicalId = "5467"
 
@@ -86,8 +86,8 @@ class IdEmbedderTests
     )
 
     val originalWork = UnidentifiedWork(title = Some("crap"),
-                            sourceIdentifier = identifier,
-                            version = 1)
+                                        sourceIdentifier = identifier,
+                                        version = 1)
 
     val expectedException = new Exception("Aaaaah something happened!")
 
@@ -127,9 +127,10 @@ class IdEmbedderTests
     )
 
     val originalWork = UnidentifiedWork(title = Some("crap"),
-                            sourceIdentifier = identifier,
-                            version = 1,
-                            items = List(originalItem1, originalItem2))
+                                        sourceIdentifier = identifier,
+                                        version = 1,
+                                        items =
+                                          List(originalItem1, originalItem2))
 
     val newItemCanonicalId1 = "item1-canonical-id"
     val newItemCanonicalId2 = "item2-canonical-id"

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -46,7 +46,7 @@ class IdEmbedderTests
       value = "1234"
     )
 
-    val originalWork = Work(title = Some("crap"),
+    val originalWork = UnidentifiedWork(title = Some("crap"),
                             sourceIdentifier = identifier,
                             version = 1,
                             canonicalId = None)
@@ -81,7 +81,7 @@ class IdEmbedderTests
       value = "1234"
     )
 
-    val originalWork = Work(title = Some("crap"),
+    val originalWork = UnidentifiedWork(title = Some("crap"),
                             sourceIdentifier = identifier,
                             version = 1,
                             canonicalId = None)
@@ -125,7 +125,7 @@ class IdEmbedderTests
       locations = List()
     )
 
-    val originalWork = Work(title = Some("crap"),
+    val originalWork = UnidentifiedWork(title = Some("crap"),
                             sourceIdentifier = identifier,
                             version = 1,
                             canonicalId = None,
@@ -167,7 +167,7 @@ class IdEmbedderTests
     )
 
     whenReady(eventualWork) { json =>
-      val work = fromJson[Work](json.toString()).get
+      val work = fromJson[UnidentifiedWork](json.toString()).get
 
       val actualItem1 = work.items.head
       val actualItem2 = work.items.tail.head

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -10,7 +10,7 @@ import org.scalatest.time._
 import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.metrics.MetricsSender
-import uk.ac.wellcome.models.{IdentifierSchemes, Item, SourceIdentifier, Work}
+import uk.ac.wellcome.models._
 import uk.ac.wellcome.test.utils.JsonTestUtil
 
 import scala.util.Try
@@ -48,8 +48,7 @@ class IdEmbedderTests
 
     val originalWork = UnidentifiedWork(title = Some("crap"),
                             sourceIdentifier = identifier,
-                            version = 1,
-                            canonicalId = None)
+                            version = 1)
 
     val newCanonicalId = "5467"
 
@@ -65,7 +64,12 @@ class IdEmbedderTests
       ).right.get
     )
 
-    val expectedWork = originalWork.copy(canonicalId = Some(newCanonicalId))
+    val expectedWork = IdentifiedWork(
+      canonicalId = newCanonicalId,
+      title = originalWork.title,
+      sourceIdentifier = originalWork.sourceIdentifier,
+      version = originalWork.version
+    )
 
     whenReady(newWorkFuture) { newWorkJson =>
       assertJsonStringsAreEqual(
@@ -83,8 +87,7 @@ class IdEmbedderTests
 
     val originalWork = UnidentifiedWork(title = Some("crap"),
                             sourceIdentifier = identifier,
-                            version = 1,
-                            canonicalId = None)
+                            version = 1)
 
     val expectedException = new Exception("Aaaaah something happened!")
 
@@ -110,14 +113,12 @@ class IdEmbedderTests
       value = "1234"
     )
 
-    val originalItem1 = Item(
-      canonicalId = None,
+    val originalItem1 = UnidentifiedItem(
       sourceIdentifier = identifier,
       locations = List()
     )
 
-    val originalItem2 = Item(
-      canonicalId = None,
+    val originalItem2 = UnidentifiedItem(
       sourceIdentifier = SourceIdentifier(
         IdentifierSchemes.miroImageNumber,
         value = "1235"
@@ -128,7 +129,6 @@ class IdEmbedderTests
     val originalWork = UnidentifiedWork(title = Some("crap"),
                             sourceIdentifier = identifier,
                             version = 1,
-                            canonicalId = None,
                             items = List(originalItem1, originalItem2))
 
     val newItemCanonicalId1 = "item1-canonical-id"
@@ -158,12 +158,14 @@ class IdEmbedderTests
       ).right.get
     )
 
-    val expectedItem1 = originalItem1.copy(
-      canonicalId = Some(newItemCanonicalId1)
+    val expectedItem1 = IdentifiedItem(
+      sourceIdentifier = originalItem1.sourceIdentifier,
+      canonicalId = newItemCanonicalId1
     )
 
-    val expectedItem2 = originalItem2.copy(
-      canonicalId = Some(newItemCanonicalId2)
+    val expectedItem2 = IdentifiedItem(
+      sourceIdentifier = originalItem2.sourceIdentifier,
+      canonicalId = newItemCanonicalId2
     )
 
     whenReady(eventualWork) { json =>

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -26,10 +26,6 @@ class IdentifierGeneratorTest
                       mock[AmazonCloudWatch],
                       ActorSystem())
 
-  private val knownIdentifierSchemes =
-    List(IdentifierSchemes.miroImageNumber,
-         IdentifierSchemes.sierraSystemNumber)
-
   val identifierGenerator = new IdentifierGenerator(
     new IdentifiersDao(DB.connect(), identifiersTable),
     metricsSender

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdMinterTestUtils.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdMinterTestUtils.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.platform.idminter.utils
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.{Matchers, Suite}
 import uk.ac.wellcome.utils.JsonUtil._
-import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, UnidentifiedWork}
+import uk.ac.wellcome.models.{
+  IdentifierSchemes,
+  SourceIdentifier,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.platform.idminter.Server
 import uk.ac.wellcome.test.utils.{AmazonCloudWatchFlag, SNSLocal, SQSLocal}
@@ -40,10 +44,11 @@ trait IdMinterTestUtils
     val identifier =
       SourceIdentifier(IdentifierSchemes.miroImageNumber, MiroID)
 
-    val work = UnidentifiedWork(title = Some("A query about a queue of quails"),
-                    sourceIdentifier = identifier,
-                    version = 1,
-                    identifiers = List(identifier))
+    val work = UnidentifiedWork(
+      title = Some("A query about a queue of quails"),
+      sourceIdentifier = identifier,
+      version = 1,
+      identifiers = List(identifier))
 
     SQSMessage(Some("subject"),
                JsonUtil.toJson(work).get,

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdMinterTestUtils.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdMinterTestUtils.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.idminter.utils
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.{Matchers, Suite}
 import uk.ac.wellcome.utils.JsonUtil._
-import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, Work}
+import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, UnidentifiedWork}
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.platform.idminter.Server
 import uk.ac.wellcome.test.utils.{AmazonCloudWatchFlag, SNSLocal, SQSLocal}
@@ -40,7 +40,7 @@ trait IdMinterTestUtils
     val identifier =
       SourceIdentifier(IdentifierSchemes.miroImageNumber, MiroID)
 
-    val work = Work(title = Some("A query about a queue of quails"),
+    val work = UnidentifiedWork(title = Some("A query about a queue of quails"),
                     sourceIdentifier = identifier,
                     version = 1,
                     identifiers = List(identifier))

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -5,7 +5,7 @@ import com.google.inject.Inject
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
-import uk.ac.wellcome.models.Work
+import uk.ac.wellcome.models.IdentifiedWork
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.sqs.{SQSReader, SQSWorker}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -21,7 +21,7 @@ class IngestorWorkerService @Inject()(
 
   override def processMessage(message: SQSMessage): Future[Unit] =
     for {
-      work <- Future.fromTry(fromJson[Work](message.body))
+      work <- Future.fromTry(fromJson[IdentifiedWork](message.body))
       _ <- identifiedWorkIndexer.indexWork(work = work)
     } yield ()
 }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -51,7 +51,9 @@ class WorkIndexer @Inject()(
                 s"Trying to ingest work ${work.canonicalId} with older version: skipping.")
               ()
             case e: Throwable =>
-              error(s"Error indexing work ${work.canonicalId} into Elasticsearch", e)
+              error(
+                s"Error indexing work ${work.canonicalId} into Elasticsearch",
+                e)
               throw e
           }
       }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -33,14 +33,14 @@ class WorkIndexer @Inject()(
     metricsSender.timeAndCount[Any](
       "ingestor-index-work",
       () => {
-        info(s"Indexing work ${work.id}")
+        info(s"Indexing work ${work.canonicalId}")
 
         elasticClient
           .execute {
             indexInto(esIndex / esType)
               .version(work.version)
               .versionType(VersionType.EXTERNAL_GTE)
-              .id(work.id)
+              .id(work.canonicalId)
               .doc(work)
           }
           .recover {
@@ -48,10 +48,10 @@ class WorkIndexer @Inject()(
                 if getErrorType(e).contains(
                   "version_conflict_engine_exception") =>
               warn(
-                s"Trying to ingest work ${work.id} with older version: skipping.")
+                s"Trying to ingest work ${work.canonicalId} with older version: skipping.")
               ()
             case e: Throwable =>
-              error(s"Error indexing work ${work.id} into Elasticsearch", e)
+              error(s"Error indexing work ${work.canonicalId} into Elasticsearch", e)
               throw e
           }
       }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -11,7 +11,7 @@ import org.elasticsearch.client.ResponseException
 import org.elasticsearch.index.VersionType
 import uk.ac.wellcome.elasticsearch.ElasticsearchExceptionManager
 import uk.ac.wellcome.metrics.MetricsSender
-import uk.ac.wellcome.models.Work
+import uk.ac.wellcome.models.IdentifiedWork
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.Future
@@ -25,10 +25,10 @@ class WorkIndexer @Inject()(
 ) extends Logging
     with ElasticsearchExceptionManager {
 
-  def indexWork(work: Work): Future[Any] = {
+  def indexWork(work: IdentifiedWork): Future[Any] = {
 
     // This is required for elastic4s, not Circe
-    implicit val jsonMapper = Work
+    implicit val jsonMapper = IdentifiedWork
 
     metricsSender.timeAndCount[Any](
       "ingestor-index-work",

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, Work}
+import uk.ac.wellcome.models.{IdentifiedWork, IdentifierSchemes, SourceIdentifier}
 import uk.ac.wellcome.platform.ingestor.test.utils.Ingestor
 import uk.ac.wellcome.test.utils.JsonTestUtil
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -34,11 +34,11 @@ class IngestorFeatureTest
 
     val workString = JsonUtil
       .toJson(
-        Work(title = Some("A type of a tame turtle"),
+        IdentifiedWork(title = Some("A type of a tame turtle"),
              sourceIdentifier = sourceIdentifier,
              version = 1,
              identifiers = List(sourceIdentifier),
-             canonicalId = Some("1234"))
+             canonicalId = "1234")
       )
       .get
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -7,7 +7,11 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.models.{IdentifiedWork, IdentifierSchemes, SourceIdentifier}
+import uk.ac.wellcome.models.{
+  IdentifiedWork,
+  IdentifierSchemes,
+  SourceIdentifier
+}
 import uk.ac.wellcome.platform.ingestor.test.utils.Ingestor
 import uk.ac.wellcome.test.utils.JsonTestUtil
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -35,10 +39,10 @@ class IngestorFeatureTest
     val workString = JsonUtil
       .toJson(
         IdentifiedWork(title = Some("A type of a tame turtle"),
-             sourceIdentifier = sourceIdentifier,
-             version = 1,
-             identifiers = List(sourceIdentifier),
-             canonicalId = "1234")
+                       sourceIdentifier = sourceIdentifier,
+                       version = 1,
+                       identifiers = List(sourceIdentifier),
+                       canonicalId = "1234")
       )
       .get
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/Ingestor.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/Ingestor.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.ingestor.test.utils
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.{BeforeAndAfterEach, Suite}
-import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, Work}
+import uk.ac.wellcome.models.{IdentifiedWork, IdentifierSchemes, SourceIdentifier}
 import uk.ac.wellcome.platform.ingestor.Server
 import uk.ac.wellcome.test.utils.{
   AmazonCloudWatchFlag,
@@ -42,7 +42,7 @@ trait Ingestor
     )
   }
 
-  def assertElasticsearchEventuallyHasWork(work: Work) = {
+  def assertElasticsearchEventuallyHasWork(work: IdentifiedWork) = {
     val workJson = toJson(work).get
 
     eventually {
@@ -61,17 +61,17 @@ trait Ingestor
                  sourceId: String,
                  title: String,
                  visible: Boolean = true,
-                 version: Int = 1): Work = {
+                 version: Int = 1): IdentifiedWork = {
     val sourceIdentifier = SourceIdentifier(
       IdentifierSchemes.miroImageNumber,
       sourceId
     )
 
-    Work(title = Some(title),
+    IdentifiedWork(title = Some(title),
          sourceIdentifier = sourceIdentifier,
          version = version,
          identifiers = List(sourceIdentifier),
-         canonicalId = Some(canonicalId),
+         canonicalId = canonicalId,
          visible = visible)
   }
 }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/Ingestor.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/Ingestor.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.platform.ingestor.test.utils
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.{BeforeAndAfterEach, Suite}
-import uk.ac.wellcome.models.{IdentifiedWork, IdentifierSchemes, SourceIdentifier}
+import uk.ac.wellcome.models.{
+  IdentifiedWork,
+  IdentifierSchemes,
+  SourceIdentifier
+}
 import uk.ac.wellcome.platform.ingestor.Server
 import uk.ac.wellcome.test.utils.{
   AmazonCloudWatchFlag,
@@ -68,10 +72,10 @@ trait Ingestor
     )
 
     IdentifiedWork(title = Some(title),
-         sourceIdentifier = sourceIdentifier,
-         version = version,
-         identifiers = List(sourceIdentifier),
-         canonicalId = canonicalId,
-         visible = visible)
+                   sourceIdentifier = sourceIdentifier,
+                   version = version,
+                   identifiers = List(sourceIdentifier),
+                   canonicalId = canonicalId,
+                   visible = visible)
   }
 }

--- a/catalogue_pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
+++ b/catalogue_pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import com.google.inject.Inject
 import io.circe.Decoder
 import uk.ac.wellcome.metrics.MetricsSender
-import uk.ac.wellcome.models.Work
+import uk.ac.wellcome.models.UnidentifiedWork
 import uk.ac.wellcome.sqs.{SQSReader, SQSWorkerToDynamo}
 import uk.ac.wellcome.utils.JsonUtil._
 
@@ -14,11 +14,11 @@ class RecorderWorkerService @Inject()(
   reader: SQSReader,
   system: ActorSystem,
   metrics: MetricsSender
-) extends SQSWorkerToDynamo[Work](reader, system, metrics) {
+) extends SQSWorkerToDynamo[UnidentifiedWork](reader, system, metrics) {
 
-  override implicit val decoder = implicitly[Decoder[Work]]
+  override implicit val decoder = implicitly[Decoder[UnidentifiedWork]]
 
-  override def store(work: Work): Future[Unit] =
+  override def store(work: UnidentifiedWork): Future[Unit] =
     Future.successful(())
 
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
@@ -7,11 +7,21 @@ import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.{UnidentifiedWork, Work}
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.models.transformable.{CalmTransformable, MiroTransformable, SierraTransformable, Transformable}
+import uk.ac.wellcome.models.transformable.{
+  CalmTransformable,
+  MiroTransformable,
+  SierraTransformable,
+  Transformable
+}
 import uk.ac.wellcome.s3.SourcedObjectStore
 import uk.ac.wellcome.sns.{PublishAttempt, SNSWriter}
 import uk.ac.wellcome.storage.HybridRecord
-import uk.ac.wellcome.transformer.transformers.{CalmTransformableTransformer, MiroTransformableTransformer, SierraTransformableTransformer, TransformableTransformer}
+import uk.ac.wellcome.transformer.transformers.{
+  CalmTransformableTransformer,
+  MiroTransformableTransformer,
+  SierraTransformableTransformer,
+  TransformableTransformer
+}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.utils.JsonUtil._
@@ -60,8 +70,9 @@ class SQSMessageReceiver @Inject()(snsWriter: SNSWriter,
     }
   }
 
-  private def transformTransformable(transformable: Transformable,
-                                     version: Int): Try[Option[UnidentifiedWork]] = {
+  private def transformTransformable(
+    transformable: Transformable,
+    version: Int): Try[Option[UnidentifiedWork]] = {
     val transformableTransformer = chooseTransformer(transformable)
     transformableTransformer.transform(transformable, version) map {
       transformed =>

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
@@ -5,23 +5,13 @@ import com.twitter.inject.Logging
 import io.circe.ParsingFailure
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
-import uk.ac.wellcome.models.Work
+import uk.ac.wellcome.models.{UnidentifiedWork, Work}
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.models.transformable.{
-  CalmTransformable,
-  MiroTransformable,
-  SierraTransformable,
-  Transformable
-}
+import uk.ac.wellcome.models.transformable.{CalmTransformable, MiroTransformable, SierraTransformable, Transformable}
 import uk.ac.wellcome.s3.SourcedObjectStore
 import uk.ac.wellcome.sns.{PublishAttempt, SNSWriter}
 import uk.ac.wellcome.storage.HybridRecord
-import uk.ac.wellcome.transformer.transformers.{
-  CalmTransformableTransformer,
-  MiroTransformableTransformer,
-  SierraTransformableTransformer,
-  TransformableTransformer
-}
+import uk.ac.wellcome.transformer.transformers.{CalmTransformableTransformer, MiroTransformableTransformer, SierraTransformableTransformer, TransformableTransformer}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.utils.JsonUtil._
@@ -71,7 +61,7 @@ class SQSMessageReceiver @Inject()(snsWriter: SNSWriter,
   }
 
   private def transformTransformable(transformable: Transformable,
-                                     version: Int): Try[Option[Work]] = {
+                                     version: Int): Try[Option[UnidentifiedWork]] = {
     val transformableTransformer = chooseTransformer(transformable)
     transformableTransformer.transform(transformable, version) map {
       transformed =>
@@ -93,7 +83,7 @@ class SQSMessageReceiver @Inject()(snsWriter: SNSWriter,
   }
 
   private def publishMessage(
-    maybeWork: Option[Work]): Future[Option[PublishAttempt]] =
+    maybeWork: Option[UnidentifiedWork]): Future[Option[PublishAttempt]] =
     maybeWork.fold(Future.successful(None: Option[PublishAttempt])) { work =>
       snsWriter
         .writeMessage(

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/CalmTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/CalmTransformableTransformer.scala
@@ -1,11 +1,7 @@
 package uk.ac.wellcome.transformer.transformers
 
-import uk.ac.wellcome.models.transformable.{
-  CalmTransformable,
-  CalmTransformableData,
-  Transformable
-}
 import uk.ac.wellcome.models._
+import uk.ac.wellcome.models.transformable.{CalmTransformable, CalmTransformableData}
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.util.Try
@@ -13,12 +9,12 @@ import scala.util.Try
 class CalmTransformableTransformer
     extends TransformableTransformer[CalmTransformable] {
   override def transformForType(calmTransformable: CalmTransformable,
-                                version: Int): Try[Option[Work]] =
+                                version: Int): Try[Option[UnidentifiedWork]] =
     fromJson[CalmTransformableData](calmTransformable.data)
       .map(
         _ =>
           Some(
-            Work(
+            UnidentifiedWork(
               title = Some("placeholder title for a Calm record"),
               sourceIdentifier = SourceIdentifier(
                 IdentifierSchemes.calmPlaceholder,

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/CalmTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/CalmTransformableTransformer.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.transformer.transformers
 
 import uk.ac.wellcome.models._
-import uk.ac.wellcome.models.transformable.{CalmTransformable, CalmTransformableData}
+import uk.ac.wellcome.models.transformable.{
+  CalmTransformable,
+  CalmTransformableData
+}
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.util.Try

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformer.scala
@@ -31,29 +31,31 @@ class MiroTransformableTransformer
     toMap[String](Source.fromInputStream(stream).mkString).get
 
   override def transformForType(miroTransformable: MiroTransformable,
-                                version: Int): Try[Option[UnidentifiedWork]] = Try {
+                                version: Int): Try[Option[UnidentifiedWork]] =
+    Try {
 
-    val miroData = MiroTransformableData.create(miroTransformable.data)
-    val (title, description) = getTitleAndDescription(miroData)
+      val miroData = MiroTransformableData.create(miroTransformable.data)
+      val (title, description) = getTitleAndDescription(miroData)
 
-    Some(
-      UnidentifiedWork(
-        title = Some(title),
-        sourceIdentifier = SourceIdentifier(IdentifierSchemes.miroImageNumber,
-                                            miroTransformable.sourceId),
-        version = version,
-        identifiers = getIdentifiers(miroData, miroTransformable.sourceId),
-        description = description,
-        lettering = miroData.suppLettering,
-        createdDate =
-          getCreatedDate(miroData, miroTransformable.MiroCollection),
-        subjects = getSubjects(miroData),
-        creators = getCreators(miroData),
-        genres = getGenres(miroData),
-        thumbnail = Some(getThumbnail(miroData, miroTransformable.sourceId)),
-        items = getItems(miroData, miroTransformable.sourceId)
-      ))
-  }
+      Some(
+        UnidentifiedWork(
+          title = Some(title),
+          sourceIdentifier =
+            SourceIdentifier(IdentifierSchemes.miroImageNumber,
+                             miroTransformable.sourceId),
+          version = version,
+          identifiers = getIdentifiers(miroData, miroTransformable.sourceId),
+          description = description,
+          lettering = miroData.suppLettering,
+          createdDate =
+            getCreatedDate(miroData, miroTransformable.MiroCollection),
+          subjects = getSubjects(miroData),
+          creators = getCreators(miroData),
+          genres = getGenres(miroData),
+          thumbnail = Some(getThumbnail(miroData, miroTransformable.sourceId)),
+          items = getItems(miroData, miroTransformable.sourceId)
+        ))
+    }
 
   /*
    * Populate the title and description.  The rules are as follows:

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformer.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.transformer.transformers
 import java.io.InputStream
 
 import uk.ac.wellcome.models._
-import uk.ac.wellcome.models.transformable.{MiroTransformable, Transformable}
+import uk.ac.wellcome.models.transformable.MiroTransformable
 import uk.ac.wellcome.transformer.source.MiroTransformableData
 import uk.ac.wellcome.utils.JsonUtil._
 
@@ -31,13 +31,13 @@ class MiroTransformableTransformer
     toMap[String](Source.fromInputStream(stream).mkString).get
 
   override def transformForType(miroTransformable: MiroTransformable,
-                                version: Int): Try[Option[Work]] = Try {
+                                version: Int): Try[Option[UnidentifiedWork]] = Try {
 
     val miroData = MiroTransformableData.create(miroTransformable.data)
     val (title, description) = getTitleAndDescription(miroData)
 
     Some(
-      Work(
+      UnidentifiedWork(
         title = Some(title),
         sourceIdentifier = SourceIdentifier(IdentifierSchemes.miroImageNumber,
                                             miroTransformable.sourceId),
@@ -302,9 +302,9 @@ class MiroTransformableTransformer
   }
 
   private def getItems(miroData: MiroTransformableData,
-                       miroId: String): List[Item] = {
+                       miroId: String): List[UnidentifiedItem] = {
     List(
-      Item(
+      UnidentifiedItem(
         sourceIdentifier =
           SourceIdentifier(IdentifierSchemes.miroImageNumber, miroId),
         identifiers = List(

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
@@ -26,7 +26,7 @@ class SierraTransformableTransformer
     fromJson[SierraItemData](itemRecord.data) match {
       case Success(sierraItemData) =>
         Some(
-          Item(
+          UnidentifiedItem(
             sourceIdentifier = SourceIdentifier(
               IdentifierSchemes.sierraSystemNumber,
               sierraItemData.id
@@ -50,14 +50,14 @@ class SierraTransformableTransformer
   override def transformForType(
     sierraTransformable: SierraTransformable,
     version: Int
-  ): Try[Option[Work]] = {
+  ): Try[Option[UnidentifiedWork]] = {
     sierraTransformable.maybeBibData
       .map { bibData =>
         info(s"Attempting to transform ${bibData.id}")
 
         fromJson[SierraBibData](bibData.data).map { sierraBibData =>
           Some(
-            Work(
+            UnidentifiedWork(
               title = getTitle(sierraBibData),
               sourceIdentifier = SourceIdentifier(
                 identifierScheme = IdentifierSchemes.sierraSystemNumber,

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/TransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/TransformableTransformer.scala
@@ -1,15 +1,15 @@
 package uk.ac.wellcome.transformer.transformers
 
-import uk.ac.wellcome.models.Work
+import uk.ac.wellcome.models.UnidentifiedWork
 import uk.ac.wellcome.models.transformable.Transformable
 
 import scala.util.Try
 
 trait TransformableTransformer[+T <: Transformable] {
-  protected[this] def transformForType(t: T, version: Int): Try[Option[Work]]
+  protected[this] def transformForType(t: T, version: Int): Try[Option[UnidentifiedWork]]
 
   def transform(transformable: Transformable,
-                version: Int): Try[Option[Work]] =
+                version: Int): Try[Option[UnidentifiedWork]] =
     Try {
       transformable match {
         case t: T => transformForType(t, version)

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/TransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/TransformableTransformer.scala
@@ -6,7 +6,9 @@ import uk.ac.wellcome.models.transformable.Transformable
 import scala.util.Try
 
 trait TransformableTransformer[+T <: Transformable] {
-  protected[this] def transformForType(t: T, version: Int): Try[Option[UnidentifiedWork]]
+  protected[this] def transformForType(
+    t: T,
+    version: Int): Try[Option[UnidentifiedWork]]
 
   def transform(transformable: Transformable,
                 version: Int): Try[Option[UnidentifiedWork]] =

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
@@ -2,9 +2,16 @@ package uk.ac.wellcome.transformer
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.transformable.CalmTransformable
-import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, UnidentifiedWork}
+import uk.ac.wellcome.models.{
+  IdentifierSchemes,
+  SourceIdentifier,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.test.utils.MessageInfo
-import uk.ac.wellcome.transformer.utils.{TransformableSQSMessageUtils, TransformerFeatureTest}
+import uk.ac.wellcome.transformer.utils.{
+  TransformableSQSMessageUtils,
+  TransformerFeatureTest
+}
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.utils.JsonUtil._
 
@@ -79,9 +86,9 @@ class CalmTransformerFeatureTest
     snsMessage.message shouldBe JsonUtil
       .toJson(
         UnidentifiedWork(title = Some("placeholder title for a Calm record"),
-             sourceIdentifier = sourceIdentifier,
-             version = 1,
-             identifiers = List(sourceIdentifier)))
+                         sourceIdentifier = sourceIdentifier,
+                         version = 1,
+                         identifiers = List(sourceIdentifier)))
       .get
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
@@ -1,16 +1,12 @@
 package uk.ac.wellcome.transformer
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.utils.JsonUtil._
-import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.models.transformable.{CalmTransformable, Transformable}
-import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, Work}
-import uk.ac.wellcome.test.utils.{MessageInfo, S3Local}
-import uk.ac.wellcome.transformer.utils.{
-  TransformableSQSMessageUtils,
-  TransformerFeatureTest
-}
+import uk.ac.wellcome.models.transformable.CalmTransformable
+import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, UnidentifiedWork}
+import uk.ac.wellcome.test.utils.MessageInfo
+import uk.ac.wellcome.transformer.utils.{TransformableSQSMessageUtils, TransformerFeatureTest}
 import uk.ac.wellcome.utils.JsonUtil
+import uk.ac.wellcome.utils.JsonUtil._
 
 class CalmTransformerFeatureTest
     extends FunSpec
@@ -82,7 +78,7 @@ class CalmTransformerFeatureTest
     //currently for calm data we only output hardcoded sample values
     snsMessage.message shouldBe JsonUtil
       .toJson(
-        Work(title = Some("placeholder title for a Calm record"),
+        UnidentifiedWork(title = Some("placeholder title for a Calm record"),
              sourceIdentifier = sourceIdentifier,
              version = 1,
              identifiers = List(sourceIdentifier)))

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
@@ -3,14 +3,11 @@ package uk.ac.wellcome.transformer
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.models.Work
+import uk.ac.wellcome.models.{UnidentifiedWork, Work}
 import uk.ac.wellcome.models.transformable.{MiroTransformable, Transformable}
 import uk.ac.wellcome.test.utils.MessageInfo
 import uk.ac.wellcome.transformer.transformers.MiroTransformableWrapper
-import uk.ac.wellcome.transformer.utils.{
-  TransformableSQSMessageUtils,
-  TransformerFeatureTest
-}
+import uk.ac.wellcome.transformer.utils.{TransformableSQSMessageUtils, TransformerFeatureTest}
 import uk.ac.wellcome.utils.JsonUtil
 
 class MiroTransformerFeatureTest
@@ -57,7 +54,7 @@ class MiroTransformerFeatureTest
   private def assertSNSMessageContains(snsMessage: MessageInfo,
                                        miroID: String,
                                        imageTitle: String) = {
-    val parsedWork = JsonUtil.fromJson[Work](snsMessage.message).get
+    val parsedWork = JsonUtil.fromJson[UnidentifiedWork](snsMessage.message).get
     parsedWork.identifiers.head.value shouldBe miroID
     parsedWork.title shouldBe Some(imageTitle)
   }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
@@ -7,7 +7,10 @@ import uk.ac.wellcome.models.{UnidentifiedWork, Work}
 import uk.ac.wellcome.models.transformable.{MiroTransformable, Transformable}
 import uk.ac.wellcome.test.utils.MessageInfo
 import uk.ac.wellcome.transformer.transformers.MiroTransformableWrapper
-import uk.ac.wellcome.transformer.utils.{TransformableSQSMessageUtils, TransformerFeatureTest}
+import uk.ac.wellcome.transformer.utils.{
+  TransformableSQSMessageUtils,
+  TransformerFeatureTest
+}
 import uk.ac.wellcome.utils.JsonUtil
 
 class MiroTransformerFeatureTest
@@ -54,7 +57,8 @@ class MiroTransformerFeatureTest
   private def assertSNSMessageContains(snsMessage: MessageInfo,
                                        miroID: String,
                                        imageTitle: String) = {
-    val parsedWork = JsonUtil.fromJson[UnidentifiedWork](snsMessage.message).get
+    val parsedWork =
+      JsonUtil.fromJson[UnidentifiedWork](snsMessage.message).get
     parsedWork.identifiers.head.value shouldBe miroID
     parsedWork.title shouldBe Some(imageTitle)
   }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
@@ -4,11 +4,8 @@ import java.time.Instant
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.utils.JsonUtil._
-import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, Work}
-import uk.ac.wellcome.transformer.utils.{
-  TransformableSQSMessageUtils,
-  TransformerFeatureTest
-}
+import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, UnidentifiedWork, Work}
+import uk.ac.wellcome.transformer.utils.{TransformableSQSMessageUtils, TransformerFeatureTest}
 import uk.ac.wellcome.utils.JsonUtil
 
 class SierraTransformerFeatureTest
@@ -55,7 +52,7 @@ class SierraTransformerFeatureTest
         id
       )
 
-      val actualWork = JsonUtil.fromJson[Work](snsMessages.head.message).get
+      val actualWork = JsonUtil.fromJson[UnidentifiedWork](snsMessages.head.message).get
 
       actualWork.sourceIdentifier shouldBe sourceIdentifier
       actualWork.title shouldBe Some(title)

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
@@ -4,8 +4,16 @@ import java.time.Instant
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.utils.JsonUtil._
-import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, UnidentifiedWork, Work}
-import uk.ac.wellcome.transformer.utils.{TransformableSQSMessageUtils, TransformerFeatureTest}
+import uk.ac.wellcome.models.{
+  IdentifierSchemes,
+  SourceIdentifier,
+  UnidentifiedWork,
+  Work
+}
+import uk.ac.wellcome.transformer.utils.{
+  TransformableSQSMessageUtils,
+  TransformerFeatureTest
+}
 import uk.ac.wellcome.utils.JsonUtil
 
 class SierraTransformerFeatureTest
@@ -52,7 +60,8 @@ class SierraTransformerFeatureTest
         id
       )
 
-      val actualWork = JsonUtil.fromJson[UnidentifiedWork](snsMessages.head.message).get
+      val actualWork =
+        JsonUtil.fromJson[UnidentifiedWork](snsMessages.head.message).get
 
       actualWork.sourceIdentifier shouldBe sourceIdentifier
       actualWork.title shouldBe Some(title)

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -15,11 +15,18 @@ import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.{SNSConfig, SQSMessage}
 import uk.ac.wellcome.models.transformable.{SierraTransformable, Transformable}
 import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord
-import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, UnidentifiedWork}
+import uk.ac.wellcome.models.{
+  IdentifierSchemes,
+  SourceIdentifier,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.s3.SourcedObjectStore
 import uk.ac.wellcome.sns.{PublishAttempt, SNSWriter}
 import uk.ac.wellcome.test.utils.SNSLocal
-import uk.ac.wellcome.transformer.transformers.{CalmTransformableTransformer, SierraTransformableTransformer}
+import uk.ac.wellcome.transformer.transformers.{
+  CalmTransformableTransformer,
+  SierraTransformableTransformer
+}
 import uk.ac.wellcome.transformer.utils.TransformableSQSMessageUtils
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
@@ -41,10 +48,11 @@ class SQSMessageReceiverTest
   val sourceIdentifier =
     SourceIdentifier(IdentifierSchemes.calmPlaceholder, "value")
 
-  val work = UnidentifiedWork(title = Some("placeholder title for a Calm record"),
-                  sourceIdentifier = sourceIdentifier,
-                  version = 1,
-                  identifiers = List(sourceIdentifier))
+  val work = UnidentifiedWork(title =
+                                Some("placeholder title for a Calm record"),
+                              sourceIdentifier = sourceIdentifier,
+                              version = 1,
+                              identifiers = List(sourceIdentifier))
 
   val metricsSender: MetricsSender = new MetricsSender(
     namespace = "record-receiver-tests",

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -15,14 +15,11 @@ import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.{SNSConfig, SQSMessage}
 import uk.ac.wellcome.models.transformable.{SierraTransformable, Transformable}
 import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord
-import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, Work}
+import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, UnidentifiedWork}
 import uk.ac.wellcome.s3.SourcedObjectStore
 import uk.ac.wellcome.sns.{PublishAttempt, SNSWriter}
 import uk.ac.wellcome.test.utils.SNSLocal
-import uk.ac.wellcome.transformer.transformers.{
-  CalmTransformableTransformer,
-  SierraTransformableTransformer
-}
+import uk.ac.wellcome.transformer.transformers.{CalmTransformableTransformer, SierraTransformableTransformer}
 import uk.ac.wellcome.transformer.utils.TransformableSQSMessageUtils
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
@@ -44,7 +41,7 @@ class SQSMessageReceiverTest
   val sourceIdentifier =
     SourceIdentifier(IdentifierSchemes.calmPlaceholder, "value")
 
-  val work = Work(title = Some("placeholder title for a Calm record"),
+  val work = UnidentifiedWork(title = Some("placeholder title for a Calm record"),
                   sourceIdentifier = sourceIdentifier,
                   version = 1,
                   identifiers = List(sourceIdentifier))
@@ -99,7 +96,7 @@ class SQSMessageReceiverTest
       val messages = listMessagesReceivedFromSNS()
       messages should have size 1
       messages.head.message shouldBe JsonUtil
-        .toJson(Work(
+        .toJson(UnidentifiedWork(
           title = Some(title),
           sourceIdentifier =
             SourceIdentifier(IdentifierSchemes.sierraSystemNumber, id),

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformerSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformerSubjectsTest.scala
@@ -78,8 +78,7 @@ class MiroTransformableTransformerSubjectsTest
     val identifier =
       SourceIdentifier(IdentifierSchemes.miroImageNumber, "M0000001")
 
-    item shouldBe Item(
-      None,
+    item shouldBe UnidentifiedItem(
       identifier,
       List(identifier),
       List(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableWrapper.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableWrapper.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.transformer.transformers
 
 import org.scalatest.{Matchers, Suite}
-import uk.ac.wellcome.models.Work
+import uk.ac.wellcome.models.UnidentifiedWork
 import uk.ac.wellcome.models.transformable.MiroTransformable
 
 /** MiroTransformable looks for several fields in the source JSON -- if they're
@@ -27,7 +27,7 @@ trait MiroTransformableWrapper extends Matchers { this: Suite =>
     data: String,
     MiroID: String = "M0000001",
     MiroCollection: String = "TestCollection"
-  ): Work = {
+  ): UnidentifiedWork = {
     val miroTransformable = MiroTransformable(
       sourceId = MiroID,
       MiroCollection = MiroCollection,

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -258,10 +258,10 @@ class SierraTransformableTransformerTest
 
     transformedSierraRecord.get shouldBe Some(
       UnidentifiedWork(title = Some(title),
-           sourceIdentifier = identifier,
-           version = 1,
-           identifiers = List(identifier),
-           visible = false)
+                       sourceIdentifier = identifier,
+                       version = 1,
+                       identifiers = List(identifier),
+                       visible = false)
     )
   }
 
@@ -292,10 +292,10 @@ class SierraTransformableTransformerTest
 
     transformedSierraRecord.get shouldBe Some(
       UnidentifiedWork(title = Some(title),
-           sourceIdentifier = identifier,
-           version = 1,
-           identifiers = List(identifier),
-           visible = false)
+                       sourceIdentifier = identifier,
+                       version = 1,
+                       identifiers = List(identifier),
+                       visible = false)
     )
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -63,11 +63,11 @@ class SierraTransformableTransformerTest
       SourceIdentifier(IdentifierSchemes.sierraSystemNumber, "i222")
 
     work.items shouldBe List(
-      Item(
+      UnidentifiedItem(
         sourceIdentifier = sourceIdentifier1,
         identifiers = List(sourceIdentifier1)
       ),
-      Item(
+      UnidentifiedItem(
         sourceIdentifier = sourceIdentifier2,
         identifiers = List(sourceIdentifier2)
       )
@@ -115,7 +115,7 @@ class SierraTransformableTransformerTest
     work.items should have size 1
     val expectedSourceIdentifier =
       SourceIdentifier(IdentifierSchemes.sierraSystemNumber, itemId)
-    work.items.head shouldBe Item(
+    work.items.head shouldBe UnidentifiedItem(
       sourceIdentifier = expectedSourceIdentifier,
       identifiers = List(expectedSourceIdentifier),
       locations = List(PhysicalLocation(locationType, locationLabel)))
@@ -219,7 +219,7 @@ class SierraTransformableTransformerTest
       SourceIdentifier(IdentifierSchemes.sierraSystemNumber, id)
 
     transformedSierraRecord.get shouldBe Some(
-      Work(
+      UnidentifiedWork(
         title = Some(title),
         sourceIdentifier = identifier,
         version = 1,
@@ -257,7 +257,7 @@ class SierraTransformableTransformerTest
       SourceIdentifier(IdentifierSchemes.sierraSystemNumber, id)
 
     transformedSierraRecord.get shouldBe Some(
-      Work(title = Some(title),
+      UnidentifiedWork(title = Some(title),
            sourceIdentifier = identifier,
            version = 1,
            identifiers = List(identifier),
@@ -291,7 +291,7 @@ class SierraTransformableTransformerTest
       SourceIdentifier(IdentifierSchemes.sierraSystemNumber, id)
 
     transformedSierraRecord.get shouldBe Some(
-      Work(title = Some(title),
+      UnidentifiedWork(title = Some(title),
            sourceIdentifier = identifier,
            version = 1,
            identifiers = List(identifier),
@@ -338,11 +338,11 @@ class SierraTransformableTransformerTest
       SourceIdentifier(IdentifierSchemes.sierraSystemNumber, "i222")
 
     work.items shouldBe List(
-      Item(
+      UnidentifiedItem(
         sourceIdentifier = sourceIdentifier1,
         identifiers = List(sourceIdentifier1)
       ),
-      Item(
+      UnidentifiedItem(
         sourceIdentifier = sourceIdentifier2,
         identifiers = List(sourceIdentifier2),
         visible = false

--- a/common/src/main/scala/uk/ac/wellcome/models/Identifiable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Identifiable.scala
@@ -1,13 +1,6 @@
 package uk.ac.wellcome.models
 
-case class UnidentifiableException()
-    extends Exception("Can't find canonicalId for this Identifiable")
-
 trait Identifiable {
-  val canonicalId: Option[String]
-  def id: String = canonicalId.getOrElse(
-    throw UnidentifiableException()
-  )
   val sourceIdentifier: SourceIdentifier
   val ontologyType: String
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/Item.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Item.scala
@@ -1,10 +1,26 @@
 package uk.ac.wellcome.models
 
-case class Item(
-  canonicalId: Option[String] = None,
+sealed trait Item extends Identifiable{
+val  sourceIdentifier: SourceIdentifier
+val  identifiers: List[SourceIdentifier]
+val  locations: List[Location]
+val  visible: Boolean
+val  ontologyType: String
+}
+
+case class UnidentifiedItem(
   sourceIdentifier: SourceIdentifier,
   identifiers: List[SourceIdentifier] = Nil,
   locations: List[Location] = List(),
   visible: Boolean = true,
   ontologyType: String = "Item"
-) extends Identifiable
+) extends Identifiable with Item
+
+case class IdentifiedItem(
+  canonicalId: String,
+  sourceIdentifier: SourceIdentifier,
+  identifiers: List[SourceIdentifier] = Nil,
+  locations: List[Location] = List(),
+  visible: Boolean = true,
+  ontologyType: String = "Item"
+) extends Identifiable with Item

--- a/common/src/main/scala/uk/ac/wellcome/models/Item.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Item.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.models
 
-sealed trait Item extends Identifiable{
-val  sourceIdentifier: SourceIdentifier
-val  identifiers: List[SourceIdentifier]
-val  locations: List[Location]
-val  visible: Boolean
-val  ontologyType: String
+sealed trait Item extends Identifiable {
+  val sourceIdentifier: SourceIdentifier
+  val identifiers: List[SourceIdentifier]
+  val locations: List[Location]
+  val visible: Boolean
+  val ontologyType: String
 }
 
 case class UnidentifiedItem(
@@ -14,7 +14,8 @@ case class UnidentifiedItem(
   locations: List[Location] = List(),
   visible: Boolean = true,
   ontologyType: String = "Item"
-) extends Identifiable with Item
+) extends Identifiable
+    with Item
 
 case class IdentifiedItem(
   canonicalId: String,
@@ -23,4 +24,5 @@ case class IdentifiedItem(
   locations: List[Location] = List(),
   visible: Boolean = true,
   ontologyType: String = "Item"
-) extends Identifiable with Item
+) extends Identifiable
+    with Item

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -4,55 +4,57 @@ import com.sksamuel.elastic4s.Indexable
 import uk.ac.wellcome.utils.JsonUtil._
 
 /** A representation of a work in our ontology */
-trait Work extends Versioned with Identifiable{
+trait Work extends Versioned with Identifiable {
   val title: Option[String]
-val  sourceIdentifier: SourceIdentifier
-val                version: Int
-val                identifiers: List[SourceIdentifier]
-val                description: Option[String]
-val                lettering: Option[String]
-val                createdDate: Option[Period]
-val                subjects: List[Concept]
-val                creators: List[Agent]
-val                genres: List[Concept]
-val                thumbnail: Option[Location]
-val                publishers: List[AbstractAgent]
-val                visible: Boolean
-val                ontologyType: String
+  val sourceIdentifier: SourceIdentifier
+  val version: Int
+  val identifiers: List[SourceIdentifier]
+  val description: Option[String]
+  val lettering: Option[String]
+  val createdDate: Option[Period]
+  val subjects: List[Concept]
+  val creators: List[Agent]
+  val genres: List[Concept]
+  val thumbnail: Option[Location]
+  val publishers: List[AbstractAgent]
+  val visible: Boolean
+  val ontologyType: String
 }
 
 case class UnidentifiedWork(title: Option[String],
-                sourceIdentifier: SourceIdentifier,
-                version: Int,
-                identifiers: List[SourceIdentifier] = List(),
-                description: Option[String] = None,
-                lettering: Option[String] = None,
-                createdDate: Option[Period] = None,
-                subjects: List[Concept] = Nil,
-                creators: List[Agent] = Nil,
-                genres: List[Concept] = Nil,
-                thumbnail: Option[Location] = None,
-                items: List[UnidentifiedItem] = Nil,
-                publishers: List[AbstractAgent] = Nil,
-                visible: Boolean = true,
-                ontologyType: String = "Work") extends Work
+                            sourceIdentifier: SourceIdentifier,
+                            version: Int,
+                            identifiers: List[SourceIdentifier] = List(),
+                            description: Option[String] = None,
+                            lettering: Option[String] = None,
+                            createdDate: Option[Period] = None,
+                            subjects: List[Concept] = Nil,
+                            creators: List[Agent] = Nil,
+                            genres: List[Concept] = Nil,
+                            thumbnail: Option[Location] = None,
+                            items: List[UnidentifiedItem] = Nil,
+                            publishers: List[AbstractAgent] = Nil,
+                            visible: Boolean = true,
+                            ontologyType: String = "Work")
+    extends Work
 
 case class IdentifiedWork(canonicalId: String,
-                           title: Option[String],
-                sourceIdentifier: SourceIdentifier,
-                version: Int,
-                identifiers: List[SourceIdentifier] = List(),
-                description: Option[String] = None,
-                lettering: Option[String] = None,
-                createdDate: Option[Period] = None,
-                subjects: List[Concept] = Nil,
-                creators: List[Agent] = Nil,
-                genres: List[Concept] = Nil,
-                thumbnail: Option[Location] = None,
-                items: List[IdentifiedItem] = Nil,
-                publishers: List[AbstractAgent] = Nil,
-                visible: Boolean = true,
-                ontologyType: String = "Work") extends Work
+                          title: Option[String],
+                          sourceIdentifier: SourceIdentifier,
+                          version: Int,
+                          identifiers: List[SourceIdentifier] = List(),
+                          description: Option[String] = None,
+                          lettering: Option[String] = None,
+                          createdDate: Option[Period] = None,
+                          subjects: List[Concept] = Nil,
+                          creators: List[Agent] = Nil,
+                          genres: List[Concept] = Nil,
+                          thumbnail: Option[Location] = None,
+                          items: List[IdentifiedItem] = Nil,
+                          publishers: List[AbstractAgent] = Nil,
+                          visible: Boolean = true,
+                          ontologyType: String = "Work")
+    extends Work
 
 case object IdentifiedWork extends Indexable[IdentifiedWork] {
   override def json(t: IdentifiedWork): String =

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -16,7 +16,6 @@ val                subjects: List[Concept]
 val                creators: List[Agent]
 val                genres: List[Concept]
 val                thumbnail: Option[Location]
-val                items: List[Item]
 val                publishers: List[AbstractAgent]
 val                visible: Boolean
 val                ontologyType: String
@@ -33,7 +32,7 @@ case class UnidentifiedWork(title: Option[String],
                 creators: List[Agent] = Nil,
                 genres: List[Concept] = Nil,
                 thumbnail: Option[Location] = None,
-                items: List[Item] = Nil,
+                items: List[UnidentifiedItem] = Nil,
                 publishers: List[AbstractAgent] = Nil,
                 visible: Boolean = true,
                 ontologyType: String = "Work") extends Work
@@ -50,7 +49,7 @@ case class IdentifiedWork(canonicalId: String,
                 creators: List[Agent] = Nil,
                 genres: List[Concept] = Nil,
                 thumbnail: Option[Location] = None,
-                items: List[Item] = Nil,
+                items: List[IdentifiedItem] = Nil,
                 publishers: List[AbstractAgent] = Nil,
                 visible: Boolean = true,
                 ontologyType: String = "Work") extends Work

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -4,11 +4,28 @@ import com.sksamuel.elastic4s.Indexable
 import uk.ac.wellcome.utils.JsonUtil._
 
 /** A representation of a work in our ontology */
-case class Work(title: Option[String],
+trait Work extends Versioned with Identifiable{
+  val title: Option[String]
+val  sourceIdentifier: SourceIdentifier
+val                version: Int
+val                identifiers: List[SourceIdentifier]
+val                description: Option[String]
+val                lettering: Option[String]
+val                createdDate: Option[Period]
+val                subjects: List[Concept]
+val                creators: List[Agent]
+val                genres: List[Concept]
+val                thumbnail: Option[Location]
+val                items: List[Item]
+val                publishers: List[AbstractAgent]
+val                visible: Boolean
+val                ontologyType: String
+}
+
+case class UnidentifiedWork(title: Option[String],
                 sourceIdentifier: SourceIdentifier,
                 version: Int,
                 identifiers: List[SourceIdentifier] = List(),
-                canonicalId: Option[String] = None,
                 description: Option[String] = None,
                 lettering: Option[String] = None,
                 createdDate: Option[Period] = None,
@@ -19,11 +36,26 @@ case class Work(title: Option[String],
                 items: List[Item] = Nil,
                 publishers: List[AbstractAgent] = Nil,
                 visible: Boolean = true,
-                ontologyType: String = "Work")
-    extends Identifiable
-    with Versioned
+                ontologyType: String = "Work") extends Work
 
-case object Work extends Indexable[Work] {
-  override def json(t: Work): String =
+case class IdentifiedWork(canonicalId: String,
+                           title: Option[String],
+                sourceIdentifier: SourceIdentifier,
+                version: Int,
+                identifiers: List[SourceIdentifier] = List(),
+                description: Option[String] = None,
+                lettering: Option[String] = None,
+                createdDate: Option[Period] = None,
+                subjects: List[Concept] = Nil,
+                creators: List[Agent] = Nil,
+                genres: List[Concept] = Nil,
+                thumbnail: Option[Location] = None,
+                items: List[Item] = Nil,
+                publishers: List[AbstractAgent] = Nil,
+                visible: Boolean = true,
+                ontologyType: String = "Work") extends Work
+
+case object IdentifiedWork extends Indexable[IdentifiedWork] {
+  override def json(t: IdentifiedWork): String =
     toJson(t).get
 }

--- a/common/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexTest.scala
@@ -33,11 +33,11 @@ class WorksIndexTest
     ensureIndexDeleted(indexName)
   }
 
-  implicitly[Arbitrary[Work]]
+  implicitly[Arbitrary[IdentifiedWork]]
 
   it("puts a valid work") {
 
-    forAll { sampleWork: Work =>
+    forAll { sampleWork: IdentifiedWork =>
       ensureIndexDeleted(indexName)
       createAndWaitIndexIsCreated(worksIndex, indexName)
 

--- a/common/src/test/scala/uk/ac/wellcome/models/IdentifiedItemTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/IdentifiedItemTest.scala
@@ -5,45 +5,12 @@ import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.test.utils.JsonTestUtil
 import uk.ac.wellcome.utils.JsonUtil
 
-class ItemTest extends FunSpec with Matchers with JsonTestUtil {
+class IdentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
 
   val identifiedItemJson: String =
     s"""
       |{
       |  "canonicalId": "canonicalId",
-      |  "sourceIdentifier": {
-      |      "identifierScheme": "${IdentifierSchemes.miroImageNumber.toString}",
-      |      "value": "value"
-      |  },
-      |  "identifiers": [
-      |    {
-      |      "identifierScheme": "${IdentifierSchemes.miroImageNumber.toString}",
-      |      "value": "value"
-      |    }
-      |  ],
-      |  "locations": [
-      |    {
-      |      "locationType": "location",
-      |      "url" : "",
-      |      "credit" : null,
-      |      "license": {
-      |        "licenseType": "${License_CCBY.licenseType}",
-      |        "label": "${License_CCBY.label}",
-      |        "url": "${License_CCBY.url}",
-      |        "type": "License"
-      |      },
-      |      "type": "DigitalLocation"
-      |    }
-      |  ],
-      |  "visible":true,
-      |  "type": "Item"
-      |}
-    """.stripMargin
-
-  val unidentifiedItemJson: String =
-    s"""
-      |{
-      |  "canonicalId" : null,
       |  "sourceIdentifier": {
       |      "identifierScheme": "${IdentifierSchemes.miroImageNumber.toString}",
       |      "value": "value"
@@ -84,33 +51,12 @@ class ItemTest extends FunSpec with Matchers with JsonTestUtil {
     value = "value"
   )
 
-  val unidentifiedItem = Item(
-    canonicalId = None,
+  val identifiedItem = IdentifiedItem(
+    canonicalId = "canonicalId",
     sourceIdentifier = identifier,
     identifiers = List(identifier),
     locations = List(location)
   )
-
-  val identifiedItem = Item(
-    canonicalId = Some("canonicalId"),
-    sourceIdentifier = identifier,
-    identifiers = List(identifier),
-    locations = List(location)
-  )
-
-  it("should serialise an unidentified Item as JSON") {
-    val result = JsonUtil.toJson(unidentifiedItem)
-
-    result.isSuccess shouldBe true
-    assertJsonStringsAreEqual(result.get, unidentifiedItemJson)
-  }
-
-  it("should deserialize a JSON string as a unidentified Item") {
-    val result = JsonUtil.fromJson[Item](unidentifiedItemJson)
-
-    result.isSuccess shouldBe true
-    result.get shouldBe unidentifiedItem
-  }
 
   it("should serialise an identified Item as JSON") {
     val result = JsonUtil.toJson(identifiedItem)

--- a/common/src/test/scala/uk/ac/wellcome/models/IdentifiedItemTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/IdentifiedItemTest.scala
@@ -66,7 +66,7 @@ class IdentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
   }
 
   it("should deserialize a JSON string as a identified Item") {
-    val result = JsonUtil.fromJson[Item](identifiedItemJson)
+    val result = JsonUtil.fromJson[IdentifiedItem](identifiedItemJson)
 
     result.isSuccess shouldBe true
     result.get shouldBe identifiedItem

--- a/common/src/test/scala/uk/ac/wellcome/models/IdentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/IdentifiedWorkTest.scala
@@ -1,0 +1,160 @@
+package uk.ac.wellcome.models
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.utils.JsonUtil._
+import uk.ac.wellcome.test.utils.JsonTestUtil
+
+class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
+
+  private val license_CCBYJson =
+    s"""{
+            "licenseType": "${License_CCBY.licenseType}",
+            "label": "${License_CCBY.label}",
+            "url": "${License_CCBY.url}",
+            "type": "License"
+          }"""
+
+  val identifiedWorkJson: String =
+    s"""
+      |{
+      |  "title": "title",
+      |  "sourceIdentifier": {
+      |    "identifierScheme": "${IdentifierSchemes.miroImageNumber.toString}",
+      |    "value": "value"
+      |  },
+      |  "version": 1,
+      |  "identifiers": [
+      |    {
+      |      "identifierScheme": "${IdentifierSchemes.miroImageNumber.toString}",
+      |      "value": "value"
+      |    }
+      |  ],
+      |  "canonicalId": "canonicalId",
+      |  "description": "description",
+      |  "lettering": "lettering",
+      |  "createdDate": {
+      |    "label": "period",
+      |    "type": "Period"
+      |  },
+      |  "subjects": [
+      |    {
+      |      "label": "subject",
+      |      "type": "Concept"
+      |    }
+      |  ],
+      |  "creators": [
+      |    {
+      |      "label": "47",
+      |      "type": "Agent"
+      |    }
+      |  ],
+      |  "genres": [
+      |    {
+      |      "label": "genre",
+      |      "type": "Concept"
+      |    }
+      |  ],
+      |  "thumbnail": {
+      |    "locationType": "location",
+      |    "url" : "",
+      |    "credit" : null,
+      |    "license": $license_CCBYJson,
+      |    "type": "DigitalLocation"
+      |  },
+      |  "items": [
+      |    {
+      |      "canonicalId": "canonicalId",
+      |      "sourceIdentifier": {
+      |        "identifierScheme": "${IdentifierSchemes.miroImageNumber.toString}",
+      |        "value": "value"
+      |      },
+      |      "identifiers": [
+      |        {
+      |          "identifierScheme": "${IdentifierSchemes.miroImageNumber.toString}",
+      |          "value": "value"
+      |        }
+      |      ],
+      |      "locations": [
+      |        {
+      |          "locationType": "location",
+      |          "url" : "",
+      |          "credit" : null,
+      |          "license": $license_CCBYJson,
+      |          "type": "DigitalLocation"
+      |        }
+      |      ],
+      |      "visible":true,
+      |      "type": "Item"
+      |    }
+      |  ],
+      |  "publishers": [
+      |    {
+      |      "label": "MIT Press",
+      |      "type": "Organisation"
+      |    }
+      |  ],
+      |  "visible":true,
+      |  "type": "Work"
+      |}
+    """.stripMargin
+
+  val location = DigitalLocation(
+    locationType = "location",
+    url = "",
+    license = License_CCBY
+  )
+
+  val identifier = SourceIdentifier(
+    identifierScheme = IdentifierSchemes.miroImageNumber,
+    value = "value"
+  )
+
+  val item = Item(
+    canonicalId = Some("canonicalId"),
+    sourceIdentifier = identifier,
+    identifiers = List(identifier),
+    locations = List(location)
+  )
+
+  val publisher = Organisation(
+    label = "MIT Press"
+  )
+
+  val publishers = List(publisher)
+  val identifiedWork = IdentifiedWork(
+    canonicalId = "canonicalId",
+    title = Some("title"),
+    sourceIdentifier = identifier,
+    version = 1,
+    identifiers = List(identifier),
+    description = Some("description"),
+    lettering = Some("lettering"),
+    createdDate = Some(Period("period")),
+    subjects = List(Concept("subject")),
+    creators = List(Agent("47")),
+    genres = List(Concept("genre")),
+    thumbnail = Some(location),
+    items = List(item),
+    publishers = publishers
+  )
+
+  it("should serialise an identified Item as Work") {
+    val result = toJson(identifiedWork)
+
+    result.isSuccess shouldBe true
+    assertJsonStringsAreEqual(result.get, identifiedWorkJson)
+  }
+
+  it("should deserialize a JSON string as a identified Item") {
+    val result = fromJson[IdentifiedWork](identifiedWorkJson)
+
+    result.isSuccess shouldBe true
+    result.get shouldBe identifiedWork
+  }
+
+  it("should have an ontology type 'Work' when serialised to JSON") {
+    val jsonString = toJson(identifiedWork).get
+
+    jsonString.contains("""type":"Work"""") should be(true)
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/models/IdentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/IdentifiedWorkTest.scala
@@ -109,8 +109,8 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
     value = "value"
   )
 
-  val item = Item(
-    canonicalId = Some("canonicalId"),
+  val item = IdentifiedItem(
+    canonicalId = "canonicalId",
     sourceIdentifier = identifier,
     identifiers = List(identifier),
     locations = List(location)

--- a/common/src/test/scala/uk/ac/wellcome/models/ItemTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/ItemTest.scala
@@ -125,9 +125,4 @@ class ItemTest extends FunSpec with Matchers with JsonTestUtil {
     result.isSuccess shouldBe true
     result.get shouldBe identifiedItem
   }
-
-  it(
-    "should throw an UnidentifiableException when trying to get the id of an unidentified Item") {
-    an[UnidentifiableException] should be thrownBy unidentifiedItem.id
-  }
 }

--- a/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedItemTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedItemTest.scala
@@ -1,0 +1,73 @@
+package uk.ac.wellcome.models
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.test.utils.JsonTestUtil
+import uk.ac.wellcome.utils.JsonUtil
+import uk.ac.wellcome.utils.JsonUtil._
+
+class UnidentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
+
+  val unidentifiedItemJson: String =
+    s"""
+      |{
+      |  "canonicalId" : null,
+      |  "sourceIdentifier": {
+      |      "identifierScheme": "${IdentifierSchemes.miroImageNumber.toString}",
+      |      "value": "value"
+      |  },
+      |  "identifiers": [
+      |    {
+      |      "identifierScheme": "${IdentifierSchemes.miroImageNumber.toString}",
+      |      "value": "value"
+      |    }
+      |  ],
+      |  "locations": [
+      |    {
+      |      "locationType": "location",
+      |      "url" : "",
+      |      "credit" : null,
+      |      "license": {
+      |        "licenseType": "${License_CCBY.licenseType}",
+      |        "label": "${License_CCBY.label}",
+      |        "url": "${License_CCBY.url}",
+      |        "type": "License"
+      |      },
+      |      "type": "DigitalLocation"
+      |    }
+      |  ],
+      |  "visible":true,
+      |  "type": "Item"
+      |}
+    """.stripMargin
+
+  val location = DigitalLocation(
+    locationType = "location",
+    url = "",
+    license = License_CCBY
+  )
+
+  val identifier = SourceIdentifier(
+    identifierScheme = IdentifierSchemes.miroImageNumber,
+    value = "value"
+  )
+
+  val unidentifiedItem = UnidentifiedItem(
+    sourceIdentifier = identifier,
+    identifiers = List(identifier),
+    locations = List(location)
+  )
+
+  it("should serialise an unidentified Item as JSON") {
+    val result = JsonUtil.toJson(unidentifiedItem)
+
+    result.isSuccess shouldBe true
+    assertJsonStringsAreEqual(result.get, unidentifiedItemJson)
+  }
+
+  it("should deserialize a JSON string as a unidentified Item") {
+    val result = JsonUtil.fromJson[Item](unidentifiedItemJson)
+
+    result.isSuccess shouldBe true
+    result.get shouldBe unidentifiedItem
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedItemTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedItemTest.scala
@@ -10,7 +10,6 @@ class UnidentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
   val unidentifiedItemJson: String =
     s"""
       |{
-      |  "canonicalId" : null,
       |  "sourceIdentifier": {
       |      "identifierScheme": "${IdentifierSchemes.miroImageNumber.toString}",
       |      "value": "value"

--- a/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedItemTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedItemTest.scala
@@ -64,7 +64,7 @@ class UnidentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
   }
 
   it("should deserialize a JSON string as a unidentified Item") {
-    val result = JsonUtil.fromJson[Item](unidentifiedItemJson)
+    val result = JsonUtil.fromJson[UnidentifiedItem](unidentifiedItemJson)
 
     result.isSuccess shouldBe true
     result.get shouldBe unidentifiedItem

--- a/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
@@ -109,7 +109,7 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
     value = "value"
   )
 
-  val item = Item(
+  val item = UnidentifiedItem(
     canonicalId = Some("canonicalId"),
     sourceIdentifier = identifier,
     identifiers = List(identifier),

--- a/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
@@ -1,10 +1,10 @@
 package uk.ac.wellcome.models
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.test.utils.JsonTestUtil
+import uk.ac.wellcome.utils.JsonUtil._
 
-class WorkTest extends FunSpec with Matchers with JsonTestUtil {
+class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
 
   private val license_CCBYJson =
     s"""{
@@ -13,90 +13,6 @@ class WorkTest extends FunSpec with Matchers with JsonTestUtil {
             "url": "${License_CCBY.url}",
             "type": "License"
           }"""
-
-  val identifiedWorkJson: String =
-    s"""
-      |{
-      |  "title": "title",
-      |  "sourceIdentifier": {
-      |    "identifierScheme": "${IdentifierSchemes.miroImageNumber.toString}",
-      |    "value": "value"
-      |  },
-      |  "version": 1,
-      |  "identifiers": [
-      |    {
-      |      "identifierScheme": "${IdentifierSchemes.miroImageNumber.toString}",
-      |      "value": "value"
-      |    }
-      |  ],
-      |  "canonicalId": "canonicalId",
-      |  "description": "description",
-      |  "lettering": "lettering",
-      |  "createdDate": {
-      |    "label": "period",
-      |    "type": "Period"
-      |  },
-      |  "subjects": [
-      |    {
-      |      "label": "subject",
-      |      "type": "Concept"
-      |    }
-      |  ],
-      |  "creators": [
-      |    {
-      |      "label": "47",
-      |      "type": "Agent"
-      |    }
-      |  ],
-      |  "genres": [
-      |    {
-      |      "label": "genre",
-      |      "type": "Concept"
-      |    }
-      |  ],
-      |  "thumbnail": {
-      |    "locationType": "location",
-      |    "url" : "",
-      |    "credit" : null,
-      |    "license": $license_CCBYJson,
-      |    "type": "DigitalLocation"
-      |  },
-      |  "items": [
-      |    {
-      |      "canonicalId": "canonicalId",
-      |      "sourceIdentifier": {
-      |        "identifierScheme": "${IdentifierSchemes.miroImageNumber.toString}",
-      |        "value": "value"
-      |      },
-      |      "identifiers": [
-      |        {
-      |          "identifierScheme": "${IdentifierSchemes.miroImageNumber.toString}",
-      |          "value": "value"
-      |        }
-      |      ],
-      |      "locations": [
-      |        {
-      |          "locationType": "location",
-      |          "url" : "",
-      |          "credit" : null,
-      |          "license": $license_CCBYJson,
-      |          "type": "DigitalLocation"
-      |        }
-      |      ],
-      |      "visible":true,
-      |      "type": "Item"
-      |    }
-      |  ],
-      |  "publishers": [
-      |    {
-      |      "label": "MIT Press",
-      |      "type": "Organisation"
-      |    }
-      |  ],
-      |  "visible":true,
-      |  "type": "Work"
-      |}
-    """.stripMargin
 
   val unidentifiedWorkJson: String =
     s"""
@@ -205,7 +121,7 @@ class WorkTest extends FunSpec with Matchers with JsonTestUtil {
   )
 
   val publishers = List(publisher)
-  val unidentifiedWork = Work(
+  val unidentifiedWork = UnidentifiedWork(
     title = Some("title"),
     sourceIdentifier = identifier,
     version = 1,
@@ -221,23 +137,6 @@ class WorkTest extends FunSpec with Matchers with JsonTestUtil {
     publishers = publishers
   )
 
-  val identifiedWork = Work(
-    title = unidentifiedWork.title,
-    sourceIdentifier = identifier,
-    version = 1,
-    identifiers = unidentifiedWork.identifiers,
-    canonicalId = Some("canonicalId"),
-    description = unidentifiedWork.description,
-    lettering = unidentifiedWork.lettering,
-    createdDate = unidentifiedWork.createdDate,
-    subjects = unidentifiedWork.subjects,
-    creators = unidentifiedWork.creators,
-    genres = unidentifiedWork.genres,
-    thumbnail = unidentifiedWork.thumbnail,
-    items = unidentifiedWork.items,
-    publishers = publishers
-  )
-
   it("should serialise an unidentified Work as JSON") {
     val result = toJson(unidentifiedWork)
 
@@ -247,37 +146,14 @@ class WorkTest extends FunSpec with Matchers with JsonTestUtil {
   }
 
   it("should deserialize a JSON string as a unidentified Work") {
-    val result = fromJson[Work](unidentifiedWorkJson)
+    val result = fromJson[UnidentifiedWork](unidentifiedWorkJson)
 
     result.isSuccess shouldBe true
     result.get shouldBe unidentifiedWork
   }
 
-  it("should serialise an identified Item as Work") {
-    val result = toJson(identifiedWork)
-
-    result.isSuccess shouldBe true
-    assertJsonStringsAreEqual(result.get, identifiedWorkJson)
-  }
-
-  it("should deserialize a JSON string as a identified Item") {
-    val result = fromJson[Work](identifiedWorkJson)
-
-    result.isSuccess shouldBe true
-    result.get shouldBe identifiedWork
-  }
-
-  it(
-    "should throw an UnidentifiableException when trying to get the id of an unidentified Work") {
-    an[UnidentifiableException] should be thrownBy unidentifiedWork.id
-  }
-
   it("should have an ontology type 'Work' when serialised to JSON") {
-    val work = Work(title = Some("A book about a blue whale"),
-                    sourceIdentifier = identifier,
-                    version = 1,
-                    identifiers = List(identifier))
-    val jsonString = toJson(work).get
+    val jsonString = toJson(unidentifiedWork).get
 
     jsonString.contains("""type":"Work"""") should be(true)
   }

--- a/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
@@ -110,7 +110,6 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
   )
 
   val item = UnidentifiedItem(
-    canonicalId = Some("canonicalId"),
     sourceIdentifier = identifier,
     identifiers = List(identifier),
     locations = List(location)

--- a/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
@@ -23,7 +23,6 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |    "value": "value"
       |  },
       |  "version": 1,
-      |  "canonicalId" : null,
       |  "identifiers": [
       |    {
       |      "identifierScheme": "${IdentifierSchemes.miroImageNumber.toString}",

--- a/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
@@ -62,7 +62,6 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |  },
       |  "items": [
       |    {
-      |      "canonicalId": "canonicalId",
       |      "sourceIdentifier": {
       |        "identifierScheme": "${IdentifierSchemes.miroImageNumber.toString}",
       |        "value": "value"

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/IndexedElasticSearchLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/IndexedElasticSearchLocal.scala
@@ -5,7 +5,7 @@ import com.sksamuel.elastic4s.http.index.IndexResponse
 import org.elasticsearch.index.VersionType
 import org.scalatest.{BeforeAndAfterEach, Suite}
 import uk.ac.wellcome.elasticsearch.WorksIndex
-import uk.ac.wellcome.models.Work
+import uk.ac.wellcome.models.IdentifiedWork
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil._
 
@@ -29,7 +29,7 @@ trait IndexedElasticSearchLocal
     createIndex(indexName)
   }
 
-  def insertIntoElasticSearchWithIndex(index: String, works: Work*) = {
+  def insertIntoElasticSearchWithIndex(index: String, works: IdentifiedWork*) = {
     if (index != indexName) {
       createIndex(index)
     }
@@ -41,7 +41,7 @@ trait IndexedElasticSearchLocal
         indexInto(index / itemType)
           .version(work.version)
           .versionType(VersionType.EXTERNAL_GTE)
-          .id(work.id)
+          .id(work.canonicalId)
           .doc(jsonDoc)
       )
 
@@ -59,6 +59,6 @@ trait IndexedElasticSearchLocal
     }
   }
 
-  def insertIntoElasticSearch(works: Work*): Unit =
+  def insertIntoElasticSearch(works: IdentifiedWork*): Unit =
     insertIntoElasticSearchWithIndex(indexName, works: _*)
 }


### PR DESCRIPTION
### What is this PR trying to achieve?
Remove the id field from `Work` that throws an exception if `canonicalId` is `None`
### Who is this change for?
🐻 🏖 
