### PR TITLE
Make the metrics flushInterval configurable

### DIFF
--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -12,6 +12,7 @@ import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models._
 import uk.ac.wellcome.test.utils.JsonTestUtil
+import scala.concurrent.duration._
 
 import scala.util.Try
 
@@ -31,6 +32,7 @@ class IdEmbedderTests
   private val metricsSender =
     new MetricsSender(
       "id_minter_test_metrics",
+      100 milliseconds,
       mock[AmazonCloudWatch],
       ActorSystem())
   private val mockIdentifierGenerator: IdentifierGenerator =

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -12,6 +12,7 @@ import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier}
 import uk.ac.wellcome.platform.idminter.database.IdentifiersDao
 import uk.ac.wellcome.platform.idminter.models.Identifier
 import uk.ac.wellcome.platform.idminter.utils.IdentifiersMysqlLocal
+import scala.concurrent.duration._
 
 import scala.util.{Failure, Success}
 
@@ -24,6 +25,7 @@ class IdentifierGeneratorTest
   private val metricsSender =
     new MetricsSender(
       "id_minter_test_metrics",
+      100 milliseconds,
       mock[AmazonCloudWatch],
       ActorSystem())
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -33,6 +33,7 @@ class IngestorWorkerServiceTest
   val metricsSender: MetricsSender =
     new MetricsSender(
       namespace = "reindexer-tests",
+      100 milliseconds,
       mock[AmazonCloudWatch],
       ActorSystem())
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.platform.ingestor.test.utils.Ingestor
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
+import scala.concurrent.duration._
 
 import scala.concurrent.Future
 
@@ -21,6 +22,7 @@ class WorkIndexerTest
   val metricsSender: MetricsSender =
     new MetricsSender(
       namespace = "reindexer-tests",
+      100 milliseconds,
       mock[AmazonCloudWatch],
       ActorSystem())
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -15,7 +15,11 @@ import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.{SNSConfig, SQSMessage}
 import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord
 import uk.ac.wellcome.models.transformable.{SierraTransformable, Transformable}
-import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, UnidentifiedWork}
+import uk.ac.wellcome.models.{
+  IdentifierSchemes,
+  SourceIdentifier,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.sns.{PublishAttempt, SNSWriter}
 import uk.ac.wellcome.test.utils.SNSLocal
 import uk.ac.wellcome.transformer.utils.TransformableSQSMessageUtils

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -13,26 +13,18 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.{SNSConfig, SQSMessage}
-import uk.ac.wellcome.models.transformable.{SierraTransformable, Transformable}
 import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord
-import uk.ac.wellcome.models.{
-  IdentifierSchemes,
-  SourceIdentifier,
-  UnidentifiedWork
-}
-import uk.ac.wellcome.s3.S3ObjectStore
+import uk.ac.wellcome.models.transformable.{SierraTransformable, Transformable}
+import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier, UnidentifiedWork}
 import uk.ac.wellcome.sns.{PublishAttempt, SNSWriter}
 import uk.ac.wellcome.test.utils.SNSLocal
-import uk.ac.wellcome.transformer.transformers.{
-  CalmTransformableTransformer,
-  SierraTransformableTransformer
-}
 import uk.ac.wellcome.transformer.utils.TransformableSQSMessageUtils
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 class SQSMessageReceiverTest
     extends FunSpec
@@ -56,6 +48,7 @@ class SQSMessageReceiverTest
 
   val metricsSender: MetricsSender = new MetricsSender(
     namespace = "record-receiver-tests",
+    100 milliseconds,
     mock[AmazonCloudWatch],
     ActorSystem()
   )

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/AmazonCloudWatchModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/AmazonCloudWatchModule.scala
@@ -1,31 +1,31 @@
 package uk.ac.wellcome.finatra.modules
 
-import akka.actor.ActorSystem
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.cloudwatch.{
-  AmazonCloudWatch,
-  AmazonCloudWatchClientBuilder
-}
+import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
 import com.google.inject.{Provides, Singleton}
+import com.twitter.app.Flaggable
 import com.twitter.inject.TwitterModule
-import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.AWSConfig
 
