### PR TITLE
Tweak our scalafmt config slightly

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,1 +1,2 @@
+align.openParenCallSite = false
 continuationIndent.defnSite = 2

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,3 @@
 align.openParenCallSite = false
 continuationIndent.defnSite = 2
+rewrite.rules = [SortImports]

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
@@ -49,9 +49,10 @@ class Server extends HttpServer {
 
   flag[String](name = "es.index", default = "records", help = "ES index name")
   flag[String](name = "es.type", default = "item", help = "ES document type")
-  flag(name = "api.context",
-       default = apiPrefix() + "/context.json",
-       help = "API JSON-LD context")
+  flag(
+    name = "api.context",
+    default = apiPrefix() + "/context.json",
+    help = "API JSON-LD context")
 
   override def jacksonModule = ApiJacksonModule
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -58,9 +58,10 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
         .responseWith[DisplayError](400, "Bad Request Error")
         .responseWith[DisplayError](404, "Not Found Error")
         .responseWith[DisplayError](500, "Internal Server Error")
-        .queryParam[Int]("page",
-                         "The page to return from the result list",
-                         required = false)
+        .queryParam[Int](
+          "page",
+          "The page to return from the result list",
+          required = false)
         .queryParam[Int](
           "pageSize",
           "The number of works to return per page (default: 10)",
@@ -139,9 +140,10 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
     // Deliberately undocumented: the index flag.  See above.
     } { request: SingleWorkRequest =>
       worksService
-        .findWorkById(request.id,
-                      request.includes.getOrElse(WorksIncludes()),
-                      index = request._index)
+        .findWorkById(
+          request.id,
+          request.includes.getOrElse(WorksIncludes()),
+          index = request._index)
         .map {
 
           // If the work is visible, we return the complete work.  If it's
@@ -170,8 +172,9 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
                 Some(s"Work not found for identifier ${request.id}")
             )
             response.notFound.json(
-              ResultResponse(context = contextUri,
-                             result = DisplayError(result))
+              ResultResponse(
+                context = contextUri,
+                result = DisplayError(result))
             )
           }
         }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
@@ -91,12 +91,14 @@ class ElasticsearchResponseExceptionMapper @Inject()(
         resultSizePattern.findFirstMatchIn(reason) match {
           case Some(s) => {
             val size = s.group(1)
-            userError(s"Only the first $size works are available in the API.",
-                      exception)
+            userError(
+              s"Only the first $size works are available in the API.",
+              exception)
           }
           case _ => {
-            serverError(s"Unknown error in search phase execution: $reason",
-                        exception)
+            serverError(
+              s"Unknown error in search phase execution: $reason",
+              exception)
           }
         }
       }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/modules/ElasticSearchServiceModule/ElasticSearchServiceModule.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/modules/ElasticSearchServiceModule/ElasticSearchServiceModule.scala
@@ -9,17 +9,19 @@ import uk.ac.wellcome.platform.api.services.ElasticSearchService
 object ElasticSearchServiceModule extends TwitterModule {
   override val modules = Seq(ElasticClientModule)
 
-  private val defaultIndex = flag[String](name = "es.index",
-                                          default = "records",
-                                          help = "ES index name")
+  private val defaultIndex = flag[String](
+    name = "es.index",
+    default = "records",
+    help = "ES index name")
   private val documentType =
     flag[String](name = "es.type", default = "item", help = "ES document type")
 
   @Provides
   def providesElasticSearchService(
     elasticClient: HttpClient): ElasticSearchService =
-    new ElasticSearchService(defaultIndex = defaultIndex(),
-                             documentType = documentType(),
-                             elasticClient = elasticClient)
+    new ElasticSearchService(
+      defaultIndex = defaultIndex(),
+      documentType = documentType(),
+      elasticClient = elasticClient)
 
 }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayIdentifier.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayIdentifier.scala
@@ -19,6 +19,7 @@ case class DisplayIdentifier(
 
 object DisplayIdentifier {
   def apply(sourceIdentifier: SourceIdentifier): DisplayIdentifier =
-    DisplayIdentifier(identifierScheme = sourceIdentifier.identifierScheme,
-                      value = sourceIdentifier.value)
+    DisplayIdentifier(
+      identifierScheme = sourceIdentifier.identifierScheme,
+      value = sourceIdentifier.value)
 }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.{JsonIgnoreProperties, JsonProperty}
 import com.sksamuel.elastic4s.http.search.SearchHit
 import com.sksamuel.elastic4s.http.get.GetResponse
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.{Item, SourceIdentifier, IdentifiedWork}
+import uk.ac.wellcome.models.{IdentifiedWork, Item, SourceIdentifier}
 import uk.ac.wellcome.utils.JsonUtil._
 
 @JsonIgnoreProperties(Array("visible"))

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
@@ -34,21 +34,23 @@ trait WorksUtil {
       ))
 
   def workWith(canonicalId: String, title: String): IdentifiedWork =
-    IdentifiedWork(title = Some(title),
-                   sourceIdentifier = sourceIdentifier,
-                   version = 1,
-                   identifiers = List(sourceIdentifier),
-                   canonicalId = canonicalId)
+    IdentifiedWork(
+      title = Some(title),
+      sourceIdentifier = sourceIdentifier,
+      version = 1,
+      identifiers = List(sourceIdentifier),
+      canonicalId = canonicalId)
 
   def workWith(canonicalId: String,
                title: String,
                visible: Boolean): IdentifiedWork =
-    IdentifiedWork(title = Some(title),
-                   sourceIdentifier = sourceIdentifier,
-                   version = 1,
-                   identifiers = List(sourceIdentifier),
-                   canonicalId = canonicalId,
-                   visible = visible)
+    IdentifiedWork(
+      title = Some(title),
+      sourceIdentifier = sourceIdentifier,
+      version = 1,
+      identifiers = List(sourceIdentifier),
+      canonicalId = canonicalId,
+      visible = visible)
 
   def workWith(
     canonicalId: String,
@@ -56,12 +58,13 @@ trait WorksUtil {
     identifiers: List[SourceIdentifier] = List(),
     items: List[IdentifiedItem] = List()
   ): IdentifiedWork =
-    IdentifiedWork(title = Some(title),
-                   sourceIdentifier = sourceIdentifier,
-                   version = 1,
-                   identifiers = identifiers,
-                   canonicalId = canonicalId,
-                   items = items)
+    IdentifiedWork(
+      title = Some(title),
+      sourceIdentifier = sourceIdentifier,
+      version = 1,
+      identifiers = identifiers,
+      canonicalId = canonicalId,
+      items = items)
 
   def identifiedWorkWith(
     canonicalId: String,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayDigitalLocationTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayDigitalLocationTest.scala
@@ -52,8 +52,9 @@ class DisplayLocationTest extends FunSpec with Matchers {
 
       val displayLocation = DisplayLocation(physicalLocation)
 
-      displayLocation shouldBe DisplayPhysicalLocation(locationType,
-                                                       locationLabel)
+      displayLocation shouldBe DisplayPhysicalLocation(
+        locationType,
+        locationLabel)
     }
   }
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayWorkTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayWorkTest.scala
@@ -51,12 +51,12 @@ class DisplayWorkTest extends FunSpec with Matchers {
   )
 
   it("correctly parses a work without any identifiers") {
-    val work = IdentifiedWork(title =
-                                Some("An irascible iguana invites impudence"),
-                              sourceIdentifier = sourceIdentifier,
-                              version = 1,
-                              identifiers = Nil,
-                              canonicalId = "xtsx8hwk")
+    val work = IdentifiedWork(
+      title = Some("An irascible iguana invites impudence"),
+      sourceIdentifier = sourceIdentifier,
+      version = 1,
+      identifiers = Nil,
+      canonicalId = "xtsx8hwk")
 
     val displayWork = DisplayWork(
       work = work,
@@ -116,8 +116,9 @@ class DisplayWorkTest extends FunSpec with Matchers {
       val displayWork = DisplayWork(work)
       displayWork.publishers shouldBe List(
         new DisplayAgent(label = "Janet Jackson", ontologyType = "Agent"),
-        new DisplayAgent(label = "Juniper Journals",
-                         ontologyType = "Organisation")
+        new DisplayAgent(
+          label = "Juniper Journals",
+          ontologyType = "Organisation")
       )
     }
   }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -39,10 +39,12 @@ class WorksServiceTest
 
     displayWorksFuture map { displayWork =>
       displayWork.results should have size 2
-      displayWork.results.head shouldBe DisplayWork(works(0).canonicalId,
-                                                    works(0).title.get)
-      displayWork.results.tail.head shouldBe DisplayWork(works(1).canonicalId,
-                                                         works(1).title.get)
+      displayWork.results.head shouldBe DisplayWork(
+        works(0).canonicalId,
+        works(0).title.get)
+      displayWork.results.tail.head shouldBe DisplayWork(
+        works(1).canonicalId,
+        works(1).title.get)
     }
   }
 
@@ -80,8 +82,9 @@ class WorksServiceTest
     val searchForDodo = worksService.searchWorks("dodo")
     whenReady(searchForDodo) { works =>
       works.results should have size 1
-      works.results.head shouldBe DisplayWork(workDodo.canonicalId,
-                                              workDodo.title.get)
+      works.results.head shouldBe DisplayWork(
+        workDodo.canonicalId,
+        workDodo.title.get)
     }
   }
 
@@ -135,8 +138,9 @@ class WorksServiceTest
       worksService.listWorks(pageSize = 1, pageNumber = 2)
 
     whenReady(displayWorksFuture) { receivedWorks =>
-      receivedWorks.results.head shouldBe DisplayWork(works(1),
-                                                      WorksIncludes())
+      receivedWorks.results.head shouldBe DisplayWork(
+        works(1),
+        WorksIncludes())
     }
   }
 
