### PR TITLE
Don’t transform ids in readers

### DIFF
--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
@@ -20,13 +20,9 @@ object SierraRecordWrapperFlow extends Logging {
   def apply(resourceType: SierraResourceTypes.Value)(
     implicit executionContext: ExecutionContext)
     : Flow[Json, SierraRecord, NotUsed] =
-    Flow.fromFunction({ json =>
-      createSierraRecord(json, resourceType)
-    })
+    Flow.fromFunction({ json => createSierraRecord(json)})
 
-  private def createSierraRecord(
-    json: Json,
-    resourceType: SierraResourceTypes.Value): SierraRecord = {
+  private def createSierraRecord(json: Json): SierraRecord = {
     logger.debug(s"Creating record from ${json.noSpaces}")
     val maybeUpdatedDate = root.updatedDate.string.getOption(json)
     maybeUpdatedDate match {

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
@@ -12,10 +12,6 @@ import uk.ac.wellcome.models.transformable.sierra.SierraRecord
 
 import scala.concurrent.ExecutionContext
 
-object SierraResourceTypes extends Enumeration {
-  val bibs, items = Value
-}
-
 object SierraRecordWrapperFlow extends Logging {
   def apply()(
     implicit executionContext: ExecutionContext)

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
@@ -76,9 +76,6 @@ object SierraRecordWrapperFlow extends Logging {
     }
   }
 
-  def addIDPrefixToBibs(json: Json): Json =
-    root.bibIds.each.string.modify(id => s"b$id")(json)
-
   private def getId(json: Json) = {
     root.id.string.getOption(json).get
   }

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
@@ -17,7 +17,7 @@ object SierraResourceTypes extends Enumeration {
 }
 
 object SierraRecordWrapperFlow extends Logging {
-  def apply(resourceType: SierraResourceTypes.Value)(
+  def apply()(
     implicit executionContext: ExecutionContext)
     : Flow[Json, SierraRecord, NotUsed] =
     Flow.fromFunction({ json => createSierraRecord(json)})

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
@@ -13,10 +13,11 @@ import uk.ac.wellcome.models.transformable.sierra.SierraRecord
 import scala.concurrent.ExecutionContext
 
 object SierraRecordWrapperFlow extends Logging {
-  def apply()(
-    implicit executionContext: ExecutionContext)
+  def apply()(implicit executionContext: ExecutionContext)
     : Flow[Json, SierraRecord, NotUsed] =
-    Flow.fromFunction({ json => createSierraRecord(json)})
+    Flow.fromFunction({ json =>
+      createSierraRecord(json)
+    })
 
   private def createSierraRecord(json: Json): SierraRecord = {
     logger.debug(s"Creating record from ${json.noSpaces}")

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/models/SierraResourceTypes.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/models/SierraResourceTypes.scala
@@ -1,0 +1,5 @@
+package uk.ac.wellcome.platform.sierra_reader.models
+
+object SierraResourceTypes extends Enumeration {
+  val bibs, items = Value
+}

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/SierraReaderModule.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/SierraReaderModule.scala
@@ -6,8 +6,8 @@ import akka.actor.ActorSystem
 import com.google.inject.Provides
 import com.twitter.inject.annotations.Flag
 import com.twitter.inject.{Injector, TwitterModule}
-import uk.ac.wellcome.platform.sierra_reader.flow.SierraResourceTypes
-import uk.ac.wellcome.platform.sierra_reader.flow.SierraResourceTypes.{
+import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
+import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes.{
   bibs,
   items
 }

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
@@ -5,7 +5,7 @@ import com.google.inject.Inject
 import com.twitter.inject.Logging
 import com.twitter.inject.annotations.Flag
 import org.apache.commons.io.IOUtils
-import uk.ac.wellcome.platform.sierra_reader.flow.SierraResourceTypes
+import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.transformable.sierra.SierraRecord

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -8,10 +8,8 @@ import com.google.inject.Inject
 import com.twitter.inject.annotations.Flag
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.platform.sierra_reader.flow.{
-  SierraRecordWrapperFlow,
-  SierraResourceTypes
-}
+import uk.ac.wellcome.platform.sierra_reader.flow.SierraRecordWrapperFlow
+import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
 import uk.ac.wellcome.sierra.{SierraSource, ThrottleRate}
 import uk.ac.wellcome.sqs.{SQSReader, SQSWorker}
 import uk.ac.wellcome.sierra_adapter.services.WindowExtractor

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -74,7 +74,7 @@ class SierraReaderWorkerService @Inject()(
       SierraSource(apiUrl, sierraOauthKey, sierraOauthSecret, throttleRate)(
         resourceType = resourceType.toString,
         params)
-        .via(SierraRecordWrapperFlow(resourceType = resourceType))
+        .via(SierraRecordWrapperFlow())
         .grouped(batchSize)
         .map(recordBatch => recordBatch.asJson)
         .zipWithIndex

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlowTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlowTest.scala
@@ -30,7 +30,7 @@ class SierraRecordWrapperFlowTest
     super.afterAll()
   }
 
-  it("creates a SierraRecord from a bib with a b-prefixed ID") {
+  it("creates a SierraRecord from a bib") {
     val id = "100001"
     val updatedDate = "2013-12-13T12:43:16Z"
     val json = parse(s"""
@@ -41,13 +41,8 @@ class SierraRecordWrapperFlowTest
       """.stripMargin).right.get
 
     val expectedRecord = SierraRecord(
-      id = s"b$id",
-      data = parse(s"""
-                      |{
-                      | "id": "b$id",
-                      | "updatedDate": "$updatedDate"
-                      |}
-      """.stripMargin).right.get.noSpaces,
+      id = id,
+      data = json.noSpaces,
       modifiedDate = updatedDate
     )
 
@@ -59,8 +54,7 @@ class SierraRecordWrapperFlowTest
     }
   }
 
-  it(
-    "creates a SierraRecord from an item with i-prefixed item ID and b-prefixed bibIds") {
+  it("creates a SierraRecord from an item") {
     val id = "400004"
     val updatedDate = "2014-04-14T14:14:14Z"
     val json = parse(s"""
@@ -72,14 +66,8 @@ class SierraRecordWrapperFlowTest
       """.stripMargin).right.get
 
     val expectedRecord = SierraRecord(
-      id = s"i$id",
-      data = parse(s"""
-                      |{
-                      | "id": "i$id",
-                      | "updatedDate": "$updatedDate",
-                      | "bibIds": ["b4", "b44", "b444", "b4444"]
-                      |}
-      """.stripMargin).right.get.noSpaces,
+      id = id,
+      data = json.noSpaces,
       modifiedDate = updatedDate
     )
 
@@ -101,14 +89,8 @@ class SierraRecordWrapperFlowTest
                        |}""".stripMargin).right.get
 
     val expectedRecord = SierraRecord(
-      id = s"b$id",
-      data = parse(s"""
-        |{
-        | "id": "b$id",
-        | "deletedDate" : "$deletedDate",
-        | "deleted" : true
-        |}
-      """.stripMargin).right.get.noSpaces,
+      id = id,
+      data = json.noSpaces,
       modifiedDate = s"${deletedDate}T00:00:00Z"
     )
 

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlowTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlowTest.scala
@@ -19,10 +19,7 @@ class SierraRecordWrapperFlowTest
   implicit val materialiser = ActorMaterializer()
   implicit val executionContext = system.dispatcher
 
-  val bibWrapperFlow = SierraRecordWrapperFlow(
-    resourceType = SierraResourceTypes.bibs)
-  val itemWrapperFlow = SierraRecordWrapperFlow(
-    resourceType = SierraResourceTypes.items)
+  val wrapperFlow = SierraRecordWrapperFlow()
 
   override def afterAll(): Unit = {
     system.terminate()
@@ -47,7 +44,7 @@ class SierraRecordWrapperFlowTest
     )
 
     val futureRecord =
-      Source.single(json).via(bibWrapperFlow).runWith(Sink.head)
+      Source.single(json).via(wrapperFlow).runWith(Sink.head)
 
     whenReady(futureRecord) { sierraRecord =>
       sierraRecord shouldBe expectedRecord
@@ -72,7 +69,7 @@ class SierraRecordWrapperFlowTest
     )
 
     val futureRecord =
-      Source.single(json).via(itemWrapperFlow).runWith(Sink.head)
+      Source.single(json).via(wrapperFlow).runWith(Sink.head)
 
     whenReady(futureRecord) { sierraRecord =>
       sierraRecord shouldBe expectedRecord
@@ -95,7 +92,7 @@ class SierraRecordWrapperFlowTest
     )
 
     val futureRecord =
-      Source.single(json).via(bibWrapperFlow).runWith(Sink.head)
+      Source.single(json).via(wrapperFlow).runWith(Sink.head)
 
     whenReady(futureRecord) { sierraRecord =>
       sierraRecord shouldBe expectedRecord
@@ -112,7 +109,7 @@ class SierraRecordWrapperFlowTest
        """.stripMargin).right.get
 
     val futureUnit =
-      Source.single(invalidSierraJson).via(bibWrapperFlow).runWith(Sink.head)
+      Source.single(invalidSierraJson).via(wrapperFlow).runWith(Sink.head)
     whenReady(futureUnit.failed) { _ =>
       ()
     }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.transformable.sierra.SierraRecord
-import uk.ac.wellcome.platform.sierra_reader.flow.SierraResourceTypes
+import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
 import uk.ac.wellcome.test.utils.{ExtendedPatience, S3Local}
 import uk.ac.wellcome.utils.JsonUtil._
 

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -14,7 +14,7 @@ import uk.ac.wellcome.test.utils.{ExtendedPatience, S3Local, SQSLocal}
 import scala.collection.JavaConversions._
 import org.mockito.Matchers.{any, anyString}
 import org.mockito.Mockito.when
-import uk.ac.wellcome.platform.sierra_reader.flow.SierraResourceTypes
+import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.transformable.sierra.SierraRecord

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -117,8 +117,6 @@ class SierraReaderWorkerServiceTest
       getRecordsFromS3(pageNames(0)) should have size 10
       getRecordsFromS3(pageNames(1)) should have size 10
       getRecordsFromS3(pageNames(2)) should have size 9
-
-      getRecordsFromS3(pageNames(0)).head.id should startWith("b")
     }
   }
 
@@ -158,8 +156,6 @@ class SierraReaderWorkerServiceTest
       getRecordsFromS3(pageNames(1)) should have size 50
       getRecordsFromS3(pageNames(2)) should have size 50
       getRecordsFromS3(pageNames(3)) should have size 7
-
-      getRecordsFromS3(pageNames(0)).head.id should startWith("i")
     }
   }
 


### PR DESCRIPTION
A first step to #1639.

Previously the Sierra readers would prefix their IDs with b or i as appropriate. Since we're migrating to use unprefixed IDs internally, this lets us delete quite a bit of code!

🎉 