### PR TITLE
Refactor logic from SierraTransformableTransformer onto SierraItems

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
@@ -14,6 +14,7 @@ class SierraTransformableTransformer
     extends TransformableTransformer[SierraTransformable]
     with SierraIdentifiers
     with SierraDescription
+    with SierraItems
     with SierraLettering
     with SierraPublishers
     with SierraTitle

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
@@ -18,26 +18,7 @@ class SierraTransformableTransformer
     with SierraLettering
     with SierraPublishers
     with SierraTitle
-    with SierraLocation
     with Logging {
-
-  private def transformItemData(sierraItemData: SierraItemData): UnidentifiedItem = {
-    info(s"Attempting to transform ${sierraItemData.id}")
-    UnidentifiedItem(
-      sourceIdentifier = SourceIdentifier(
-        IdentifierSchemes.sierraSystemNumber,
-        sierraItemData.id
-      ),
-      identifiers = List(
-        SourceIdentifier(
-          identifierScheme = IdentifierSchemes.sierraSystemNumber,
-          sierraItemData.id
-        )
-      ),
-      locations = getLocation(sierraItemData).toList,
-      visible = !sierraItemData.deleted
-    )
-  }
 
   override def transformForType(
     sierraTransformable: SierraTransformable,
@@ -59,8 +40,7 @@ class SierraTransformableTransformer
               identifiers = getIdentifiers(sierraBibData),
               description = getDescription(sierraBibData),
               lettering = getLettering(sierraBibData),
-              items = extractItemData(sierraTransformable)
-                .map(transformItemData),
+              items = getItems(sierraTransformable),
               publishers = getPublishers(sierraBibData),
               visible = !(sierraBibData.deleted || sierraBibData.suppressed)
             ))

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
@@ -1,3 +1,27 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
-trait SierraItems { }
+import com.twitter.inject.Logging
+import scala.util.{Failure, Success}
+import uk.ac.wellcome.models.transformable.SierraTransformable
+import uk.ac.wellcome.transformer.source.SierraItemData
+import uk.ac.wellcome.utils.JsonUtil._
+
+trait SierraItems extends Logging {
+  def extractItemData(sierraTransformable: SierraTransformable): List[SierraItemData] = {
+    sierraTransformable
+      .itemData
+      .values
+      .map { _.data }
+      .map { jsonString =>
+        fromJson[SierraItemData](jsonString) match {
+          case Success(d) => Some(d)
+          case Failure(e) => {
+            error(s"Failed to parse item!", e)
+            None
+          }
+        }
+      }
+      .toList
+      .flatten
+  }
+}

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
@@ -2,11 +2,16 @@ package uk.ac.wellcome.transformer.transformers.sierra
 
 import com.twitter.inject.Logging
 import scala.util.{Failure, Success}
+import uk.ac.wellcome.models.{
+  IdentifierSchemes,
+  SourceIdentifier,
+  UnidentifiedItem
+}
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.transformer.source.SierraItemData
 import uk.ac.wellcome.utils.JsonUtil._
 
