### PR TITLE
assets/s3.tf: add short-term versioning to the workingstorage bucket

### DIFF
--- a/assets/terraform/s3.tf
+++ b/assets/terraform/s3.tf
@@ -16,4 +16,20 @@ resource "aws_s3_bucket" "working_storage" {
 
     enabled = true
   }
+
+  # To protect against accidental deletions, we enable versioning on this
+  # bucket and expire non-current versions after 30 days.  This gives us an
+  # additional safety net against mistakes.
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    enabled = true
+
+    noncurrent_version_expiration {
+      days = 30
+    }
+  }
 }

--- a/assets/terraform/s3.tf
+++ b/assets/terraform/s3.tf
@@ -24,7 +24,6 @@ resource "aws_s3_bucket" "working_storage" {
   versioning {
     enabled = true
   }
-
   lifecycle_rule {
     enabled = true
 


### PR DESCRIPTION
As the miro-images-sync bucket gradually empties, it's hard not to be struck by scary thoughts:

*What if I’m deleting from the wrong place?*

*What if I applied the lifecycle policy to the wrong bucket?*

etc.

Hooray for anxiety!

This PR adds rules on the asset buckets to protect against accidental deletions. Specifically: **version all objects, and expire deleted versions after 30 days**. That gives us a recovery window if we accidentally screw up.

---

(To be crystal clear: I am not aware of any accidental deletions that have happened so far. This is meant as a preventative measure, not a band-aid for an existing problem.)