### PR TITLE
Do not serialize ontologyType as type in json

### DIFF
--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedder.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedder.scala
@@ -46,7 +46,7 @@ class IdEmbedder @Inject()(metricsSender: MetricsSender,
   private def addIdentifierToJsonObject(obj: JsonObject): JsonObject = {
     if (obj.contains("sourceIdentifier")) {
       val sourceIdentifier = parseSourceIdentifier(obj)
-      val ontologyType = obj("type").get.asString.get
+      val ontologyType = obj("ontologyType").get.asString.get
 
       val canonicalId = identifierGenerator
         .retrieveOrGenerateCanonicalId(

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -263,7 +263,7 @@ class IdEmbedderTests
           "identifierScheme": "${sourceIdentifier.identifierScheme}",
           "value": "${sourceIdentifier.value}"
         },
-        "type": "$ontologyType"
+        "ontologyType": "$ontologyType"
       }
       """
 
@@ -274,7 +274,7 @@ class IdEmbedderTests
           "identifierScheme": "${sourceIdentifier.identifierScheme}",
           "value": "${sourceIdentifier.value}"
         },
-        "type": "$ontologyType"
+        "ontologyType": "$ontologyType"
       }
       """
 
@@ -313,7 +313,7 @@ class IdEmbedderTests
             "identifierScheme": "${sourceIdentifier.identifierScheme}",
             "value": "${sourceIdentifier.value}"
           },
-          "type": "$ontologyType"
+          "ontologyType": "$ontologyType"
         }
       }
       """
@@ -328,7 +328,7 @@ class IdEmbedderTests
             "identifierScheme": "${sourceIdentifier.identifierScheme}",
             "value": "${sourceIdentifier.value}"
           },
-          "type": "$ontologyType"
+          "ontologyType": "$ontologyType"
         }
       }
       """

