### PR TITLE
migrate_dynamodb_items.py: add script for migrating the SierraData_items table

### DIFF
--- a/migrate_dynamodb_items.py
+++ b/migrate_dynamodb_items.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+import json
+import re
+
+import boto3
+
+
+dynamodb = boto3.resource('dynamodb')
+table = dynamodb.Table('SierraData_items')
+
+
+def items():
+    """Generate all items from a DynamoDB table."""
+    kwargs = {}
+    while True:
+        resp = table.scan(**kwargs)
+        yield from resp['Items']
+        kwargs['ExclusiveStartKey'] = resp['LastEvaluatedKey']
+        break
+
+
+def transform_item(item):
+    print(f'Processing {item["id"]}')
+
+    item['id'] = item['id'].lstrip('i')
+    assert re.match(r'^\d{7}$', item['id'])
+
+    for bib_id_key in ('bibIds', 'unlinkedBibIds'):
+        item[bib_id_key] = [bib_id.lstrip('b') for bib_id in item[bib_id_key]]
+        assert all(re.match(r'^\d{7}$', bib_id) for bib_id in item[bib_id_key])
+
+    data = json.loads(item['data'])
+    data['id'] = data['id'].lstrip('i')
+    assert re.match(r'^\d{7}$', data['id'])
+
+    data['bibIds'] = [bib_id.lstrip('b') for bib_id in data['bibIds']]
+    assert all(re.match(r'^\d{7}$', bib_id) for bib_id in data['bibIds'])
+
+    item['data'] = json.dumps(data, separators=(',', ':'))
+
+    return item
+
+
+for item in items():
+    old_item = item.copy()
+    new_item = transform_item(item)
+    if old_item == new_item:
+        continue
+    table.put_item(Item=new_item)
+    # table.delete_item(Key={'id': item['id']})
+    break

--- a/migrate_dynamodb_sourcedata.py
+++ b/migrate_dynamodb_sourcedata.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+import json
+import re
+
+import boto3
+
+
+dynamodb = boto3.resource('dynamodb')
+table = dynamodb.Table('SourceData')
+
+
+def items():
+    """Generate all items from a DynamoDB table."""
+    kwargs = {}
+    while True:
+        resp = table.scan(**kwargs)
+        yield from resp['Items']
+        kwargs['ExclusiveStartKey'] = resp['LastEvaluatedKey']
+        break
+
+
+def transform_item(item):
+    print(f'Processing {item["id"]}')
+
+    prefix, id = item['id'].split('/')
+    if prefix == 'sierra':
+        new_id = id.lstrip('b')
+        assert re.match(r'^\d{7}$', new_id)
+        item['id'] = '/'.join([prefix, new_id])
+
+    return item
+
+
+for item in items():
+    old_item = item.copy()
+    new_item = transform_item(item)
+    if old_item == new_item:
+        continue
+    print(new_item)
+    # table.put_item(Item=new_item)
+    # table.delete_item(Key={'id': item['id']})
+    break

--- a/migrate_dynamodb_sourcedata.py
+++ b/migrate_dynamodb_sourcedata.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 
-import json
 import re
 
 import boto3


### PR DESCRIPTION
Part 2 of #1639.

Transforms are tested; DynamoDB logic is not. Should be fairly fast, as there are only 850k records in the table.