### PR TITLE
Remove deleted items from works in the transformer

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
@@ -29,31 +29,27 @@ trait SierraItems extends Logging with SierraLocation {
       .flatten
   }
 
-  def transformItemData(sierraItemData: SierraItemData): Option[UnidentifiedItem] = {
+  def transformItemData(sierraItemData: SierraItemData): UnidentifiedItem = {
     info(s"Attempting to transform ${sierraItemData.id}")
-    if (sierraItemData.deleted) {
-      None
-    } else {
-      Some(UnidentifiedItem(
-        sourceIdentifier = SourceIdentifier(
-          IdentifierSchemes.sierraSystemNumber,
+    UnidentifiedItem(
+      sourceIdentifier = SourceIdentifier(
+        IdentifierSchemes.sierraSystemNumber,
+        sierraItemData.id
+      ),
+      identifiers = List(
+        SourceIdentifier(
+          identifierScheme = IdentifierSchemes.sierraSystemNumber,
           sierraItemData.id
-        ),
-        identifiers = List(
-          SourceIdentifier(
-            identifierScheme = IdentifierSchemes.sierraSystemNumber,
-            sierraItemData.id
-          )
-        ),
-        locations = getLocation(sierraItemData).toList
-      ))
-    }
+        )
+      ),
+      locations = getLocation(sierraItemData).toList
+    )
   }
 
   def getItems(
     sierraTransformable: SierraTransformable): List[UnidentifiedItem] = {
     extractItemData(sierraTransformable)
+      .filterNot { _.deleted }
       .map(transformItemData)
-      .flatten
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
@@ -29,9 +29,9 @@ trait SierraItems extends Logging with SierraLocation {
       .flatten
   }
 
-  def transformItemData(sierraItemData: SierraItemData): UnidentifiedItem = {
+  def transformItemData(sierraItemData: SierraItemData): Option[UnidentifiedItem] = {
     info(s"Attempting to transform ${sierraItemData.id}")
-    UnidentifiedItem(
+    Some(UnidentifiedItem(
       sourceIdentifier = SourceIdentifier(
         IdentifierSchemes.sierraSystemNumber,
         sierraItemData.id
@@ -44,12 +44,13 @@ trait SierraItems extends Logging with SierraLocation {
       ),
       locations = getLocation(sierraItemData).toList,
       visible = !sierraItemData.deleted
-    )
+    ))
   }
 
   def getItems(
     sierraTransformable: SierraTransformable): List[UnidentifiedItem] = {
     extractItemData(sierraTransformable)
       .map(transformItemData)
+      .flatten
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
@@ -45,8 +45,7 @@ trait SierraItems extends Logging with SierraLocation {
             sierraItemData.id
           )
         ),
-        locations = getLocation(sierraItemData).toList,
-        visible = !sierraItemData.deleted
+        locations = getLocation(sierraItemData).toList
       ))
     }
   }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
@@ -31,20 +31,24 @@ trait SierraItems extends Logging with SierraLocation {
 
   def transformItemData(sierraItemData: SierraItemData): Option[UnidentifiedItem] = {
     info(s"Attempting to transform ${sierraItemData.id}")
-    Some(UnidentifiedItem(
-      sourceIdentifier = SourceIdentifier(
-        IdentifierSchemes.sierraSystemNumber,
-        sierraItemData.id
-      ),
-      identifiers = List(
-        SourceIdentifier(
-          identifierScheme = IdentifierSchemes.sierraSystemNumber,
+    if (sierraItemData.deleted) {
+      None
+    } else {
+      Some(UnidentifiedItem(
+        sourceIdentifier = SourceIdentifier(
+          IdentifierSchemes.sierraSystemNumber,
           sierraItemData.id
-        )
-      ),
-      locations = getLocation(sierraItemData).toList,
-      visible = !sierraItemData.deleted
-    ))
+        ),
+        identifiers = List(
+          SourceIdentifier(
+            identifierScheme = IdentifierSchemes.sierraSystemNumber,
+            sierraItemData.id
+          )
+        ),
+        locations = getLocation(sierraItemData).toList,
+        visible = !sierraItemData.deleted
+      ))
+    }
   }
 
   def getItems(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -305,59 +305,6 @@ class SierraTransformableTransformerTest
     )
   }
 