--- a/common/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/common/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -21,7 +21,7 @@ class WorksIndex @Inject()(client: HttpClient,
   val indexName = name
 
   val license = objectField("license").fields(
-    keywordField("type"),
+    keywordField("ontologyType"),
     keywordField("licenseType"),
     textField("label"),
     textField("url")
@@ -29,14 +29,14 @@ class WorksIndex @Inject()(client: HttpClient,
 
   val sourceIdentifier = objectField("sourceIdentifier")
     .fields(
-      keywordField("type"),
+      keywordField("ontologyType"),
       keywordField("identifierScheme"),
       keywordField("value")
     )
 
   val identifiers = objectField("identifiers")
     .fields(
-      keywordField("type"),
+      keywordField("ontologyType"),
       keywordField("identifierScheme"),
       keywordField("value")
     )
@@ -44,6 +44,7 @@ class WorksIndex @Inject()(client: HttpClient,
   def location(fieldName: String = "locations") =
     objectField(fieldName).fields(
       keywordField("type"),
+      keywordField("ontologyType"),
       keywordField("locationType"),
       keywordField("label"),
       textField("url"),
@@ -53,12 +54,12 @@ class WorksIndex @Inject()(client: HttpClient,
 
   def date(fieldName: String) = objectField(fieldName).fields(
     textField("label"),
-    keywordField("type")
+    keywordField("ontologyType")
   )
 
   def labelledTextField(fieldName: String) = objectField(fieldName).fields(
     textField("label"),
-    keywordField("type")
+    keywordField("ontologyType")
   )
 
   val items = objectField("items").fields(
@@ -67,18 +68,19 @@ class WorksIndex @Inject()(client: HttpClient,
     identifiers,
     location(),
     booleanField("visible"),
-    keywordField("type")
+    keywordField("ontologyType")
   )
   val publishers = objectField("publishers").fields(
     textField("label"),
-    keywordField("type")
+    keywordField("type"),
+    keywordField("ontologyType")
   )
 
   val rootIndexFields: Seq[FieldDefinition with Product with Serializable] =
     Seq(
       keywordField("canonicalId"),
       booleanField("visible"),
-      keywordField("type"),
+      keywordField("ontologyType"),
       intField("version"),
       sourceIdentifier,
       identifiers,

--- a/common/src/main/scala/uk/ac/wellcome/models/License.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/License.scala
@@ -18,7 +18,7 @@ object License extends Logging {
         ("licenseType", Json.fromString(license.licenseType)),
         ("label", Json.fromString(license.label)),
         ("url", Json.fromString(license.url)),
-        ("type", Json.fromString(license.ontologyType))
+        ("ontologyType", Json.fromString(license.ontologyType))
     ))
 
   implicit val licenseDecoder = Decoder.instance[License](cursor =>

--- a/common/src/main/scala/uk/ac/wellcome/utils/JsonUtil.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/JsonUtil.scala
@@ -16,10 +16,6 @@ object JsonUtil extends AutoDerivation with TimeInstances with Logging {
   implicit val customConfig: Configuration =
     Configuration.default.withDefaults
       .withDiscriminator("type")
-      .copy(transformMemberNames = {
-        case "ontologyType" => "type"
-        case other => other
-      })
 
   def toJson[T](value: T)(implicit encoder: Encoder[T]): Try[String] =
     Try(value.asJson.noSpaces)

--- a/common/src/test/scala/uk/ac/wellcome/models/IdentifiedItemTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/IdentifiedItemTest.scala
@@ -30,12 +30,13 @@ class IdentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
       |        "licenseType": "${License_CCBY.licenseType}",
       |        "label": "${License_CCBY.label}",
       |        "url": "${License_CCBY.url}",
-      |        "type": "License"
+      |        "ontologyType": "License"
       |      },
-      |      "type": "DigitalLocation"
+      |      "type": "DigitalLocation",
+      |      "ontologyType": "DigitalLocation"
       |    }
       |  ],
-      |  "type": "Item"
+      |  "ontologyType": "Item"
       |}
     """.stripMargin
 

--- a/common/src/test/scala/uk/ac/wellcome/models/IdentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/IdentifiedWorkTest.scala
@@ -11,7 +11,7 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
             "licenseType": "${License_CCBY.licenseType}",
             "label": "${License_CCBY.label}",
             "url": "${License_CCBY.url}",
-            "type": "License"
+            "ontologyType": "License"
           }"""
 
   // TRIVIA: On 18 April 1930, the BBC had a slow news day.  The bulletin
@@ -48,24 +48,24 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |  "lettering": "lettering",
       |  "createdDate": {
       |    "label": "period",
-      |    "type": "Period"
+      |    "ontologyType": "Period"
       |  },
       |  "subjects": [
       |    {
       |      "label": "subject",
-      |      "type": "Concept"
+      |      "ontologyType": "Concept"
       |    }
       |  ],
       |  "creators": [
       |    {
       |      "label": "47",
-      |      "type": "Agent"
+      |      "ontologyType": "Agent"
       |    }
       |  ],
       |  "genres": [
       |    {
       |      "label": "genre",
-      |      "type": "Concept"
+      |      "ontologyType": "Concept"
       |    }
       |  ],
       |  "thumbnail": {
@@ -73,7 +73,8 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |    "url" : "",
       |    "credit" : null,
       |    "license": $license_CCBYJson,
-      |    "type": "DigitalLocation"
+      |    "type": "DigitalLocation",
+      |    "ontologyType": "DigitalLocation"
       |  },
       |  "items": [
       |    {
@@ -94,24 +95,26 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |          "url" : "",
       |          "credit" : null,
       |          "license": $license_CCBYJson,
-      |          "type": "DigitalLocation"
+      |          "type": "DigitalLocation",
+      |          "ontologyType": "DigitalLocation"
       |        }
       |      ],
-      |      "type": "Item"
+      |      "ontologyType": "Item"
       |    }
       |  ],
       |  "publishers": [
       |    {
       |      "label": "MIT Press",
-      |      "type": "Organisation"
+      |      "type": "Organisation",
+      |      "ontologyType": "Organisation"
       |    }
       |  ],
       |  "publicationDate": {
       |    "label": "$publicationDate",
-      |    "type": "Period"
+      |    "ontologyType": "Period"
       |  },
       |  "visible":true,
-      |  "type": "Work"
+      |  "ontologyType": "Work"
       |}
     """.stripMargin
 
@@ -176,6 +179,6 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
   it("should have an ontology type 'Work' when serialised to JSON") {
     val jsonString = toJson(identifiedWork).get
 
-    jsonString.contains("""type":"Work"""") should be(true)
+    jsonString.contains("""ontologyType":"Work"""") should be(true)
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/models/LicenseTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/LicenseTest.scala
@@ -9,7 +9,7 @@ class LicenseTest extends FunSpec with Matchers {
   it("should serialise a License as JSON") {
     val result = JsonUtil.toJson[License](License_CCBY)
     result.isSuccess shouldBe true
-    result.get shouldBe """{"licenseType":"CC-BY","label":"Attribution 4.0 International (CC BY 4.0)","url":"http://creativecommons.org/licenses/by/4.0/","type":"License"}"""
+    result.get shouldBe """{"licenseType":"CC-BY","label":"Attribution 4.0 International (CC BY 4.0)","url":"http://creativecommons.org/licenses/by/4.0/","ontologyType":"License"}"""
   }
 
   it("should deserialise a JSON string as a License") {
@@ -22,7 +22,7 @@ class LicenseTest extends FunSpec with Matchers {
         "licenseType": "$licenseType",
         "label": "$label",
         "url": "$url",
-        "type": "License"
+        "ontologyType": "License"
       }"""
     val result = JsonUtil.fromJson[License](jsonString)
     result.isSuccess shouldBe true

--- a/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedItemTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedItemTest.scala
@@ -29,12 +29,13 @@ class UnidentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
       |        "licenseType": "${License_CCBY.licenseType}",
       |        "label": "${License_CCBY.label}",
       |        "url": "${License_CCBY.url}",
-      |        "type": "License"
+      |        "ontologyType": "License"
       |      },
-      |      "type": "DigitalLocation"
+      |      "type": "DigitalLocation",
+      |      "ontologyType": "DigitalLocation"
       |    }
       |  ],
