### PR TITLE
Get rid of the old infra bucket

### DIFF
--- a/functions.Makefile
+++ b/functions.Makefile
@@ -204,7 +204,7 @@ endef
 #	$2 - Path to the Lambda source directory.
 #
 define __lambda_target_template
-$(1)-test: 
+$(1)-test:
 	$(call test_lambda,$(2))
 
 $(1)-publish:

--- a/functions.Makefile
+++ b/functions.Makefile
@@ -67,7 +67,7 @@ define terraform_apply
 	$(ROOT)/docker_run.py --aws -- \
 		--volume $(ROOT):/data \
 		--workdir /data/$(1) \
-		--env BUCKET_NAME=wellcomecollection-platform-infra \
+		--env BUCKET_NAME=wellcomecollection-platform-monitoring \
 		--env OP=apply \
 		wellcome/terraform_wrapper:latest
 endef

--- a/monitoring/ecs_dashboard/Makefile
+++ b/monitoring/ecs_dashboard/Makefile
@@ -25,6 +25,6 @@ $(ROOT)/.docker/ecs_dashboard:
 ecs_dashboard_client-publish: $(ROOT)/.docker/ecs_dashboard
 	$(ROOT)/docker_run.py --aws -- \
 		--volume $(ECS_DASHBOARD)/client:/dashboard \
-		--env BUCKET_NAME=wellcome-platform-dash \
-		--env PATH_PREFIX=https://s3-eu-west-1.amazonaws.com/wellcome-platform-dash/ \
+		--env BUCKET_NAME=wellcomecollection-platform-dashboard \
+		--env PATH_PREFIX=https://s3-eu-west-1.amazonaws.com/wellcomecollection-platform-dashboard/ \
 		ecs_dashboard

--- a/monitoring/ecs_dashboard/client/.gitignore
+++ b/monitoring/ecs_dashboard/client/.gitignore
@@ -19,6 +19,3 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-# app specific
-config.js

--- a/monitoring/ecs_dashboard/client/Dockerfile
+++ b/monitoring/ecs_dashboard/client/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:8
+FROM alpine
 
-LABEL maintainer "Alex Chan <a.chan@wellcome.ac.uk>"
+LABEL maintainer "Digital Platform <wellcomedigitalplatform@wellcome.ac.uk>"
 LABEL description "Used for deploying our ECS dashboard to AWS"
 
-RUN apt-get update
-RUN apt-get install --yes awscli jq
+RUN apk update && apk add jq nodejs py2-pip
+RUN pip install awscli
 
 VOLUME ["/dashboard"]
 WORKDIR /dashboard

--- a/monitoring/ecs_dashboard/client/package.json
+++ b/monitoring/ecs_dashboard/client/package.json
@@ -24,5 +24,5 @@
     "eject": "react-scripts eject",
     "flow": "flow"
   },
-  "homepage": "https://s3-eu-west-1.amazonaws.com/wellcome-platform-dash/"
+  "homepage": "https://s3-eu-west-1.amazonaws.com/wellcomecollection-platform-dashboard/"
 }

--- a/monitoring/ecs_dashboard/client/src/config.js
+++ b/monitoring/ecs_dashboard/client/src/config.js
@@ -1,0 +1,9 @@
+// @flow
+
+import type {Config} from './models'
+
+const AppConfig: Config = {
+    serviceListLocation: 'https://s3-eu-west-1.amazonaws.com/wellcomecollection-platform-dashboard/data/ecs_status.json'
+}
+
+export default AppConfig;

--- a/monitoring/ecs_dashboard/iam_policy_document.tf
+++ b/monitoring/ecs_dashboard/iam_policy_document.tf
@@ -1,5 +1,5 @@
-data "aws_s3_bucket" "monitoring" {
-  bucket = "${var.monitoring_bucket_id}"
+data "aws_s3_bucket" "dashboard" {
+  bucket = "${var.dashboard_bucket}"
 }
 
 data "aws_iam_policy_document" "s3_put_dashboard_status" {
@@ -11,7 +11,7 @@ data "aws_iam_policy_document" "s3_put_dashboard_status" {
     ]
 
     resources = [
-      "${data.aws_s3_bucket.monitoring.arn}/data/*",
+      "${data.aws_s3_bucket.dashboard.arn}/data/*",
     ]
   }
 }

--- a/monitoring/ecs_dashboard/iam_policy_document.tf
+++ b/monitoring/ecs_dashboard/iam_policy_document.tf
@@ -31,3 +31,14 @@ data "aws_iam_policy_document" "describe_services" {
     ]
   }
 }
