### PR TITLE
Various improvements to our Loris image

### DIFF
--- a/loris/Makefile
+++ b/loris/Makefile
@@ -23,8 +23,4 @@ $(LORIS)/loris/requirements.txt: $(LORIS)/requirements.in
 		pip-compile
 
 loris-run: loris-build
-	$(ROOT)/docker_run.py --aws -- \
-		--publish 8888:8888 \
-		--env INFRA_BUCKET=$(INFRA_BUCKET) \
-		--env CONFIG_KEY=config/prod/loris.ini \
-		loris
+	$(ROOT)/docker_run.py -- --publish 8888:8888 loris

--- a/loris/Makefile
+++ b/loris/Makefile
@@ -16,9 +16,9 @@ $(val $(call stack_setup))
 
 # TODO: Flip this to using micktwomey/pip-tools when that's updated
 # with a newer version of pip-tools.
-$(LORIS)/loris/requirements.txt: $(LORIS)/requirements.in
+$(ROOT)/loris/loris/requirements.txt: $(ROOT)/loris/loris/requirements.in
 	docker run --rm \
-		-v $(LORIS):/data \
+		--volume $(ROOT)/loris/loris:/data \
 		wellcome/build_tooling:latest \
 		pip-compile
 

--- a/loris/README.md
+++ b/loris/README.md
@@ -21,15 +21,7 @@ Once you've changed these variables, the new version of Loris will be installed 
 Sometimes it can be convenient to test Loris locally, without pushing a new commit to GitHub -- e.g. for testing a code patch, or experimenting with config.
 You can run Loris locally with the following two commands:
 
-    make loris-build
-
-    docker run \
-        --volume $PLATFORM/terraform/services/config/templates/loris.ini.template:/opt/loris/etc/loris2.conf \
-        --volume $LORIS/loris:/usr/local/lib/python2.7/dist-packages/Loris-2.0.0-py2.7.egg/loris \
-        --volume $LORIS/www/icons:/var/www/loris2/icons \
-        --publish 8888:8888 loris
-
-where `$PLATFORM` is the root of the platform repo, and `$LORIS` is the root of a local checkout of the Loris repo.
+    make loris-run
 
 You'll then have a development version of Loris running at <http://localhost:8888>.
 

--- a/loris/docker-compose.yml
+++ b/loris/docker-compose.yml
@@ -4,12 +4,6 @@ services:
     build: .
     ports:
      - "8888:8888"
-    environment:
-      - INFRA_BUCKET=platform-infra
-      - CONFIG_KEY=${CONFIG_KEY}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-
   nginx:
     image: "nginx_loris:${NGINX_TAG}"
     ports:

--- a/loris/loris/Dockerfile
+++ b/loris/loris/Dockerfile
@@ -1,15 +1,28 @@
 FROM ubuntu:16.04
 
+
+# Install base Python and uWSGI (web server) dependencies
 RUN apt-get update && \
-    apt-get install --yes python uwsgi uwsgi-plugin-python && \
+    apt-get install --yes python3 python3-pip uwsgi uwsgi-plugin-python3 && \
     apt-get clean
 
-ENV LORIS_COMMIT a349d24b63bf1ae1af97e376304c4b1acc983639
+RUN pip3 install --upgrade pip
+
+# Imaging dependencies.  These libraries don't change much between versions
+# of Loris, so we can cache their installation.
+RUN apt-get update && \
+    apt-get install --yes libffi-dev libjpeg-turbo8-dev libfreetype6-dev zlib1g-dev \
+        liblcms2-dev liblcms2-utils libssl-dev libtiff5-dev libwebp-dev && \
+    apt-get clean
+
+
 ENV LORIS_GITHUB_USER loris-imageserver
+ENV LORIS_COMMIT 841383810cdd62ae591f532fd89330bb0be06565
 
 COPY requirements.txt /
 COPY install_loris.sh /install_loris.sh
 RUN /install_loris.sh
+
 
 # This is an sRGB color profile downloaded from
 # http://www.color.org/srgbprofiles.xalter

--- a/loris/loris/Dockerfile
+++ b/loris/loris/Dockerfile
@@ -34,6 +34,8 @@ COPY loris2.conf /opt/loris/etc/loris2.conf
 COPY loris2.wsgi /var/www/loris2/loris2.wsgi
 COPY uwsgi.ini /etc/uwsgi
 
+COPY wellcome_loris.py /usr/local/lib/python3.5/dist-packages
+
 EXPOSE 8888
 
 CMD ["/usr/bin/uwsgi", "--ini", "/etc/uwsgi/uwsgi.ini"]

--- a/loris/loris/install_loris.sh
+++ b/loris/loris/install_loris.sh
@@ -4,13 +4,6 @@
 set -o errexit
 set -o nounset
 
-# Install dependencies.  We don't include Apache because we're running
-# Loris with UWSGI and nginx, not Apache.
-echo "*** Installing Ubuntu imaging dependencies"
-apt-get update
-apt-get install --yes libffi-dev libjpeg-turbo8-dev libfreetype6-dev zlib1g-dev \
-    liblcms2-dev liblcms2-utils libssl-dev libtiff5-dev libwebp-dev
-
 # Download and install the Loris code itself
 echo "*** Downloading the Loris source code"
 apt-get install --yes unzip wget
