### PR TITLE
catalogue_api: remove two outputs that refer to non-existent buckets

### DIFF
--- a/catalogue_api/terraform/outputs.tf
+++ b/catalogue_api/terraform/outputs.tf
@@ -1,11 +1,3 @@
-output "bucket_miro_data_id" {
-  value = "${aws_s3_bucket.miro-data.id}"
-}
-
-output "bucket_miro_data_arn" {
-  value = "${aws_s3_bucket.miro-data.arn}"
-}
-
 output "bucket_miro_images_sync_arn" {
   value = "${aws_s3_bucket.miro-images-sync.arn}"
 }


### PR DESCRIPTION
Spotted when trying to deploy a new API with publicationDate.