-  it("makes deleted items on a work invisible") {
-    val id = "b5757575"
-    val title = "A morning mixture of molasses and muesli"
-    val data =
-      s"""
-         |{
-         | "id": "$id",
-         | "title": "$title",
-         | "varFields": []
-         |}
-        """.stripMargin
-
-    val sierraTransformable = SierraTransformable(
-      sourceId = id,
-      maybeBibData =
-        Some(SierraBibRecord(id = id, data = data, modifiedDate = now())),
-      itemData = Map(
-        "i111" -> sierraItemRecord(
-          id = "i111",
-          title = title,
-          bibIds = List(id)),
-        "i222" -> sierraItemRecord(
-          id = "i222",
-          title = title,
-          deleted = true,
-          bibIds = List(id))
-      )
-    )
-
-    val transformedSierraRecord =
-      transformer.transform(sierraTransformable, version = 1)
-
-    transformedSierraRecord.isSuccess shouldBe true
-    val work = transformedSierraRecord.get.get
-
-    val sourceIdentifier1 =
-      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, "i111")
-    val sourceIdentifier2 =
-      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, "i222")
-
-    work.items shouldBe List(
-      UnidentifiedItem(
-        sourceIdentifier = sourceIdentifier1,
-        identifiers = List(sourceIdentifier1)
-      ),
-      UnidentifiedItem(
-        sourceIdentifier = sourceIdentifier2,
-        identifiers = List(sourceIdentifier2),
-        visible = false
-      )
-    )
-  }
-
   it("transforms bib records that don't have a title") {
     // This example is taken from a failure observed in the transformer, based on
     // real records from Sierra.

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
@@ -80,4 +80,33 @@ class SierraItemsTest extends FunSpec with Matchers with SierraData {
       transformer.extractItemData(transformable) shouldBe List(item)
     }
   }
+
+  describe("getItems") {
+    it("removes items with deleted=true") {
+      val item1 = SierraItemData(id = "3000001", deleted = true)
+      val item2 = SierraItemData(id = "3000002", deleted = false)
+
+      val itemData = Map(
+        item1.id -> SierraItemRecord(
+          id = item1.id,
+          data = toJson(item1).get,
+          modifiedDate = Instant.now,
+          bibIds = List()
+        ),
+        item2.id -> SierraItemRecord(
+          id = item2.id,
+          data = toJson(item2).get,
+          modifiedDate = Instant.now,
+          bibIds = List()
+        )
+      )
+
+      val transformable = SierraTransformable(
+        sourceId = "b3333333",
+        itemData = itemData
+      )
+
+      transformer.getItems(transformable) should have size (1)
+    }
+  }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
@@ -2,6 +2,11 @@ package uk.ac.wellcome.transformer.transformers.sierra
 
 import java.time.Instant
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.{
+  IdentifierSchemes,
+  SourceIdentifier,
+  UnidentifiedItem
+}
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.test.utils.SierraData
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
@@ -81,10 +86,36 @@ class SierraItemsTest extends FunSpec with Matchers with SierraData {
     }
   }
 
