### PR TITLE
Use tenacity in complete_reindex lambda

### DIFF
--- a/reindexer/complete_reindex/src/complete_reindex.py
+++ b/reindexer/complete_reindex/src/complete_reindex.py
@@ -4,10 +4,23 @@ import os
 
 from boto3.dynamodb.conditions import Attr
 import boto3
-
+from botocore.exceptions import ClientError
+from tenacity import *
 from wellcome_aws_utils import sns_utils
 
 
+def should_retry(err):
+    if isinstance(err, ClientError):
+        if err.response['Error']['Code'] == 'ProvisionedThroughputExceededException':
+            return True
+
+    return False
+
+
+@retry(
+    wait=wait_exponential(multiplier=1, max=10),
+    retry=retry_if_exception(should_retry)
+)
 def _update_versioned_item(table, item):
     print(f'Attempting conditional update to {item}')
 
@@ -21,6 +34,10 @@ def _update_versioned_item(table, item):
     print(f'Successful update to {item}')
 
 
+@retry(
+    wait=wait_exponential(multiplier=1, max=10),
+    retry=retry_if_exception(should_retry)
+)
 def _process_reindex_tracker_update_job(table, message):
     shard_id = message['shardId']
     completed_reindex_version = message['completedReindexVersion']

--- a/reindexer/complete_reindex/src/requirements.in
+++ b/reindexer/complete_reindex/src/requirements.in
@@ -1,0 +1,2 @@
+wellcome_aws_utils==2.0.1
+tenacity

--- a/reindexer/complete_reindex/src/requirements.txt
+++ b/reindexer/complete_reindex/src/requirements.txt
@@ -1,1 +1,0 @@
-wellcome_aws_utils==2.0.1

--- a/reindexer/complete_reindex/src/test_complete_reindex.py
+++ b/reindexer/complete_reindex/src/test_complete_reindex.py
@@ -6,7 +6,7 @@ import os
 from botocore.exceptions import ClientError
 import pytest
 
-from complete_reindex import _run, _process_reindex_tracker_update_job, _update_versioned_item
+from complete_reindex import _run, _process_reindex_tracker_update_job, _update_versioned_item, should_retry
 
 
 @pytest.fixture
@@ -68,6 +68,25 @@ def _create_event(shard_id, current_version, desired_version):
             }
         ]
     }
+
+
+def test_should_retry():
+    err_good = ClientError({
+        'Error': {
+            'Code': 'ProvisionedThroughputExceededException',
+            'Message': 'oops'
+        }
+    },'testing')
+
+    err_bad = ClientError({
+        'Error': {
+            'Code': 'Bangarang!',
+            'Message': 'oops'
+        }
+    },'testing')
+
+    assert should_retry(err_good) == True
+    assert should_retry(err_bad) == False
 
 
 def test_request_reindex(reindex_shard_tracker_table):


### PR DESCRIPTION
### What is this PR trying to achieve?

Implement some of our own retry/backoff logic in the complete_reindex lambda to allow time for dynamo autoscaling.

### Who is this change for?

🍡 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.