+
+data "aws_iam_policy_document" "assume_roles" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    resources = [
+      "arn:aws:iam::130871440101:role/platform-team-assume-role",
+      "arn:aws:iam::299497370133:role/platform-team-assume-role",
+    ]
+  }
+}

--- a/monitoring/ecs_dashboard/iam_role_policy.tf
+++ b/monitoring/ecs_dashboard/iam_role_policy.tf
@@ -9,23 +9,6 @@ resource "aws_iam_role_policy" "update_service_list_push_to_s3" {
 }
 
 resource "aws_iam_role_policy" "update_service_list_read_from_webplatform" {
-  role = "${module.update_service_list.role_name}"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": "sts:AssumeRole",
-      "Resource": "arn:aws:iam::130871440101:role/platform-team-assume-role"
-    },
-    {
-      "Effect": "Allow",
-      "Action": "sts:AssumeRole",
-      "Resource": "arn:aws:iam::299497370133:role/platform-team-assume-role"
-    }
-  ]
-}
-EOF
+  role   = "${module.update_service_list.role_name}"
+  policy = "${data.aws_iam_policy_document.assume_roles.json}"
 }

--- a/monitoring/ecs_dashboard/main.tf
+++ b/monitoring/ecs_dashboard/main.tf
@@ -4,7 +4,7 @@ module "update_service_list" {
   every_minute_name = "${var.every_minute_name}"
   every_minute_arn  = "${var.every_minute_arn}"
 
-  monitoring_bucket_id      = "${var.monitoring_bucket_id}"
+  dashboard_bucket          = "${var.dashboard_bucket}"
   dashboard_assumable_roles = "${var.dashboard_assumable_roles}"
 
   lambda_error_alarm_arn = "${var.lambda_error_alarm_arn}"

--- a/monitoring/ecs_dashboard/update_service_list/main.tf
+++ b/monitoring/ecs_dashboard/update_service_list/main.tf
@@ -9,7 +9,7 @@ module "lambda_update_service_list" {
   timeout     = 30
 
   environment_variables = {
-    BUCKET_NAME     = "${var.monitoring_bucket_id}"
+    BUCKET_NAME     = "${var.dashboard_bucket}"
     OBJECT_KEY      = "data/ecs_status.json"
     ASSUMABLE_ROLES = "${join(",", var.dashboard_assumable_roles)}"
   }

--- a/monitoring/ecs_dashboard/update_service_list/variables.tf
+++ b/monitoring/ecs_dashboard/update_service_list/variables.tf
@@ -1,4 +1,4 @@
-variable "monitoring_bucket_id" {}
+variable "dashboard_bucket" {}
 
 variable "dashboard_assumable_roles" {
   type = "list"

--- a/monitoring/ecs_dashboard/variables.tf
+++ b/monitoring/ecs_dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "monitoring_bucket_id" {}
+variable "dashboard_bucket" {}
 variable "lambda_error_alarm_arn" {}
 variable "every_minute_arn" {}
 variable "every_minute_name" {}

--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -93,7 +93,7 @@ module "terraform_tracker" {
   lambda_error_alarm_arn     = "${local.lambda_error_alarm_arn}"
   terraform_apply_topic_name = "${local.terraform_apply_topic_name}"
 
-  infra_bucket       = "${var.infra_bucket}"
+  infra_bucket = "${var.infra_bucket}"
 
   monitoring_bucket  = "${aws_s3_bucket.monitoring.id}"
   slack_webhook      = "${var.non_critical_slack_webhook}"

--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -83,7 +83,7 @@ module "slack_budget_bot" {
 
   slack_webhook           = "${var.non_critical_slack_webhook}"
   release_ids             = "${var.release_ids}"
-  monitoring_bucket_id    = "${aws_s3_bucket.monitoring.id}"
+  monitoring_bucket_id    = "${aws_s3_bucket.dashboard.id}"
   account_id              = "${data.aws_caller_identity.current.account_id}"
   ecs_services_cluster_id = "${local.ecs_services_cluster_id}"
 }

--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -38,7 +38,7 @@ module "ecs_dashboard" {
   source = "ecs_dashboard"
 
   dashboard_assumable_roles = "${var.dashboard_assumable_roles}"
-  monitoring_bucket_id      = "${aws_s3_bucket.monitoring.id}"
+  dashboard_bucket          = "${aws_s3_bucket.dashboard.id}"
 
   every_minute_arn  = "${aws_cloudwatch_event_rule.every_minute.arn}"
   every_minute_name = "${aws_cloudwatch_event_rule.every_minute.name}"

--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -94,6 +94,8 @@ module "terraform_tracker" {
   terraform_apply_topic_name = "${local.terraform_apply_topic_name}"
 
   infra_bucket       = "${var.infra_bucket}"
+
+  monitoring_bucket  = "${aws_s3_bucket.monitoring.id}"
   slack_webhook      = "${var.non_critical_slack_webhook}"
   bitly_access_token = "${var.bitly_access_token}"
 }

--- a/monitoring/s3.tf
+++ b/monitoring/s3.tf
@@ -7,16 +7,6 @@ resource "aws_s3_bucket" "monitoring" {
   }
 
   lifecycle_rule {
-    id      = "budget_graphs"
-    prefix  = "budget_graphs/"
-    enabled = true
-
-    expiration {
-      days = 30
-    }
-  }
-
-  lifecycle_rule {
     id      = "gatling"
     prefix  = "gatling/"
     enabled = true
@@ -47,5 +37,15 @@ resource "aws_s3_bucket" "dashboard" {
     allowed_origins = ["*"]
     expose_headers  = ["ETag"]
     max_age_seconds = 3000
+  }
+
+  lifecycle_rule {
+    id      = "budget_graphs"
+    prefix  = "budget_graphs/"
+    enabled = true
+
+    expiration {
+      days = 30
+    }
   }
 }

--- a/monitoring/s3.tf
+++ b/monitoring/s3.tf
@@ -1,14 +1,6 @@
 resource "aws_s3_bucket" "monitoring" {
   bucket = "wellcomecollection-platform-monitoring"
-  acl    = "public-read"
-
-  cors_rule {
-    allowed_headers = ["*"]
-    allowed_methods = ["GET"]
-    allowed_origins = ["*"]
-    expose_headers  = ["ETag"]
-    max_age_seconds = 3000
-  }
+  acl    = "private"
 
   lifecycle {
     prevent_destroy = true
@@ -32,5 +24,18 @@ resource "aws_s3_bucket" "monitoring" {
     expiration {
       days = 30
     }
+  }
+}
+
+resource "aws_s3_bucket" "dashboard" {
+  bucket = "wellcomecollection-platform-dashboard"
+  acl    = "public-read"
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET"]
+    allowed_origins = ["*"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
   }
 }

--- a/monitoring/s3.tf
+++ b/monitoring/s3.tf
@@ -25,6 +25,16 @@ resource "aws_s3_bucket" "monitoring" {
       days = 30
     }
   }
+
+  lifecycle_rule {
+    id      = "terraform_plans"
+    prefix  = "terraform_plans/"
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
 }
 
 resource "aws_s3_bucket" "dashboard" {

--- a/monitoring/terraform_tracker/main.tf
+++ b/monitoring/terraform_tracker/main.tf
@@ -9,7 +9,7 @@ module "lambda_terraform_tracker" {
   timeout     = 10
 
   environment_variables = {
-    INFRA_BUCKET       = "${var.infra_bucket}"
+    INFRA_BUCKET       = "${var.monitoring_bucket}"
     SLACK_WEBHOOK      = "${var.slack_webhook}"
     BITLY_ACCESS_TOKEN = "${var.bitly_access_token}"
   }

--- a/monitoring/terraform_tracker/variables.tf
+++ b/monitoring/terraform_tracker/variables.tf
@@ -8,6 +8,6 @@ variable "slack_webhook" {
 
 variable "bitly_access_token" {}
 
-variable "infra_bucket" {
-  description = "Bucket where 'terraform plan' outputs are saved"
-}
+variable "monitoring_bucket" {}
+
+variable "infra_bucket" {}

--- a/shared_infra/ecs_ec2_instance_tagger/iam_policy_document.tf
+++ b/shared_infra/ecs_ec2_instance_tagger/iam_policy_document.tf
@@ -1,3 +1,7 @@
+data "aws_s3_bucket" "infra" {
+  bucket = "${var.infra_bucket}"
+}
+
 data "aws_iam_policy_document" "write_ec2_tags" {
   statement {
     actions = [
@@ -17,7 +21,7 @@ data "aws_iam_policy_document" "s3_put_infra_tmp" {
     ]
 
     resources = [
-      "${var.bucket_infra_arn}/tmp/*",
+      "${data.aws_s3_bucket.infra.arn}/tmp/*",
     ]
   }
 

--- a/shared_infra/ecs_ec2_instance_tagger/main.tf
+++ b/shared_infra/ecs_ec2_instance_tagger/main.tf
@@ -8,7 +8,7 @@ module "lambda_ecs_ec2_instance_tagger" {
   timeout     = 10
 
   environment_variables = {
-    BUCKET_NAME = "${var.bucket_infra_id}"
+    BUCKET_NAME = "${var.infra_bucket}"
     OBJECT_PATH = "tmp/ecs_ec2_instance_tagger"
   }
 

--- a/shared_infra/ecs_ec2_instance_tagger/variables.tf
+++ b/shared_infra/ecs_ec2_instance_tagger/variables.tf
@@ -1,7 +1,5 @@
-variable "bucket_infra_id" {}
 variable "lambda_error_alarm_arn" {}
 variable "ecs_container_instance_state_change_arn" {}
 variable "ecs_container_instance_state_change_name" {}
-variable "bucket_infra_arn" {}
 
 variable "infra_bucket" {}

--- a/shared_infra/iam_policy_document.tf
+++ b/shared_infra/iam_policy_document.tf
@@ -44,8 +44,8 @@ data "aws_iam_policy_document" "travis_permissions" {
     ]
 
     resources = [
-      "${aws_s3_bucket.infra.arn}/lambdas/*",
-      "${aws_s3_bucket.infra.arn}/releases/*",
+      "${aws_s3_bucket.platform_infra.arn}/lambdas/*",
+      "${aws_s3_bucket.platform_infra.arn}/releases/*",
     ]
   }
 
@@ -114,7 +114,7 @@ data "aws_iam_policy_document" "upload_sqs_freeze" {
     ]
 
     resources = [
-      "${aws_s3_bucket.infra.arn}/sqs/*",
+      "${aws_s3_bucket.platform_infra.arn}/sqs/*",
     ]
   }
 }

--- a/shared_infra/main.tf
+++ b/shared_infra/main.tf
@@ -12,9 +12,6 @@ module "drain_ecs_container_instance" {
 module "ecs_ec2_instance_tagger" {
   source = "ecs_ec2_instance_tagger"
 
-  bucket_infra_id  = "${aws_s3_bucket.infra.id}"
-  bucket_infra_arn = "${aws_s3_bucket.infra.arn}"
-
   ecs_container_instance_state_change_name = "${aws_cloudwatch_event_rule.ecs_container_instance_state_change.name}"
   ecs_container_instance_state_change_arn  = "${aws_cloudwatch_event_rule.ecs_container_instance_state_change.arn}"
 

--- a/shared_infra/provider.tf
+++ b/shared_infra/provider.tf
@@ -1,8 +1,6 @@
-# Specify the provider and access details
 provider "aws" {
-  region = "${var.aws_region}"
-
-  version = "0.1.4"
+  region  = "${var.aws_region}"
+  version = "1.10.0"
 }
 
 data "aws_caller_identity" "current" {}

--- a/shared_infra/s3.tf
+++ b/shared_infra/s3.tf
@@ -21,25 +21,6 @@ resource "aws_s3_bucket" "platform_infra" {
   }
 }
 
-resource "aws_s3_bucket" "infra" {
-  bucket = "platform-infra"
-  acl    = "private"
-
-  lifecycle {
-    prevent_destroy = true
-  }
-
-  lifecycle_rule {
-    id      = "elasticdump"
-    prefix  = "elasticdump/"
-    enabled = true
-
-    expiration {
-      days = 30
-    }
-  }
-}
-
 locals {
   alb_logs_bucket_name = "wellcomecollection-platform-logs-alb"
 }

--- a/shared_infra/s3.tf
+++ b/shared_infra/s3.tf
@@ -38,16 +38,6 @@ resource "aws_s3_bucket" "infra" {
       days = 30
     }
   }
-
-  lifecycle_rule {
-    id      = "terraform_plans"
-    prefix  = "terraform_plans/"
-    enabled = true
-
-    expiration {
-      days = 30
-    }
-  }
 }
 
 locals {

--- a/shared_infra/s3.tf
+++ b/shared_infra/s3.tf
@@ -2,6 +2,16 @@ resource "aws_s3_bucket" "platform_infra" {
   bucket = "wellcomecollection-platform-infra"
   acl    = "private"
 
+  lifecycle_rule {
+    id      = "tmp"
+    prefix  = "tmp/"
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
+
   lifecycle {
     prevent_destroy = true
   }
@@ -17,16 +27,6 @@ resource "aws_s3_bucket" "infra" {
 
   lifecycle {
     prevent_destroy = true
-  }
-
-  lifecycle_rule {
-    id      = "tmp"
-    prefix  = "tmp/"
-    enabled = true
-
-    expiration {
-      days = 30
-    }
   }
 
   lifecycle_rule {


### PR DESCRIPTION
This patch contains a mixture of pieces that allow us to delete the old platform-infra bucket:

* Creates a new bucket **wellcomecollection-platform-dashboard** which is entirely public, and holds the ECS dashboard and associated data. Plus some improvements to the dashboard build process.

* Switch the terraform-tracker to use the monitoring bucket, not platform-infra. Ditto for the budget bot and ecs_ec2_instance_tagger.

* Plus a bunch of small things to hold it all together.

Resolves #1544.