### PR TITLE
Add extent to Works

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -30,7 +30,8 @@ case class DisplayWork(
     String] = None,
   @ApiModelProperty(
     dataType = "String",
-    value = "Number of physical pages, volumes, cassettes, total playing time, etc., of of each type of unit"
+    value =
+      "Number of physical pages, volumes, cassettes, total playing time, etc., of of each type of unit"
   ) extent: Option[String] = None,
   @ApiModelProperty(
     dataType = "String",

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -30,6 +30,10 @@ case class DisplayWork(
     String] = None,
   @ApiModelProperty(
     dataType = "String",
+    value = "Number of physical pages, volumes, cassettes, total playing time, etc., of of each type of unit"
+  ) extent: Option[String] = None,
+  @ApiModelProperty(
+    dataType = "String",
     value = "Recording written text on a (usually visual) work.") lettering: Option[
     String] = None,
   @ApiModelProperty(
@@ -88,6 +92,7 @@ case object DisplayWork {
       title = work.title.get,
       description = work.description,
       physicalDescription = work.physicalDescription,
+      extent = work.extent,
       lettering = work.lettering,
       createdDate = work.createdDate.map { DisplayPeriod(_) },
       creators = work.creators.map { DisplayAgent(_) },

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayWorkTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayWorkTest.scala
@@ -150,4 +150,19 @@ class DisplayWorkTest extends FunSpec with Matchers {
     val displayWork = DisplayWork(work)
     displayWork.physicalDescription shouldBe Some(physicalDescription)
   }
+
+  it("gets the extent from a Work") {
+    val extent = "Bound in boxes of bark"
+
+    val work = IdentifiedWork(
+      title = Some("Brilliant beeches in Bucharest"),
+      canonicalId = "bmnppscn",
+      sourceIdentifier = sourceIdentifier,
+      extent = Some(extent),
+      version = 1
+    )
+
+    val displayWork = DisplayWork(work)
+    displayWork.extent shouldBe Some(extent)
+  }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
@@ -15,6 +15,7 @@ class SierraTransformableTransformer
     with SierraIdentifiers
     with SierraDescription
     with SierraPhysicalDescription
+    with SierraExtent
     with SierraItems
     with SierraLettering
     with SierraPublishers
@@ -43,6 +44,7 @@ class SierraTransformableTransformer
               identifiers = getIdentifiers(sierraBibData),
               description = getDescription(sierraBibData),
               physicalDescription = getPhysicalDescription(sierraBibData),
+              extent = getExtent(sierraBibData),
               lettering = getLettering(sierraBibData),
               items = getItems(sierraTransformable),
               publishers = getPublishers(sierraBibData),

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraExtent.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraExtent.scala
@@ -1,0 +1,43 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+import uk.ac.wellcome.transformer.source.SierraBibData
+
+trait SierraExtent extends MarcUtils {
+
+  // Populate wwork:extent.
+  //
+  // We use MARC field 300 and subfield $a.
+  //
+  // Notes:
+  //
+  //  - MARC field 300 and subfield $a are both labelled "R" (repeatable),
+  //    and include examples of it being repeated.
+  //
+  //  - This field is usually meant to be joined with other fields, with
+  //    display logic that isn't entirely clear.
+  //
+  //    So far we don't do any stripping of punctuation, and if multiple
+  //    subfields are found on a record, I'm just joining them with spaces.
+  //
+  //    TODO: Decide a proper strategy for joining multiple physical
+  //    descriptions!
+  //
+  // https://www.loc.gov/marc/bibliographic/bd300.html
+  //
+  def getExtent(bibData: SierraBibData): Option[String] = {
+    val matchingSubfields = getMatchingSubfields(
+      bibData = bibData,
+      marcTag = "300",
+      marcSubfieldTag = "a"
+    )
+
+    if (matchingSubfields.isEmpty) {
+      None
+    } else {
+      val label = matchingSubfields
+        .map { _.content }
+        .mkString(" ")
+      Some(label)
+    }
+  }
+}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -395,4 +395,41 @@ class SierraTransformableTransformerTest
       physicalDescription)
   }
 
+  it("includes the extent, if present") {
+    val id = "b8000008"
+    val extent = "Purple pages"
+
+    val data =
+      s"""
+        | {
+        |   "id": "$id",
+        |   "title": "English earwigs earn evidence of evil",
+        |   "varFields": [
+        |     {
+        |       "fieldTag": "a",
+        |       "marcTag": "300",
+        |       "ind1": " ",
+        |       "ind2": " ",
+        |       "subfields": [
+        |         {
+        |           "tag": "b",
+        |           "content": "$extent"
+        |         }
+        |       ]
+        |     }
+        |   ]
+        | }
+      """.stripMargin
+
+    val sierraTransformable = SierraTransformable(
+      sourceId = id,
+      maybeBibData =
+        Some(SierraBibRecord(id = id, data = data, modifiedDate = now())))
+
+    val transformedSierraRecord =
+      transformer.transform(sierraTransformable, version = 1)
+    transformedSierraRecord.isSuccess shouldBe true
+
+    transformedSierraRecord.get.get.extent shouldBe Some(extent)
+  }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -412,7 +412,7 @@ class SierraTransformableTransformerTest
         |       "ind2": " ",
         |       "subfields": [
         |         {
-        |           "tag": "b",
+        |           "tag": "a",
         |           "content": "$extent"
         |         }
         |       ]

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraExtentTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraExtentTest.scala
@@ -1,0 +1,115 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.transformer.source.{
+  MarcSubfield,
+  SierraBibData,
+  VarField
+}
+
+class SierraExtentTest extends FunSpec with Matchers {
+
+  val transformer = new SierraExtent {}
+
+  it("gets no extent if there is no MARC field 300 with subfield $a") {
+    val bibData = SierraBibData(
+      id = "e1000001",
+      title = Some("Egad!  An egg exits eastwards."),
+      varFields = List()
+    )
+
+    transformer.getExtent(bibData = bibData) shouldBe None
+  }
+
+  it("extracts extent from MARC field 300 subfield $a") {
+    val extent = "Eleven elephant etchings"
+
+    val varFields = List(
+      VarField(
+        fieldTag = "?",
+        marcTag = "300",
+        indicator1 = " ",
+        indicator2 = " ",
+        subfields = List(
+          MarcSubfield(
+            tag = "a",
+            content = extent
+          ),
+          MarcSubfield(
+            tag = "b",
+            content = "Grey, gigantic, graceful (?)"
+          )
+        )
+      )
+    )
+
+    val bibData = SierraBibData(
+      id = "e2000002",
+      title = Some("Even eagles eschew exasperating elephants"),
+      varFields = varFields
+    )
+
+    transformer.getExtent(bibData = bibData) shouldBe Some(extent)
+  }
+
+  it("extracts an extent where there are multiple MARC field 300 $a") {
+    // This is based on the "repeatable $a" example in the MARC spec.
+    // https://www.loc.gov/marc/bibliographic/bd300.html
+    val extent1 = "diary"
+    val extent2 = "1"
+    val extent3 = "(463"
+
+    val expectedExtent = s"$extent1 $extent2 $extent3"
+
+    val varFields = List(
+      VarField(
+        fieldTag = "?",
+        marcTag = "300",
+        indicator1 = " ",
+        indicator2 = " ",
+        subfields = List(
+          MarcSubfield(
+            tag = "a",
+            content = extent1
+          )
+        )
+      ),
+      VarField(
+        fieldTag = "?",
+        marcTag = "300",
+        indicator1 = " ",
+        indicator2 = " ",
+        subfields = List(
+          MarcSubfield(
+            tag = "a",
+            content = extent2
+          ),
+          MarcSubfield(
+            tag = "b",
+            content = "Endless ecstasy from ecclesiastic echoes"
+          )
+        )
+      ),
+      VarField(
+        fieldTag = "?",
+        marcTag = "300",
+        indicator1 = " ",
+        indicator2 = " ",
+        subfields = List(
+          MarcSubfield(
+            tag = "a",
+            content = extent3
+          )
+        )
+      )
+    )
+
+    val bibData = SierraBibData(
+      id = "e3000003",
+      title = Some("Eager electric eels are exciting"),
+      varFields = varFields
+    )
+
+    transformer.getExtent(bibData = bibData) shouldBe Some(expectedExtent)
+  }
+}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraExtentTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraExtentTest.scala
@@ -11,7 +11,7 @@ class SierraExtentTest extends FunSpec with Matchers {
 
   val transformer = new SierraExtent {}
 
-  it("gets no extent if there is no MARC field 300 with subfield $a") {
+  it("gets no extent if there is no MARC field 300 with subfield $$a") {
     val bibData = SierraBibData(
       id = "e1000001",
       title = Some("Egad!  An egg exits eastwards."),
@@ -21,7 +21,7 @@ class SierraExtentTest extends FunSpec with Matchers {
     transformer.getExtent(bibData = bibData) shouldBe None
   }
 
-  it("extracts extent from MARC field 300 subfield $a") {
+  it("extracts extent from MARC field 300 subfield $$a") {
     val extent = "Eleven elephant etchings"
 
     val varFields = List(
@@ -52,7 +52,7 @@ class SierraExtentTest extends FunSpec with Matchers {
     transformer.getExtent(bibData = bibData) shouldBe Some(extent)
   }
 
-  it("extracts an extent where there are multiple MARC field 300 $a") {
+  it("extracts an extent where there are multiple MARC field 300 $$a") {
     // This is based on the "repeatable $a" example in the MARC spec.
     // https://www.loc.gov/marc/bibliographic/bd300.html
     val extent1 = "diary"

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraPhysicalDescriptionTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraPhysicalDescriptionTest.scala
@@ -11,7 +11,7 @@ class SierraPhysicalDescriptionTest extends FunSpec with Matchers {
 
   val transformer = new SierraPhysicalDescription {}
 
-  it("gets no physical if there is no MARC field 300 with subfield $b") {
+  it("gets no physical description if there is no MARC field 300 with subfield $b") {
     val bibData = SierraBibData(
       id = "pd1000001",
       title = Some("Quick!  The quails are quadrupling."),
@@ -54,7 +54,7 @@ class SierraPhysicalDescriptionTest extends FunSpec with Matchers {
       .get shouldBe physicalDescription
   }
 
-  it("extracts a physical description where there are multiple MARC field 399") {
+  it("extracts a physical description where there are multiple MARC field 300 $b") {
     val physicalDescription1 = "The queer quolls quits and quarrels"
     val physicalDescription2 = "A quintessential quadraped is quick"
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraPhysicalDescriptionTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraPhysicalDescriptionTest.scala
@@ -11,7 +11,8 @@ class SierraPhysicalDescriptionTest extends FunSpec with Matchers {
 
   val transformer = new SierraPhysicalDescription {}
 
-  it("gets no physical description if there is no MARC field 300 with subfield $b") {
+  it(
+    "gets no physical description if there is no MARC field 300 with subfield $b") {
     val bibData = SierraBibData(
       id = "pd1000001",
       title = Some("Quick!  The quails are quadrupling."),
@@ -54,7 +55,8 @@ class SierraPhysicalDescriptionTest extends FunSpec with Matchers {
       .get shouldBe physicalDescription
   }
 
-  it("extracts a physical description where there are multiple MARC field 300 $b") {
+  it(
+    "extracts a physical description where there are multiple MARC field 300 $b") {
     val physicalDescription1 = "The queer quolls quits and quarrels"
     val physicalDescription2 = "A quintessential quadraped is quick"
 

--- a/common/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/common/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -88,6 +88,8 @@ class WorksIndex @Inject()(client: HttpClient,
         textField("english").analyzer(EnglishLanguageAnalyzer)),
       textField("physicalDescription").fields(
         textField("english").analyzer(EnglishLanguageAnalyzer)),
+      textField("extent").fields(
+        textField("english").analyzer(EnglishLanguageAnalyzer)),
       textField("lettering").fields(
         textField("english").analyzer(EnglishLanguageAnalyzer)),
       date("createdDate"),

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -11,6 +11,7 @@ trait Work extends Versioned with Identifiable {
   val identifiers: List[SourceIdentifier]
   val description: Option[String]
   val physicalDescription: Option[String]
+  val extent: Option[String]
   val lettering: Option[String]
   val createdDate: Option[Period]
   val subjects: List[Concept]
@@ -29,6 +30,7 @@ case class UnidentifiedWork(title: Option[String],
                             identifiers: List[SourceIdentifier] = List(),
                             description: Option[String] = None,
                             physicalDescription: Option[String] = None,
+                            extent: Option[String] = None,
                             lettering: Option[String] = None,
                             createdDate: Option[Period] = None,
                             subjects: List[Concept] = Nil,
@@ -49,6 +51,7 @@ case class IdentifiedWork(canonicalId: String,
                           identifiers: List[SourceIdentifier] = List(),
                           description: Option[String] = None,
                           physicalDescription: Option[String] = None,
+                          extent: Option[String] = None,
                           lettering: Option[String] = None,
                           createdDate: Option[Period] = None,
                           subjects: List[Concept] = Nil,

--- a/common/src/test/scala/uk/ac/wellcome/models/IdentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/IdentifiedWorkTest.scala
@@ -18,6 +18,10 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
   // read "There is no news", followed by 15 minutes of piano music.
   val publicationDate = "18 April 1930"
 
+  // TRIVIA: This isn't describing a book, but instead the allocation
+  // of disk space inside Microsoft SQL Server.
+  val extent = "A collection of eight physically contiguous pages"
+
   // TRIVIA: This is how Willem de Vlamingh, a Dutch scientist, described
   // seeing the quokka when exploring near Australia.
   val physicalDescription = "A kind of rat as big as a cat"
@@ -40,6 +44,7 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |  "canonicalId": "canonicalId",
       |  "description": "description",
       |  "physicalDescription": "$physicalDescription",
+      |  "extent": "$extent",
       |  "lettering": "lettering",
       |  "createdDate": {
       |    "label": "period",
@@ -142,6 +147,7 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
     identifiers = List(identifier),
     description = Some("description"),
     physicalDescription = Some(physicalDescription),
+    extent = Some(extent),
     lettering = Some("lettering"),
     createdDate = Some(Period("period")),
     subjects = List(Concept("subject")),

--- a/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
@@ -19,6 +19,9 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
   val physicalDescription =
     "Hair like that of a buffalo, feet like those of an elephant"
 
+  // TRIVIA: This is based on Harry Potter, when we first meet Dobby.
+  val extent = "Both socks pulled up to their highest extent"
+
   // TRIVIA: on 3 July 1998, LNER 4468 "Mallard" set the world speed record
   // for steam locomotives, reaching 126 mph.
   val publicationDate = "3 July 1938"
@@ -40,6 +43,7 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |  ],
       |  "description": "description",
       |  "physicalDescription": "$physicalDescription",
+      |  "extent": "$extent",
       |  "lettering": "lettering",
       |  "createdDate": {
       |    "label": "period",
@@ -138,6 +142,7 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
     identifiers = List(identifier),
     description = Some("description"),
     physicalDescription = Some(physicalDescription),
+    extent = Some(extent),
     lettering = Some("lettering"),
     createdDate = Some(Period("period")),
     subjects = List(Concept("subject")),


### PR DESCRIPTION
This patch adds the 'extent' field to Works, and all the necessary plumbing to expose it in the API.

Related: #1419.

Transformation checklist:

- [x] Added any new fields to Work/Item (and the unidentified/identified variants)
- [x] Update the JSON serialisation tests in [Un]IdentifiedWorkTest
- [x] Implemented the new transformation
- [x] Added any new fields to the Elasticsearch mapping
- [x] Updated the Display models in the API