+import scala.concurrent.duration._
+
 object AmazonCloudWatchModule extends TwitterModule {
-  private val awsNamespace = flag[String](
+  implicit val finteDurationFlaggable = Flaggable.mandatory[FiniteDuration](config => Duration.apply(config).asInstanceOf[FiniteDuration])
+
+  flag[String](
     "aws.metrics.namespace",
     "",
     "Namespace for cloudwatch metrics")
+
+  flag[FiniteDuration](
+    "aws.metrics.flushInterval",
+    10 minutes,
+    "Interval within which metrics get flushed to cloudwatch. A short interval will result in an increased number of PutMetric requests.")
+
   private val awsEndpoint = flag[String](
     "aws.cloudWatch.endpoint",
     "",
     "Endpoint of AWS CloudWatch. If not set, it will use the region")
-
-  @Provides
-  @Singleton
-  def providesMetricsSender(amazonCloudWatch: AmazonCloudWatch,
-                            actorSystem: ActorSystem) =
-    new MetricsSender(awsNamespace(), amazonCloudWatch, actorSystem)
 
   @Provides
   @Singleton

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/AmazonCloudWatchModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/AmazonCloudWatchModule.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.finatra.modules
 
 import akka.actor.ActorSystem
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
+import com.amazonaws.services.cloudwatch.{
+  AmazonCloudWatch,
+  AmazonCloudWatchClientBuilder
+}
 import com.google.inject.{Provides, Singleton}
 import com.twitter.app.Flaggable
 import com.twitter.inject.TwitterModule
@@ -12,7 +15,9 @@ import uk.ac.wellcome.models.aws.AWSConfig
 import scala.concurrent.duration._
 
 object AmazonCloudWatchModule extends TwitterModule {
-  implicit val finteDurationFlaggable = Flaggable.mandatory[FiniteDuration](config => Duration.apply(config).asInstanceOf[FiniteDuration])
+  implicit val finteDurationFlaggable =
+    Flaggable.mandatory[FiniteDuration](config =>
+      Duration.apply(config).asInstanceOf[FiniteDuration])
 
   val awsNamespace = flag[String](
     "aws.metrics.namespace",
@@ -22,7 +27,8 @@ object AmazonCloudWatchModule extends TwitterModule {
   val flushInterval = flag[FiniteDuration](
     "aws.metrics.flushInterval",
     10 minutes,
-    "Interval within which metrics get flushed to cloudwatch. A short interval will result in an increased number of PutMetric requests.")
+    "Interval within which metrics get flushed to cloudwatch. A short interval will result in an increased number of PutMetric requests."
+  )
 
   private val awsEndpoint = flag[String](
     "aws.cloudWatch.endpoint",
@@ -33,7 +39,11 @@ object AmazonCloudWatchModule extends TwitterModule {
   @Singleton
   def providesMetricsSender(amazonCloudWatch: AmazonCloudWatch,
                             actorSystem: ActorSystem) =
-    new MetricsSender(awsNamespace(), flushInterval(),amazonCloudWatch, actorSystem)
+    new MetricsSender(
+      awsNamespace(),
+      flushInterval(),
+      amazonCloudWatch,
+      actorSystem)
 
   @Provides
   @Singleton

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/AmazonCloudWatchModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/AmazonCloudWatchModule.scala
@@ -40,10 +40,10 @@ object AmazonCloudWatchModule extends TwitterModule {
   def providesMetricsSender(amazonCloudWatch: AmazonCloudWatch,
                             actorSystem: ActorSystem) =
     new MetricsSender(
-      awsNamespace(),
-      flushInterval(),
-      amazonCloudWatch,
-      actorSystem)
+      namespace = awsNamespace(),
+      flushInterval = flushInterval(),
+      amazonCloudWatch = amazonCloudWatch,
+      actorSystem = actorSystem)
 
   @Provides
   @Singleton

--- a/common/src/main/scala/uk/ac/wellcome/metrics/MetricsSender.scala
+++ b/common/src/main/scala/uk/ac/wellcome/metrics/MetricsSender.scala
@@ -22,10 +22,11 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
-class MetricsSender @Inject()(@Flag("aws.metrics.namespace") namespace: String,
-                              @Flag("aws.metrics.flushInterval") flushInterval: FiniteDuration,
-                              amazonCloudWatch: AmazonCloudWatch,
-                              actorSystem: ActorSystem)
+class MetricsSender @Inject()(
+  @Flag("aws.metrics.namespace") namespace: String,
+  @Flag("aws.metrics.flushInterval") flushInterval: FiniteDuration,
+  amazonCloudWatch: AmazonCloudWatch,
+  actorSystem: ActorSystem)
     extends Logging {
   implicit val system = actorSystem
   implicit val materialiser = ActorMaterializer()

--- a/common/src/main/scala/uk/ac/wellcome/metrics/MetricsSender.scala
+++ b/common/src/main/scala/uk/ac/wellcome/metrics/MetricsSender.scala
@@ -23,6 +23,7 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 class MetricsSender @Inject()(@Flag("aws.metrics.namespace") namespace: String,
+                              @Flag("aws.metrics.flushInterval") flushInterval: FiniteDuration,
                               amazonCloudWatch: AmazonCloudWatch,
                               actorSystem: ActorSystem)
     extends Logging {
@@ -41,7 +42,7 @@ class MetricsSender @Inject()(@Flag("aws.metrics.namespace") namespace: String,
       // Group the MetricDatum objects into lists of at max 20 items.
       // Send smaller chunks if not appearing within 10 seconds
       .viaMat(
-        Flow[MetricDatum].groupedWithin(metricDataListMaxSize, 10 seconds))(
+        Flow[MetricDatum].groupedWithin(metricDataListMaxSize, flushInterval))(
         Keep.left)
       // Make sure we don't exceed aws rate limit
       .throttle(

--- a/common/src/test/scala/uk/ac/wellcome/metrics/MetricsSenderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/metrics/MetricsSenderTest.scala
@@ -33,7 +33,7 @@ class MetricsSenderTest
     it("should record the time and count of a successful future") {
       val amazonCloudWatch = mock[AmazonCloudWatch]
       val metricsSender =
-        new MetricsSender("test", amazonCloudWatch, actorSystem)
+        new MetricsSender("test", 1 second, amazonCloudWatch, actorSystem)
       val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
       val expectedResult = "foo"
@@ -65,7 +65,7 @@ class MetricsSenderTest
     it("should record the time and count of a failed future") {
       val amazonCloudWatch = mock[AmazonCloudWatch]
       val metricsSender =
-        new MetricsSender("test", amazonCloudWatch, actorSystem)
+        new MetricsSender("test", 1 second, amazonCloudWatch, actorSystem)
       val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
       val timedFunction = () => Future { throw new RuntimeException() }
@@ -95,7 +95,7 @@ class MetricsSenderTest
     it("should group 20 MetricDatum into one PutMetricDataRequest") {
       val amazonCloudWatch = mock[AmazonCloudWatch]
       val metricsSender =
-        new MetricsSender("test", amazonCloudWatch, actorSystem)
+        new MetricsSender("test", 1 second, amazonCloudWatch, actorSystem)
       val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
       val emptyFunction = () => Future.successful(())
@@ -120,7 +120,7 @@ class MetricsSenderTest
     it("should take at least one second to make 150 PutMetricData requests") {
       val amazonCloudWatch = mock[AmazonCloudWatch]
       val metricsSender =
-        new MetricsSender("test", amazonCloudWatch, actorSystem)
+        new MetricsSender("test", 2 second, amazonCloudWatch, actorSystem)
       val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
       val expectedDuration = (1 second).toMillis
@@ -155,7 +155,7 @@ class MetricsSenderTest
     it("should putMetricData with the correct value") {
       val amazonCloudWatch = mock[AmazonCloudWatch]
       val metricsSender =
-        new MetricsSender("test", amazonCloudWatch, actorSystem)
+        new MetricsSender("test", 100 millisecond, amazonCloudWatch, actorSystem)
       val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
       val expectedValue = 3.0F
@@ -175,7 +175,7 @@ class MetricsSenderTest
     it("should putMetricData with the correct value") {
       val amazonCloudWatch = mock[AmazonCloudWatch]
       val metricsSender =
-        new MetricsSender("test", amazonCloudWatch, actorSystem)
+        new MetricsSender("test", 100 milliseconds,amazonCloudWatch, actorSystem)
       val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
       val expectedValue = 5 millis

--- a/common/src/test/scala/uk/ac/wellcome/metrics/MetricsSenderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/metrics/MetricsSenderTest.scala
@@ -155,7 +155,11 @@ class MetricsSenderTest
     it("should putMetricData with the correct value") {
       val amazonCloudWatch = mock[AmazonCloudWatch]
       val metricsSender =
-        new MetricsSender("test", 100 millisecond, amazonCloudWatch, actorSystem)
+        new MetricsSender(
+          "test",
+          100 millisecond,
+          amazonCloudWatch,
+          actorSystem)
       val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
       val expectedValue = 3.0F
@@ -175,7 +179,11 @@ class MetricsSenderTest
     it("should putMetricData with the correct value") {
       val amazonCloudWatch = mock[AmazonCloudWatch]
       val metricsSender =
-        new MetricsSender("test", 100 milliseconds,amazonCloudWatch, actorSystem)
+        new MetricsSender(
+          "test",
+          100 milliseconds,
+          amazonCloudWatch,
+          actorSystem)
       val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
       val expectedValue = 5 millis

--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerToDynamoTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerToDynamoTest.scala
@@ -39,7 +39,7 @@ class SQSWorkerToDynamoTest
   when(mockCloudWatch.putMetricData(any())).thenReturn(mockPutMetricDataResult)
 
   private val metricsSender: MetricsSender =
-    new MetricsSender("namespace", mockCloudWatch, ActorSystem())
+    new MetricsSender("namespace", 100 milliseconds, mockCloudWatch, ActorSystem())
 
   val testMessage = TestSqsMessage()
 

--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerToDynamoTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerToDynamoTest.scala
@@ -39,7 +39,11 @@ class SQSWorkerToDynamoTest
   when(mockCloudWatch.putMetricData(any())).thenReturn(mockPutMetricDataResult)
 
   private val metricsSender: MetricsSender =
-    new MetricsSender("namespace", 100 milliseconds, mockCloudWatch, ActorSystem())
+    new MetricsSender(
+      "namespace",
+      100 milliseconds,
+      mockCloudWatch,
+      ActorSystem())
 
   val testMessage = TestSqsMessage()
 

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
@@ -14,6 +14,7 @@ import uk.ac.wellcome.models.aws.DynamoConfig
 import uk.ac.wellcome.platform.reindex_worker.TestRecord
 import uk.ac.wellcome.platform.reindex_worker.models.ReindexJob
 import uk.ac.wellcome.test.utils.ExtendedPatience
+import scala.concurrent.duration._
 
 class ReindexServiceTest
     extends FunSpec
@@ -31,6 +32,7 @@ class ReindexServiceTest
   val metricsSender: MetricsSender =
     new MetricsSender(
       namespace = "reindexer-tests",
+      100 milliseconds,
       mock[AmazonCloudWatch],
       ActorSystem())
 

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -43,6 +43,7 @@ class ReindexWorkerServiceTest
   val metricsSender: MetricsSender =
     new MetricsSender(
       namespace = "reindexer-tests",
+      100 milliseconds,
       mock[AmazonCloudWatch],
       actorSystem)
 

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -47,7 +47,11 @@ class SierraItemsToDynamoWorkerServiceTest
 
   when(mockCloudWatch.putMetricData(any())).thenReturn(mockPutMetricDataResult)
   val mockMetrics =
-    new MetricsSender("namespace", 100 milliseconds, mockCloudWatch, ActorSystem())
+    new MetricsSender(
+      "namespace",
+      100 milliseconds,
+      mockCloudWatch,
+      ActorSystem())
 
   var worker: Option[SierraItemsToDynamoWorkerService] = None
   val actorSystem = ActorSystem()

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -47,7 +47,7 @@ class SierraItemsToDynamoWorkerServiceTest
 
   when(mockCloudWatch.putMetricData(any())).thenReturn(mockPutMetricDataResult)
   val mockMetrics =
-    new MetricsSender("namespace", mockCloudWatch, ActorSystem())
+    new MetricsSender("namespace", 100 milliseconds, mockCloudWatch, ActorSystem())
 
   var worker: Option[SierraItemsToDynamoWorkerService] = None
   val actorSystem = ActorSystem()

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -45,7 +45,7 @@ class SierraReaderWorkerServiceTest
   when(mockCloudWatch.putMetricData(any())).thenReturn(mockPutMetricDataResult)
 
   val mockMetrics =
-    new MetricsSender("namespace", mockCloudWatch, ActorSystem())
+    new MetricsSender("namespace", 100 milliseconds, mockCloudWatch, ActorSystem())
 
   case class FixtureParams(worker: SierraReaderWorkerService, queueUrl: String)
 

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -45,7 +45,11 @@ class SierraReaderWorkerServiceTest
   when(mockCloudWatch.putMetricData(any())).thenReturn(mockPutMetricDataResult)
 
   val mockMetrics =
-    new MetricsSender("namespace", 100 milliseconds, mockCloudWatch, ActorSystem())
+    new MetricsSender(
+      "namespace",
+      100 milliseconds,
+      mockCloudWatch,
+      ActorSystem())
 
   case class FixtureParams(worker: SierraReaderWorkerService, queueUrl: String)
 


### PR DESCRIPTION
We seem to be still spending ~10£ a day on cloudwatch which means ~300£ a month and it's a bit more than I expected to spend with the MetricSender changes we did last month. 
The way `MetricSender` works is that it collects metrics to be sent to cloudwatch until they reach the maximum number metric that we can send in one PutMetric request to AWS. These metrics are collected in an in memory buffer in windows of 10 seconds, so if 10 seconds pass without having reached the maximum number of metrics, `MetricsSender` will send a PutMetric data request with fewer metrics.
I think 10 seconds might be a bit too short and causing a lot of these requests to not use the maximum number of metrics, so this is to make the interval configurable with the default value 5 minutes instead of 10 seconds