### PR TITLE
Add an implementation of the Sierra check digit algorithm

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigits.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigits.scala
@@ -31,7 +31,7 @@ trait SierraCheckDigits {
     // Then pick the record type prefix.
     val prefix = recordType match {
       case SierraRecordTypes.bibs => "b"
-      case SierraRecordTypes.items => "s"
+      case SierraRecordTypes.items => "i"
       case _ => throw new RuntimeException(
         s"Received unrecognised record type: $recordType"
       )

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigits.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigits.scala
@@ -16,25 +16,28 @@ trait SierraCheckDigits {
   // scala> addCheckDigit("1952770", recordType = SierraRecordTypes.items)
   // res1: String = i19527706
   //
-  def addCheckDigit(sierraId: String, recordType: SierraRecordTypes.Value): String = {
+  def addCheckDigit(sierraId: String,
+                    recordType: SierraRecordTypes.Value): String = {
 
     // First check that we're being passed a 7-digit numeric ID -- anything
     // else is an error.
     val regexMatch = """^([0-9]{7})$""".r.unapplySeq(sierraId)
     val checkDigit = regexMatch match {
       case Some(s) => getCheckDigit(s.head)
-      case _ => throw new RuntimeException(
-        s"Expected 7-digit numeric ID, got $sierraId"
-      )
+      case _ =>
+        throw new RuntimeException(
+          s"Expected 7-digit numeric ID, got $sierraId"
+        )
     }
 
     // Then pick the record type prefix.
     val prefix = recordType match {
       case SierraRecordTypes.bibs => "b"
       case SierraRecordTypes.items => "i"
-      case _ => throw new RuntimeException(
-        s"Received unrecognised record type: $recordType"
-      )
+      case _ =>
+        throw new RuntimeException(
+          s"Received unrecognised record type: $recordType"
+        )
     }
 
     s"$prefix$sierraId$checkDigit"
@@ -58,8 +61,7 @@ trait SierraCheckDigits {
   // Sierra ID.
   //
   private def getCheckDigit(sierraId: String): String = {
-    val remainder = sierraId
-      .reverse
+    val remainder = sierraId.reverse
       .zip(Stream from 2)
       .map { case (char: Char, count: Int) => char.toString.toInt * count }
       .foldLeft(0)(_ + _) % 11

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigits.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigits.scala
@@ -1,0 +1,70 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+object SierraRecordTypes extends Enumeration {
+  val bibs, items = Value
+}
+
+trait SierraCheckDigits {
+
+  // Add the check digit to a Sierra ID.
+  //
+  // Examples:
+  //
+  // scala> addCheckDigit("1024364", recordType = SierraRecordTypes.bibs)
+  // res0: String = b10243641
+  //
+  // scala> addCheckDigit("1952770", recordType = SierraRecordTypes.items)
+  // res1: String = i19527706
+  //
+  def addCheckDigit(sierraId: String, recordType: SierraRecordTypes.Value): String = {
+
+    // First check that we're being passed a 7-digit numeric ID -- anything
+    // else is an error.
+    val regexMatch = """^[0-9]{7}$""".r.unapplySeq(sierraId)
+    val checkDigit = regexMatch match {
+      case Some(s) => getCheckDigit(s)
+      case _ => throw new RuntimeException(
+        s"Expected 7-digit numeric ID, got $sierraId"
+      )
+    }
+
+    // Then pick the record type prefix.
+    val prefix = recordType match {
+      case SierraRecordTypes.bibs => "b"
+      case SierraRecordTypes.items => "s"
+      case _ => throw new RuntimeException(
+        s"Received unrecognised record type: $recordType"
+      )
+    }
+
+    s"$prefix$sierraId$checkDigit"
+  }
+
+  // Quoting from the Sierra manual:
+  //
+  // Quoting from the Sierra manual:
+  //
+  //    Check digits may be any one of 11 possible digits (0, 1, 2, 3, 4, 5, 6,
+  //    7, 8, 9, or x).
+  //
+  //    The check digit is calculated as follows:
+  //
+  //    Multiply the rightmost digit of the record number by 2, the next digit
+  //    to the left by 3, the next by 4, etc., and total the products.
+  //
+  //    Divide the total by 11 and retain the remainder.  The remainder after
+  //    the division is the check digit.  If the remainder is 10, the letter x
+  //    is used as the check digit.
+  //
+  // This method does no error checking, and assumes it is passed a 7-digit
+  // Sierra ID.
+  //
+  private def getCheckDigit(sierraId: String): String = {
+    val remainder = sierraId
+      .reverse
+      .zip(Stream from 2)
+      .map { case (char: Char, count: Int) => char.toString.toInt * count }
+      .foldLeft(0)(_ + _) % 11
+    if (remainder == 10) "x" else remainder.toString
+  }
+}

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigits.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigits.scala
@@ -22,7 +22,7 @@ trait SierraCheckDigits {
     // else is an error.
     val regexMatch = """^[0-9]{7}$""".r.unapplySeq(sierraId)
     val checkDigit = regexMatch match {
-      case Some(s) => getCheckDigit(s)
+      case Some(s) => getCheckDigit(s.head)
       case _ => throw new RuntimeException(
         s"Expected 7-digit numeric ID, got $sierraId"
       )

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigits.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigits.scala
@@ -42,8 +42,6 @@ trait SierraCheckDigits {
 
   // Quoting from the Sierra manual:
   //
-  // Quoting from the Sierra manual:
-  //
   //    Check digits may be any one of 11 possible digits (0, 1, 2, 3, 4, 5, 6,
   //    7, 8, 9, or x).
   //

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigits.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigits.scala
@@ -20,7 +20,7 @@ trait SierraCheckDigits {
 
     // First check that we're being passed a 7-digit numeric ID -- anything
     // else is an error.
-    val regexMatch = """^[0-9]{7}$""".r.unapplySeq(sierraId)
+    val regexMatch = """^([0-9]{7})$""".r.unapplySeq(sierraId)
     val checkDigit = regexMatch match {
       case Some(s) => getCheckDigit(s.head)
       case _ => throw new RuntimeException(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigitsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigitsTest.scala
@@ -1,8 +1,25 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.prop.TableDrivenPropertyChecks._
 
 class SierraCheckDigitsTest extends FunSpec with Matchers {
+
+  val testCases = Table(
+    ("1828888", "bibs", "b18288881"),
+    ("1828888", "items", "i18288881")
+  )
+
+  it("correctly handles all of our test cases") {
+    forAll (testCases) { (sierraId: String, recordType: String, expectedId: String) =>
+      val sierraRecordType = recordType match {
+        case "bibs" => SierraRecordTypes.bibs
+        case "items" => SierraRecordTypes.bibs
+      }
+
+      transformer.addCheckDigit(sierraId, recordType = sierraRecordType) shouldBe expectedId
+    }
+  }
 
   it("throws an error if passed a Sierra ID which is non-numeric") {
     val caught = intercept[RuntimeException] {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigitsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigitsTest.scala
@@ -6,15 +6,22 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 class SierraCheckDigitsTest extends FunSpec with Matchers {
 
   val testCases = Table(
+    // Example from the Sierra docs
+    ("1024364", "bibs", "b10243641"),
+
+    // Examples taken from catalogue records
     ("1828888", "bibs", "b18288881"),
-    ("1828888", "items", "i18288881")
+    ("1828888", "items", "i18288881"),
+
+    // Example from a catalogue record with an "x" check digit
+    ("1840974", "items", "i1840974x")
   )
 
   it("correctly handles all of our test cases") {
     forAll (testCases) { (sierraId: String, recordType: String, expectedId: String) =>
       val sierraRecordType = recordType match {
         case "bibs" => SierraRecordTypes.bibs
-        case "items" => SierraRecordTypes.bibs
+        case "items" => SierraRecordTypes.items
       }
 
       transformer.addCheckDigit(sierraId, recordType = sierraRecordType) shouldBe expectedId

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigitsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigitsTest.scala
@@ -1,0 +1,32 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+import org.scalatest.{FunSpec, Matchers}
+
+class SierraCheckDigitsTest extends FunSpec with Matchers {
+
+  it("throws an error if passed a Sierra ID which is non-numeric") {
+    val caught = intercept[RuntimeException] {
+      transformer.addCheckDigit("abcdefg", recordType = SierraRecordTypes.bibs)
+    }
+
+    caught.getMessage shouldEqual "Expected 7-digit numeric ID, got abcdefg"
+  }
+
+  it("throws an error if passed a Sierra ID which is too short") {
+    val caught = intercept[RuntimeException] {
+      transformer.addCheckDigit("123", recordType = SierraRecordTypes.bibs)
+    }
+
+    caught.getMessage shouldEqual "Expected 7-digit numeric ID, got 123"
+  }
+
+  it("throws an error if passed a Sierra ID which is too long") {
+    val caught = intercept[RuntimeException] {
+      transformer.addCheckDigit("12345678", recordType = SierraRecordTypes.bibs)
+    }
+
+    caught.getMessage shouldEqual "Expected 7-digit numeric ID, got 12345678"
+  }
+
+  val transformer = new SierraCheckDigits {}
+}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigitsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCheckDigitsTest.scala
@@ -8,23 +8,22 @@ class SierraCheckDigitsTest extends FunSpec with Matchers {
   val testCases = Table(
     // Example from the Sierra docs
     ("1024364", "bibs", "b10243641"),
-
     // Examples taken from catalogue records
     ("1828888", "bibs", "b18288881"),
     ("1828888", "items", "i18288881"),
-
     // Example from a catalogue record with an "x" check digit
     ("1840974", "items", "i1840974x")
   )
 
   it("correctly handles all of our test cases") {
-    forAll (testCases) { (sierraId: String, recordType: String, expectedId: String) =>
-      val sierraRecordType = recordType match {
-        case "bibs" => SierraRecordTypes.bibs
-        case "items" => SierraRecordTypes.items
-      }
+    forAll(testCases) {
+      (sierraId: String, recordType: String, expectedId: String) =>
+        val sierraRecordType = recordType match {
+          case "bibs" => SierraRecordTypes.bibs
+          case "items" => SierraRecordTypes.items
+        }
 
-      transformer.addCheckDigit(sierraId, recordType = sierraRecordType) shouldBe expectedId
+        transformer.addCheckDigit(sierraId, recordType = sierraRecordType) shouldBe expectedId
     }
   }
 
@@ -46,7 +45,9 @@ class SierraCheckDigitsTest extends FunSpec with Matchers {
 
   it("throws an error if passed a Sierra ID which is too long") {
     val caught = intercept[RuntimeException] {
-      transformer.addCheckDigit("12345678", recordType = SierraRecordTypes.bibs)
+      transformer.addCheckDigit(
+        "12345678",
+        recordType = SierraRecordTypes.bibs)
     }
 
     caught.getMessage shouldEqual "Expected 7-digit numeric ID, got 12345678"


### PR DESCRIPTION
Required for #1639.

Of particular note is the use of [table-driven property checks](http://www.scalatest.org/user_guide/table_driven_property_checks), which give us an efficient way to define multiple examples for the same test case.