-trait SierraItems extends Logging {
+trait SierraItems extends Logging with SierraLocation {
   def extractItemData(sierraTransformable: SierraTransformable): List[SierraItemData] = {
     sierraTransformable
       .itemData
@@ -23,5 +28,28 @@ trait SierraItems extends Logging {
       }
       .toList
       .flatten
+  }
+
+  def transformItemData(sierraItemData: SierraItemData): UnidentifiedItem = {
+    info(s"Attempting to transform ${sierraItemData.id}")
+    UnidentifiedItem(
+      sourceIdentifier = SourceIdentifier(
+        IdentifierSchemes.sierraSystemNumber,
+        sierraItemData.id
+      ),
+      identifiers = List(
+        SourceIdentifier(
+          identifierScheme = IdentifierSchemes.sierraSystemNumber,
+          sierraItemData.id
+        )
+      ),
+      locations = getLocation(sierraItemData).toList,
+      visible = !sierraItemData.deleted
+    )
+  }
+
+  def getItems(sierraTransformable: SierraTransformable): List[UnidentifiedItem] = {
+    extractItemData(sierraTransformable)
+      .map(transformItemData)
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
@@ -1,0 +1,3 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+trait SierraItems { }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
@@ -12,10 +12,9 @@ import uk.ac.wellcome.transformer.source.SierraItemData
 import uk.ac.wellcome.utils.JsonUtil._
 
 trait SierraItems extends Logging with SierraLocation {
-  def extractItemData(sierraTransformable: SierraTransformable): List[SierraItemData] = {
-    sierraTransformable
-      .itemData
-      .values
+  def extractItemData(
+    sierraTransformable: SierraTransformable): List[SierraItemData] = {
+    sierraTransformable.itemData.values
       .map { _.data }
       .map { jsonString =>
         fromJson[SierraItemData](jsonString) match {
@@ -48,7 +47,8 @@ trait SierraItems extends Logging with SierraLocation {
     )
   }
 
-  def getItems(sierraTransformable: SierraTransformable): List[UnidentifiedItem] = {
+  def getItems(
+    sierraTransformable: SierraTransformable): List[UnidentifiedItem] = {
     extractItemData(sierraTransformable)
       .map(transformItemData)
   }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
@@ -1,0 +1,83 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+import java.time.Instant
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.transformable.SierraTransformable
+import uk.ac.wellcome.test.utils.SierraData
+import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
+import uk.ac.wellcome.transformer.source.{SierraItemData, VarField}
+import uk.ac.wellcome.utils.JsonUtil._
+
+class SierraItemsTest extends FunSpec with Matchers with SierraData {
+
+  val transformer = new Object with SierraItems
+
+  describe("extractItemData") {
+    it("parses instances of SierraItemData") {
+      val item1 = SierraItemData(
+        id = "i1000001",
+        deleted = true
+      )
+
+      val item2 = SierraItemData(
+        id = "i1000002",
+        deleted = false,
+        varFields = List(
+          VarField(fieldTag = "b", content = "X111658"),
+          VarField(fieldTag = "c", content = "X111659")
+        )
+      )
+
+      val itemData = Map(
+        item1.id -> SierraItemRecord(
+          id = item1.id,
+          data = toJson(item1).get,
+          modifiedDate = Instant.now,
+          bibIds = List()
+        ),
+        item2.id -> SierraItemRecord(
+          id = item2.id,
+          data = toJson(item2).get,
+          modifiedDate = Instant.now,
+          bibIds = List()
+        )
+      )
+
+      val transformable = SierraTransformable(
+        sourceId = "b1111111",
+        itemData = itemData
+      )
+
+      transformer.extractItemData(transformable) shouldBe List(item1, item2)
+    }
+
+    it("ignores items it can't parse as JSON") {
+      val item = SierraItemData(
+        id = "i2000001",
+        deleted = true
+      )
+
+      val itemData = Map(
+        item.id -> SierraItemRecord(
+          id = item.id,
+          data = toJson(item).get,
+          modifiedDate = Instant.now,
+          bibIds = List()
+        ),
+        "i2000002" -> SierraItemRecord(
+          id = "i2000002",
+          data = "<xml?>This is not a real 'JSON' string",
+          modifiedDate = Instant.now,
+          bibIds = List()
+        )
+      )
+
+      val transformable = SierraTransformable(
+        sourceId = "b2222222",
+        itemData = itemData
+      )
+
+      transformer.extractItemData(transformable) shouldBe List(item)
+    }
+  }
+}

--- a/common/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
@@ -40,8 +40,6 @@ case class MiroTransformable(sourceId: String,
   *   - `maybeBibData`: data from the associated bib.  This may be None if
   *     we've received an item but haven't had the bib yet.
   *   - `itemData`: a map from item IDs to item records
-  *   - `version`: used to track updates to the record in DynamoDB.  The exact
-  *     value at any time is unimportant, but it should only ever increase.
   *
   */
 case class SierraTransformable(


### PR DESCRIPTION
This is a pure refactoring change in anticipation of #1466. It should have no changes in functionality; it just moves some logic to a new SierraItems trait.