@@ -168,8 +172,9 @@ class WorksServiceTest
 
     whenReady(searchForEmu) { works =>
       works.results should have size 1
-      works.results.head shouldBe DisplayWork(workEmu.canonicalId,
-                                              workEmu.title.get)
+      works.results.head shouldBe DisplayWork(
+        workEmu.canonicalId,
+        workEmu.title.get)
     }
   }
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
@@ -67,14 +67,15 @@ class ApiWorksTest extends ApiWorksTestBase {
   }
 
   it("should return a single work when requested with id") {
-    val work = workWith(canonicalId = canonicalId,
-                        title = title,
-                        description = description,
-                        lettering = lettering,
-                        createdDate = period,
-                        creator = agent,
-                        items = List(defaultItem),
-                        visible = true)
+    val work = workWith(
+      canonicalId = canonicalId,
+      title = title,
+      description = description,
+      lettering = lettering,
+      createdDate = period,
+      creator = agent,
+      items = List(defaultItem),
+      visible = true)
 
     insertIntoElasticSearch(work)
 
@@ -180,12 +181,12 @@ class ApiWorksTest extends ApiWorksTestBase {
       identifiers = List(),
       locations = List(location)
     )
-    val workWithCopyright = IdentifiedWork(title =
-                                             Some("A scarf on a squirrel"),
-                                           sourceIdentifier = sourceIdentifier,
-                                           version = 1,
-                                           canonicalId = "yxh928a",
-                                           items = List(item))
+    val workWithCopyright = IdentifiedWork(
+      title = Some("A scarf on a squirrel"),
+      sourceIdentifier = sourceIdentifier,
+      version = 1,
+      canonicalId = "yxh928a",
+      items = List(item))
     insertIntoElasticSearch(workWithCopyright)
 
     eventually {
@@ -238,9 +239,10 @@ class ApiWorksTest extends ApiWorksTestBase {
         andExpect = Status.Ok,
         withJsonBody = s"""
                           |{
-                          |  ${resultList(pageSize = 1,
-                                          totalPages = 3,
-                                          totalResults = 3)},
+                          |  ${resultList(
+                            pageSize = 1,
+                            totalPages = 3,
+                            totalResults = 3)},
                           |  "prevPage": "https://localhost:8888/$apiPrefix/works?page=1&pageSize=1",
                           |  "nextPage": "https://localhost:8888/$apiPrefix/works?page=3&pageSize=1",
                           |  "results": [
@@ -268,9 +270,10 @@ class ApiWorksTest extends ApiWorksTestBase {
         andExpect = Status.Ok,
         withJsonBody = s"""
                           |{
-                          |  ${resultList(pageSize = 1,
-                                          totalPages = 3,
-                                          totalResults = 3)},
+                          |  ${resultList(
+                            pageSize = 1,
+                            totalPages = 3,
+                            totalResults = 3)},
                           |  "nextPage": "https://localhost:8888/$apiPrefix/works?page=2&pageSize=1",
                           |  "results": [
                           |   {
@@ -297,9 +300,10 @@ class ApiWorksTest extends ApiWorksTestBase {
         andExpect = Status.Ok,
         withJsonBody = s"""
                           |{
-                          |  ${resultList(pageSize = 1,
-                                          totalPages = 3,
-                                          totalResults = 3)},
+                          |  ${resultList(
+                            pageSize = 1,
+                            totalPages = 3,
+                            totalResults = 3)},
                           |  "prevPage": "https://localhost:8888/$apiPrefix/works?page=2&pageSize=1",
                           |  "results": [
                           |   {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/LocationsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/LocationsTest.scala
@@ -6,17 +6,19 @@ import uk.ac.wellcome.models._
 class LocationsTest extends ApiWorksTestBase {
   it("should render a physical location correctly") {
     val physicalLocation: Location =
-      PhysicalLocation(locationType = "smeg",
-                       label = "a stack of slick slimes")
+      PhysicalLocation(
+        locationType = "smeg",
+        label = "a stack of slick slimes")
     val work = IdentifiedWork(
       canonicalId = "zm9q6c6h",
       sourceIdentifier = sourceIdentifier,
       version = 1,
       title = Some("A zoo of zebras doing zumba"),
       items = List(
-        IdentifiedItem(canonicalId = "mhberjwy7",
-                       sourceIdentifier = sourceIdentifier,
-                       locations = List(physicalLocation)))
+        IdentifiedItem(
+          canonicalId = "mhberjwy7",
+          sourceIdentifier = sourceIdentifier,
+          locations = List(physicalLocation)))
     )
 
     insertIntoElasticSearch(work)

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/TableProvisioner.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/TableProvisioner.scala
@@ -13,9 +13,10 @@ class TableProvisioner @Inject()(@Flag("aws.rds.host") host: String,
 
   def provision(database: String, tableName: String): Unit = {
     val flyway = new Flyway()
-    flyway.setDataSource(s"jdbc:mysql://$host:$port/$database",
-                         userName,
-                         password)
+    flyway.setDataSource(
+      s"jdbc:mysql://$host:$port/$database",
+      userName,
+      password)
     flyway.setPlaceholders(
       Map("database" -> database, "tableName" -> tableName))
     flyway.migrate()

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerModule.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerModule.scala
@@ -6,12 +6,14 @@ import uk.ac.wellcome.platform.idminter.database.TableProvisioner
 import uk.ac.wellcome.platform.idminter.services.IdMinterWorkerService
 
 object IdMinterWorkerModule extends TwitterModule {
-  val database = flag[String]("aws.rds.identifiers.database",
-                              "",
-                              "Name of the identifiers database")
-  val tableName = flag[String]("aws.rds.identifiers.table",
-                               "",
-                               "Name of the identifiers table")
+  val database = flag[String](
+    "aws.rds.identifiers.database",
+    "",
+    "Name of the identifiers database")
+  val tableName = flag[String](
+    "aws.rds.identifiers.table",
+    "",
+    "Name of the identifiers table")
 
   override def singletonStartup(injector: Injector) {
     val tableProvisioner = injector.instance[TableProvisioner]

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/MysqlModule.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/MysqlModule.scala
@@ -10,9 +10,10 @@ object MysqlModule extends TwitterModule {
     flag[String]("aws.rds.host", "", "Host of the MySQL database")
   private val port =
     flag[String]("aws.rds.port", "3306", "Port of the MySQL database")
-  private val userName = flag[String]("aws.rds.userName",
-                                      "",
-                                      "User to connect to the MySQL database")
+  private val userName = flag[String](
+    "aws.rds.userName",
+    "",
+    "User to connect to the MySQL database")
   private val password = flag[String](
     "aws.rds.password",
     "",
@@ -21,9 +22,10 @@ object MysqlModule extends TwitterModule {
   @Provides
   def providesDB(): DB = {
     Class.forName("com.mysql.jdbc.Driver")
-    ConnectionPool.singleton(s"jdbc:mysql://${host()}:${port()}",
-                             userName(),
-                             password())
+    ConnectionPool.singleton(
+      s"jdbc:mysql://${host()}:${port()}",
+      userName(),
+      password())
     implicit val session = AutoSession
     DB.connect()
   }

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -34,10 +34,11 @@ class IdMinterFeatureTest
     val identifier =
       SourceIdentifier(IdentifierSchemes.miroImageNumber, miroID)
 
-    val work = UnidentifiedWork(title = Some(title),
-                                sourceIdentifier = identifier,
-                                version = 1,
-                                identifiers = List(identifier))
+    val work = UnidentifiedWork(
+      title = Some(title),
+      sourceIdentifier = identifier,
+      version = 1,
+      identifiers = List(identifier))
 
     val sqsMessage = SQSMessage(
       Some("subject"),

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/ServerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/ServerTest.scala
@@ -25,8 +25,9 @@ class ServerTest
   )
 
   test("it should show the healthcheck message") {
-    server.httpGet(path = "/management/healthcheck",
-                   andExpect = Ok,
-                   withJsonBody = """{"message": "ok"}""")
+    server.httpGet(
+      path = "/management/healthcheck",
+      andExpect = Ok,
+      withJsonBody = """{"message": "ok"}""")
   }
 }

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -105,8 +105,9 @@ class IdentifiersDaoTest
         select
           .from(identifiersTable as identifiersTable.i)
           .where
-          .eq(identifiersTable.i.SourceSystem,
-              IdentifierSchemes.miroImageNumber.toString)
+          .eq(
+            identifiersTable.i.SourceSystem,
+            IdentifierSchemes.miroImageNumber.toString)
           .and
           .eq(identifiersTable.i.CanonicalId, identifier.CanonicalId)
       }.map(Identifier(identifiersTable.i)).single.apply()

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/TableProvisionerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/TableProvisionerTest.scala
@@ -35,31 +35,36 @@ class TableProvisionerTest
         sql"DESCRIBE $identifiersDatabase.$tableName"
           .map(
             rs =>
-              FieldDescription(rs.string("Field"),
-                               rs.string("Type"),
-                               rs.string("Null"),
-                               rs.string("Key")))
+              FieldDescription(
+                rs.string("Field"),
+                rs.string("Type"),
+                rs.string("Null"),
+                rs.string("Key")))
           .list()
           .apply()
       }
 
       fields.sortBy(_.field) shouldBe Seq(
-        FieldDescription(field = "CanonicalId",
-                         dataType = "varchar(255)",
-                         nullable = "NO",
-                         key = "PRI"),
-        FieldDescription(field = "OntologyType",
-                         dataType = "varchar(255)",
-                         nullable = "NO",
-                         key = "MUL"),
-        FieldDescription(field = "SourceSystem",
-                         dataType = "varchar(255)",
-                         nullable = "NO",
-                         key = ""),
-        FieldDescription(field = "SourceId",
-                         dataType = "varchar(255)",
-                         nullable = "NO",
-                         key = "")
+        FieldDescription(
+          field = "CanonicalId",
+          dataType = "varchar(255)",
+          nullable = "NO",
+          key = "PRI"),
+        FieldDescription(
+          field = "OntologyType",
+          dataType = "varchar(255)",
+          nullable = "NO",
+          key = "MUL"),
+        FieldDescription(
+          field = "SourceSystem",
+          dataType = "varchar(255)",
+          nullable = "NO",
+          key = ""),
+        FieldDescription(
+          field = "SourceId",
+          dataType = "varchar(255)",
+          nullable = "NO",
+          key = "")
       ).sortBy(_.field)
     }
   }

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
@@ -33,10 +33,11 @@ class IdMinterWorkerTest
         sql"DESCRIBE $database.$tableName"
           .map(
             rs =>
-              FieldDescription(rs.string("Field"),
-                               rs.string("Type"),
-                               rs.string("Null"),
-                               rs.string("Key")))
+              FieldDescription(
+                rs.string("Field"),
+                rs.string("Type"),
+                rs.string("Null"),
+                rs.string("Key")))
           .list()
           .apply()
       }
@@ -49,10 +50,11 @@ class IdMinterWorkerTest
         sql"DESCRIBE $database.$tableName"
           .map(
             rs =>
-              FieldDescription(rs.string("Field"),
-                               rs.string("Type"),
-                               rs.string("Null"),
-                               rs.string("Key")))
+              FieldDescription(
+                rs.string("Field"),
+                rs.string("Type"),
+                rs.string("Null"),
+                rs.string("Key")))
           .list()
           .apply()
       }

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -29,9 +29,10 @@ class IdEmbedderTests
   )
 
   private val metricsSender =
-    new MetricsSender("id_minter_test_metrics",
-                      mock[AmazonCloudWatch],
-                      ActorSystem())
+    new MetricsSender(
+      "id_minter_test_metrics",
+      mock[AmazonCloudWatch],
+      ActorSystem())
   private val mockIdentifierGenerator: IdentifierGenerator =
     mock[IdentifierGenerator]
 
@@ -46,9 +47,10 @@ class IdEmbedderTests
       value = "1234"
     )
 
-    val originalWork = UnidentifiedWork(title = Some("crap"),
-                                        sourceIdentifier = identifier,
-                                        version = 1)
+    val originalWork = UnidentifiedWork(
+      title = Some("crap"),
+      sourceIdentifier = identifier,
+      version = 1)
 
     val newCanonicalId = "5467"
 
@@ -85,9 +87,10 @@ class IdEmbedderTests
       value = "1234"
     )
 
-    val originalWork = UnidentifiedWork(title = Some("crap"),
-                                        sourceIdentifier = identifier,
-                                        version = 1)
+    val originalWork = UnidentifiedWork(
+      title = Some("crap"),
+      sourceIdentifier = identifier,
+      version = 1)
 
     val expectedException = new Exception("Aaaaah something happened!")
 
@@ -126,11 +129,11 @@ class IdEmbedderTests
       locations = List()
     )
 
-    val originalWork = UnidentifiedWork(title = Some("crap"),
-                                        sourceIdentifier = identifier,
-                                        version = 1,
-                                        items =
-                                          List(originalItem1, originalItem2))
+    val originalWork = UnidentifiedWork(
+      title = Some("crap"),
+      sourceIdentifier = identifier,
+      version = 1,
+      items = List(originalItem1, originalItem2))
 
     val newItemCanonicalId1 = "item1-canonical-id"
     val newItemCanonicalId2 = "item2-canonical-id"

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -22,9 +22,10 @@ class IdentifierGeneratorTest
     with MockitoSugar {
 
   private val metricsSender =
-    new MetricsSender("id_minter_test_metrics",
-                      mock[AmazonCloudWatch],
-                      ActorSystem())
+    new MetricsSender(
+      "id_minter_test_metrics",
+      mock[AmazonCloudWatch],
+      ActorSystem())
 
   val identifierGenerator = new IdentifierGenerator(
     new IdentifiersDao(DB.connect(), identifiersTable),

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdMinterTestUtils.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdMinterTestUtils.scala
@@ -50,11 +50,12 @@ trait IdMinterTestUtils
       version = 1,
       identifiers = List(identifier))
 
-    SQSMessage(Some("subject"),
-               JsonUtil.toJson(work).get,
-               "topic",
-               "messageType",
-               "timestamp")
+    SQSMessage(
+      Some("subject"),
+      JsonUtil.toJson(work).get,
+      "topic",
+      "messageType",
+      "timestamp")
   }
 
   def assertMessageIsNotDeleted(): Unit = {

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -38,11 +38,12 @@ class IngestorFeatureTest
 
     val workString = JsonUtil
       .toJson(
-        IdentifiedWork(title = Some("A type of a tame turtle"),
-                       sourceIdentifier = sourceIdentifier,
-                       version = 1,
-                       identifiers = List(sourceIdentifier),
-                       canonicalId = "1234")
+        IdentifiedWork(
+          title = Some("A type of a tame turtle"),
+          sourceIdentifier = sourceIdentifier,
+          version = 1,
+          identifiers = List(sourceIdentifier),
+          canonicalId = "1234")
       )
       .get
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -31,9 +31,10 @@ class IngestorWorkerServiceTest
     with Ingestor {
 
   val metricsSender: MetricsSender =
-    new MetricsSender(namespace = "reindexer-tests",
-                      mock[AmazonCloudWatch],
-                      ActorSystem())
+    new MetricsSender(
+      namespace = "reindexer-tests",
+      mock[AmazonCloudWatch],
+      ActorSystem())
 
   val workIndexer =
     new WorkIndexer(indexName, itemType, elasticClient, metricsSender)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -19,9 +19,10 @@ class WorkIndexerTest
     with Ingestor {
 
   val metricsSender: MetricsSender =
-    new MetricsSender(namespace = "reindexer-tests",
-                      mock[AmazonCloudWatch],
-                      ActorSystem())
+    new MetricsSender(
+      namespace = "reindexer-tests",
+      mock[AmazonCloudWatch],
+      ActorSystem())
 
   val workIndexer =
     new WorkIndexer(indexName, itemType, elasticClient, metricsSender)
@@ -65,10 +66,11 @@ class WorkIndexerTest
   }
 
   it("replaces a work with the same version") {
-    val work = createWork(canonicalId = "5678",
-                          sourceId = "1234",
-                          title = "A multiplicity of mice",
-                          version = 3)
+    val work = createWork(
+      canonicalId = "5678",
+      sourceId = "1234",
+      title = "A multiplicity of mice",
+      version = 3)
 
     insertIntoElasticSearch(work)
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/Ingestor.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/test/utils/Ingestor.scala
@@ -71,11 +71,12 @@ trait Ingestor
       sourceId
     )
 
-    IdentifiedWork(title = Some(title),
-                   sourceIdentifier = sourceIdentifier,
-                   version = version,
-                   identifiers = List(sourceIdentifier),
-                   canonicalId = canonicalId,
-                   visible = visible)
+    IdentifiedWork(
+      title = Some(title),
+      sourceIdentifier = sourceIdentifier,
+      version = version,
+      identifiers = List(sourceIdentifier),
+      canonicalId = canonicalId,
+      visible = visible)
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformer.scala
@@ -40,9 +40,9 @@ class MiroTransformableTransformer
       Some(
         UnidentifiedWork(
           title = Some(title),
-          sourceIdentifier =
-            SourceIdentifier(IdentifierSchemes.miroImageNumber,
-                             miroTransformable.sourceId),
+          sourceIdentifier = SourceIdentifier(
+            IdentifierSchemes.miroImageNumber,
+            miroTransformable.sourceId),
           version = version,
           identifiers = getIdentifiers(miroData, miroTransformable.sourceId),
           description = description,
@@ -210,8 +210,9 @@ class MiroTransformableTransformer
     // put them all in the same identifier scheme, because we're not doing
     // any transformation or cleaning.
     val libraryRefsList: List[SourceIdentifier] =
-      zipMiroFields(keys = miroData.libraryRefDepartment,
-                    values = miroData.libraryRefId)
+      zipMiroFields(
+        keys = miroData.libraryRefDepartment,
+        values = miroData.libraryRefId)
         .collect {
           case (Some(label), Some(value)) =>
             SourceIdentifier(
@@ -350,18 +351,24 @@ class MiroTransformableTransformer
       // them up.
       case Some(line) =>
         Some(line
-          .replaceAll("Adrian Wressell, Heart of England NHSFT",
-                      "Adrian Wressell, Heart of England NHS FT")
-          .replaceAll("Andrew Dilley,Jane Greening & Bruce Lynn",
-                      "Andrew Dilley, Jane Greening & Bruce Lynn")
-          .replaceAll("Andrew Dilley,Nicola DeLeon & Bruce Lynn",
-                      "Andrew Dilley, Nicola De Leon & Bruce Lynn")
-          .replaceAll("Ashley Prytherch, Royal Surrey County Hospital NHS Foundation Trust",
-                      "Ashley Prytherch, Royal Surrey County Hospital NHS FT")
-          .replaceAll("David Gregory & Debbie Marshall",
-                      "David Gregory and Debbie Marshall")
-          .replaceAll("David Gregory&Debbie Marshall",
-                      "David Gregory and Debbie Marshall")
+          .replaceAll(
+            "Adrian Wressell, Heart of England NHSFT",
+            "Adrian Wressell, Heart of England NHS FT")
+          .replaceAll(
+            "Andrew Dilley,Jane Greening & Bruce Lynn",
+            "Andrew Dilley, Jane Greening & Bruce Lynn")
+          .replaceAll(
+            "Andrew Dilley,Nicola DeLeon & Bruce Lynn",
+            "Andrew Dilley, Nicola De Leon & Bruce Lynn")
+          .replaceAll(
+            "Ashley Prytherch, Royal Surrey County Hospital NHS Foundation Trust",
+            "Ashley Prytherch, Royal Surrey County Hospital NHS FT")
+          .replaceAll(
+            "David Gregory & Debbie Marshall",
+            "David Gregory and Debbie Marshall")
+          .replaceAll(
+            "David Gregory&Debbie Marshall",
+            "David Gregory and Debbie Marshall")
           .replaceAll("Geraldine Thompson.", "Geraldine Thompson")
           .replaceAll("John & Penny Hubley.", "John & Penny Hubley")
           .replaceAll(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
@@ -36,15 +36,17 @@ class CalmTransformerFeatureTest
   it(
     "should poll the dynamo stream for calm data, transform it into unified items and push them into the id_minter SNS topic") {
     val calmTransformable =
-      CalmTransformable(sourceId = "RecordID1",
-                        RecordType = "Collection",
-                        AltRefNo = "AltRefNo1",
-                        RefNo = "RefNo1",
-                        data = """{"AccessStatus": ["public"]}""")
+      CalmTransformable(
+        sourceId = "RecordID1",
+        RecordType = "Collection",
+        AltRefNo = "AltRefNo1",
+        RefNo = "RefNo1",
+        data = """{"AccessStatus": ["public"]}""")
     val calmHybridRecordMessage =
       hybridRecordSqsMessage(JsonUtil.toJson(calmTransformable).get, "calm")
-    sqsClient.sendMessage(queueUrl,
-                          JsonUtil.toJson(calmHybridRecordMessage).get)
+    sqsClient.sendMessage(
+      queueUrl,
+      JsonUtil.toJson(calmHybridRecordMessage).get)
 
     eventually {
       val snsMessages = listMessagesReceivedFromSNS()
@@ -53,23 +55,26 @@ class CalmTransformerFeatureTest
     }
 
     val calmTransformable2 =
-      CalmTransformable(sourceId = "RecordID2",
-                        RecordType = "Collection",
-                        AltRefNo = "AltRefNo2",
-                        RefNo = "RefNo2",
-                        data = """{"AccessStatus": ["restricted"]}""")
+      CalmTransformable(
+        sourceId = "RecordID2",
+        RecordType = "Collection",
+        AltRefNo = "AltRefNo2",
+        RefNo = "RefNo2",
+        data = """{"AccessStatus": ["restricted"]}""")
     val calmHybridRecordMessage2 =
       hybridRecordSqsMessage(JsonUtil.toJson(calmTransformable2).get, "calm")
-    sqsClient.sendMessage(queueUrl,
-                          JsonUtil.toJson(calmHybridRecordMessage2).get)
+    sqsClient.sendMessage(
+      queueUrl,
+      JsonUtil.toJson(calmHybridRecordMessage2).get)
 
     eventually {
       val snsMessages = listMessagesReceivedFromSNS()
       snsMessages should have size 2
 
       assertSNSMessageContainsCalmDataWith(snsMessages.head, Some("public"))
-      assertSNSMessageContainsCalmDataWith(snsMessages.tail.head,
-                                           Some("restricted"))
+      assertSNSMessageContainsCalmDataWith(
+        snsMessages.tail.head,
+        Some("restricted"))
     }
   }
 
@@ -85,10 +90,11 @@ class CalmTransformerFeatureTest
     //currently for calm data we only output hardcoded sample values
     snsMessage.message shouldBe JsonUtil
       .toJson(
-        UnidentifiedWork(title = Some("placeholder title for a Calm record"),
-                         sourceIdentifier = sourceIdentifier,
-                         version = 1,
-                         identifiers = List(sourceIdentifier)))
+        UnidentifiedWork(
+          title = Some("placeholder title for a Calm record"),
+          sourceIdentifier = sourceIdentifier,
+          version = 1,
+          identifiers = List(sourceIdentifier)))
       .get
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
@@ -41,15 +41,17 @@ class SierraTransformerFeatureTest
     val lastModifiedDate = Instant.now()
 
     val sierraHybridRecordMessage =
-      hybridRecordSqsMessage(createValidSierraTransformableJson(
-                               id,
-                               title,
-                               lastModifiedDate
-                             ),
-                             "sierra")
+      hybridRecordSqsMessage(
+        createValidSierraTransformableJson(
+          id,
+          title,
+          lastModifiedDate
+        ),
+        "sierra")
 
-    sqsClient.sendMessage(queueUrl,
-                          JsonUtil.toJson(sierraHybridRecordMessage).get)
+    sqsClient.sendMessage(
+      queueUrl,
+      JsonUtil.toJson(sierraHybridRecordMessage).get)
 
     eventually {
       val snsMessages = listMessagesReceivedFromSNS()

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -48,11 +48,11 @@ class SQSMessageReceiverTest
   val sourceIdentifier =
     SourceIdentifier(IdentifierSchemes.calmPlaceholder, "value")
 
-  val work = UnidentifiedWork(title =
-                                Some("placeholder title for a Calm record"),
-                              sourceIdentifier = sourceIdentifier,
-                              version = 1,
-                              identifiers = List(sourceIdentifier))
+  val work = UnidentifiedWork(
+    title = Some("placeholder title for a Calm record"),
+    sourceIdentifier = sourceIdentifier,
+    version = 1,
+    identifiers = List(sourceIdentifier))
 
   val metricsSender: MetricsSender = new MetricsSender(
     namespace = "record-receiver-tests",
@@ -147,14 +147,15 @@ class SQSMessageReceiverTest
   it(
     "should return a failed future if it's unable to transform the transformable object") {
     val failingTransformCalmSqsMessage: SQSMessage =
-      hybridRecordSqsMessage(createValidCalmTramsformableJson(
-                               RecordID = "abcdef",
-                               RecordType = "collection",
-                               AltRefNo = "AB/CD/12",
-                               RefNo = "AB/CD/12",
-                               data = """not a json string"""
-                             ),
-                             "calm")
+      hybridRecordSqsMessage(
+        createValidCalmTramsformableJson(
+          RecordID = "abcdef",
+          RecordType = "collection",
+          AltRefNo = "AB/CD/12",
+          RefNo = "AB/CD/12",
+          data = """not a json string"""
+        ),
+        "calm")
 
     val future = recordReceiver.receiveMessage(failingTransformCalmSqsMessage)
 
@@ -166,16 +167,19 @@ class SQSMessageReceiverTest
   it("should return a failed future if it's unable to publish the work") {
     val id = "b123"
     val sierraTransformable: Transformable =
-      SierraTransformable(sourceId = id,
-                          bibData = JsonUtil
-                            .toJson(
-                              SierraBibRecord(id = id,
-                                              data = s"""{"id": "$id"}""",
-                                              modifiedDate = Instant.now))
-                            .get)
+      SierraTransformable(
+        sourceId = id,
+        bibData = JsonUtil
+          .toJson(
+            SierraBibRecord(
+              id = id,
+              data = s"""{"id": "$id"}""",
+              modifiedDate = Instant.now))
+          .get)
     val message =
-      hybridRecordSqsMessage(JsonUtil.toJson(sierraTransformable).get,
-                             "sierra")
+      hybridRecordSqsMessage(
+        JsonUtil.toJson(sierraTransformable).get,
+        "sierra")
 
     val mockSNS = mockFailPublishMessage
     val recordReceiver =

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformerTest.scala
@@ -372,8 +372,9 @@ class MiroTransformableTransformerTest
     )
     work.identifiers shouldBe List(
       SourceIdentifier(IdentifierSchemes.miroImageNumber, miroID),
-      SourceIdentifier(IdentifierSchemes.sierraSystemNumber,
-                       expectedSierraNumber)
+      SourceIdentifier(
+        IdentifierSchemes.sierraSystemNumber,
+        expectedSierraNumber)
     )
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -42,12 +42,14 @@ class SierraTransformableTransformerTest
       maybeBibData =
         Some(SierraBibRecord(id = id, data = data, modifiedDate = now())),
       itemData = Map(
-        "i111" -> sierraItemRecord(id = "i111",
-                                   title = title,
-                                   bibIds = List(id)),
-        "i222" -> sierraItemRecord(id = "i222",
-                                   title = title,
-                                   bibIds = List(id))
+        "i111" -> sierraItemRecord(
+          id = "i111",
+          title = title,
+          bibIds = List(id)),
+        "i222" -> sierraItemRecord(
+          id = "i222",
+          title = title,
+          bibIds = List(id))
       )
     )
 
@@ -96,16 +98,18 @@ class SierraTransformableTransformerTest
     val transformable = SierraTransformable(
       sourceId = bibId,
       maybeBibData = Some(
-        SierraBibRecord(id = bibId,
-                        data = bibData,
-                        modifiedDate = modifiedDate)),
+        SierraBibRecord(
+          id = bibId,
+          data = bibData,
+          modifiedDate = modifiedDate)),
       itemData = Map(
-        itemId -> SierraItemRecord(id = itemId,
-                                   data = itemData,
-                                   modifiedDate = modifiedDate,
-                                   bibIds = List(bibId),
-                                   unlinkedBibIds = Nil,
-                                   version = 1))
+        itemId -> SierraItemRecord(
+          id = itemId,
+          data = itemData,
+          modifiedDate = modifiedDate,
+          bibIds = List(bibId),
+          unlinkedBibIds = Nil,
+          version = 1))
     )
 
     val triedMaybeWork = transformer.transform(transformable, version = 1)
@@ -257,11 +261,12 @@ class SierraTransformableTransformerTest
       SourceIdentifier(IdentifierSchemes.sierraSystemNumber, id)
 
     transformedSierraRecord.get shouldBe Some(
-      UnidentifiedWork(title = Some(title),
-                       sourceIdentifier = identifier,
-                       version = 1,
-                       identifiers = List(identifier),
-                       visible = false)
+      UnidentifiedWork(
+        title = Some(title),
+        sourceIdentifier = identifier,
+        version = 1,
+        identifiers = List(identifier),
+        visible = false)
     )
   }
 
@@ -291,11 +296,12 @@ class SierraTransformableTransformerTest
       SourceIdentifier(IdentifierSchemes.sierraSystemNumber, id)
 
     transformedSierraRecord.get shouldBe Some(
-      UnidentifiedWork(title = Some(title),
-                       sourceIdentifier = identifier,
-                       version = 1,
-                       identifiers = List(identifier),
-                       visible = false)
+      UnidentifiedWork(
+        title = Some(title),
+        sourceIdentifier = identifier,
+        version = 1,
+        identifiers = List(identifier),
+        visible = false)
     )
   }
 
@@ -316,13 +322,15 @@ class SierraTransformableTransformerTest
       maybeBibData =
         Some(SierraBibRecord(id = id, data = data, modifiedDate = now())),
       itemData = Map(
-        "i111" -> sierraItemRecord(id = "i111",
-                                   title = title,
-                                   bibIds = List(id)),
-        "i222" -> sierraItemRecord(id = "i222",
-                                   title = title,
-                                   deleted = true,
-                                   bibIds = List(id))
+        "i111" -> sierraItemRecord(
+          id = "i111",
+          title = title,
+          bibIds = List(id)),
+        "i222" -> sierraItemRecord(
+          id = "i222",
+          title = title,
+          deleted = true,
+          bibIds = List(id))
       )
     )
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformableSQSMessageUtils.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformableSQSMessageUtils.scala
@@ -86,10 +86,11 @@ trait TransformableSQSMessageUtils extends S3Local { this: Suite =>
       None,
       JsonUtil
         .toJson(
-          HybridRecord(version = version,
-                       sourceId = "testId",
-                       sourceName = testSource,
-                       s3key = key))
+          HybridRecord(
+            version = version,
+            sourceId = "testId",
+            sourceName = testSource,
+            s3key = key))
         .get,
       "test_transformer_topic",
       "notification",

--- a/common/src/main/scala/uk/ac/wellcome/dynamo/VersionedDao.scala
+++ b/common/src/main/scala/uk/ac/wellcome/dynamo/VersionedDao.scala
@@ -7,10 +7,10 @@ import com.gu.scanamo.{DynamoFormat, Scanamo, Table}
 import com.twitter.inject.Logging
 import uk.ac.wellcome.models.aws.DynamoConfig
 import uk.ac.wellcome.models.{
-  VersionUpdater,
-  Versioned,
   Sourced,
-  SourcedDynamoFormatWrapper
+  SourcedDynamoFormatWrapper,
+  VersionUpdater,
+  Versioned
 }
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/AkkaModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/AkkaModule.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.utils.GuiceAkkaExtension
 import akka.actor.ActorSystem
 import com.google.inject.Provides
 import com.google.inject.Injector
-import com.twitter.inject.{TwitterModule, InjectorModule}
+import com.twitter.inject.{InjectorModule, TwitterModule}
 
 object AkkaModule extends TwitterModule {
   override val modules = Seq(InjectorModule)

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/AmazonCloudWatchModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/AmazonCloudWatchModule.scala
@@ -12,9 +12,10 @@ import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.AWSConfig
 
 object AmazonCloudWatchModule extends TwitterModule {
-  private val awsNamespace = flag[String]("aws.metrics.namespace",
-                                          "",
-                                          "Namespace for cloudwatch metrics")
+  private val awsNamespace = flag[String](
+    "aws.metrics.namespace",
+    "",
+    "Namespace for cloudwatch metrics")
   private val awsEndpoint = flag[String](
     "aws.cloudWatch.endpoint",
     "",

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/S3ClientModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/S3ClientModule.scala
@@ -32,8 +32,8 @@ object S3ClientModule extends TwitterModule {
         .withCredentials(new AWSStaticCredentialsProvider(
           new BasicAWSCredentials(accessKey(), secretKey())))
         .withPathStyleAccessEnabled(true)
-        .withEndpointConfiguration(new EndpointConfiguration(s3Endpoint(),
-                                                             awsConfig.region))
+        .withEndpointConfiguration(
+          new EndpointConfiguration(s3Endpoint(), awsConfig.region))
         .build()
   }
 

--- a/common/src/main/scala/uk/ac/wellcome/metrics/MetricsSender.scala
+++ b/common/src/main/scala/uk/ac/wellcome/metrics/MetricsSender.scala
@@ -40,13 +40,15 @@ class MetricsSender @Inject()(@Flag("aws.metrics.namespace") namespace: String,
       .queue[MetricDatum](5000, OverflowStrategy.backpressure)
       // Group the MetricDatum objects into lists of at max 20 items.
       // Send smaller chunks if not appearing within 10 seconds
-      .viaMat(Flow[MetricDatum].groupedWithin(metricDataListMaxSize,
-                                              10 seconds))(Keep.left)
+      .viaMat(
+        Flow[MetricDatum].groupedWithin(metricDataListMaxSize, 10 seconds))(
+        Keep.left)
       // Make sure we don't exceed aws rate limit
-      .throttle(maxPutMetricDataRequestsPerSecond,
-                1 second,
-                0,
-                ThrottleMode.shaping)
+      .throttle(
+        maxPutMetricDataRequestsPerSecond,
+        1 second,
+        0,
+        ThrottleMode.shaping)
       .to(
         Sink.foreach(
           metricDataSeq =>
@@ -65,16 +67,18 @@ class MetricsSender @Inject()(@Flag("aws.metrics.namespace") namespace: String,
       case Success(_) =>
         val end = new Date()
         incrementCount("success")
-        sendTime(metricName,
-                 (end.getTime - start.getTime) milliseconds,
-                 Map("success" -> "true"))
+        sendTime(
+          metricName,
+          (end.getTime - start.getTime) milliseconds,
+          Map("success" -> "true"))
 
       case Failure(_) =>
         val end = new Date()
         incrementCount("failure")
-        sendTime(metricName,
-                 (end.getTime - start.getTime) milliseconds,
-                 Map("success" -> "false"))
+        sendTime(
+          metricName,
+          (end.getTime - start.getTime) milliseconds,
+          Map("success" -> "false"))
 
     }
 

--- a/common/src/main/scala/uk/ac/wellcome/models/IdentifierSchemes.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/IdentifierSchemes.scala
@@ -35,11 +35,12 @@ class IdentifierSchemeSerialiser
   *  the strings that will be presented to users of the API.
   */
 object IdentifierSchemes extends Logging {
-  final val identifierSchemes = Seq(miroImageNumber,
-                                    miroLibraryReference,
-                                    calmPlaceholder,
-                                    calmAltRefNo,
-                                    sierraSystemNumber)
+  final val identifierSchemes = Seq(
+    miroImageNumber,
+    miroLibraryReference,
+    calmPlaceholder,
+    calmAltRefNo,
+    sierraSystemNumber)
 
   @JsonDeserialize(using = classOf[IdentifierSchemeDeserialiser])
   @JsonSerialize(using = classOf[IdentifierSchemeSerialiser])

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
@@ -58,11 +58,13 @@ object SierraTransformable {
   }
 
   def apply(bibRecord: SierraBibRecord): SierraTransformable =
-    SierraTransformable(sourceId = bibRecord.id,
-                        maybeBibData = Some(bibRecord))
+    SierraTransformable(
+      sourceId = bibRecord.id,
+      maybeBibData = Some(bibRecord))
 
   def apply(sourceId: String,
             itemRecord: SierraItemRecord): SierraTransformable =
-    SierraTransformable(sourceId = sourceId,
-                        itemData = Map(itemRecord.id -> itemRecord))
+    SierraTransformable(
+      sourceId = sourceId,
+      itemData = Map(itemRecord.id -> itemRecord))
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecord.scala
@@ -11,9 +11,10 @@ import scala.util.Try
 
 case class SierraRecord(id: String, data: String, modifiedDate: Instant) {
   def toBibRecord: SierraBibRecord =
-    SierraBibRecord(id = this.id,
-                    data = this.data,
-                    modifiedDate = this.modifiedDate)
+    SierraBibRecord(
+      id = this.id,
+      data = this.data,
+      modifiedDate = this.modifiedDate)
 
   def toItemRecord: Try[SierraItemRecord] =
     for {
@@ -27,10 +28,11 @@ case class SierraRecord(id: String, data: String, modifiedDate: Instant) {
           throw new InvalidArgumentException("Found non string in bibIds"))
       }.toList
     } yield {
-      SierraItemRecord(id = this.id,
-                       data = this.data,
-                       modifiedDate = this.modifiedDate,
-                       bibIds = bibIds)
+      SierraItemRecord(
+        id = this.id,
+        data = this.data,
+        modifiedDate = this.modifiedDate,
+        bibIds = bibIds)
     }
 }
 

--- a/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
@@ -7,7 +7,7 @@ import com.twitter.inject.Logging
 import uk.ac.wellcome.models.aws.SNSConfig
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
-import scala.concurrent.{Future, blocking}
+import scala.concurrent.{blocking, Future}
 
 case class PublishAttempt(id: Either[Throwable, String])
 

--- a/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.aws.SQSConfig
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import scala.collection.JavaConversions._
-import scala.concurrent.{Future, blocking}
+import scala.concurrent.{blocking, Future}
 
 class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
     extends Logging {
@@ -42,8 +42,9 @@ class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
       }
     } recover {
       case exception: Throwable =>
-        error(s"Error retrieving messages from queue ${sqsConfig.queueUrl}",
-              exception)
+        error(
+          s"Error retrieving messages from queue ${sqsConfig.queueUrl}",
+          exception)
         throw exception
     }
 
@@ -83,8 +84,9 @@ class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
     Future {
       blocking {
         sqsClient.deleteMessage(
-          new DeleteMessageRequest(sqsConfig.queueUrl,
-                                   message.getReceiptHandle)
+          new DeleteMessageRequest(
+            sqsConfig.queueUrl,
+            message.getReceiptHandle)
         )
         info(s"Deleted message ${message.getMessageId}")
       }

--- a/common/src/main/scala/uk/ac/wellcome/sqs/SQSWorker.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sqs/SQSWorker.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.utils.{TryBackoff, JsonUtil}
+import uk.ac.wellcome.utils.{JsonUtil, TryBackoff}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import scala.concurrent.Future
 import scala.util.Try

--- a/common/src/main/scala/uk/ac/wellcome/storage/VersionedHybridStore.scala
+++ b/common/src/main/scala/uk/ac/wellcome/storage/VersionedHybridStore.scala
@@ -5,10 +5,10 @@ import io.circe.{Decoder, Encoder}
 import uk.ac.wellcome.dynamo.VersionedDao
 import uk.ac.wellcome.models.transformable.Reindexable
 import uk.ac.wellcome.models.{
-  VersionUpdater,
-  Versioned,
   Sourced,
-  SourcedDynamoFormatWrapper
+  SourcedDynamoFormatWrapper,
+  VersionUpdater,
+  Versioned
 }
 import uk.ac.wellcome.s3.SourcedObjectStore
 
@@ -56,9 +56,10 @@ class VersionedHybridStore @Inject()(
         val transformedS3Record = ifExisting(s3Record)
 
         if (transformedS3Record != s3Record) {
-          putObject(id,
-                    transformedS3Record,
-                    key => hybridRecord.copy(s3key = key))
+          putObject(
+            id,
+            transformedS3Record,
+            key => hybridRecord.copy(s3key = key))
         } else {
           Future.successful(())
         }

--- a/common/src/main/scala/uk/ac/wellcome/utils/GuiceAkkaExtension.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/GuiceAkkaExtension.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.utils
 
 import akka.actor._
 import com.google.inject.name.Names
-import com.google.inject.{Key, Injector}
+import com.google.inject.{Injector, Key}
 
 /**
   * An Akka extension implementation for Guice-based injection. The Extension provides Akka access to

--- a/common/src/test/scala/uk/ac/wellcome/dynamo/VersionedDaoTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/dynamo/VersionedDaoTest.scala
@@ -54,10 +54,11 @@ class VersionedDaoTest
   describe("get a record") {
     it("returns a future of a record if its in dynamo") {
 
-      val testVersioned = TestVersioned(sourceId = "b110101001",
-                                        sourceName = "testSource",
-                                        somethingElse = "whatever",
-                                        version = 0)
+      val testVersioned = TestVersioned(
+        sourceId = "b110101001",
+        sourceName = "testSource",
+        somethingElse = "whatever",
+        version = 0)
 
       Scanamo.put(dynamoDbClient)(tableName)(testVersioned)(
         enrichedDynamoFormat)
@@ -69,10 +70,11 @@ class VersionedDaoTest
     }
 
     it("returns a future of None if the record isn't in dynamo") {
-      val testVersioned = TestVersioned(sourceId = "b110101001",
-                                        sourceName = "testSource",
-                                        somethingElse = "whatever",
-                                        version = 0)
+      val testVersioned = TestVersioned(
+        sourceId = "b110101001",
+        sourceName = "testSource",
+        somethingElse = "whatever",
+        version = 0)
 
       Scanamo.put(dynamoDbClient)(tableName)(testVersioned)(
         enrichedDynamoFormat)
@@ -106,10 +108,11 @@ class VersionedDaoTest
     it("inserts a new record if it doesn't already exist") {
       val sourceId = "b1111"
 
-      val testVersioned = TestVersioned(sourceId = sourceId,
-                                        sourceName = "testSource",
-                                        somethingElse = "whatever",
-                                        version = 0)
+      val testVersioned = TestVersioned(
+        sourceId = sourceId,
+        sourceName = "testSource",
+        somethingElse = "whatever",
+        version = 0)
 
       val expectedTestVersioned = testVersioned.copy(version = 1)
 
@@ -122,10 +125,11 @@ class VersionedDaoTest
     it("updates an existing record if the update has a higher version") {
       val sourceId = "b1111"
 
-      val testVersioned = TestVersioned(sourceId = sourceId,
-                                        sourceName = "testSource",
-                                        somethingElse = "whatever",
-                                        version = 1)
+      val testVersioned = TestVersioned(
+        sourceId = sourceId,
+        sourceName = "testSource",
+        somethingElse = "whatever",
+        version = 1)
 
       val newerTestVersioned = testVersioned.copy(version = 2)
 
@@ -146,10 +150,11 @@ class VersionedDaoTest
     it("updates a record if it already exists and has the same version") {
       val sourceId = "b1111"
 
-      val testVersioned = TestVersioned(sourceId = sourceId,
-                                        sourceName = "testSource",
-                                        somethingElse = "whatever",
-                                        version = 1)
+      val testVersioned = TestVersioned(
+        sourceId = sourceId,
+        sourceName = "testSource",
+        somethingElse = "whatever",
+        version = 1)
 
       Scanamo.put(dynamoDbClient)(tableName)(testVersioned)(
         enrichedDynamoFormat)
@@ -167,15 +172,17 @@ class VersionedDaoTest
     it("does not update an existing record if the update has a lower version") {
       val sourceId = "b1111"
 
-      val testVersioned = TestVersioned(sourceId = sourceId,
-                                        sourceName = "testSource",
-                                        somethingElse = "whatever",
-                                        version = 1)
+      val testVersioned = TestVersioned(
+        sourceId = sourceId,
+        sourceName = "testSource",
+        somethingElse = "whatever",
+        version = 1)
 
-      val newerTestVersioned = TestVersioned(sourceId = sourceId,
-                                             sourceName = "testSource",
-                                             somethingElse = "whatever",
-                                             version = 2)
+      val newerTestVersioned = TestVersioned(
+        sourceId = sourceId,
+        sourceName = "testSource",
+        somethingElse = "whatever",
+        version = 2)
 
       Scanamo.put(dynamoDbClient)(tableName)(newerTestVersioned)(
         enrichedDynamoFormat)
@@ -201,10 +208,11 @@ class VersionedDaoTest
       val failingDao =
         new VersionedDao(dynamoDbClient, DynamoConfig(tableName))
 
-      val testVersioned = TestVersioned(sourceId = "b1111",
-                                        sourceName = "testSource",
-                                        somethingElse = "whatever",
-                                        version = 1)
+      val testVersioned = TestVersioned(
+        sourceId = "b1111",
+        sourceName = "testSource",
+        somethingElse = "whatever",
+        version = 1)
 
       whenReady(failingDao.updateRecord(testVersioned).failed) { ex =>
         ex shouldBe expectedException

--- a/common/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordTest.scala
@@ -23,16 +23,18 @@ class SierraRecordTest extends FunSpec with Matchers {
         SierraRecord(id = id, data = data, modifiedDate = modifiedDate)
 
       sierraRecord.toItemRecord shouldBe Success(
-        SierraItemRecord(id = id,
-                         data = data,
-                         modifiedDate = modifiedDate,
-                         bibIds = List(bibId)))
+        SierraItemRecord(
+          id = id,
+          data = data,
+          modifiedDate = modifiedDate,
+          bibIds = List(bibId)))
     }
 
     it("return a failure for an invalid json") {
-      val sierraRecord = SierraRecord(id = "i12345",
-                                      data = "not a json string",
-                                      modifiedDate = modifiedDate)
+      val sierraRecord = SierraRecord(
+        id = "i12345",
+        data = "not a json string",
+        modifiedDate = modifiedDate)
 
       val triedItemRecord = sierraRecord.toItemRecord
       triedItemRecord shouldBe a[Failure[_]]
@@ -49,9 +51,10 @@ class SierraRecordTest extends FunSpec with Matchers {
     }
 
     it("return a failure if bibIds is a list of non strings") {
-      val sierraRecord = SierraRecord(id = "i12345",
-                                      data = """{"bibIds":[1,2,3]}""",
-                                      modifiedDate = modifiedDate)
+      val sierraRecord = SierraRecord(
+        id = "i12345",
+        data = """{"bibIds":[1,2,3]}""",
+        modifiedDate = modifiedDate)
 
       val triedItemRecord = sierraRecord.toItemRecord
       triedItemRecord shouldBe a[Failure[_]]
@@ -59,9 +62,10 @@ class SierraRecordTest extends FunSpec with Matchers {
     }
 
     it("return a failure if bibIds is not a list") {
-      val sierraRecord = SierraRecord(id = "i12345",
-                                      data = """{"bibIds":"blah"}""",
-                                      modifiedDate = modifiedDate)
+      val sierraRecord = SierraRecord(
+        id = "i12345",
+        data = """{"bibIds":"blah"}""",
+        modifiedDate = modifiedDate)
 
       val triedItemRecord = sierraRecord.toItemRecord
       triedItemRecord shouldBe a[Failure[_]]

--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
@@ -53,9 +53,10 @@ class SQSReaderTest
 
   it("should return a failed future if reading from the SQS queue fails") {
     val sqsConfig =
-      SQSConfig("not a valid queue url",
-                waitTime = 20 seconds,
-                maxMessages = 1)
+      SQSConfig(
+        "not a valid queue url",
+        waitTime = 20 seconds,
+        maxMessages = 1)
     val sqsReader = new SQSReader(sqsClient, sqsConfig)
 
     val futureMessages =
@@ -72,9 +73,10 @@ class SQSReaderTest
       SQSConfig(queueUrl, waitTime = 20 seconds, maxMessages = 10)
 
     val failingMessage = "This message will fail"
-    val messageStrings = List("This is the first message",
-                              failingMessage,
-                              "This is the final message")
+    val messageStrings = List(
+      "This is the first message",
+      failingMessage,
+      "This is the final message")
     messageStrings.foreach(sqsClient.sendMessage(queueUrl, _))
     val sqsReader =
       new SQSReader(sqsClient, sqsConfig)
@@ -98,9 +100,10 @@ class SQSReaderTest
       SQSConfig(queueUrl, waitTime = 20 seconds, maxMessages = 10)
 
     val failingMessage = "This message will fail"
-    val messageStrings = List("This is the first message",
-                              failingMessage,
-                              "This is the final message")
+    val messageStrings = List(
+      "This is the first message",
+      failingMessage,
+      "This is the final message")
     messageStrings.foreach(sqsClient.sendMessage(queueUrl, _))
     val sqsReader =
       new SQSReader(sqsClient, sqsConfig)
@@ -124,9 +127,10 @@ class SQSReaderTest
       SQSConfig(queueUrl, waitTime = 20 seconds, maxMessages = 10)
 
     val failingMessage = "This message will fail gracefully"
-    val messageStrings = List("This is the first message",
-                              failingMessage,
-                              "This is the final message")
+    val messageStrings = List(
+      "This is the first message",
+      failingMessage,
+      "This is the final message")
     messageStrings.foreach(sqsClient.sendMessage(queueUrl, _))
     val sqsReader =
       new SQSReader(sqsClient, sqsConfig)

--- a/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreLocal.scala
@@ -22,10 +22,11 @@ trait VersionedHybridStoreLocal
   val hybridStore = new VersionedHybridStore(
     sourcedObjectStore =
       new SourcedObjectStore(s3Client = s3Client, bucketName = bucketName),
-    versionedDao = new VersionedDao(dynamoDbClient = dynamoDbClient,
-                                    dynamoConfig = DynamoConfig(
-                                      table = tableName
-                                    ))
+    versionedDao = new VersionedDao(
+      dynamoDbClient = dynamoDbClient,
+      dynamoConfig = DynamoConfig(
+        table = tableName
+      ))
   )
 
   def assertHybridRecordIsStoredCorrectly(record: Sourced,

--- a/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
@@ -86,9 +86,9 @@ class VersionedHybridStoreTest
       record)(identity)
 
     val updatedFuture = future.flatMap { _ =>
-      hybridStore.updateRecord(updatedRecord.sourceName,
-                               updatedRecord.sourceId)(updatedRecord)(_ =>
-        updatedRecord)
+      hybridStore.updateRecord(
+        updatedRecord.sourceName,
+        updatedRecord.sourceId)(updatedRecord)(_ => updatedRecord)
     }
 
     whenReady(updatedFuture) { _ =>
@@ -114,8 +114,9 @@ class VersionedHybridStoreTest
       content = "Five fishing flinging flint"
     )
 
-    val putFuture = hybridStore.updateRecord(record.sourceName,
-                                             record.sourceId)(record)(identity)
+    val putFuture =
+      hybridStore.updateRecord(record.sourceName, record.sourceId)(record)(
+        identity)
 
     val getFuture = putFuture.flatMap { _ =>
       hybridStore.getRecord[ExampleRecord](record.id)
@@ -158,8 +159,9 @@ class VersionedHybridStoreTest
     )
 
     val future =
-      hybridStore.updateRecord(sourceName = record.sourceName,
-                               sourceId = "not_the_same_id")(record)(identity)
+      hybridStore.updateRecord(
+        sourceName = record.sourceName,
+        sourceId = "not_the_same_id")(record)(identity)
 
     whenReady(future.failed) { e: Throwable =>
       e shouldBe a[IllegalArgumentException]

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/SNSLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/SNSLocal.scala
@@ -20,10 +20,11 @@ trait SNSLocal extends BeforeAndAfterEach with Logging { this: Suite =>
   private val secretKey = "secret"
 
   val snsLocalFlags: Map[String, String] =
-    Map("aws.sns.endpoint" -> localSNSEndpointUrl,
-        "aws.sns.accessKey" -> accessKey,
-        "aws.sns.secretKey" -> secretKey,
-        "aws.region" -> "localhost")
+    Map(
+      "aws.sns.endpoint" -> localSNSEndpointUrl,
+      "aws.sns.accessKey" -> accessKey,
+      "aws.sns.secretKey" -> secretKey,
+      "aws.region" -> "localhost")
 
   val snsClient: AmazonSNS = AmazonSNSClientBuilder
     .standard()

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
@@ -58,12 +58,13 @@ class ReindexerFeatureTest
     val numberOfRecords = 4
 
     val hybridRecords = (1 to numberOfRecords).map(i => {
-      HybridRecord(version = 1,
-                   sourceId = s"id$i",
-                   sourceName = "source",
-                   s3key = "s3://bucket/key",
-                   reindexShard = shardName,
-                   reindexVersion = currentVersion)
+      HybridRecord(
+        version = 1,
+        sourceId = s"id$i",
+        sourceName = "source",
+        s3key = "s3://bucket/key",
+        reindexShard = shardName,
+        reindexVersion = currentVersion)
     })
 
     hybridRecords.foreach(
@@ -71,8 +72,8 @@ class ReindexerFeatureTest
 
     val expectedRecords = hybridRecords.map(
       record =>
-        record.copy(reindexVersion = desiredVersion,
-                    version = record.version + 1))
+        record
+          .copy(reindexVersion = desiredVersion, version = record.version + 1))
 
     val reindexJob = ReindexJob(
       shardId = shardName,

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
@@ -27,9 +27,10 @@ class ReindexServiceTest
   override lazy val tableName: String = "table"
 
   val metricsSender: MetricsSender =
-    new MetricsSender(namespace = "reindexer-tests",
-                      mock[AmazonCloudWatch],
-                      ActorSystem())
+    new MetricsSender(
+      namespace = "reindexer-tests",
+      mock[AmazonCloudWatch],
+      ActorSystem())
 
   override lazy val evidence: DynamoFormat[HybridRecord] =
     DynamoFormat[HybridRecord]
@@ -44,12 +45,13 @@ class ReindexServiceTest
 
     val shardName = "shard"
 
-    val exampleRecord = HybridRecord(version = 1,
-                                     sourceId = "id",
-                                     sourceName = "source",
-                                     s3key = "s3://bucket/key",
-                                     reindexShard = shardName,
-                                     reindexVersion = currentVersion)
+    val exampleRecord = HybridRecord(
+      version = 1,
+      sourceId = "id",
+      sourceName = "source",
+      s3key = "s3://bucket/key",
+      reindexShard = shardName,
+      reindexVersion = currentVersion)
 
     val newerRecord = exampleRecord.copy(
       sourceId = "id1",
@@ -81,8 +83,9 @@ class ReindexServiceTest
         dynamoDBClient = dynamoDbClient,
         dynamoConfig = DynamoConfig(tableName),
         metricsSender = metricsSender,
-        versionedDao = new VersionedDao(dynamoDbClient = dynamoDbClient,
-                                        DynamoConfig(tableName))
+        versionedDao = new VersionedDao(
+          dynamoDbClient = dynamoDbClient,
+          DynamoConfig(tableName))
       )
 
     val reindexJob = ReindexJob(
@@ -104,12 +107,13 @@ class ReindexServiceTest
 
     val shardName = "shard"
 
-    val exampleRecord = HybridRecord(version = 1,
-                                     sourceId = "id",
-                                     sourceName = "source",
-                                     s3key = "s3://bucket/key",
-                                     reindexShard = shardName,
-                                     reindexVersion = currentVersion)
+    val exampleRecord = HybridRecord(
+      version = 1,
+      sourceId = "id",
+      sourceName = "source",
+      s3key = "s3://bucket/key",
+      reindexShard = shardName,
+      reindexVersion = currentVersion)
 
     val inShardRecords = List(
       exampleRecord.copy(sourceId = "id1"),
@@ -117,8 +121,8 @@ class ReindexServiceTest
     )
 
     val notInShardRecords = List(
-      exampleRecord.copy(sourceId = "id3",
-                         reindexShard = "not_the_same_shard"),
+      exampleRecord
+        .copy(sourceId = "id3", reindexShard = "not_the_same_shard"),
       exampleRecord.copy(sourceId = "id4", reindexShard = "not_the_same_shard")
     )
 
@@ -134,16 +138,17 @@ class ReindexServiceTest
 
     val expectedUpdatedRecords = inShardRecords.map(
       record =>
-        record.copy(reindexVersion = desiredVersion,
-                    version = record.version + 1))
+        record
+          .copy(reindexVersion = desiredVersion, version = record.version + 1))
 
     val reindexService =
       new ReindexService(
         dynamoDBClient = dynamoDbClient,
         dynamoConfig = DynamoConfig(tableName),
         metricsSender = metricsSender,
-        versionedDao = new VersionedDao(dynamoDbClient = dynamoDbClient,
-                                        DynamoConfig(tableName))
+        versionedDao = new VersionedDao(
+          dynamoDbClient = dynamoDbClient,
+          DynamoConfig(tableName))
       )
 
     whenReady(reindexService.runReindex(reindexJob)) { _ =>

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -42,9 +42,10 @@ class ReindexWorkerServiceTest
   val actorSystem = ActorSystem()
 
   val metricsSender: MetricsSender =
-    new MetricsSender(namespace = "reindexer-tests",
-                      mock[AmazonCloudWatch],
-                      actorSystem)
+    new MetricsSender(
+      namespace = "reindexer-tests",
+      mock[AmazonCloudWatch],
+      actorSystem)
 
   override lazy val tableName = "reindex-worker-service-test"
 
@@ -76,8 +77,9 @@ class ReindexWorkerServiceTest
     Scanamo.put(dynamoDbClient)(tableName)(hybridRecord)(enrichedDynamoFormat)
 
     val expectedRecords = List(
-      hybridRecord.copy(version = hybridRecord.version + 1,
-                        reindexVersion = reindexJob.desiredVersion)
+      hybridRecord.copy(
+        version = hybridRecord.version + 1,
+        reindexVersion = reindexJob.desiredVersion)
     )
 
     val sqsMessage = SQSMessage(

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
@@ -14,8 +14,9 @@ class ServerTest extends FeatureTest {
   )
 
   test("it shows the healthcheck message") {
-    server.httpGet(path = "/management/healthcheck",
-                   andExpect = Ok,
-                   withJsonBody = """{"message": "ok"}""")
+    server.httpGet(
+      path = "/management/healthcheck",
+      andExpect = Ok,
+      withJsonBody = """{"message": "ok"}""")
   }
 }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -24,19 +24,22 @@ class SierraBibMergerWorkerServiceTest
     val sqsReader = mock[SQSReader]
     val metricsSender = mock[MetricsSender]
     val mergerUpdaterService =
-      new SierraBibMergerUpdaterService(mock[VersionedHybridStore],
-                                        metricsSender)
-    val worker = new SierraBibMergerWorkerService(sqsReader,
-                                                  ActorSystem(),
-                                                  metricsSender,
-                                                  mergerUpdaterService)
+      new SierraBibMergerUpdaterService(
+        mock[VersionedHybridStore],
+        metricsSender)
+    val worker = new SierraBibMergerWorkerService(
+      sqsReader,
+      ActorSystem(),
+      metricsSender,
+      mergerUpdaterService)
 
     val future = worker.processMessage(
-      SQSMessage(subject = Some("default-subject"),
-                 body = "null",
-                 topic = "",
-                 messageType = "",
-                 timestamp = ""))
+      SQSMessage(
+        subject = Some("default-subject"),
+        body = "null",
+        topic = "",
+        messageType = "",
+        timestamp = ""))
 
     whenReady(future.failed) { ex =>
       ex shouldBe a[GracefulFailureException]

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
@@ -14,8 +14,9 @@ class ServerTest extends FeatureTest {
   )
 
   test("it shows the healthcheck message") {
-    server.httpGet(path = "/management/healthcheck",
-                   andExpect = Ok,
-                   withJsonBody = """{"message": "ok"}""")
+    server.httpGet(
+      path = "/management/healthcheck",
+      andExpect = Ok,
+      withJsonBody = """{"message": "ok"}""")
   }
 }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -44,11 +44,12 @@ class SierraItemMergerUpdaterServiceTest
 
     whenReady(sierraUpdaterService.update(newItemRecord)) { _ =>
       val expectedSierraTransformable =
-        SierraTransformable(sourceId = bibId,
-                            maybeBibData = None,
-                            itemData = Map(
-                              newItemRecord.id -> newItemRecord
-                            ))
+        SierraTransformable(
+          sourceId = bibId,
+          maybeBibData = None,
+          itemData = Map(
+            newItemRecord.id -> newItemRecord
+          ))
 
       val futureRecord1 = hybridStore.getRecord[SierraTransformable](
         expectedSierraTransformable.id)

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/dynamo/SierraItemRecordDao.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/dynamo/SierraItemRecordDao.scala
@@ -51,8 +51,9 @@ class SierraItemRecordDao @Inject()(dynamoDbClient: AmazonDynamoDB,
       case Some(Left(readError)) =>
         val exception = new RuntimeException(
           s"An error occurred while retrieving item $id: $readError")
-        error(s"An error occurred while retrieving item $id: $readError",
-              exception)
+        error(
+          s"An error occurred while retrieving item $id: $readError",
+          exception)
         throw exception
     }
   }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
@@ -14,8 +14,9 @@ class ServerTest extends FeatureTest {
   )
 
   test("it shows the healthcheck message") {
-    server.httpGet(path = "/management/healthcheck",
-                   andExpect = Ok,
-                   withJsonBody = """{"message": "ok"}""")
+    server.httpGet(
+      path = "/management/healthcheck",
+      andExpect = Ok,
+      withJsonBody = """{"message": "ok"}""")
   }
 }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
@@ -48,11 +48,12 @@ class SierraItemsToDynamoFeatureTest
     val message = SierraRecord(id, data, modifiedDate)
 
     val sqsMessage =
-      SQSMessage(Some("subject"),
-                 toJson(message).get,
-                 "topic",
-                 "messageType",
-                 "timestamp")
+      SQSMessage(
+        Some("subject"),
+        toJson(message).get,
+        "topic",
+        "messageType",
+        "timestamp")
     sqsClient.sendMessage(queueUrl, toJson(sqsMessage).get)
 
     eventually {

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/dynamo/SierraItemRecordDaoTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/dynamo/SierraItemRecordDaoTest.scala
@@ -34,11 +34,11 @@ class SierraItemRecordDaoTest
 
     it("should return an item record if it exists in the database") {
       val id = "i111"
-      val sierraItemRecord = SierraItemRecord(id = id,
-                                              data = "{}",
-                                              modifiedDate =
-                                                "2005-01-01T00:00:00Z",
-                                              bibIds = List())
+      val sierraItemRecord = SierraItemRecord(
+        id = id,
+        data = "{}",
+        modifiedDate = "2005-01-01T00:00:00Z",
+        bibIds = List())
       Scanamo.put(dynamoDbClient)(tableName)(sierraItemRecord)
 
       whenReady(sierraItemRecordDao.getItem(id = id)) { maybeItem =>
@@ -71,11 +71,11 @@ class SierraItemRecordDaoTest
 
     it("should insert an item") {
       val id = "i111"
-      val sierraItemRecord = SierraItemRecord(id = id,
-                                              data = "{}",
-                                              modifiedDate =
-                                                "2005-01-01T00:00:00Z",
-                                              bibIds = List())
+      val sierraItemRecord = SierraItemRecord(
+        id = id,
+        data = "{}",
+        modifiedDate = "2005-01-01T00:00:00Z",
+        bibIds = List())
 
       whenReady(sierraItemRecordDao.updateItem(sierraItemRecord)) { _ =>
         Scanamo.get[SierraItemRecord](dynamoDbClient)(tableName)('id -> id) shouldBe Some(
@@ -87,11 +87,11 @@ class SierraItemRecordDaoTest
 
     it("does not update an existing item if the update has a lower version") {
       val id = "i111"
-      val sierraItemRecord = SierraItemRecord(id = id,
-                                              data = "old data!",
-                                              modifiedDate =
-                                                "2005-01-01T00:00:00Z",
-                                              bibIds = List())
+      val sierraItemRecord = SierraItemRecord(
+        id = id,
+        data = "old data!",
+        modifiedDate = "2005-01-01T00:00:00Z",
+        bibIds = List())
 
       val newerSierraItemRecord = sierraItemRecord.copy(
         version = 1,
@@ -113,11 +113,11 @@ class SierraItemRecordDaoTest
     }
 
     it("should fail if an exception is thrown by dynamoDbClient") {
-      val sierraItemRecord = SierraItemRecord(id = "i111",
-                                              data = "{}",
-                                              modifiedDate =
-                                                "2005-01-01T00:00:00Z",
-                                              bibIds = List())
+      val sierraItemRecord = SierraItemRecord(
+        id = "i111",
+        data = "{}",
+        modifiedDate = "2005-01-01T00:00:00Z",
+        bibIds = List())
 
       val dynamoDbClient = mock[AmazonDynamoDB]
       val sierraItemRecordDao =

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
@@ -10,74 +10,89 @@ class SierraItemRecordMergerTest extends FunSpec with Matchers {
 
   it("combines the bibIds in the final result") {
     val existingRecord =
-      sierraItemRecord(bibIds = List("1", "2", "3"),
-                       modifiedDate = "2001-01-01T01:01:01Z")
+      sierraItemRecord(
+        bibIds = List("1", "2", "3"),
+        modifiedDate = "2001-01-01T01:01:01Z")
     val updatedRecord =
-      sierraItemRecord(bibIds = List("1", "2", "3", "4", "5"),
-                       modifiedDate = "2002-01-01T01:01:01Z")
+      sierraItemRecord(
+        bibIds = List("1", "2", "3", "4", "5"),
+        modifiedDate = "2002-01-01T01:01:01Z")
 
     val mergedRecord =
-      SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
-                                        updatedRecord = updatedRecord)
+      SierraItemRecordMerger.mergeItems(
+        existingRecord = existingRecord,
+        updatedRecord = updatedRecord)
     mergedRecord.bibIds shouldBe List("1", "2", "3", "4", "5")
     mergedRecord.unlinkedBibIds shouldBe List()
   }
 
   it("records unlinked bibIds") {
     val existingRecord =
-      sierraItemRecord(bibIds = List("1", "2", "3"),
-                       modifiedDate = "2001-01-01T01:01:01Z")
-    val updatedRecord = sierraItemRecord(bibIds = List("3", "4", "5"),
-                                         modifiedDate = "2002-01-01T01:01:01Z")
+      sierraItemRecord(
+        bibIds = List("1", "2", "3"),
+        modifiedDate = "2001-01-01T01:01:01Z")
+    val updatedRecord = sierraItemRecord(
+      bibIds = List("3", "4", "5"),
+      modifiedDate = "2002-01-01T01:01:01Z")
 
     val mergedRecord =
-      SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
-                                        updatedRecord = updatedRecord)
+      SierraItemRecordMerger.mergeItems(
+        existingRecord = existingRecord,
+        updatedRecord = updatedRecord)
     mergedRecord.bibIds shouldBe List("3", "4", "5")
     mergedRecord.unlinkedBibIds shouldBe List("1", "2")
   }
 
   it("preserves existing unlinked bibIds") {
     val existingRecord =
-      sierraItemRecord(bibIds = List("1", "2", "3"),
-                       unlinkedBibIds = List("4", "5"),
-                       modifiedDate = "2001-01-01T01:01:01Z")
-    val updatedRecord = sierraItemRecord(bibIds = List("1", "2", "3"),
-                                         modifiedDate = "2002-01-01T01:01:01Z")
+      sierraItemRecord(
+        bibIds = List("1", "2", "3"),
+        unlinkedBibIds = List("4", "5"),
+        modifiedDate = "2001-01-01T01:01:01Z")
+    val updatedRecord = sierraItemRecord(
+      bibIds = List("1", "2", "3"),
+      modifiedDate = "2002-01-01T01:01:01Z")
 
     val mergedRecord =
-      SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
-                                        updatedRecord = updatedRecord)
+      SierraItemRecordMerger.mergeItems(
+        existingRecord = existingRecord,
+        updatedRecord = updatedRecord)
     mergedRecord.unlinkedBibIds shouldBe List("4", "5")
   }
 
   it("does not duplicate unlinked bibIds") {
     // This would be an unusual scenario to arise, but check we handle it anyway!
     val existingRecord =
-      sierraItemRecord(bibIds = List("1", "2", "3"),
-                       unlinkedBibIds = List("3"),
-                       modifiedDate = "2001-01-01T01:01:01Z")
-    val updatedRecord = sierraItemRecord(bibIds = List("1", "2"),
-                                         modifiedDate = "2002-01-01T01:01:01Z")
+      sierraItemRecord(
+        bibIds = List("1", "2", "3"),
+        unlinkedBibIds = List("3"),
+        modifiedDate = "2001-01-01T01:01:01Z")
+    val updatedRecord = sierraItemRecord(
+      bibIds = List("1", "2"),
+      modifiedDate = "2002-01-01T01:01:01Z")
 
     val mergedRecord =
-      SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
-                                        updatedRecord = updatedRecord)
+      SierraItemRecordMerger.mergeItems(
+        existingRecord = existingRecord,
+        updatedRecord = updatedRecord)
     mergedRecord.bibIds shouldBe List("1", "2")
     mergedRecord.unlinkedBibIds shouldBe List("3")
   }
 
   it("removes an unlinked bibId if it appears on a new record") {
     val existingRecord =
-      sierraItemRecord(bibIds = List(),
-                       unlinkedBibIds = List("1", "2", "3"),
-                       modifiedDate = "2001-01-01T01:01:01Z")
-    val updatedRecord = sierraItemRecord(bibIds = List("1", "2"),
-                                         modifiedDate = "2002-01-01T01:01:01Z")
+      sierraItemRecord(
+        bibIds = List(),
+        unlinkedBibIds = List("1", "2", "3"),
+        modifiedDate = "2001-01-01T01:01:01Z")
+    val updatedRecord = sierraItemRecord(
+      bibIds = List("1", "2"),
+      modifiedDate = "2002-01-01T01:01:01Z")
 
     val mergedRecord =
-      SierraItemRecordMerger.mergeItems(existingRecord = existingRecord,
-                                        updatedRecord = updatedRecord)
+      SierraItemRecordMerger.mergeItems(
+        existingRecord = existingRecord,
+        updatedRecord = updatedRecord)
     mergedRecord.bibIds shouldBe List("1", "2")
     mergedRecord.unlinkedBibIds shouldBe List("3")
   }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
@@ -252,10 +252,11 @@ class DynamoInserterTest
       .thenReturn(
         Future.successful(
           Some(
-            SierraItemRecord(id = "500005",
-                             "{}",
-                             "2001-01-01T00:00:00Z",
-                             List()))))
+            SierraItemRecord(
+              id = "500005",
+              "{}",
+              "2001-01-01T00:00:00Z",
+              List()))))
 
     when(mockedDao.updateItem(any[SierraItemRecord]))
       .thenThrow(expectedException)

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -88,11 +88,12 @@ class SierraItemsToDynamoWorkerServiceTest
     val message = SierraRecord(id, data, modifiedDate)
 
     val sqsMessage =
-      SQSMessage(Some("subject"),
-                 toJson(message).get,
-                 "topic",
-                 "messageType",
-                 "timestamp")
+      SQSMessage(
+        Some("subject"),
+        toJson(message).get,
+        "topic",
+        "messageType",
+        "timestamp")
     sqsClient.sendMessage(queueUrl, toJson(sqsMessage).get)
 
     eventually {

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
@@ -27,8 +27,9 @@ object SierraRecordWrapperFlow extends Logging {
   private def createSierraRecord(
     unprefixedJson: Json,
     resourceType: SierraResourceTypes.Value): SierraRecord = {
-    val json = addIDPrefix(json = unprefixedJson,
-                           resourceType: SierraResourceTypes.Value)
+    val json = addIDPrefix(
+      json = unprefixedJson,
+      resourceType: SierraResourceTypes.Value)
     logger.debug(s"Creating record from ${json.noSpaces}")
     val maybeUpdatedDate = root.updatedDate.string.getOption(json)
     maybeUpdatedDate match {

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/SierraReaderModule.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/SierraReaderModule.scala
@@ -19,9 +19,10 @@ object SierraReaderModule extends TwitterModule {
   flag[String]("sierra.apiUrl", "", "Sierra API url")
   flag[String]("sierra.oauthKey", "", "Sierra API oauth key")
   flag[String]("sierra.oauthSecret", "", "Sierra API oauth secret")
-  flag[String]("sierra.fields",
-               "",
-               "List of fields to include in the Sierra API response")
+  flag[String](
+    "sierra.fields",
+    "",
+    "List of fields to include in the Sierra API response")
 
   override def singletonStartup(injector: Injector) {
     val workerService = injector.instance[SierraReaderWorkerService]

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -70,17 +70,15 @@ class SierraReaderWorkerService @Inject()(
       keyPrefix = windowManager.buildWindowShard(window),
       offset = windowStatus.offset
     )
-    val outcome = SierraSource(apiUrl,
-                               sierraOauthKey,
-                               sierraOauthSecret,
-                               throttleRate)(resourceType =
-                                               resourceType.toString,
-                                             params)
-      .via(SierraRecordWrapperFlow(resourceType = resourceType))
-      .grouped(batchSize)
-      .map(recordBatch => recordBatch.asJson)
-      .zipWithIndex
-      .runWith(s3sink)
+    val outcome =
+      SierraSource(apiUrl, sierraOauthKey, sierraOauthSecret, throttleRate)(
+        resourceType = resourceType.toString,
+        params)
+        .via(SierraRecordWrapperFlow(resourceType = resourceType))
+        .grouped(batchSize)
+        .map(recordBatch => recordBatch.asJson)
+        .zipWithIndex
+        .runWith(s3sink)
 
     // This serves as a marker that the window is complete, so we can audit our S3 bucket to see which windows
     // were never successfully completed.

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/ServerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/ServerTest.scala
@@ -6,14 +6,16 @@ import com.twitter.inject.server.FeatureTest
 
 class ServerTest extends FeatureTest {
 
-  val server = new EmbeddedHttpServer(new Server(),
-                                      Map(
-                                        "reader.resourceType" -> "bibs"
-                                      ))
+  val server = new EmbeddedHttpServer(
+    new Server(),
+    Map(
+      "reader.resourceType" -> "bibs"
+    ))
 
   test("it shows the healthcheck message") {
-    server.httpGet(path = "/management/healthcheck",
-                   andExpect = Ok,
-                   withJsonBody = """{"message": "ok"}""")
+    server.httpGet(
+      path = "/management/healthcheck",
+      andExpect = Ok,
+      withJsonBody = """{"message": "ok"}""")
   }
 }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/sink/SequentialS3SinkTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/sink/SequentialS3SinkTest.scala
@@ -64,9 +64,10 @@ class SequentialS3SinkTest
     whenReady(futureDone) { _ =>
       val s3objects = s3Client.listObjects(bucketName).getObjectSummaries
       s3objects should have size 3
-      s3objects.map { _.getKey() } shouldBe List("testB_0000.json",
-                                                 "testB_0001.json",
-                                                 "testB_0002.json")
+      s3objects.map { _.getKey() } shouldBe List(
+        "testB_0000.json",
+        "testB_0001.json",
+        "testB_0002.json")
 
       getJsonFromS3(bucketName, "testB_0000.json") shouldBe json0
       getJsonFromS3(bucketName, "testB_0001.json") shouldBe json1
@@ -75,10 +76,11 @@ class SequentialS3SinkTest
   }
 
   it("uses the offset if provided") {
-    val sink = SequentialS3Sink(s3Client,
-                                bucketName = bucketName,
-                                keyPrefix = "testC_",
-                                offset = 3)
+    val sink = SequentialS3Sink(
+      s3Client,
+      bucketName = bucketName,
+      keyPrefix = "testC_",
+      offset = 3)
 
     val json0 = parse(s"""{"red": "orange"}""").right.get
     val json1 = parse(s"""{"orange": "yellow"}""").right.get
@@ -89,9 +91,10 @@ class SequentialS3SinkTest
 
     whenReady(futureDone) { _ =>
       val s3objects = s3Client.listObjects(bucketName).getObjectSummaries
-      s3objects.map { _.getKey() } shouldBe List("testC_0003.json",
-                                                 "testC_0004.json",
-                                                 "testC_0005.json")
+      s3objects.map { _.getKey() } shouldBe List(
+        "testC_0003.json",
+        "testC_0004.json",
+        "testC_0005.json")
 
       getJsonFromS3(bucketName, "testC_0003.json") shouldBe json0
       getJsonFromS3(bucketName, "testC_0004.json") shouldBe json1


### PR DESCRIPTION
* Sort imports just for neatness
* Code is no longer aligned against an open paren, but put on a newline and indented two spaces. e.g.

    ```scala
            .queryParam[Int]("page",
                             "The page to return from the result list",
                             required = false)
    ```

    to

    ```scala
            .queryParam[Int](
              "page",
              "The page to return from the result list",
              required = false)
    ```

  which should reduce churn a bit when we rename things.