### PR TITLE
Store our Lambdas in the new infra bucket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ script:
 
 env:
   global:
-    - CONFIG_BUCKET=platform-infra
     - AWS_ECR_REPO=760097843905.dkr.ecr.eu-west-1.amazonaws.com
 
 jobs:

--- a/functions.Makefile
+++ b/functions.Makefile
@@ -1,5 +1,5 @@
 ROOT = $(shell git rev-parse --show-toplevel)
-INFRA_BUCKET = platform-infra
+INFRA_BUCKET = wellcomecollection-platform-infra
 
 
 ifndef UPTODATE_GIT_DEFINED

--- a/monitoring/deployment_tracking/main.tf
+++ b/monitoring/deployment_tracking/main.tf
@@ -5,6 +5,7 @@ module "service_deployment_status" {
   every_minute_arn  = "${var.every_minute_arn}"
 
   lambda_error_alarm_arn = "${var.lambda_error_alarm_arn}"
+  infra_bucket           = "${var.infra_bucket}"
 }
 
 module "notify_old_deploys" {
@@ -17,4 +18,5 @@ module "notify_old_deploys" {
   dynamodb_table_deployments_arn  = "${module.service_deployment_status.dynamodb_table_deployments_arn}"
 
   lambda_error_alarm_arn = "${var.lambda_error_alarm_arn}"
+  infra_bucket           = "${var.infra_bucket}"
 }

--- a/monitoring/deployment_tracking/notify_old_deploys/main.tf
+++ b/monitoring/deployment_tracking/notify_old_deploys/main.tf
@@ -15,7 +15,9 @@ module "lambda_notify_old_deploys" {
   timeout = 10
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
-  s3_key          = "lambdas/monitoring/deployment_tracking/notify_old_deploys.zip"
+
+  s3_bucket = "${var.infra_bucket}"
+  s3_key    = "lambdas/monitoring/deployment_tracking/notify_old_deploys.zip"
 }
 
 module "trigger_notify_old_deploys" {

--- a/monitoring/deployment_tracking/notify_old_deploys/variables.tf
+++ b/monitoring/deployment_tracking/notify_old_deploys/variables.tf
@@ -4,3 +4,5 @@ variable "every_minute_name" {}
 
 variable "dynamodb_table_deployments_name" {}
 variable "dynamodb_table_deployments_arn" {}
+
+variable "infra_bucket" {}

--- a/monitoring/deployment_tracking/service_deployment_status/main.tf
+++ b/monitoring/deployment_tracking/service_deployment_status/main.tf
@@ -12,7 +12,9 @@ module "lambda_service_deployment_status" {
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
-  s3_key          = "lambdas/monitoring/deployment_tracking/service_deployment_status.zip"
+
+  s3_bucket = "${var.infra_bucket}"
+  s3_key    = "lambdas/monitoring/deployment_tracking/service_deployment_status.zip"
 }
 
 module "trigger_service_deployment_status" {

--- a/monitoring/deployment_tracking/service_deployment_status/variables.tf
+++ b/monitoring/deployment_tracking/service_deployment_status/variables.tf
@@ -1,3 +1,5 @@
 variable "lambda_error_alarm_arn" {}
 variable "every_minute_arn" {}
 variable "every_minute_name" {}
+
+variable "infra_bucket" {}

--- a/monitoring/deployment_tracking/variables.tf
+++ b/monitoring/deployment_tracking/variables.tf
@@ -1,3 +1,5 @@
 variable "lambda_error_alarm_arn" {}
 variable "every_minute_arn" {}
 variable "every_minute_name" {}
+
+variable "infra_bucket" {}

--- a/monitoring/ecs_dashboard/main.tf
+++ b/monitoring/ecs_dashboard/main.tf
@@ -8,4 +8,5 @@ module "update_service_list" {
   dashboard_assumable_roles = "${var.dashboard_assumable_roles}"
 
   lambda_error_alarm_arn = "${var.lambda_error_alarm_arn}"
+  infra_bucket           = "${var.infra_bucket}"
 }

--- a/monitoring/ecs_dashboard/update_service_list/main.tf
+++ b/monitoring/ecs_dashboard/update_service_list/main.tf
@@ -1,6 +1,8 @@
 module "lambda_update_service_list" {
   source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.0"
-  s3_key = "lambdas/monitoring/ecs_dashboard/update_service_list.zip"
+
+  s3_bucket = "${var.infra_bucket}"
+  s3_key    = "lambdas/monitoring/ecs_dashboard/update_service_list.zip"
 
   name        = "update_service_list"
   description = "Publish ECS service status summary to S3"

--- a/monitoring/ecs_dashboard/update_service_list/variables.tf
+++ b/monitoring/ecs_dashboard/update_service_list/variables.tf
@@ -7,3 +7,5 @@ variable "dashboard_assumable_roles" {
 variable "lambda_error_alarm_arn" {}
 variable "every_minute_arn" {}
 variable "every_minute_name" {}
+
+variable "infra_bucket" {}

--- a/monitoring/ecs_dashboard/variables.tf
+++ b/monitoring/ecs_dashboard/variables.tf
@@ -6,3 +6,5 @@ variable "every_minute_name" {}
 variable "dashboard_assumable_roles" {
   type = "list"
 }
+
+variable "infra_bucket" {}

--- a/monitoring/load_test/gatling_to_cloudwatch/main.tf
+++ b/monitoring/load_test/gatling_to_cloudwatch/main.tf
@@ -7,6 +7,8 @@ module "lambda_gatling_to_cloudwatch" {
   timeout     = 5
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+
+  infra_bucket = "${var.infra_bucket}"
 }
 
 module "trigger_gatling_to_cloudwatch" {

--- a/monitoring/load_test/gatling_to_cloudwatch/main.tf
+++ b/monitoring/load_test/gatling_to_cloudwatch/main.tf
@@ -1,14 +1,14 @@
 module "lambda_gatling_to_cloudwatch" {
   source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.0"
-  s3_key = "lambdas/monitoring/load_test/gatling_to_cloudwatch.zip"
+
+  s3_bucket = "${var.infra_bucket}"
+  s3_key    = "lambdas/monitoring/load_test/gatling_to_cloudwatch.zip"
 
   name        = "gatling_to_cloudwatch"
   description = "Record gatling results as CloudWatch metrics"
   timeout     = 5
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
-
-  infra_bucket = "${var.infra_bucket}"
 }
 
 module "trigger_gatling_to_cloudwatch" {

--- a/monitoring/load_test/gatling_to_cloudwatch/variables.tf
+++ b/monitoring/load_test/gatling_to_cloudwatch/variables.tf
@@ -1,3 +1,5 @@
 variable "lambda_error_alarm_arn" {}
 variable "load_test_results_arn" {}
 variable "allow_cloudwatch_push_metrics_json" {}
+
+variable "infra_bucket" {}

--- a/monitoring/load_test/main.tf
+++ b/monitoring/load_test/main.tf
@@ -5,4 +5,6 @@ module "gatling_to_cloudwatch" {
   allow_cloudwatch_push_metrics_json = "${data.aws_iam_policy_document.allow_cloudwatch_push_metrics.json}"
 
   lambda_error_alarm_arn = "${var.lambda_error_alarm_arn}"
+
+  infra_bucket = "${var.infra_bucket}"
 }

--- a/monitoring/load_test/variables.tf
+++ b/monitoring/load_test/variables.tf
@@ -8,3 +8,4 @@ variable "release_ids" {
 
 variable "aws_region" {}
 variable "monitoring_bucket_id" {}
+variable "infra_bucket" {}

--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -30,6 +30,8 @@ module "deployment_tracking" {
   every_minute_name = "${aws_cloudwatch_event_rule.every_minute.name}"
 
   lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
+
+  infra_bucket = "${var.infra_bucket}"
 }
 
 module "ecs_dashboard" {
@@ -42,6 +44,8 @@ module "ecs_dashboard" {
   every_minute_name = "${aws_cloudwatch_event_rule.every_minute.name}"
 
   lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
+
+  infra_bucket = "${var.infra_bucket}"
 }
 
 module "load_test" {
@@ -55,6 +59,8 @@ module "load_test" {
   ecs_services_cluster_id = "${local.ecs_services_cluster_id}"
 
   lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
+
+  infra_bucket = "${var.infra_bucket}"
 }
 
 module "post_to_slack" {
@@ -68,6 +74,8 @@ module "post_to_slack" {
   dlq_alarm_arn                                   = "${local.dlq_alarm_arn}"
   bitly_access_token                              = "${var.bitly_access_token}"
   ec2_instance_terminating_for_too_long_alarm_arn = "${local.ec2_instance_terminating_for_too_long_alarm_arn}"
+
+  infra_bucket = "${var.infra_bucket}"
 }
 
 module "slack_budget_bot" {
@@ -85,7 +93,7 @@ module "terraform_tracker" {
   lambda_error_alarm_arn     = "${local.lambda_error_alarm_arn}"
   terraform_apply_topic_name = "${local.terraform_apply_topic_name}"
 
-  infra_bucket       = "platform-infra"
+  infra_bucket       = "${var.infra_bucket}"
   slack_webhook      = "${var.non_critical_slack_webhook}"
   bitly_access_token = "${var.bitly_access_token}"
 }

--- a/monitoring/post_to_slack/main.tf
+++ b/monitoring/post_to_slack/main.tf
@@ -1,6 +1,8 @@
 module "lambda_post_to_slack" {
   source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.0"
-  s3_key = "lambdas/monitoring/post_to_slack.zip"
+
+  s3_bucket = "${var.infra_bucket}"
+  s3_key    = "lambdas/monitoring/post_to_slack.zip"
 
   name        = "post_to_slack"
   description = "Post notification to Slack when an alarm is triggered"

--- a/monitoring/post_to_slack/variables.tf
+++ b/monitoring/post_to_slack/variables.tf
@@ -12,3 +12,5 @@ variable "critical_slack_webhook" {
 variable "non_critical_slack_webhook" {
   description = "Incoming Webhook URL to send non-critical Slack notifications"
 }
+
+variable "infra_bucket" {}

--- a/monitoring/terraform_tracker/main.tf
+++ b/monitoring/terraform_tracker/main.tf
@@ -1,6 +1,8 @@
 module "lambda_terraform_tracker" {
   source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.0"
-  s3_key = "lambdas/monitoring/terraform_tracker.zip"
+
+  s3_bucket = "${var.infra_bucket}"
+  s3_key    = "lambdas/monitoring/terraform_tracker.zip"
 
   name        = "terraform_tracker"
   description = "Post notifications of 'terraform apply' to Slack"

--- a/monitoring/variables.tf
+++ b/monitoring/variables.tf
@@ -51,3 +51,5 @@ variable "grafana_admin_user" {
 variable "grafana_admin_password" {
   description = "The password of the default Grafana admin"
 }
+
+variable "infra_bucket" {}

--- a/reindexer/terraform/lambda_complete_reindex.tf
+++ b/reindexer/terraform/lambda_complete_reindex.tf
@@ -1,8 +1,9 @@
 module "complete_reindex_lambda" {
   source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.5"
 
-  name   = "complete_reindex"
-  s3_key = "lambdas/reindexer/complete_reindex.zip"
+  name      = "complete_reindex"
+  s3_bucket = "${var.infra_bucket}"
+  s3_key    = "lambdas/reindexer/complete_reindex.zip"
 
   description = "Mark reindex work as done in the ${aws_dynamodb_table.reindex_shard_tracker.name} table."
 

--- a/reindexer/terraform/lambda_reindex_job_creator.tf
+++ b/reindexer/terraform/lambda_reindex_job_creator.tf
@@ -1,8 +1,9 @@
 module "reindex_job_creator_lambda" {
   source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.5"
 
-  name   = "reindex_job_creator"
-  s3_key = "lambdas/reindexer/reindex_job_creator.zip"
+  name      = "reindex_job_creator"
+  s3_bucket = "${var.infra_bucket}"
+  s3_key    = "lambdas/reindexer/reindex_job_creator.zip"
 
   description = "Generate jobs for the reindexer from the ${aws_dynamodb_table.reindex_shard_tracker.id} table"
 

--- a/reindexer/terraform/lambda_reindex_shard_generator.tf
+++ b/reindexer/terraform/lambda_reindex_shard_generator.tf
@@ -1,8 +1,9 @@
 module "shard_generator_lambda" {
   source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v6.4.0"
 
-  name   = "reindex_shard_generator"
-  s3_key = "lambdas/reindexer/reindex_shard_generator.zip"
+  name      = "reindex_shard_generator"
+  s3_bucket = "${var.infra_bucket}"
+  s3_key    = "lambdas/reindexer/reindex_shard_generator.zip"
 
   description = "Generate reindexShards for items in the ${local.vhs_table_name} table"
 

--- a/reindexer/terraform/variables.tf
+++ b/reindexer/terraform/variables.tf
@@ -7,3 +7,5 @@ variable "release_ids" {
   description = "Release tags for platform apps"
   type        = "map"
 }
+
+variable "infra_bucket" {}

--- a/shared_infra/drain_ecs_container_instance/main.tf
+++ b/shared_infra/drain_ecs_container_instance/main.tf
@@ -6,6 +6,7 @@ module "lambda_drain_ecs_container_instance" {
   timeout     = 60
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_bucket       = "${var.infra_bucket}"
   s3_key          = "lambdas/shared_infra/drain_ecs_container_instance.zip"
 }
 

--- a/shared_infra/drain_ecs_container_instance/variables.tf
+++ b/shared_infra/drain_ecs_container_instance/variables.tf
@@ -1,3 +1,5 @@
 variable "lambda_error_alarm_arn" {}
 variable "ec2_terminating_topic_publish_policy" {}
 variable "ec2_terminating_topic_arn" {}
+
+variable "infra_bucket" {}

--- a/shared_infra/dynamo_to_sns/main.tf
+++ b/shared_infra/dynamo_to_sns/main.tf
@@ -13,6 +13,7 @@ module "lambda_dynamo_to_sns" {
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_bucket       = "${var.infra_bucket}"
   s3_key          = "lambdas/shared_infra/dynamo_to_sns.zip"
 }
 

--- a/shared_infra/dynamo_to_sns/variables.tf
+++ b/shared_infra/dynamo_to_sns/variables.tf
@@ -12,3 +12,5 @@ variable "stream_view_type" {
 }
 
 variable "lambda_error_alarm_arn" {}
+
+variable "infra_bucket" {}

--- a/shared_infra/ecs_ec2_instance_tagger/main.tf
+++ b/shared_infra/ecs_ec2_instance_tagger/main.tf
@@ -13,6 +13,7 @@ module "lambda_ecs_ec2_instance_tagger" {
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_bucket       = "${var.infra_bucket}"
   s3_key          = "lambdas/shared_infra/ecs_ec2_instance_tagger.zip"
 }
 

--- a/shared_infra/ecs_ec2_instance_tagger/variables.tf
+++ b/shared_infra/ecs_ec2_instance_tagger/variables.tf
@@ -3,3 +3,5 @@ variable "lambda_error_alarm_arn" {}
 variable "ecs_container_instance_state_change_arn" {}
 variable "ecs_container_instance_state_change_name" {}
 variable "bucket_infra_arn" {}
+
+variable "infra_bucket" {}

--- a/shared_infra/main.tf
+++ b/shared_infra/main.tf
@@ -5,6 +5,8 @@ module "drain_ecs_container_instance" {
   ec2_terminating_topic_arn            = "${module.ec2_terminating_topic.arn}"
 
   lambda_error_alarm_arn = "${module.lambda_error_alarm.arn}"
+
+  infra_bucket = "${var.infra_bucket}"
 }
 
 module "ecs_ec2_instance_tagger" {
@@ -17,12 +19,16 @@ module "ecs_ec2_instance_tagger" {
   ecs_container_instance_state_change_arn  = "${aws_cloudwatch_event_rule.ecs_container_instance_state_change.arn}"
 
   lambda_error_alarm_arn = "${module.lambda_error_alarm.arn}"
+
+  infra_bucket = "${var.infra_bucket}"
 }
 
 module "run_ecs_task" {
   source = "run_ecs_task"
 
   lambda_error_alarm_arn = "${module.lambda_error_alarm.arn}"
+
+  infra_bucket = "${var.infra_bucket}"
 }
 
 module "service_scheduler" {
@@ -30,6 +36,8 @@ module "service_scheduler" {
 
   service_scheduler_topic_publish_policy = "${module.service_scheduler_topic.publish_policy}"
   lambda_error_alarm_arn                 = "${module.lambda_error_alarm.arn}"
+
+  infra_bucket = "${var.infra_bucket}"
 }
 
 module "update_ecs_service_size" {
@@ -38,4 +46,6 @@ module "update_ecs_service_size" {
   service_scheduler_topic_arn = "${module.service_scheduler_topic.arn}"
 
   lambda_error_alarm_arn = "${module.lambda_error_alarm.arn}"
+
+  infra_bucket = "${var.infra_bucket}"
 }

--- a/shared_infra/run_ecs_task/main.tf
+++ b/shared_infra/run_ecs_task/main.tf
@@ -7,6 +7,7 @@ module "lambda_run_ecs_task" {
   description = "Run an ECS task from a message published to SNS"
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_bucket       = "${var.infra_bucket}"
   s3_key          = "lambdas/shared_infra/run_ecs_task.zip"
 }
 

--- a/shared_infra/run_ecs_task/variables.tf
+++ b/shared_infra/run_ecs_task/variables.tf
@@ -1,1 +1,3 @@
 variable "lambda_error_alarm_arn" {}
+
+variable "infra_bucket" {}

--- a/shared_infra/s3.tf
+++ b/shared_infra/s3.tf
@@ -12,7 +12,7 @@ resource "aws_s3_bucket" "platform_infra" {
 }
 
 resource "aws_s3_bucket" "infra" {
-  bucket = "${var.infra_bucket}"
+  bucket = "platform-infra"
   acl    = "private"
 
   lifecycle {

--- a/shared_infra/service_scheduler/main.tf
+++ b/shared_infra/service_scheduler/main.tf
@@ -7,5 +7,6 @@ module "lambda_service_scheduler" {
   description = "Publish an ECS service schedule to SNS"
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_bucket       = "${var.infra_bucket}"
   s3_key          = "lambdas/shared_infra/service_scheduler.zip"
 }

--- a/shared_infra/service_scheduler/variables.tf
+++ b/shared_infra/service_scheduler/variables.tf
@@ -1,2 +1,4 @@
 variable "lambda_error_alarm_arn" {}
 variable "service_scheduler_topic_publish_policy" {}
+
+variable "infra_bucket" {}

--- a/shared_infra/update_ecs_service_size/main.tf
+++ b/shared_infra/update_ecs_service_size/main.tf
@@ -6,6 +6,7 @@ module "lambda_update_ecs_service_size" {
   description = "Update the desired count of an ECS service"
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  s3_bucket       = "${var.infra_bucket}"
   s3_key          = "lambdas/shared_infra/update_ecs_service_size.zip"
 }
 

--- a/shared_infra/update_ecs_service_size/variables.tf
+++ b/shared_infra/update_ecs_service_size/variables.tf
@@ -1,2 +1,4 @@
 variable "lambda_error_alarm_arn" {}
 variable "service_scheduler_topic_arn" {}
+
+variable "infra_bucket" {}

--- a/shared_infra/variables.tf
+++ b/shared_infra/variables.tf
@@ -5,7 +5,6 @@ variable "aws_region" {
 
 variable "infra_bucket" {
   description = "S3 bucket storing our configuration"
-  default     = "platform-infra"
 }
 
 variable "release_ids" {

--- a/sierra_adapter/terraform/pipeline_bibs.tf
+++ b/sierra_adapter/terraform/pipeline_bibs.tf
@@ -40,6 +40,8 @@ module "bibs_reader" {
   lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
 
   account_id = "${data.aws_caller_identity.current.account_id}"
+
+  infra_bucket = "${var.infra_bucket}"
 }
 
 module "bibs_merger" {

--- a/sierra_adapter/terraform/pipeline_bibs.tf
+++ b/sierra_adapter/terraform/pipeline_bibs.tf
@@ -7,6 +7,7 @@ module "bibs_window_generator" {
   trigger_interval_minutes = 15
 
   lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
+  infra_bucket           = "${var.infra_bucket}"
 }
 
 module "bibs_reader" {

--- a/sierra_adapter/terraform/pipeline_items.tf
+++ b/sierra_adapter/terraform/pipeline_items.tf
@@ -40,6 +40,8 @@ module "items_reader" {
   lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
 
   account_id = "${data.aws_caller_identity.current.account_id}"
+
+  infra_bucket = "${var.infra_bucket}"
 }
 
 module "items_to_dynamo" {

--- a/sierra_adapter/terraform/pipeline_items.tf
+++ b/sierra_adapter/terraform/pipeline_items.tf
@@ -7,6 +7,7 @@ module "items_window_generator" {
   trigger_interval_minutes = 15
 
   lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
+  infra_bucket           = "${var.infra_bucket}"
 }
 
 module "items_reader" {

--- a/sierra_adapter/terraform/sierra_reader/lambdas.tf
+++ b/sierra_adapter/terraform/sierra_reader/lambdas.tf
@@ -1,5 +1,6 @@
 module "s3_demultiplexer_lambda" {
   source      = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.3"
+  s3_bucket   = "${var.infra_bucket}"
   s3_key      = "lambdas/sierra_adapter/s3_demultiplexer.zip"
   module_name = "s3_demultiplexer"
 

--- a/sierra_adapter/terraform/sierra_reader/variables.tf
+++ b/sierra_adapter/terraform/sierra_reader/variables.tf
@@ -29,3 +29,4 @@ variable "aws_region" {
 }
 
 variable "account_id" {}
+variable "infra_bucket" {}

--- a/sierra_adapter/terraform/sierra_window_generator/lambdas.tf
+++ b/sierra_adapter/terraform/sierra_window_generator/lambdas.tf
@@ -3,6 +3,7 @@ module "window_generator_lambda" {
 
   name = "sierra_${var.resource_type}_window_generator"
 
+  s3_bucket   = "${var.infra_bucket}"
   s3_key      = "lambdas/sierra_adapter/sierra_window_generator.zip"
   module_name = "sierra_window_generator"
 

--- a/sierra_adapter/terraform/sierra_window_generator/variables.tf
+++ b/sierra_adapter/terraform/sierra_window_generator/variables.tf
@@ -4,3 +4,5 @@ variable "window_length_minutes" {}
 variable "trigger_interval_minutes" {}
 
 variable "lambda_error_alarm_arn" {}
+
+variable "infra_bucket" {}

--- a/sierra_adapter/terraform/variables.tf
+++ b/sierra_adapter/terraform/variables.tf
@@ -17,3 +17,5 @@ variable "sierra_oauth_secret" {}
 
 variable "sierra_bibs_fields" {}
 variable "sierra_items_fields" {}
+
+variable "infra_bucket" {}


### PR DESCRIPTION
Another piece of #1544 – Lambdas now live in wellcomecollection-platform-infra.

I’m going to get this migrated, and merge it as soon as tests go green, or we'll have conflicting Terraform state.