@@ -23,22 +16,11 @@ apt-get remove --yes unzip wget
 echo "*** Creating Loris user"
 useradd -d /var/www/loris -s /sbin/false loris
 
-# Install pip.  We don't use pip from the Ubuntu package repositories
-# because it tends to be out-of-date and using it gets issues like:
-# https://github.com/pyca/cryptography/issues/3959
-apt-get install --yes wget
-wget https://bootstrap.pypa.io/get-pip.py
-python ./get-pip.py
-
-rm -rf get-pip.py
-apt-get remove --yes wget
-apt-get autoremove --yes
-
 echo "*** Installing Loris dependencies"
-pip install -r /requirements.txt
+pip3 install -r /requirements.txt
 
 echo "*** Installing Loris itself"
 cd "loris-$LORIS_COMMIT"
-python setup.py install
+python3 setup.py install
 
 apt-get clean

--- a/loris/loris/loris2.conf
+++ b/loris/loris/loris2.conf
@@ -43,7 +43,7 @@ log_level = 'INFO'  # 'DEBUG'|'INFO'|'WARNING'|'ERROR'|'CRITICAL'
 format = '%(asctime)s (%(name)s) [%(levelname)s]: %(message)s'
 
 [resolver]
-impl = 'loris.resolver.TemplateHTTPResolver'
+impl = 'wellcome_loris.WellcomeTemplateHTTPResolver'
 cache_root = '/mnt/loris/resolver_cache'
 templates = 'wordpress,s3,prismic'
 

--- a/loris/loris/requirements.in
+++ b/loris/loris/requirements.in
@@ -1,6 +1,15 @@
-# Copy from the Loris repo at commit a349d24
+tenacity
+
+### Copied from the Loris repo at commit 14fd219 ###
+
 werkzeug >= 0.11.4
-pillow >= 2.4.0
+
+# We put an upper bound on the version of Pillow so we can cope with
+# JPEG-compressed TIFFs.
+#
+# See https://github.com/loris-imageserver/loris/issues/405
+pillow >= 2.4.0, <5.0
+
 configobj >= 4.7.2,<=5.0.0
 requests >= 2.12.0
 netaddr >= 0.7.19

--- a/loris/loris/requirements.txt
+++ b/loris/loris/requirements.txt
@@ -12,12 +12,14 @@ chardet==3.0.4            # via requests
 configobj==5.0.0
 cryptography==2.1
 idna==2.6                 # via cryptography, requests
+monotonic==1.4            # via tenacity
 netaddr==0.7.19
 olefile==0.44             # via pillow
 pillow==4.3.0
 pycparser==2.18           # via cffi
 pyjwt==1.5.3
 requests==2.18.4
-six==1.11.0               # via cryptography
+six==1.11.0               # via cryptography, tenacity
+tenacity==4.9.0
 urllib3==1.22             # via requests
 werkzeug==0.12.2

--- a/loris/loris/uwsgi.ini
+++ b/loris/loris/uwsgi.ini
@@ -2,4 +2,4 @@
 http-socket = :8888
 processes = 64
 wsgi-file = /var/www/loris2/loris2.wsgi
-plugins = python
+plugins = python3

--- a/loris/loris/wellcome_loris.py
+++ b/loris/loris/wellcome_loris.py
@@ -1,0 +1,29 @@
+# -*- encoding: utf-8 -*-
+"""This file contains the code specific to the Wellcome Loris deployment.
+
+Code in this file will usually be highly specialised, and is unlikely to
+be of interest to other users -- anything generic should be submitted as
+an upstream patch.
+
+"""
+
+from loris.resolvers import TemplateHTTPResolver
+from requests.exceptions import RequestException
+from tenacity import retry, retry_if_exception_type, stop_after_attempt
+
+
+class WellcomeTemplateHTTPResolver(TemplateHTTPResolver):
+
+    # We currently store the old Miro images in an S3 bucket, and request
+    # them over HTTP.  Occasionally we've seen the HTTP connections flake out,
+    # which causes a user-facing 500 -- and reloading the page fixes it.
+    #
+    # This causes us to retry the request once, if it's some sort of
+    # HTTP error.  We've been running this in prod for months, and that sort
+    # of 500 essentially vanished.
+    @retry(
+        stop=stop_after_attempt(2),
+        retry=retry_if_exception_type(RequestException)
+    )
+    def copy_to_cache(self, ident):
+        super().copy_to_cache(self, ident)


### PR DESCRIPTION
This patch:

* Upgrades us to the latest version of Loris, plus a few extra fixes (see https://github.com/loris-imageserver/loris/pull/410)

* Upgrades Loris to use Python 3, which should bring a tidy perf improvement (resolves #1627)

* Moves our customisations into this repo, rather than squirrelling them away in a fork (resolves #1628, resolves #924).

  This includes the tenacity patch for fetching from S3, which was the source of all our flakey S3 errors. We still have some flakiness in the ALB, but that's not appearing in Loris logs. Now we copy that file into our Docker image, which:

  - Isolates any Wellcome-specific code from core Loris
  - Opens the door for easy customisation later (e.g. loading some images from boto3, others over HTTP)
  - Makes it easy to see exactly what we're doing that's unusual

  In particular, I'm hoping this makes further customisations to our image more accessible to other devs.