### PR TITLE
Don't have a "visible" field on DisplayWork

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -114,9 +114,12 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
       works
         .map { resultList =>
           DisplayResultList(
-            results = resultList.results.map { DisplayWork(_, includes) }.toArray,
+            results =
+              resultList.results.map { DisplayWork(_, includes) }.toArray,
             pageSize = pageSize,
-            totalPages = Math.ceil(resultList.totalResults.toDouble / pageSize.toDouble).toInt,
+            totalPages = Math
+              .ceil(resultList.totalResults.toDouble / pageSize.toDouble)
+              .toInt,
             totalResults = resultList.totalResults
           )
         }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -153,7 +153,8 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
       worksService
         .findWorkById(canonicalId = request.id, index = request._index)
         .map {
-          case Some(work) => Some(DisplayWork(work = work, includes = includes))
+          case Some(work) =>
+            Some(DisplayWork(work = work, includes = includes))
           case None => None
         }
         .map {

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -93,6 +93,7 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
 
     } { request: MultipleResultsRequest =>
       val pageSize = request.pageSize.getOrElse((defaultPageSize))
+      val includes = request.includes.getOrElse(WorksIncludes())
 
       val works = request.query match {
         case Some(queryString) =>
@@ -100,14 +101,14 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
             queryString,
             pageSize = pageSize,
             pageNumber = request.page,
-            includes = request.includes.getOrElse(WorksIncludes()),
+            includes = includes,
             index = request._index
           )
         case None =>
           worksService.listWorks(
             pageSize = pageSize,
             pageNumber = request.page,
-            includes = request.includes.getOrElse(WorksIncludes()),
+            includes = includes,
             index = request._index
           )
       }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -153,7 +153,7 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
       worksService
         .findWorkById(canonicalId = request.id, index = request._index)
         .map {
-          case Some(work) => DisplayWork(work = work, includes = includes)
+          case Some(work) => Some(DisplayWork(work = work, includes = includes))
           case None => None
         }
         .map {

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -114,13 +114,9 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
       works
         .map { resultList =>
           DisplayResultList(
-            results =
-              resultList.results.map { DisplayWork(_, includes) }.toArray,
+            resultList = resultList,
             pageSize = pageSize,
-            totalPages = Math
-              .ceil(resultList.totalResults.toDouble / pageSize.toDouble)
-              .toInt,
-            totalResults = resultList.totalResults
+            includes = includes
           )
         }
         .map(

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -139,13 +139,11 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
         .parameter(includesSwaggerParam)
     // Deliberately undocumented: the index flag.  See above.
     } { request: SingleWorkRequest =>
+      val includes = request.includes.getOrElse(WorksIncludes())
       worksService
         .findWorkById(canonicalId = request.id, index = request._index)
         .map {
-          case Some(work) => DisplayWork(
-            work = work,
-            includes = request.includes.getOrElse(WorksIncludes())
-          )
+          case Some(work) => DisplayWork(work = work, includes = includes)
           case None => None
         }
         .map {

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -101,19 +101,25 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
             queryString,
             pageSize = pageSize,
             pageNumber = request.page,
-            includes = includes,
             index = request._index
           )
         case None =>
           worksService.listWorks(
             pageSize = pageSize,
             pageNumber = request.page,
-            includes = includes,
             index = request._index
           )
       }
 
       works
+        .map { resultList =>
+          DisplayResultList(
+            results = resultList.results.map { DisplayWork(_, includes) }.toArray,
+            pageSize = pageSize,
+            totalPages = Math.ceil(resultList.totalResults.toDouble / pageSize.toDouble).toInt,
+            totalResults = resultList.totalResults
+          )
+        }
         .map(
           displayResultList => {
             ResultListResponse.create(

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayResultList.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayResultList.scala
@@ -18,7 +18,9 @@ case class DisplayResultList(
 }
 
 case object DisplayResultList {
-  def apply(resultList: ResultList, pageSize: Int, includes: WorksIncludes): DisplayResultList =
+  def apply(resultList: ResultList,
+            pageSize: Int,
+            includes: WorksIncludes): DisplayResultList =
     DisplayResultList(
       results = resultList.results.map { DisplayWork(_, includes) }.toArray,
       pageSize = pageSize,

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayResultList.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayResultList.scala
@@ -17,17 +17,3 @@ case class DisplayResultList(
   @ApiModelProperty(name = "type", value = "A type of thing", readOnly = true)
   val ontologyType: String = "ResultList"
 }
-
-case object DisplayResultList {
-  def apply(searchResponse: SearchResponse,
-            pageSize: Int,
-            includes: WorksIncludes): DisplayResultList = {
-    DisplayResultList(
-      results = searchResponse.hits.hits.map { DisplayWork(_, includes) },
-      pageSize = pageSize,
-      totalPages =
-        Math.ceil(searchResponse.totalHits.toDouble / pageSize.toDouble).toInt,
-      totalResults = searchResponse.totalHits.toInt
-    )
-  }
-}

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayResultList.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayResultList.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.api.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.sksamuel.elastic4s.http.search.SearchResponse
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 
 @ApiModel(
@@ -16,4 +15,16 @@ case class DisplayResultList(
     DisplayWork]) {
   @ApiModelProperty(name = "type", value = "A type of thing", readOnly = true)
   val ontologyType: String = "ResultList"
+}
+
+case object DisplayResultList {
+  def apply(resultList: ResultList, pageSize: Int, includes: WorksIncludes): DisplayResultList =
+    DisplayResultList(
+      results = resultList.results.map { DisplayWork(_, includes) }.toArray,
+      pageSize = pageSize,
+      totalPages = Math
+        .ceil(resultList.totalResults.toDouble / pageSize.toDouble)
+        .toInt,
+      totalResults = resultList.totalResults
+    )
 }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -1,12 +1,8 @@
 package uk.ac.wellcome.platform.api.models
 
-import scala.util.{Failure, Success}
 import com.fasterxml.jackson.annotation.{JsonIgnoreProperties, JsonProperty}
-import com.sksamuel.elastic4s.http.search.SearchHit
-import com.sksamuel.elastic4s.http.get.GetResponse
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.{IdentifiedWork, Item, SourceIdentifier}
-import uk.ac.wellcome.utils.JsonUtil._
+import uk.ac.wellcome.models.IdentifiedWork
 
 @JsonIgnoreProperties(Array("visible"))
 @ApiModel(
@@ -109,25 +105,4 @@ case object DisplayWork {
 
   def apply(work: IdentifiedWork): DisplayWork =
     DisplayWork(work = work, includes = WorksIncludes())
-
-  def apply(hit: SearchHit): DisplayWork =
-    apply(hit, includes = WorksIncludes())
-
-  def apply(hit: SearchHit, includes: WorksIncludes): DisplayWork = {
-    jsonToDisplayWork(hit.sourceAsString, includes)
-  }
-
-  def apply(got: GetResponse, includes: WorksIncludes): DisplayWork = {
-    jsonToDisplayWork(got.sourceAsString, includes)
-  }
-
-  private def jsonToDisplayWork(document: String, includes: WorksIncludes) = {
-    fromJson[IdentifiedWork](document) match {
-      case Success(work) => DisplayWork(work = work, includes = includes)
-      case Failure(e) =>
-        throw new RuntimeException(
-          s"Unable to parse JSON as Work ($e): $document"
-        )
-    }
-  }
 }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/ResultList.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/ResultList.scala
@@ -1,0 +1,8 @@
+package uk.ac.wellcome.platform.api.models
+
+import uk.ac.wellcome.models.IdentifiedWork
+
+case class ResultList(
+  results: List[IdentifiedWork],
+  totalResults: Int
+)

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -11,11 +11,6 @@ import uk.ac.wellcome.utils.JsonUtil._
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
-case class ResultList(
-  results: List[IdentifiedWork],
-  totalResults: Int
-)
-
 @Singleton
 class WorksService @Inject()(@Flag("api.pageSize") defaultPageSize: Int,
                              searchService: ElasticSearchService) {

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.api.services
 
 import javax.inject.{Inject, Singleton}
 
+import com.sksamuel.elastic4s.http.search.SearchHit
 import com.twitter.inject.Logging
 import com.twitter.inject.annotations.Flag
 import uk.ac.wellcome.models.IdentifiedWork
@@ -47,10 +48,10 @@ class WorksService @Inject()(@Flag("api.pageSize") defaultPageSize: Int,
       )
       .map { searchResponse =>
         ResultList(
-          results = searchResponse.hits.hits.map {
-            jsonToIdentifiedWork(_.sourceAsString)
-          },
-          totalResults = searchResponse.totalHits.toInt
+          results = searchResponse.hits.hits.map { h: SearchHit =>
+            jsonToIdentifiedWork(h.sourceAsString)
+          }.toList,
+          totalResults = searchResponse.totalHits
         )
       }
 
@@ -67,10 +68,10 @@ class WorksService @Inject()(@Flag("api.pageSize") defaultPageSize: Int,
       )
       .map { searchResponse =>
         ResultList(
-          results = searchResponse.hits.hits.map {
-            jsonToIdentifiedWork(_.sourceAsString)
-          },
-          totalResults = searchResponse.totalHits.toInt
+          results = searchResponse.hits.hits.map { h: SearchHit =>
+            jsonToIdentifiedWork(h.sourceAsString)
+          }.toList,
+          totalResults = searchResponse.totalHits
         )
       }
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -5,6 +5,7 @@ import javax.inject.{Inject, Singleton}
 import com.sksamuel.elastic4s.http.search.SearchHit
 import com.twitter.inject.annotations.Flag
 import uk.ac.wellcome.models.IdentifiedWork
+import uk.ac.wellcome.platform.api.models.ResultList
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil._
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -3,14 +3,8 @@ package uk.ac.wellcome.platform.api.services
 import javax.inject.{Inject, Singleton}
 
 import com.sksamuel.elastic4s.http.search.SearchHit
-import com.twitter.inject.Logging
 import com.twitter.inject.annotations.Flag
 import uk.ac.wellcome.models.IdentifiedWork
-import uk.ac.wellcome.platform.api.models.{
-  DisplayResultList,
-  DisplayWork,
-  WorksIncludes
-}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil._
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -20,8 +20,9 @@ case class ResultList(
 class WorksService @Inject()(@Flag("api.pageSize") defaultPageSize: Int,
                              searchService: ElasticSearchService) {
 
-  def findWorkById(canonicalId: String,
-                   index: Option[String] = None): Future[Option[IdentifiedWork]] =
+  def findWorkById(
+    canonicalId: String,
+    index: Option[String] = None): Future[Option[IdentifiedWork]] =
     searchService
       .findResultById(canonicalId, index = index)
       .map { result =>

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -135,7 +135,9 @@ class ElasticsearchServiceTest
     whenReady(searchResultFuture) { result =>
       result.hits should have size expectedWorks.length
       val returnedWorks = result.hits.hits
-        .map { h: SearchHit => jsonToIdentifiedWork(h.sourceAsString) }
+        .map { h: SearchHit =>
+          jsonToIdentifiedWork(h.sourceAsString)
+        }
         .map { DisplayWork(_) }
       returnedWorks.toList shouldBe expectedWorks
     }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -36,6 +36,8 @@ class ElasticsearchServiceTest
       title = "Circling a Cheetah"
     )
 
+    insertIntoElasticSearch(work1, work2, work3)
+
     assertSliceIsCorrect(
       limit = 3,
       from = 0,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.api.services
 
+import com.sksamuel.elastic4s.http.search.SearchHit
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.IdentifiedWork
@@ -38,11 +39,7 @@ class ElasticsearchServiceTest
     assertSliceIsCorrect(
       limit = 3,
       from = 0,
-      expectedWorks = List(
-        work3,
-        work2,
-        work1
-      )
+      expectedWorks = List(work3, work2, work1).map { DisplayWork(_) }
     )
 
     // TODO: canonicalID is the only user-defined field that we can sort on.
@@ -138,7 +135,7 @@ class ElasticsearchServiceTest
     whenReady(searchResultFuture) { result =>
       result.hits should have size expectedWorks.length
       val returnedWorks = result.hits.hits
-        .map { jsonToIdentifiedWork(_.sourceAsString) }
+        .map { h: SearchHit => jsonToIdentifiedWork(h.sourceAsString) }
         .map { DisplayWork(_) }
       returnedWorks.toList shouldBe expectedWorks
     }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -82,9 +82,7 @@ class WorksServiceTest
     val searchForDodo = worksService.searchWorks("dodo")
     whenReady(searchForDodo) { works =>
       works.results should have size 1
-      works.results.head shouldBe DisplayWork(
-        workDodo.canonicalId,
-        workDodo.title.get)
+      works.results.head shouldBe workDodo
     }
   }
 
@@ -100,47 +98,7 @@ class WorksServiceTest
     val displayWorksFuture = worksService.listWorks(pageSize = 10)
 
     whenReady(displayWorksFuture) { works =>
-      works.totalPages shouldBe 0
-    }
-  }
-
-  it(
-    "should return the correct totalPages for the number of results and pageSize") {
-    val works = createWorks(2)
-
-    insertIntoElasticSearch(works: _*)
-
-    val displayWorksFuture = worksService.listWorks(pageSize = 1)
-
-    whenReady(displayWorksFuture) { works =>
-      works.totalPages shouldBe 2
-    }
-  }
-
-  it("should return the correct number of results per page for the pageSize") {
-    val works = createWorks(3)
-
-    insertIntoElasticSearch(works: _*)
-
-    val displayWorksFuture = worksService.listWorks(pageSize = 2)
-
-    whenReady(displayWorksFuture) { works =>
-      works.results.length shouldBe 2
-    }
-  }
-
-  it("should display the correct page when asked") {
-    val works = createWorks(3)
-
-    insertIntoElasticSearch(works: _*)
-
-    val displayWorksFuture =
-      worksService.listWorks(pageSize = 1, pageNumber = 2)
-
-    whenReady(displayWorksFuture) { receivedWorks =>
-      receivedWorks.results.head shouldBe DisplayWork(
-        works(1),
-        WorksIncludes())
+      works.totalResults shouldBe 0
     }
   }
 
@@ -172,57 +130,7 @@ class WorksServiceTest
 
     whenReady(searchForEmu) { works =>
       works.results should have size 1
-      works.results.head shouldBe DisplayWork(
-        workEmu.canonicalId,
-        workEmu.title.get)
-    }
-  }
-
-  it("should return identifiers if specified in the includes for listWorks") {
-    val canonicalId = "1234"
-
-    val title = "image title"
-    val miroId = "abcdef"
-    val identifierScheme = IdentifierSchemes.miroImageNumber
-    val work = workWith(
-      canonicalId,
-      title,
-      identifiers = List(
-        SourceIdentifier(identifierScheme = identifierScheme, value = miroId)))
-    insertIntoElasticSearch(work)
-
-    val listWorksResult =
-      worksService.listWorks(includes = WorksIncludes(identifiers = true))
-
-    whenReady(listWorksResult) { (displayWork: DisplayResultList) =>
-      displayWork.results.head.identifiers.get shouldBe List(
-        DisplayIdentifier(identifierScheme = identifierScheme, value = miroId))
-
-    }
-  }
-
-  it("should return identifiers if specified in the includes for searchWorks") {
-    val canonicalId = "1234"
-
-    val title = "A search for a snail"
-    val miroId = "abcdef"
-    val identifierScheme = IdentifierSchemes.miroImageNumber
-    val work = workWith(
-      canonicalId,
-      title,
-      identifiers = List(
-        SourceIdentifier(identifierScheme = identifierScheme, value = miroId)))
-    insertIntoElasticSearch(work)
-
-    val searchWorksResult = worksService.searchWorks(
-      query = "snail",
-      includes = WorksIncludes(identifiers = true)
-    )
-
-    whenReady(searchWorksResult) { (displayWork: DisplayResultList) =>
-      displayWork.results.head.identifiers.get shouldBe List(
-        DisplayIdentifier(identifierScheme = identifierScheme, value = miroId))
-
+      works.results.head shouldBe workEmu
     }
   }
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -57,7 +57,7 @@ class WorksServiceTest
 
     whenReady(recordsFuture) { records =>
       records.isDefined shouldBe true
-      records.get shouldBe DisplayWork(works.head, WorksIncludes())
+      records.get shouldBe works.head
     }
   }
 
@@ -175,33 +175,6 @@ class WorksServiceTest
       works.results.head shouldBe DisplayWork(
         workEmu.canonicalId,
         workEmu.title.get)
-    }
-  }
-
-  it("should return identifiers if specified in the includes for findWorkById") {
-    val canonicalId = "1234"
-
-    val title = "image title"
-    val miroId = "abcdef"
-    val identifierScheme = IdentifierSchemes.miroImageNumber
-    val work = workWith(
-      canonicalId,
-      title,
-      identifiers = List(
-        SourceIdentifier(identifierScheme = identifierScheme, value = miroId)))
-    insertIntoElasticSearch(work)
-
-    val getByIdResult = worksService.findWorkById(
-      canonicalId,
-      includes = WorksIncludes(identifiers = true)
-    )
-
-    whenReady(getByIdResult) { maybeDisplayWork =>
-      maybeDisplayWork.isDefined shouldBe true
-      maybeDisplayWork.get.identifiers.isDefined shouldBe true
-      maybeDisplayWork.get.identifiers.get shouldBe List(
-        DisplayIdentifier(identifierScheme = identifierScheme, value = miroId))
-
     }
   }
 


### PR DESCRIPTION
This refactors WorkService to deal exclusively in the sort of Work that lives internal to Elasticsearch, and pushes out the display logic.

Resolves #1619.