-      |  "type": "Item"
+      |  "ontologyType": "Item"
       |}
     """.stripMargin
 

--- a/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
@@ -11,7 +11,7 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
             "licenseType": "${License_CCBY.licenseType}",
             "label": "${License_CCBY.label}",
             "url": "${License_CCBY.url}",
-            "type": "License"
+            "ontologyType": "License"
           }"""
 
   // TRIVIA: This is an extract from Marco Polo's diaries, in which he
@@ -47,24 +47,24 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |  "lettering": "lettering",
       |  "createdDate": {
       |    "label": "period",
-      |    "type": "Period"
+      |    "ontologyType": "Period"
       |  },
       |  "subjects": [
       |    {
       |      "label": "subject",
-      |      "type": "Concept"
+      |      "ontologyType": "Concept"
       |    }
       |  ],
       |  "creators": [
       |    {
       |      "label": "47",
-      |      "type": "Agent"
+      |      "ontologyType": "Agent"
       |    }
       |  ],
       |  "genres": [
       |    {
       |      "label": "genre",
-      |      "type": "Concept"
+      |      "ontologyType": "Concept"
       |    }
       |  ],
       |  "thumbnail": {
@@ -72,7 +72,8 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |    "url" : "",
       |    "credit" : null,
       |    "license": $license_CCBYJson,
-      |    "type": "DigitalLocation"
+      |    "type": "DigitalLocation",
+      |    "ontologyType": "DigitalLocation"
       |  },
       |  "items": [
       |    {
@@ -92,24 +93,26 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |          "url" : "",
       |          "credit" : null,
       |          "license": $license_CCBYJson,
+      |          "ontologyType": "DigitalLocation",
       |          "type": "DigitalLocation"
       |        }
       |      ],
-      |      "type": "Item"
+      |      "ontologyType": "Item"
       |    }
       |  ],
       |  "publishers": [
       |    {
       |      "label": "MIT Press",
-      |      "type": "Organisation"
+      |      "type": "Organisation",
+      |      "ontologyType": "Organisation"
       |    }
       |  ],
       |  "visible":true,
       |  "publicationDate": {
       |    "label": "$publicationDate",
-      |    "type": "Period"
+      |    "ontologyType": "Period"
       |  },
-      |  "type": "Work"
+      |  "ontologyType": "Work"
       |}
     """.stripMargin
 
@@ -172,6 +175,6 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
   it("should have an ontology type 'Work' when serialised to JSON") {
     val jsonString = toJson(unidentifiedWork).get
 
-    jsonString.contains("""type":"Work"""") should be(true)
+    jsonString.contains("""ontologyType":"Work"""") should be(true)
   }
 }


### PR DESCRIPTION
Currently, we serialise `ontologyType` as `type` in json. The `type` field is also used as type discriminator by circe to decide how to deserialise something belonging to a trait hierarchy (such as `Location` and `Agent` currently). The only reason why it works is because the values of `ontologyType` and the names of the class match, but it feels wrong that the `type` field has two different functions. Also we should be able to deserialise and serialise classes whose name does not match the value of the `ontologyType` field.
