### PR TITLE
Add both forms of the Sierra ID in the transformer

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformer.scala
@@ -192,7 +192,7 @@ class MiroTransformableTransformer
         //                      be an X
         //    $                 end of the string
         //
-        val regexMatch = """^(?:\.?[bB])?([0-9]{7})[0-9xX]$""".r.unapplySeq(s)
+        val regexMatch = """^(?:\.?[bB])?([0-9]{7}[0-9xX])$""".r.unapplySeq(s)
         regexMatch match {
           case Some(s) =>
             s.map { id =>

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformer.scala
@@ -178,7 +178,8 @@ class MiroTransformableTransformer
       case Some(s) => {
 
         // The ID in the Miro record is an 8-digit number with a check digit
-        // (which may be x), but the system number is 7-digits, sans checksum.
+        // (which may be x).  The format we use for Sierra system numbers
+        // is a record type prefix ("b") and 8-digits.
         //
         // Regex explanation:
         //
@@ -186,9 +187,9 @@ class MiroTransformableTransformer
         //    (?:\.?[bB])?      non-capturing group, which trims 'b' or 'B'
         //                      or '.b' or '.B' from the start of the string,
         //                      but *not* a lone '.'
-        //    ([0-9]{7})        capturing group, the 7 digits of the system
-        //                      number
-        //    [0-9xX]           the final check digit, which may be X
+        //    ([0-9]{7}[0-9xX]) capturing group, the 8 digits of the system
+        //                      number plus the final check digit, which may
+        //                      be an X
         //    $                 end of the string
         //
         val regexMatch = """^(?:\.?[bB])?([0-9]{7})[0-9xX]$""".r.unapplySeq(s)

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
@@ -39,7 +39,10 @@ class SierraTransformableTransformer
               title = getTitle(sierraBibData),
               sourceIdentifier = SourceIdentifier(
                 identifierScheme = IdentifierSchemes.sierraSystemNumber,
-                sierraBibData.id
+                value = addCheckDigit(
+                  sierraBibData.id,
+                  resourceType = SierraRecordTypes.bibs
+                )
               ),
               version = version,
               identifiers = getIdentifiers(sierraBibData),

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
@@ -41,7 +41,7 @@ class SierraTransformableTransformer
                 identifierScheme = IdentifierSchemes.sierraSystemNumber,
                 value = addCheckDigit(
                   sierraBibData.id,
-                  resourceType = SierraRecordTypes.bibs
+                  recordType = SierraRecordTypes.bibs
                 )
               ),
               version = version,

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraIdentifiers.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraIdentifiers.scala
@@ -22,7 +22,7 @@ trait SierraIdentifiers extends SierraCheckDigits {
         identifierScheme = IdentifierSchemes.sierraSystemNumber,
         value = addCheckDigit(
           bibData.id,
-          resourceType = SierraRecordTypes.bibs
+          recordType = SierraRecordTypes.bibs
         )
       ),
       SourceIdentifier(

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraIdentifiers.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraIdentifiers.scala
@@ -4,18 +4,26 @@ import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier}
 
 import uk.ac.wellcome.transformer.source.SierraBibData
 
-trait SierraIdentifiers {
+trait SierraIdentifiers extends SierraCheckDigits {
 
   // Populate wwork:identifiers.
   //
-  //    We populate with "identifierScheme": "sierra-system-number" for the
-  //    main ID on the original bib.  Adding other identifiers is out-of-scope
-  //    for now.
+  //    We populate with two identifier schemes:
+  //
+  //    -   "sierra-system-number" for the full record type (incl. prefix and
+  //        check digit)
+  //    -   "sierra-identifier" for the 7-digit interal ID
+  //
+  //    Adding other identifiers is out-of-scope for now.
   //
   def getIdentifiers(bibData: SierraBibData): List[SourceIdentifier] =
     List(
       SourceIdentifier(
         identifierScheme = IdentifierSchemes.sierraSystemNumber,
+        value = addCheckDigit(bibData.id)
+      ),
+      SourceIdentifier(
+        identifierScheme = IdentifierSchemes.sierraIdentifier,
         value = bibData.id
       )
     )

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraIdentifiers.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraIdentifiers.scala
@@ -20,7 +20,10 @@ trait SierraIdentifiers extends SierraCheckDigits {
     List(
       SourceIdentifier(
         identifierScheme = IdentifierSchemes.sierraSystemNumber,
-        value = addCheckDigit(bibData.id)
+        value = addCheckDigit(
+          bibData.id,
+          resourceType = SierraRecordTypes.bibs
+        )
       ),
       SourceIdentifier(
         identifierScheme = IdentifierSchemes.sierraIdentifier,

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItems.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.transformer.source.SierraItemData
 import uk.ac.wellcome.utils.JsonUtil._
 
-trait SierraItems extends Logging with SierraLocation {
+trait SierraItems extends Logging with SierraCheckDigits with SierraLocation {
   def extractItemData(
     sierraTransformable: SierraTransformable): List[SierraItemData] = {
     sierraTransformable.itemData.values
@@ -33,13 +33,23 @@ trait SierraItems extends Logging with SierraLocation {
     info(s"Attempting to transform ${sierraItemData.id}")
     UnidentifiedItem(
       sourceIdentifier = SourceIdentifier(
-        IdentifierSchemes.sierraSystemNumber,
-        sierraItemData.id
+        identifierScheme = IdentifierSchemes.sierraSystemNumber,
+        value = addCheckDigit(
+          sierraItemData.id,
+          recordType = SierraRecordTypes.items
+        )
       ),
       identifiers = List(
         SourceIdentifier(
           identifierScheme = IdentifierSchemes.sierraSystemNumber,
-          sierraItemData.id
+          addCheckDigit(
+            sierraItemData.id,
+            recordType = SierraRecordTypes.items
+          )
+        ),
+        SourceIdentifier(
+          identifierScheme = IdentifierSchemes.sierraIdentifier,
+          value = sierraItemData.id
         )
       ),
       locations = getLocation(sierraItemData).toList

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
@@ -79,7 +79,9 @@ class SierraTransformerFeatureTest
 
               actualWork.sourceIdentifier shouldBe sourceIdentifier
               actualWork.title shouldBe Some(title)
-              actualWork.identifiers shouldBe List(sourceIdentifier, sierraIdentifier)
+              actualWork.identifiers shouldBe List(
+                sourceIdentifier,
+                sierraIdentifier)
             }
           }
         }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
@@ -27,7 +27,7 @@ class SierraTransformerFeatureTest
     with TransformableMessageUtils {
 
   it("transforms sierra records and publishes the result to the given topic") {
-    val id = "b001"
+    val id = "1001001"
     val title = "A pot of possums"
     val lastModifiedDate = Instant.now()
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
@@ -63,8 +63,13 @@ class SierraTransformerFeatureTest
               snsMessages should have size 1
 
               val sourceIdentifier = SourceIdentifier(
-                IdentifierSchemes.sierraSystemNumber,
-                id
+                identifierScheme = IdentifierSchemes.sierraSystemNumber,
+                value = "b10010014"
+              )
+
+              val sierraIdentifier = SourceIdentifier(
+                identifierScheme = IdentifierSchemes.sierraIdentifier,
+                value = id
               )
 
               val actualWork =
@@ -74,7 +79,7 @@ class SierraTransformerFeatureTest
 
               actualWork.sourceIdentifier shouldBe sourceIdentifier
               actualWork.title shouldBe Some(title)
-              actualWork.identifiers shouldBe List(sourceIdentifier)
+              actualWork.identifiers shouldBe List(sourceIdentifier, sierraIdentifier)
             }
           }
         }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -128,17 +128,24 @@ class SQSMessageReceiverTest
           withSQSMessageReceiver(topicArn, bucketName) { recordReceiver =>
             val future = recordReceiver.receiveMessage(sierraMessage)
 
+            val sourceIdentifier = SourceIdentifier(
+              identifierScheme = IdentifierSchemes.sierraSystemNumber,
+              value = "b50050059"
+            )
+            val sierraIdentifier = SourceIdentifier(
+              identifierScheme = IdentifierSchemes.sierraIdentifier,
+              value = id
+            )
+
             whenReady(future) { _ =>
               val messages = listMessagesReceivedFromSNS(topicArn)
               messages should have size 1
               messages.head.message shouldBe JsonUtil
                 .toJson(UnidentifiedWork(
                   title = Some(title),
-                  sourceIdentifier =
-                    SourceIdentifier(IdentifierSchemes.sierraSystemNumber, id),
+                  sourceIdentifier = sourceIdentifier,
                   version = version,
-                  identifiers = List(
-                    SourceIdentifier(IdentifierSchemes.sierraSystemNumber, id))
+                  identifiers = List(sourceIdentifier, sierraIdentifier)
                 ))
                 .get
               messages.head.subject shouldBe "source: SQSMessageReceiver.publishMessage"
@@ -184,7 +191,7 @@ class SQSMessageReceiverTest
             recordReceiver =>
               val future = recordReceiver.receiveMessage(
                 createValidEmptySierraBibSQSMessage(
-                  id = "000",
+                  id = "0101010",
                   s3Client = s3Client,
                   bucketName = bucketName
                 )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -141,12 +141,13 @@ class SQSMessageReceiverTest
               val messages = listMessagesReceivedFromSNS(topicArn)
               messages should have size 1
               messages.head.message shouldBe JsonUtil
-                .toJson(UnidentifiedWork(
-                  title = Some(title),
-                  sourceIdentifier = sourceIdentifier,
-                  version = version,
-                  identifiers = List(sourceIdentifier, sierraIdentifier)
-                ))
+                .toJson(
+                  UnidentifiedWork(
+                    title = Some(title),
+                    sourceIdentifier = sourceIdentifier,
+                    version = version,
+                    identifiers = List(sourceIdentifier, sierraIdentifier)
+                  ))
                 .get
               messages.head.subject shouldBe "source: SQSMessageReceiver.publishMessage"
             }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -108,7 +108,7 @@ class SQSMessageReceiverTest
     }
   }
   it("receives a message and add the version to the transformed work") {
-    val id = "b001"
+    val id = "5005005"
     val title = "A pot of possums"
     val lastModifiedDate = Instant.now()
     val version = 5
@@ -235,7 +235,7 @@ class SQSMessageReceiverTest
 
   it("should return a failed future if it's unable to publish the work") {
 
-    val id = "b123"
+    val id = "1001001"
     val sierraTransformable: Transformable =
       SierraTransformable(
         sourceId = id,

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformerTest.scala
@@ -25,14 +25,14 @@ class MiroTransformableTransformerTest
   }
 
   it("passes through the INNOPAC ID as the Sierra system number") {
-    forAll(Table("", ".", "b", "B", ".b", ".B")) { prefix =>
+    forAll(Table("", "b", "B", ".b", ".B")) { prefix =>
       forAll(Table("8", "x")) { checkDigit =>
         val innopacId = s"${prefix}1234567${checkDigit}"
         val expectedSierraNumber = s"b1234567${checkDigit}"
 
         transformRecordAndCheckSierraSystemNumber(
           innopacId = innopacId,
-          expectedSierraNumber = "b12345678"
+          expectedSierraNumber = s"b1234567${checkDigit}"
         )
       }
     }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformerTest.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.transformer.transformers
 
 import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.prop.TableDrivenPropertyChecks._
 import uk.ac.wellcome.models.{
   Agent,
   IdentifierSchemes,
@@ -23,41 +24,17 @@ class MiroTransformableTransformerTest
       SourceIdentifier(IdentifierSchemes.miroImageNumber, MiroID))
   }
 
-  describe(
-    "The INNOPAC ID should be passed through as the Sierra system number") {
-    it("plain numeric ID") {
-      transformRecordAndCheckSierraSystemNumber(
-        innopacId = "12345678",
-        expectedSierraNumber = "b1234567"
-      )
-    }
+  it("passes through the INNOPAC ID as the Sierra system number") {
+    forAll(Table("", ".", "b", "B", ".b", ".B")) { prefix =>
+      forAll(Table("8", "x")) { checkDigit =>
+        val innopacId = s"${prefix}1234567${checkDigit}"
+        val expectedSierraNumber = s"b1234567${checkDigit}"
 
-    it("with an x for a check digit") {
-      transformRecordAndCheckSierraSystemNumber(
-        innopacId = "1234567x",
-        expectedSierraNumber = "b1234567"
-      )
-    }
-
-    it("with a leading b on the b-number") {
-      transformRecordAndCheckSierraSystemNumber(
-        innopacId = "b12345678",
-        expectedSierraNumber = "b1234567"
-      )
-    }
-
-    it("with a leading B on the b-number") {
-      transformRecordAndCheckSierraSystemNumber(
-        innopacId = "b12345678",
-        expectedSierraNumber = "b1234567"
-      )
-    }
-
-    it("with a leading .b on the b-number") {
-      transformRecordAndCheckSierraSystemNumber(
-        innopacId = ".b12345678",
-        expectedSierraNumber = "b1234567"
-      )
+        transformRecordAndCheckSierraSystemNumber(
+          innopacId = innopacId,
+          expectedSierraNumber = "b12345678"
+        )
+      }
     }
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -490,7 +490,7 @@ class SierraTransformableTransformerTest
 
     val expectedSourceIdentifier = SourceIdentifier(
       identifierScheme = IdentifierSchemes.sierraSystemNumber,
-      value = "b9000009a"
+      value = "b90000092"
     )
 
     transformedSierraRecord.get.get.sourceIdentifier

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -123,8 +123,8 @@ class SierraTransformableTransformerTest
     )
 
     work.items.head shouldBe UnidentifiedItem(
-      sourceIdentifier = expectedSourceIdentifier,
-      identifiers = List(expectedSourceIdentifier),
+      sourceIdentifier = expectedSourceIdentifiers.head,
+      identifiers = expectedSourceIdentifiers,
       locations = List(PhysicalLocation(locationType, locationLabel)))
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -472,4 +472,27 @@ class SierraTransformableTransformerTest
       label = place)
 
   }
+
+  it("uses the full Sierra system number as the source identifier") {
+    val id = "9000009"
+    val sierraTransformable = SierraTransformable(
+      sourceId = id,
+      maybeBibData = Some(SierraBibRecord(
+        id = id,
+        data = s"""{"id": "$id"}""",
+        modifiedDate = now()
+      ))
+    )
+
+    val transformedSierraRecord =
+      transformer.transform(sierraTransformable, version=1)
+    transformedSierraRecord.isSuccess shouldBe true
+
+    val expectedSourceIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.sierraSystemNumber,
+      value = "b9000009a"
+    )
+
+    transformedSierraRecord.get.get.sourceIdentifier
+  }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -477,15 +477,16 @@ class SierraTransformableTransformerTest
     val id = "9000009"
     val sierraTransformable = SierraTransformable(
       sourceId = id,
-      maybeBibData = Some(SierraBibRecord(
-        id = id,
-        data = s"""{"id": "$id"}""",
-        modifiedDate = now()
-      ))
+      maybeBibData = Some(
+        SierraBibRecord(
+          id = id,
+          data = s"""{"id": "$id"}""",
+          modifiedDate = now()
+        ))
     )
 
     val transformedSierraRecord =
-      transformer.transform(sierraTransformable, version=1)
+      transformer.transform(sierraTransformable, version = 1)
     transformedSierraRecord.isSuccess shouldBe true
 
     val expectedSourceIdentifier = SourceIdentifier(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -26,7 +26,7 @@ class SierraTransformableTransformerTest
   val transformer = new SierraTransformableTransformer
 
   it("performs a transformation on a work with items") {
-    val id = "b5757575"
+    val id = "5757575"
     val title = "A morning mixture of molasses and muesli"
     val data =
       s"""
@@ -42,12 +42,12 @@ class SierraTransformableTransformerTest
       maybeBibData =
         Some(SierraBibRecord(id = id, data = data, modifiedDate = now())),
       itemData = Map(
-        "i111" -> sierraItemRecord(
-          id = "i111",
+        "5151515" -> sierraItemRecord(
+          id = "5151515",
           title = title,
           bibIds = List(id)),
-        "i222" -> sierraItemRecord(
-          id = "i222",
+        "5252525" -> sierraItemRecord(
+          id = "5252525",
           title = title,
           bibIds = List(id))
       )
@@ -60,26 +60,20 @@ class SierraTransformableTransformerTest
     val work = transformedSierraRecord.get.get
 
     val sourceIdentifier1 =
-      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, "i111")
+      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, "i51515155")
     val sourceIdentifier2 =
-      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, "i222")
+      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, "i52525259")
 
-    work.items shouldBe List(
-      UnidentifiedItem(
-        sourceIdentifier = sourceIdentifier1,
-        identifiers = List(sourceIdentifier1)
-      ),
-      UnidentifiedItem(
-        sourceIdentifier = sourceIdentifier2,
-        identifiers = List(sourceIdentifier2)
-      )
+    work.items.map { _.sourceIdentifier } shouldBe List(
+      sourceIdentifier1,
+      sourceIdentifier2
     )
   }
 
   it("should extract information from items") {
     val modifiedDate = Instant.now
-    val bibId = "b1234567"
-    val itemId = "i1234567"
+    val bibId = "6262626"
+    val itemId = "6363636"
     val locationType = "sgmed"
     val locationLabel = "A museum of mermaids"
     val bibData =
@@ -117,8 +111,17 @@ class SierraTransformableTransformerTest
     triedMaybeWork.get.isDefined shouldBe true
     val work = triedMaybeWork.get.get
     work.items should have size 1
-    val expectedSourceIdentifier =
-      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, itemId)
+    val expectedSourceIdentifiers = List(
+      SourceIdentifier(
+        identifierScheme = IdentifierSchemes.sierraSystemNumber,
+        value = "i63636360"
+      ),
+      SourceIdentifier(
+        identifierScheme = IdentifierSchemes.sierraIdentifier,
+        value = itemId
+      )
+    )
+
     work.items.head shouldBe UnidentifiedItem(
       sourceIdentifier = expectedSourceIdentifier,
       identifiers = List(expectedSourceIdentifier),
@@ -127,7 +130,7 @@ class SierraTransformableTransformerTest
 
   it("should not perform a transformation without bibData") {
     val sierraTransformable =
-      SierraTransformable(sourceId = "000", maybeBibData = None)
+      SierraTransformable(sourceId = "0102010", maybeBibData = None)
 
     val transformedSierraRecord =
       transformer.transform(sierraTransformable, version = 1)
@@ -139,14 +142,14 @@ class SierraTransformableTransformerTest
   it(
     "should not perform a transformation without bibData, even if some itemData is present") {
     val sierraTransformable = SierraTransformable(
-      sourceId = "b111",
+      sourceId = "1113111",
       maybeBibData = None,
       itemData = Map(
-        "i111" -> sierraItemRecord(
-          id = "i111",
+        "1313131" -> sierraItemRecord(
+          id = "1313131",
           title = "An incomplete invocation of items",
           modifiedDate = "2001-01-01T01:01:01Z",
-          bibIds = List("b111")
+          bibIds = List("1113111")
         ))
     )
 
@@ -157,7 +160,7 @@ class SierraTransformableTransformerTest
   }
 
   it("performs a transformation on a work using all varfields") {
-    val id = "000"
+    val id = "0606060"
     val title = "Hi Diddle Dee Dee"
     val lettering = "An actor's life for me"
 
@@ -238,15 +241,21 @@ class SierraTransformableTransformerTest
       transformer.transform(sierraTransformable, version = 1)
     transformedSierraRecord.isSuccess shouldBe true
 
-    val identifier =
-      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, id)
+    val sourceIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.sierraSystemNumber,
+      value = "b06060602"
+    )
+    val sierraIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.sierraIdentifier,
+      value = id
+    )
 
     transformedSierraRecord.get shouldBe Some(
       UnidentifiedWork(
         title = Some(title),
-        sourceIdentifier = identifier,
+        sourceIdentifier = sourceIdentifier,
         version = 1,
-        identifiers = List(identifier),
+        identifiers = List(sourceIdentifier, sierraIdentifier),
         description = Some("A delightful description of a dead daisy."),
         publishers = List(Organisation(label = "Peaceful Poetry")),
         lettering = Some(lettering),
@@ -256,7 +265,7 @@ class SierraTransformableTransformerTest
   }
 
   it("makes deleted works invisible") {
-    val id = "000"
+    val id = "1789871"
     val title = "Hi Diddle Dee Dee"
     val data =
       s"""
@@ -277,22 +286,28 @@ class SierraTransformableTransformerTest
       transformer.transform(sierraTransformable, version = 1)
     transformedSierraRecord.isSuccess shouldBe true
 
-    val identifier =
-      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, id)
+    val sourceIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.sierraSystemNumber,
+      value = "b17898717"
+    )
+    val sierraIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.sierraIdentifier,
+      value = id
+    )
 
     transformedSierraRecord.get shouldBe Some(
       UnidentifiedWork(
         title = Some(title),
-        sourceIdentifier = identifier,
+        sourceIdentifier = sourceIdentifier,
         version = 1,
-        identifiers = List(identifier),
+        identifiers = List(sourceIdentifier, sierraIdentifier),
         visible = false,
         publicationDate = None)
     )
   }
 
-  it("makes supressed works invisible") {
-    val id = "000"
+  it("makes suppressed works invisible") {
+    val id = "0001000"
     val title = "Hi Diddle Dee Dee"
     val data =
       s"""
@@ -313,24 +328,30 @@ class SierraTransformableTransformerTest
       transformer.transform(sierraTransformable, version = 1)
     transformedSierraRecord.isSuccess shouldBe true
 
-    val identifier =
-      SourceIdentifier(IdentifierSchemes.sierraSystemNumber, id)
+    val sourceIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.sierraSystemNumber,
+      value = "b00010005"
+    )
+    val sierraIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.sierraIdentifier,
+      value = id
+    )
 
     transformedSierraRecord.get shouldBe Some(
       UnidentifiedWork(
         title = Some(title),
-        sourceIdentifier = identifier,
+        sourceIdentifier = sourceIdentifier,
         version = 1,
-        identifiers = List(identifier),
+        identifiers = List(sourceIdentifier, sierraIdentifier),
         visible = false,
         publicationDate = None)
     )
   }
 
   it("transforms bib records that don't have a title") {
-    // This example is taken from a failure observed in the transformer, based on
-    // real records from Sierra.
-    val id = "b2524736"
+    // This example is taken from a failure observed in the transformer,
+    // based on real records from Sierra.
+    val id = "2524736"
     val data =
       s"""
          |{
@@ -357,7 +378,7 @@ class SierraTransformableTransformerTest
   }
 
   it("includes the physical description, if present") {
-    val id = "b7000007"
+    val id = "7000007"
     val physicalDescription = "A dusty depiction of dodos"
 
     val data =
@@ -396,7 +417,7 @@ class SierraTransformableTransformerTest
   }
 
   it("includes the extent, if present") {
-    val id = "b8000008"
+    val id = "8000008"
     val extent = "Purple pages"
 
     val data =
@@ -434,7 +455,7 @@ class SierraTransformableTransformerTest
   }
 
   it("includes place of publications") {
-    val id = "b8000008"
+    val id = "8008008"
     val place = "Purple pages"
 
     val data =

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraIdentifiersTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraIdentifiersTest.scala
@@ -12,12 +12,12 @@ class SierraIdentifiersTest extends FunSpec with Matchers with SierraData {
       bibDataId = "1782863",
       expectedIdentifiers = List(
         SourceIdentifier(
-          identifierScheme = IdentifierSchemes.sierraIdentifier,
-          value = "1782863"
-        ),
-        SourceIdentifier(
           identifierScheme = IdentifierSchemes.sierraSystemNumber,
           value = "b17828636"
+        ),
+        SourceIdentifier(
+          identifierScheme = IdentifierSchemes.sierraIdentifier,
+          value = "1782863"
         )
       )
     )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraIdentifiersTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraIdentifiersTest.scala
@@ -9,11 +9,15 @@ class SierraIdentifiersTest extends FunSpec with Matchers with SierraData {
 
   it("passes through the main identifier from the bib record") {
     assertIdentifiersAreCorrect(
-      bibDataId = "b1782863",
+      bibDataId = "1782863",
       expectedIdentifiers = List(
         SourceIdentifier(
+          identifierScheme = IdentifierSchemes.sierraIdentifier,
+          value = "1782863"
+        ),
+        SourceIdentifier(
           identifierScheme = IdentifierSchemes.sierraSystemNumber,
-          value = "b1782863"
+          value = "b17828636"
         )
       )
     )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
@@ -109,7 +109,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraData {
 
       val sourceIdentifier1 = SourceIdentifier(
         identifierScheme = IdentifierSchemes.sierraSystemNumber,
-        value = "i4000004a"
+        value = "i40000047"
       )
       val sourceIdentifier2 = SourceIdentifier(
         identifierScheme = IdentifierSchemes.sierraIdentifier,
@@ -126,7 +126,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraData {
 
       val sourceIdentifier = SourceIdentifier(
         identifierScheme = IdentifierSchemes.sierraSystemNumber,
-        value = "i5000005a"
+        value = "i50000056"
       )
 
       val transformedItem = transformer.transformItemData(item)

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
@@ -88,20 +88,8 @@ class SierraItemsTest extends FunSpec with Matchers with SierraData {
 
   describe("transformItemData") {
     it("returns UnidentifiedItem if an item is not deleted") {
-      val item = SierraItemData(id = "i4000002", deleted = false)
-
-      val sourceIdentifier = SourceIdentifier(
-        identifierScheme = IdentifierSchemes.sierraSystemNumber,
-        value = "i4000002"
-      )
-
-      val expectedItem = UnidentifiedItem(
-        sourceIdentifier = sourceIdentifier,
-        identifiers = List(sourceIdentifier),
-        locations = List()
-      )
-
-      transformer.transformItemData(item) shouldBe expectedItem
+      val item = SierraItemData(id = "4000002", deleted = false)
+      transformer.transformItemData(item) shouldBe a[UnidentifiedItem]
     }
 
     it("creates both forms of the Sierra ID in 'identifiers'") {
@@ -136,8 +124,8 @@ class SierraItemsTest extends FunSpec with Matchers with SierraData {
 
   describe("getItems") {
     it("removes items with deleted=true") {
-      val item1 = SierraItemData(id = "i3000001", deleted = true)
-      val item2 = SierraItemData(id = "i3000002", deleted = false)
+      val item1 = SierraItemData(id = "3000001", deleted = true)
+      val item2 = SierraItemData(id = "3000002", deleted = false)
 
       val itemData = Map(
         item1.id -> SierraItemRecord(
@@ -155,7 +143,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraData {
       )
 
       val transformable = SierraTransformable(
-        sourceId = "b3333333",
+        sourceId = "3333333",
         itemData = itemData
       )
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraItemsTest.scala
@@ -103,6 +103,35 @@ class SierraItemsTest extends FunSpec with Matchers with SierraData {
 
       transformer.transformItemData(item) shouldBe expectedItem
     }
+
+    it("creates both forms of the Sierra ID in 'identifiers'") {
+      val item = SierraItemData(id = "4000004", deleted = false)
+
+      val sourceIdentifier1 = SourceIdentifier(
+        identifierScheme = IdentifierSchemes.sierraSystemNumber,
+        value = "i4000004a"
+      )
+      val sourceIdentifier2 = SourceIdentifier(
+        identifierScheme = IdentifierSchemes.sierraIdentifier,
+        value = "4000004"
+      )
+
+      val expectedIdentifiers = List(sourceIdentifier1, sourceIdentifier2)
+      val transformedItem = transformer.transformItemData(item)
+      transformedItem.identifiers shouldBe expectedIdentifiers
+    }
+
+    it("uses the full Sierra system number as the source identifier") {
+      val item = SierraItemData(id = "5000005", deleted = false)
+
+      val sourceIdentifier = SourceIdentifier(
+        identifierScheme = IdentifierSchemes.sierraSystemNumber,
+        value = "i5000005a"
+      )
+
+      val transformedItem = transformer.transformItemData(item)
+      transformedItem.sourceIdentifier shouldBe sourceIdentifier
+    }
   }
 
   describe("getItems") {

--- a/common/src/main/scala/uk/ac/wellcome/models/IdentifierSchemes.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/IdentifierSchemes.scala
@@ -69,8 +69,18 @@ object IdentifierSchemes extends Logging {
     override def toString: String = "calm-altrefno"
   }
 
+  // Represents the full form of a Sierra record number, including the record
+  // type prefix ("b" for bibs, "i" for items, etc.) and the check digit.
+  // Examples: b17828636, i17832846
   case object sierraSystemNumber extends IdentifierScheme {
     override def toString: String = "sierra-system-number"
+  }
+
+  // Represents the internal form of a Sierra record number, with no record
+  // type prefix or check digit.  7 digits.
+  // Examples: 1782863, 1783284
+  case object sierraIdentifier extends IdentifierScheme {
+    override def toString: String = "sierra-identifier"
   }
 
   case object marcCountries extends IdentifierScheme {

--- a/common/src/main/scala/uk/ac/wellcome/models/IdentifierSchemes.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/IdentifierSchemes.scala
@@ -94,6 +94,8 @@ object IdentifierSchemes extends Logging {
         IdentifierSchemes.miroImageNumber
       case s: String if s == IdentifierSchemes.sierraSystemNumber.toString =>
         IdentifierSchemes.sierraSystemNumber
+      case s: String if s == IdentifierSchemes.sierraIdentifier.toString =>
+        IdentifierSchemes.sierraIdentifier
       case s: String if s == IdentifierSchemes.calmAltRefNo.toString =>
         IdentifierSchemes.calmAltRefNo
       case s: String if s == IdentifierSchemes.calmPlaceholder.toString =>


### PR DESCRIPTION
Another part of #1639. Rather than just including the "sierra-system-number", plumb through both versions of the ID as discussed on that ticket.