### PR TITLE
Rename the S3 bucket holding our VHS tapes

### DIFF
--- a/catalogue_pipeline/terraform/iam_role_policy.tf
+++ b/catalogue_pipeline/terraform/iam_role_policy.tf
@@ -7,7 +7,7 @@ resource "aws_iam_role_policy" "ecs_transformer_task_sns" {
 
 resource "aws_iam_role_policy" "ecs_transformer_task_vhs" {
   role   = "${module.transformer.task_role_name}"
-  policy = "${module.versioned-hybrid-store.read_policy}"
+  policy = "${module.vhs_sourcedata.read_policy}"
 }
 
 resource "aws_iam_role_policy" "transformer_task_cloudwatch_metric" {

--- a/catalogue_pipeline/terraform/outputs.tf
+++ b/catalogue_pipeline/terraform/outputs.tf
@@ -7,23 +7,23 @@ output "miro_transformer_topic_publish_policy" {
 }
 
 output "vhs_full_access_policy" {
-  value = "${module.versioned-hybrid-store.full_access_policy}"
+  value = "${module.vhs_sourcedata.full_access_policy}"
 }
 
 output "vhs_dynamodb_update_policy" {
-  value = "${module.versioned-hybrid-store.dynamodb_update_policy}"
+  value = "${module.vhs_sourcedata.dynamodb_update_policy}"
 }
 
 output "vhs_table_name" {
-  value = "${module.versioned-hybrid-store.table_name}"
+  value = "${module.vhs_sourcedata.table_name}"
 }
 
 output "vhs_table_stream_arn" {
-  value = "${module.versioned-hybrid-store.table_stream_arn}"
+  value = "${module.vhs_sourcedata.table_stream_arn}"
 }
 
 output "vhs_bucket_name" {
-  value = "${module.versioned-hybrid-store.bucket_name}"
+  value = "${module.vhs_sourcedata.bucket_name}"
 }
 
 output "vpc_services_id" {

--- a/catalogue_pipeline/terraform/outputs.tf
+++ b/catalogue_pipeline/terraform/outputs.tf
@@ -6,8 +6,8 @@ output "miro_transformer_topic_publish_policy" {
   value = "${module.miro_transformer_topic.publish_policy}"
 }
 
-output "vhs_dynamodb_full_access_policy" {
-  value = "${module.versioned-hybrid-store.dynamodb_full_access_policy}"
+output "vhs_full_access_policy" {
+  value = "${module.versioned-hybrid-store.full_access_policy}"
 }
 
 output "vhs_dynamodb_update_policy" {

--- a/catalogue_pipeline/terraform/service_transformer.tf
+++ b/catalogue_pipeline/terraform/service_transformer.tf
@@ -14,7 +14,7 @@ module "transformer" {
     sns_arn              = "${module.id_minter_topic.arn}"
     transformer_queue_id = "${module.transformer_queue.id}"
     metrics_namespace    = "transformer"
-    bucket_name          = "${module.versioned-hybrid-store.bucket_name}"
+    bucket_name          = "${module.vhs_sourcedata.bucket_name}"
   }
 
   env_vars_length = 4
@@ -38,7 +38,7 @@ module "transformer_dynamo_to_sns" {
   source = "git::https://github.com/wellcometrust/platform.git//shared_infra/dynamo_to_sns"
 
   name           = "sierra"
-  src_stream_arn = "${module.versioned-hybrid-store.table_stream_arn}"
+  src_stream_arn = "${module.vhs_sourcedata.table_stream_arn}"
   dst_topic_arn  = "${module.transformer_topic.arn}"
 
   stream_view_type = "NEW_IMAGE_ONLY"

--- a/catalogue_pipeline/terraform/variables.tf
+++ b/catalogue_pipeline/terraform/variables.tf
@@ -13,7 +13,6 @@ variable "admin_cidr_ingress" {
 
 variable "infra_bucket" {
   description = "S3 bucket storing our configuration"
-  default     = "platform-infra"
 }
 
 variable "aws_region" {

--- a/catalogue_pipeline/terraform/vhs.tf
+++ b/catalogue_pipeline/terraform/vhs.tf
@@ -1,5 +1,6 @@
 module "vhs_sourcedata" {
-  source      = "vhs"
-  bucket_name = "sourcedata"
-  table_name  = "SourceData"
+  source = "./vhs"
+
+  name              = "SourceData"
+  table_name_prefix = ""
 }

--- a/catalogue_pipeline/terraform/vhs.tf
+++ b/catalogue_pipeline/terraform/vhs.tf
@@ -1,5 +1,5 @@
 module "vhs_sourcedata" {
   source      = "vhs"
-  bucket_name = "wellcomecollection-source-data"
+  bucket_name = "sourcedata"
   table_name  = "SourceData"
 }

--- a/catalogue_pipeline/terraform/vhs.tf
+++ b/catalogue_pipeline/terraform/vhs.tf
@@ -1,4 +1,4 @@
-module "versioned-hybrid-store" {
+module "vhs_sourcedata" {
   source      = "vhs"
   bucket_name = "wellcomecollection-source-data"
   table_name  = "SourceData"

--- a/catalogue_pipeline/terraform/vhs/dynamo.tf
+++ b/catalogue_pipeline/terraform/vhs/dynamo.tf
@@ -1,5 +1,5 @@
 resource "aws_dynamodb_table" "table" {
-  name             = "${var.table_name}"
+  name             = "${var.table_name_prefix}${var.name}"
   read_capacity    = 1
   write_capacity   = 1
   hash_key         = "id"

--- a/catalogue_pipeline/terraform/vhs/iam_policy_document.tf
+++ b/catalogue_pipeline/terraform/vhs/iam_policy_document.tf
@@ -22,8 +22,8 @@ data "aws_iam_policy_document" "read_policy" {
     ]
 
     resources = [
-      "${aws_s3_bucket.sierra_data.arn}/",
-      "${aws_s3_bucket.sierra_data.arn}/*",
+      "${aws_s3_bucket.bucket.arn}/",
+      "${aws_s3_bucket.bucket.arn}/*",
     ]
   }
 }
@@ -48,8 +48,8 @@ data "aws_iam_policy_document" "dynamodb_full_access_policy" {
     ]
 
     resources = [
-      "${aws_s3_bucket.sierra_data.arn}/",
-      "${aws_s3_bucket.sierra_data.arn}/*",
+      "${aws_s3_bucket.bucket.arn}/",
+      "${aws_s3_bucket.bucket.arn}/*",
     ]
   }
 }

--- a/catalogue_pipeline/terraform/vhs/iam_policy_document.tf
+++ b/catalogue_pipeline/terraform/vhs/iam_policy_document.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "read_policy" {
   }
 }
 
-data "aws_iam_policy_document" "dynamodb_full_access_policy" {
+data "aws_iam_policy_document" "full_access_policy" {
   statement {
     actions = [
       "dynamodb:*",

--- a/catalogue_pipeline/terraform/vhs/outputs.tf
+++ b/catalogue_pipeline/terraform/vhs/outputs.tf
@@ -7,7 +7,7 @@ output "table_name" {
 }
 
 output "bucket_name" {
-  value = "${aws_s3_bucket.sierra_data.id}"
+  value = "${aws_s3_bucket.bucket.id}"
 }
 
 output "read_policy" {

--- a/catalogue_pipeline/terraform/vhs/outputs.tf
+++ b/catalogue_pipeline/terraform/vhs/outputs.tf
@@ -14,8 +14,8 @@ output "read_policy" {
   value = "${data.aws_iam_policy_document.read_policy.json}"
 }
 
-output "dynamodb_full_access_policy" {
-  value = "${data.aws_iam_policy_document.dynamodb_full_access_policy.json}"
+output "full_access_policy" {
+  value = "${data.aws_iam_policy_document.full_access_policy.json}"
 }
 
 output "dynamodb_update_policy" {

--- a/catalogue_pipeline/terraform/vhs/s3.tf
+++ b/catalogue_pipeline/terraform/vhs/s3.tf
@@ -1,4 +1,4 @@
-resource "aws_s3_bucket" "sierra_data" {
+resource "aws_s3_bucket" "bucket" {
   bucket = "${var.bucket_name}"
 
   lifecycle {

--- a/catalogue_pipeline/terraform/vhs/s3.tf
+++ b/catalogue_pipeline/terraform/vhs/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "bucket" {
-  bucket = "${var.bucket_prefix}${var.bucket_name}"
+  bucket = "${var.bucket_name_prefix}${lower(var.name)}"
 
   lifecycle {
     prevent_destroy = true

--- a/catalogue_pipeline/terraform/vhs/s3.tf
+++ b/catalogue_pipeline/terraform/vhs/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "bucket" {
-  bucket = "${var.bucket_name}"
+  bucket = "${var.bucket_prefix}${var.bucket_name}"
 
   lifecycle {
     prevent_destroy = true

--- a/catalogue_pipeline/terraform/vhs/variables.tf
+++ b/catalogue_pipeline/terraform/vhs/variables.tf
@@ -1,6 +1,9 @@
-variable "bucket_name" {}
-variable "bucket_prefix" {
+variable "name" {}
+
+variable "bucket_name_prefix" {
   default = "wellcomecollection-vhs-"
 }
 
-variable "table_name" {}
+variable "table_name_prefix" {
+  default = "vhs-"
+}

--- a/catalogue_pipeline/terraform/vhs/variables.tf
+++ b/catalogue_pipeline/terraform/vhs/variables.tf
@@ -1,3 +1,6 @@
 variable "bucket_name" {}
+variable "bucket_prefix" {
+  default = "wellcomecollection-vhs-"
+}
 
 variable "table_name" {}

--- a/reindexer/terraform/locals.tf
+++ b/reindexer/terraform/locals.tf
@@ -1,8 +1,8 @@
 locals {
-  vhs_dynamodb_full_access_policy = "${data.terraform_remote_state.catalogue_pipeline.vhs_dynamodb_full_access_policy}"
-  vhs_dynamodb_update_policy      = "${data.terraform_remote_state.catalogue_pipeline.vhs_dynamodb_update_policy}"
-  vhs_table_name                  = "${data.terraform_remote_state.catalogue_pipeline.vhs_table_name}"
-  vhs_table_stream_arn            = "${data.terraform_remote_state.catalogue_pipeline.vhs_table_stream_arn}"
+  vhs_full_access_policy     = "${data.terraform_remote_state.catalogue_pipeline.vhs_full_access_policy}"
+  vhs_dynamodb_update_policy = "${data.terraform_remote_state.catalogue_pipeline.vhs_dynamodb_update_policy}"
+  vhs_table_name             = "${data.terraform_remote_state.catalogue_pipeline.vhs_table_name}"
+  vhs_table_stream_arn       = "${data.terraform_remote_state.catalogue_pipeline.vhs_table_stream_arn}"
 
   vpc_services_id = "${data.terraform_remote_state.catalogue_pipeline.vpc_services_id}"
 

--- a/reindexer/terraform/service_reindexer.tf
+++ b/reindexer/terraform/service_reindexer.tf
@@ -43,5 +43,5 @@ resource "aws_iam_role_policy" "reindexer_reindexer_task_cloudwatch_metric" {
 
 resource "aws_iam_role_policy" "reindexer_allow_table_access" {
   role   = "${module.reindexer.task_role_name}"
-  policy = "${local.vhs_dynamodb_full_access_policy}"
+  policy = "${local.vhs_full_access_policy}"
 }

--- a/sierra_adapter/terraform/locals.tf
+++ b/sierra_adapter/terraform/locals.tf
@@ -9,7 +9,7 @@ locals {
   ec2_instance_terminating_for_too_long_alarm_arn = "${data.terraform_remote_state.shared_infra.ec2_instance_terminating_for_too_long_alarm_arn}"
   ec2_terminating_topic_publish_policy            = "${data.terraform_remote_state.shared_infra.ec2_terminating_topic_publish_policy}"
 
-  vhs_dynamodb_full_access_policy = "${data.terraform_remote_state.catalogue_pipeline.vhs_dynamodb_full_access_policy}"
-  vhs_table_name                  = "${data.terraform_remote_state.catalogue_pipeline.vhs_table_name}"
-  vhs_bucket_name                 = "${data.terraform_remote_state.catalogue_pipeline.vhs_bucket_name}"
+  vhs_full_access_policy = "${data.terraform_remote_state.catalogue_pipeline.vhs_full_access_policy}"
+  vhs_table_name         = "${data.terraform_remote_state.catalogue_pipeline.vhs_table_name}"
+  vhs_bucket_name        = "${data.terraform_remote_state.catalogue_pipeline.vhs_bucket_name}"
 }

--- a/sierra_adapter/terraform/merger/iam_role_policy.tf
+++ b/sierra_adapter/terraform/merger/iam_role_policy.tf
@@ -1,6 +1,6 @@
-resource "aws_iam_role_policy" "vhs_dynamodb_full_access_policy" {
+resource "aws_iam_role_policy" "vhs_full_access_policy" {
   role   = "${module.sierra_merger_service.task_role_name}"
-  policy = "${var.vhs_dynamodb_full_access_policy}"
+  policy = "${var.vhs_full_access_policy}"
 }
 
 resource "aws_iam_role_policy" "push_cloudwatch_metric" {

--- a/sierra_adapter/terraform/merger/variables.tf
+++ b/sierra_adapter/terraform/merger/variables.tf
@@ -22,5 +22,5 @@ variable "aws_region" {
 }
 
 variable "account_id" {}
-variable "vhs_dynamodb_full_access_policy" {}
+variable "vhs_full_access_policy" {}
 variable "bucket_name" {}

--- a/sierra_adapter/terraform/pipeline_bibs.tf
+++ b/sierra_adapter/terraform/pipeline_bibs.tf
@@ -68,7 +68,7 @@ module "bibs_merger" {
 
   account_id = "${data.aws_caller_identity.current.account_id}"
 
-  vhs_dynamodb_full_access_policy = "${local.vhs_dynamodb_full_access_policy}"
+  vhs_full_access_policy = "${local.vhs_full_access_policy}"
 
   bucket_name = "${local.vhs_bucket_name}"
 }

--- a/sierra_adapter/terraform/pipeline_items.tf
+++ b/sierra_adapter/terraform/pipeline_items.tf
@@ -89,7 +89,7 @@ module "items_merger" {
 
   account_id = "${data.aws_caller_identity.current.account_id}"
 
-  vhs_dynamodb_full_access_policy = "${local.vhs_dynamodb_full_access_policy}"
+  vhs_full_access_policy = "${local.vhs_full_access_policy}"
 
   bucket_name = "${local.vhs_bucket_name}"
 }


### PR DESCRIPTION
This renames the **wellcomecollection-source-data** bucket to **wellcomecollection-vhs-sourcedata** (no hyphen, for consistency with DynamoDB).

The "vhs" module can also create appropriate names for future modules. I'm not renaming the DynamoDB table yet, but we might want to at a later data.

The data is still in-flight, so we shouldn't merge this yet. I've got the Terraform state ready to go, but I don't want to do it until all the data is synced.

Related to #1511.