### PR TITLE
Add a data_api stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ include formatting.Makefile
 include assets/Makefile
 include loris/Makefile
 include shared_infra/Makefile
+include data_api/Makefile
 include catalogue_api/Makefile
 include catalogue_pipeline/Makefile
 include monitoring/Makefile

--- a/data_api/Makefile
+++ b/data_api/Makefile
@@ -1,0 +1,14 @@
+ROOT = $(shell git rev-parse --show-toplevel)
+include $(ROOT)/functions.Makefile
+
+STACK_ROOT  = data_api
+
+SBT_APPS    =
+ECS_TASKS   =
+LAMBDAS     =
+
+TF_NAME     = data_api
+TF_PATH     = $(STACK_ROOT)
+TF_IS_PUBLIC_FACING = true
+
+$(val $(call stack_setup))

--- a/data_api/README.md
+++ b/data_api/README.md
@@ -1,0 +1,7 @@
+# data_api
+
+This directory contains infrastructure and applications providing services for `data.wellcomecollection.org`.
+
+## Overview
+
+`data.wellcomecollection.org` provides large data sets from Wellcome to the public.

--- a/data_api/iam.tf
+++ b/data_api/iam.tf
@@ -1,0 +1,4 @@
+module "ecs_elasticdump_iam" {
+  source = "git::https://github.com/wellcometrust/terraform.git//ecs_iam?ref=v1.0.0"
+  name   = "elasticdump"
+}

--- a/data_api/main.tf
+++ b/data_api/main.tf
@@ -1,0 +1,11 @@
+module "elasticdump" {
+  source        = "git::https://github.com/wellcometrust/terraform.git//ecs_script_task?ref=v1.0.0"
+  task_name     = "elasticdump"
+  app_uri       = "wellcome/elasticdump:latest"
+  task_role_arn = "${module.ecs_elasticdump_iam.task_role_arn}"
+
+  env_vars = [
+    "{\"name\": \"BUCKET\", \"value\": \"${var.elasticdump_config_bucket}\"}",
+    "{\"name\": \"S3_KEY\", \"value\": \"${var.elasticdump_config_s3_key}\"}",
+  ]
+}

--- a/data_api/provider.tf
+++ b/data_api/provider.tf
@@ -1,0 +1,6 @@
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.10.0"
+}
+
+data "aws_caller_identity" "current" {}

--- a/data_api/terraform.tf
+++ b/data_api/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.9"
+
+  backend "s3" {
+    bucket         = "wellcomecollection-platform-infra"
+    key            = "terraform/data_api.tfstate"
+    dynamodb_table = "terraform-locktable"
+    region         = "eu-west-1"
+  }
+}

--- a/data_api/variables.tf
+++ b/data_api/variables.tf
@@ -1,0 +1,4 @@
+variable "elasticdump_config_bucket" {}
+variable "elasticdump_config_s3_key" {}
+
+variable "aws_region" {}


### PR DESCRIPTION
### What is this PR trying to achieve?

Adds a new terraform stack for the mooted `data.wellcomecollection.org` services.

Part of: 

- https://github.com/wellcometrust/platform/issues/1397

### Who is this change for?

Folk who want to access (and make available) large datasets.

### Have the following been considered/are they needed?

- [ ] Reviewed by @jtweed
- [ ] Deployed new versions
- [ ] Run `terraform apply`.