### PR TITLE
Adds ExtendedPatience to common SQSWorkerToDynamoTest

### DIFF
--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerToDynamoTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerToDynamoTest.scala
@@ -21,6 +21,7 @@ import scala.collection.JavaConversions._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import org.scalatest.Outcome
+import uk.ac.wellcome.test.utils.ExtendedPatience
 
 case class TestObject(foo: String)
 
@@ -29,6 +30,7 @@ class SQSWorkerToDynamoTest
     with MockitoSugar
     with Matchers
     with Eventually
+    with ExtendedPatience
     with SqsFixtures {
 
   val mockPutMetricDataResult = mock[PutMetricDataResult]
@@ -48,6 +50,7 @@ class SQSWorkerToDynamoTest
         new SQSReader(sqsClient, SQSConfig(queueUrl, 1.second, 1)),
         system,
         metricsSender) {
+
     override lazy val poll = 100 millisecond
 
     override implicit val decoder = Decoder[TestObject]


### PR DESCRIPTION
### What is this PR trying to achieve?

Stable `SQSWorkerToDynamoTest` test runs.

This test previously used SQSLocal which made use of `ExtendedPatience`. This has subsequently been replaced with `SqsFixtures` which doesn't use `ExtendedPatience`. 

This may account for flakiness now apparent in this test.

### Who is this change for?

Developers who want consistently passing or failing tests.