+  describe("transformItemData") {
+    it("returns None if an item is deleted") {
+      val item = SierraItemData(id = "i4000001", deleted = true)
+
+      transformer.transformItemData(item) shouldBe None
+    }
+
+    it("returns Some[UnidentifiedItem] if an item is not deleted") {
+      val item = SierraItemData(id = "i4000002", deleted = false)
+
+      val sourceIdentifier = SourceIdentifier(
+        identifierScheme = IdentifierSchemes.sierraSystemNumber,
+        value = "i4000002"
+      )
+
+      val expectedItem = UnidentifiedItem(
+        sourceIdentifier = sourceIdentifier,
+        identifiers = List(sourceIdentifier),
+        locations = List(),
+        visible = true
+      )
+
+      transformer.transformItemData(item) shouldBe Some(expectedItem)
+    }
+  }
+
   describe("getItems") {
     it("removes items with deleted=true") {
-      val item1 = SierraItemData(id = "3000001", deleted = true)
-      val item2 = SierraItemData(id = "3000002", deleted = false)
+      val item1 = SierraItemData(id = "i3000001", deleted = true)
+      val item2 = SierraItemData(id = "i3000002", deleted = false)
 
       val itemData = Map(
         item1.id -> SierraItemRecord(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
@@ -101,7 +101,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraData {
         locations = List()
       )
 
-      transformer.transformItemData(item) shouldBe Some(expectedItem)
+      transformer.transformItemData(item) shouldBe expectedItem
     }
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
@@ -87,13 +87,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraData {
   }
 
   describe("transformItemData") {
-    it("returns None if an item is deleted") {
-      val item = SierraItemData(id = "i4000001", deleted = true)
-
-      transformer.transformItemData(item) shouldBe None
-    }
-
-    it("returns Some[UnidentifiedItem] if an item is not deleted") {
+    it("returns UnidentifiedItem if an item is not deleted") {
       val item = SierraItemData(id = "i4000002", deleted = false)
 
       val sourceIdentifier = SourceIdentifier(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
@@ -104,8 +104,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraData {
       val expectedItem = UnidentifiedItem(
         sourceIdentifier = sourceIdentifier,
         identifiers = List(sourceIdentifier),
-        locations = List(),
-        visible = true
+        locations = List()
       )
 
       transformer.transformItemData(item) shouldBe Some(expectedItem)

--- a/common/src/main/scala/uk/ac/wellcome/models/Item.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Item.scala
@@ -12,7 +12,6 @@ case class UnidentifiedItem(
   sourceIdentifier: SourceIdentifier,
   identifiers: List[SourceIdentifier] = Nil,
   locations: List[Location] = List(),
-  visible: Boolean = true,
   ontologyType: String = "Item"
 ) extends Identifiable
     with Item
@@ -22,7 +21,6 @@ case class IdentifiedItem(
   sourceIdentifier: SourceIdentifier,
   identifiers: List[SourceIdentifier] = Nil,
   locations: List[Location] = List(),
-  visible: Boolean = true,
   ontologyType: String = "Item"
 ) extends Identifiable
     with Item

--- a/common/src/main/scala/uk/ac/wellcome/models/Item.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Item.scala
@@ -4,7 +4,6 @@ sealed trait Item extends Identifiable {
   val sourceIdentifier: SourceIdentifier
   val identifiers: List[SourceIdentifier]
   val locations: List[Location]
-  val visible: Boolean
   val ontologyType: String
 }
 

--- a/common/src/test/scala/uk/ac/wellcome/models/IdentifiedItemTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/IdentifiedItemTest.scala
@@ -35,7 +35,6 @@ class IdentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
       |      "type": "DigitalLocation"
       |    }
       |  ],
-      |  "visible":true,
       |  "type": "Item"
       |}
     """.stripMargin

--- a/common/src/test/scala/uk/ac/wellcome/models/IdentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/IdentifiedWorkTest.scala
@@ -83,7 +83,6 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |          "type": "DigitalLocation"
       |        }
       |      ],
-      |      "visible":true,
       |      "type": "Item"
       |    }
       |  ],

--- a/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedItemTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedItemTest.scala
@@ -34,7 +34,6 @@ class UnidentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
       |      "type": "DigitalLocation"
       |    }
       |  ],
-      |  "visible":true,
       |  "type": "Item"
       |}
     """.stripMargin

--- a/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
@@ -81,7 +81,6 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |          "type": "DigitalLocation"
       |        }
       |      ],
-      |      "visible":true,
       |      "type": "Item"
       |    }
       |  ],


### PR DESCRIPTION
Per discussion yesterday, when the transformer sees an Item with deleted=true, rather than passing it along with visibility=false, it removes it entirely from the Work.

Resolves #1456.