### PR TITLE
formatting: Add a Make task for auto-formatting Python in CI

### DIFF
--- a/.travis/run_autoformat.py
+++ b/.travis/run_autoformat.py
@@ -11,7 +11,7 @@ auto-formatted (yet).
 import os
 import sys
 
-from travistooling import changed_files, git, make
+from travistooling import changed_files, git, make, check_call
 
 
 if __name__ == '__main__':

--- a/.travis/run_autoformat.py
+++ b/.travis/run_autoformat.py
@@ -11,7 +11,7 @@ auto-formatted (yet).
 import os
 import sys
 
-from travistooling import changed_files, git, make, check_call
+from travistooling import changed_files, git, make
 
 
 if __name__ == '__main__':

--- a/formatting.Makefile
+++ b/formatting.Makefile
@@ -20,7 +20,7 @@ format-terraform:
 		hashicorp/terraform:light fmt
 
 format-python:
-	$(ROOT)/builds/docker_run.py -- \
+	$(ROOT)/docker_run.py -- \
 		--volume $(ROOT):/repo \
 		wellcome/format_python
 

--- a/formatting.Makefile
+++ b/formatting.Makefile
@@ -19,6 +19,11 @@ format-terraform:
 		--workdir /repo \
 		hashicorp/terraform:light fmt
 
+format-python:
+	$(ROOT)/builds/docker_run.py -- \
+		--volume $(ROOT):/repo \
+		pyformat
+
 format-scala:
 	$(ROOT)/docker_run.py --sbt -- \
 		--volume $(ROOT):/repo \
@@ -30,7 +35,7 @@ format-json:
 		--workdir /src \
 		wellcome/format_json:latest
 
-format: format-terraform format-scala format-json
+format: format-terraform format-scala format-python format-json
 
 check-format: format lint-python lint-ontologies
 	git diff --exit-code

--- a/formatting.Makefile
+++ b/formatting.Makefile
@@ -22,7 +22,7 @@ format-terraform:
 format-python:
 	$(ROOT)/builds/docker_run.py -- \
 		--volume $(ROOT):/repo \
-		pyformat
+		wellcome/format_python
 
 format-scala:
 	$(ROOT)/docker_run.py --sbt -- \


### PR DESCRIPTION
This delete unused imports, which are 99% of our lint failures.