### PR TITLE
Add transformation for WorkType

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
@@ -2,7 +2,11 @@ package uk.ac.wellcome.platform.api
 
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.HttpServer
-import com.twitter.finatra.http.filters.{CommonFilters, LoggingMDCFilter, TraceIdMDCFilter}
+import com.twitter.finatra.http.filters.{
+  CommonFilters,
+  LoggingMDCFilter,
+  TraceIdMDCFilter
+}
 import com.twitter.finatra.http.routing.HttpRouter
 import com.twitter.finatra.json.modules.FinatraJacksonModule
 import com.twitter.finatra.json.utils.CamelCasePropertyNamingStrategy
@@ -10,7 +14,11 @@ import io.swagger.models.Swagger
 import uk.ac.wellcome.elasticsearch.finatra.modules.ElasticClientModule
 import uk.ac.wellcome.finatra.modules._
 import uk.ac.wellcome.platform.api.controllers._
-import uk.ac.wellcome.platform.api.finatra.exceptions.{CaseClassMappingExceptionWrapper, ElasticsearchResponseExceptionMapper, GeneralExceptionMapper}
+import uk.ac.wellcome.platform.api.finatra.exceptions.{
+  CaseClassMappingExceptionWrapper,
+  ElasticsearchResponseExceptionMapper,
+  GeneralExceptionMapper
+}
 import uk.ac.wellcome.models.WorksIncludesDeserializerModule
 
 object ServerMain extends Server

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
@@ -2,11 +2,7 @@ package uk.ac.wellcome.platform.api
 
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.HttpServer
-import com.twitter.finatra.http.filters.{
-  CommonFilters,
-  LoggingMDCFilter,
-  TraceIdMDCFilter
-}
+import com.twitter.finatra.http.filters.{CommonFilters, LoggingMDCFilter, TraceIdMDCFilter}
 import com.twitter.finatra.http.routing.HttpRouter
 import com.twitter.finatra.json.modules.FinatraJacksonModule
 import com.twitter.finatra.json.utils.CamelCasePropertyNamingStrategy
@@ -14,11 +10,7 @@ import io.swagger.models.Swagger
 import uk.ac.wellcome.elasticsearch.finatra.modules.ElasticClientModule
 import uk.ac.wellcome.finatra.modules._
 import uk.ac.wellcome.platform.api.controllers._
-import uk.ac.wellcome.platform.api.finatra.exceptions.{
-  CaseClassMappingExceptionWrapper,
-  ElasticsearchResponseExceptionMapper,
-  GeneralExceptionMapper
-}
+import uk.ac.wellcome.platform.api.finatra.exceptions.{CaseClassMappingExceptionWrapper, ElasticsearchResponseExceptionMapper, GeneralExceptionMapper}
 import uk.ac.wellcome.models.WorksIncludesDeserializerModule
 
 object ServerMain extends Server

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
@@ -12,8 +12,8 @@ trait WorksUtil {
   val period = Period("the past")
   val agent = Agent("a person")
   val workType = WorkType(
-    id = "id",
-    label = "label"
+    id = "1dz4yn34va",
+    label = "An aggregation of angry archipelago aged ankylosaurs."
   )
 
   val sourceIdentifier = SourceIdentifier(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
@@ -11,6 +11,10 @@ trait WorksUtil {
 
   val period = Period("the past")
   val agent = Agent("a person")
+  val workType = WorkType(
+    id = "id",
+    label = "label"
+  )
 
   val sourceIdentifier = SourceIdentifier(
     IdentifierSchemes.miroImageNumber,
@@ -96,6 +100,7 @@ trait WorksUtil {
       version = 1,
       identifiers = List(sourceIdentifier),
       canonicalId = canonicalId,
+      workType = Some(workType),
       description = Some(description),
       lettering = Some(lettering),
       createdDate = Some(createdDate),

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
@@ -26,8 +26,8 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "title": "${works(0).title.get}",
                           |     "description": "${works(0).description.get}",
                           |     "workType": {
-                          |       "id": "1dz4yn34va",
-                          |       "label": "An aggregation of angry archipelago aged ankylosaurs.",
+                          |       "id": "${works(0).workType.get.id}",
+                          |       "label": "${works(0).workType.get.label}",
                           |       "type": "WorkType"
                           |     },
                           |     "lettering": "${works(0).lettering.get}",
@@ -45,8 +45,8 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "title": "${works(1).title.get}",
                           |     "description": "${works(1).description.get}",
                           |     "workType": {
-                          |       "id": "b00p4900p",
-                          |       "label": "Brewed bears being backwards behind baleen.",
+                          |       "id": "${works(1).workType.get.id}",
+                          |       "label": "${works(1).workType.get.label}",
                           |       "type": "WorkType"
                           |     },
                           |     "lettering": "${works(1).lettering.get}",
@@ -64,8 +64,8 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "title": "${works(2).title.get}",
                           |     "description": "${works(2).description.get}",
                           |     "workType": {
-                          |       "id": "c4t54r3l1f3",
-                          |       "label": "Creamed clams cut cunningly by Calligula.",
+                          |       "id": "${works(2).workType.get.id}",
+                          |       "label": "${works(2).workType.get.label}",
                           |       "type": "WorkType"
                           |     },
                           |     "lettering": "${works(2).lettering.get}",
@@ -109,8 +109,8 @@ class ApiWorksTest extends ApiWorksTestBase {
                           | "title": "$title",
                           | "description": "$description",
                           | "workType": {
-                          |       "id": "b34r54r3",
-                          |       "label": "Dreaming dunkleosteus dancing dangerously.",
+                          |       "id": s"${workType.id}",
+                          |       "label": s"${workType.label}",
                           |       "type": "WorkType"
                           | },
                           | "lettering": "$lettering",
@@ -278,8 +278,8 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "title": "${works(1).title.get}",
                           |     "description": "${works(1).description.get}",
                           |     "workType" : {
-                          |        "id" : "h1gg5b050n",
-                          |        "label" : "Poached paleognaths picking packs of prepacked platypus.",
+                          |        "id" : "${works(1).workType.get.id}",
+                          |        "label" : "${works(1).workType.get.label}",
                           |        "type" : "WorkType"
                           |      },
                           |     "lettering": "${works(1).lettering.get}",
@@ -314,8 +314,8 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "title": "${works(0).title.get}",
                           |     "description": "${works(0).description.get}",
                           |     "workType" : {
-                          |        "id" : "n0s0up4u",
-                          |        "label" : "Red ruby rollerskates racing Rob Roy relentlessly.",
+                          |        "id" : "${works(0).workType.get.id}",
+                          |        "label" : "${works(0).workType.get.label}",
                           |        "type" : "WorkType"
                           |      },
                           |     "lettering": "${works(0).lettering.get}",
@@ -350,8 +350,8 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "title": "${works(2).title.get}",
                           |     "description": "${works(2).description.get}",
                           |     "workType" : {
-                          |        "id" : "4nyw4yw84m3",
-                          |        "label" : "Mulled molluscs masking many malign makers.",
+                          |        "id" : "${works(2).workType.get.id}",
+                          |        "label" : "${works(2).workType.get.id}",
                           |        "type" : "WorkType"
                           |      },
                           |     "lettering": "${works(2).lettering.get}",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.models._
 
 class ApiWorksTest extends ApiWorksTestBase {
 
-  it("should return a list of works") {
+  it("returns a list of works") {
 
     val works = createWorks(3)
 
@@ -26,8 +26,8 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "title": "${works(0).title.get}",
                           |     "description": "${works(0).description.get}",
                           |     "workType": {
-                          |       "id": "id",
-                          |       "label": "label",
+                          |       "id": "1dz4yn34va",
+                          |       "label": "An aggregation of angry archipelago aged ankylosaurs.",
                           |       "type": "WorkType"
                           |     },
                           |     "lettering": "${works(0).lettering.get}",
@@ -45,8 +45,8 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "title": "${works(1).title.get}",
                           |     "description": "${works(1).description.get}",
                           |     "workType": {
-                          |       "id": "id",
-                          |       "label": "label",
+                          |       "id": "b00p4900p",
+                          |       "label": "Brewed bears being backwards behind baleen.",
                           |       "type": "WorkType"
                           |     },
                           |     "lettering": "${works(1).lettering.get}",
@@ -64,8 +64,8 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "title": "${works(2).title.get}",
                           |     "description": "${works(2).description.get}",
                           |     "workType": {
-                          |       "id": "id",
-                          |       "label": "label",
+                          |       "id": "c4t54r3l1f3",
+                          |       "label": "Creamed clams cut cunningly by Calligula.",
                           |       "type": "WorkType"
                           |     },
                           |     "lettering": "${works(2).lettering.get}",
@@ -84,7 +84,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("should return a single work when requested with id") {
+  it("returns a single work when requested with id") {
     val work = workWith(
       canonicalId = canonicalId,
       title = title,
@@ -109,8 +109,8 @@ class ApiWorksTest extends ApiWorksTestBase {
                           | "title": "$title",
                           | "description": "$description",
                           | "workType": {
-                          |       "id": "id",
-                          |       "label": "label",
+                          |       "id": "b34r54r3",
+                          |       "label": "Dreaming dunkleosteus dancing dangerously.",
                           |       "type": "WorkType"
                           | },
                           | "lettering": "$lettering",
@@ -126,7 +126,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("should be able to render an item if the items include is present") {
+  it("renders an item if the items include is present") {
     val work = workWith(
       canonicalId = "b4heraz7",
       title = "Inside an irate igloo",
@@ -163,8 +163,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it(
-    "always includes 'items' if the items include is present, even with no items") {
+  it("includes 'items' if the items include is present, even with no items") {
     val work = workWith(
       canonicalId = "dgdb712",
       title = "Without windows or wind or washing-up liquid",
@@ -194,7 +193,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("should include credit information in API responses") {
+  it("includes credit information in API responses") {
     val location = DigitalLocation(
       locationType = "thumbnail-image",
       url = "",
@@ -255,7 +254,7 @@ class ApiWorksTest extends ApiWorksTestBase {
   }
 
   it(
-    "should return the requested page of results when requested with page & pageSize, alongside correct next/prev links ") {
+    "returns the requested page of results when requested with page & pageSize, alongside correct next/prev links ") {
     val works = createWorks(3)
 
     insertIntoElasticSearch(works: _*)
@@ -279,8 +278,8 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "title": "${works(1).title.get}",
                           |     "description": "${works(1).description.get}",
                           |     "workType" : {
-                          |        "id" : "id",
-                          |        "label" : "label",
+                          |        "id" : "h1gg5b050n",
+                          |        "label" : "Poached paleognaths picking packs of prepacked platypus.",
                           |        "type" : "WorkType"
                           |      },
                           |     "lettering": "${works(1).lettering.get}",
@@ -315,8 +314,8 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "title": "${works(0).title.get}",
                           |     "description": "${works(0).description.get}",
                           |     "workType" : {
-                          |        "id" : "id",
-                          |        "label" : "label",
+                          |        "id" : "n0s0up4u",
+                          |        "label" : "Red ruby rollerskates racing Rob Roy relentlessly.",
                           |        "type" : "WorkType"
                           |      },
                           |     "lettering": "${works(0).lettering.get}",
@@ -351,8 +350,8 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "title": "${works(2).title.get}",
                           |     "description": "${works(2).description.get}",
                           |     "workType" : {
-                          |        "id" : "id",
-                          |        "label" : "label",
+                          |        "id" : "4nyw4yw84m3",
+                          |        "label" : "Mulled molluscs masking many malign makers.",
                           |        "type" : "WorkType"
                           |      },
                           |     "lettering": "${works(2).lettering.get}",
@@ -373,7 +372,7 @@ class ApiWorksTest extends ApiWorksTestBase {
   }
 
   it(
-    "should return a BadRequest when malformed query parameters are presented") {
+    "returns a BadRequest when malformed query parameters are presented") {
     server.httpGet(
       path = s"/$apiPrefix/works?pageSize=penguin",
       andExpect = Status.BadRequest,
@@ -381,7 +380,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     )
   }
 
-  it("should ignore parameters that are unused when making an api request") {
+  it("ignores parameters that are unused when making an api request") {
     server.httpGet(
       path = s"/$apiPrefix/works?foo=bar",
       andExpect = Status.Ok,
@@ -390,7 +389,7 @@ class ApiWorksTest extends ApiWorksTestBase {
   }
 
   it(
-    "should return a not found error when requesting a single work with a non existing id") {
+    "returns a not found error when requesting a single work with a non existing id") {
     val badId = "non-existing-id"
     server.httpGet(
       path = s"/$apiPrefix/works/$badId",
@@ -400,7 +399,7 @@ class ApiWorksTest extends ApiWorksTestBase {
   }
 
   it(
-    "should return an HTTP Bad Request error if the user asks for a page size just over the maximum") {
+    "returns an HTTP Bad Request error if the user asks for a page size just over the maximum") {
     val pageSize = 101
     server.httpGet(
       path = s"/$apiPrefix/works?pageSize=$pageSize",
@@ -411,7 +410,7 @@ class ApiWorksTest extends ApiWorksTestBase {
   }
 
   it(
-    "should return an HTTP Bad Request error if the user asks for an overly large page size") {
+    "returns an HTTP Bad Request error if the user asks for an overly large page size") {
     val pageSize = 100000
     server.httpGet(
       path = s"/$apiPrefix/works?pageSize=$pageSize",
@@ -422,7 +421,7 @@ class ApiWorksTest extends ApiWorksTestBase {
   }
 
   it(
-    "should return an HTTP Bad Request error if the user asks for zero-length pages") {
+    "returns an HTTP Bad Request error if the user asks for zero-length pages") {
     val pageSize = 0
     server.httpGet(
       path = s"/$apiPrefix/works?pageSize=$pageSize",
@@ -433,7 +432,7 @@ class ApiWorksTest extends ApiWorksTestBase {
   }
 
   it(
-    "should return an HTTP Bad Request error if the user asks for a negative page size") {
+    "returns an HTTP Bad Request error if the user asks for a negative page size") {
     val pageSize = -50
     server.httpGet(
       path = s"/$apiPrefix/works?pageSize=$pageSize",
@@ -443,7 +442,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     )
   }
 
-  it("should return an HTTP Bad Request error if the user asks for page 0") {
+  it("returns an HTTP Bad Request error if the user asks for page 0") {
     server.httpGet(
       path = s"/$apiPrefix/works?page=0",
       andExpect = Status.BadRequest,
@@ -451,8 +450,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     )
   }
 
-  it(
-    "should return an HTTP Bad Request error if the user asks for a page before 0") {
+  it("returns an HTTP Bad Request error if the user asks for a page before 0") {
     server.httpGet(
       path = s"/$apiPrefix/works?page=-50",
       andExpect = Status.BadRequest,
@@ -461,8 +459,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     )
   }
 
-  it(
-    "should return multiple errors if there's more than one invalid parameter") {
+  it("returns multiple errors if there's more than one invalid parameter") {
     server.httpGet(
       path = s"/$apiPrefix/works?pageSize=-60&page=-50",
       andExpect = Status.BadRequest,
@@ -471,7 +468,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     )
   }
 
-  it("should return matching results if doing a full-text search") {
+  it("returns matching results if doing a full-text search") {
     val work1 = workWith(
       canonicalId = "1234",
       title = "A drawing of a dodo"
@@ -514,7 +511,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("should include subject information in API responses") {
+  it("includes subject information in API responses") {
     val workWithSubjects = IdentifiedWork(
       title = Some("A seal selling seaweed sandwiches in Scotland"),
       sourceIdentifier = sourceIdentifier,
@@ -550,7 +547,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("should include genre information in API responses") {
+  it("includes genre information in API responses") {
     val workWithSubjects = IdentifiedWork(
       title = Some("A guppy in a greenhouse"),
       sourceIdentifier = sourceIdentifier,
@@ -585,8 +582,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it(
-    "should include a list of identifiers on a list endpoint if we pass ?includes=identifiers") {
+  it("includes a list of identifiers on a list endpoint if we pass ?includes=identifiers") {
     val identifier1 = SourceIdentifier(
       identifierScheme = IdentifierSchemes.miroImageNumber,
       value = "Test1234"
@@ -648,8 +644,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it(
-    "should include a list of identifiers on a single work endpoint if we pass ?includes=identifiers") {
+  it("includes a list of identifiers on a single work endpoint if we pass ?includes=identifiers") {
     val srcIdentifier = SourceIdentifier(
       identifierScheme = IdentifierSchemes.miroImageNumber,
       value = "Test1234"
@@ -683,8 +678,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it(
-    "always includes 'identifiers' with the identifiers include, even if there are no identifiers") {
+  it("always includes 'identifiers' with the identifiers include, even if there are no identifiers") {
     val work = workWith(
       canonicalId = "a87na87",
       title = "Idling inkwells of indigo images",
@@ -714,8 +708,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it(
-    "should be able to look at different Elasticsearch indices based on the ?index query parameter") {
+  it("can look at different Elasticsearch indices based on the ?index query parameter") {
     val work = workWith(
       canonicalId = "1234",
       title = "A whale on a wave"
@@ -769,8 +762,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it(
-    "should be able to search different Elasticsearch indices based on the ?_index query parameter") {
+  it("can search different Elasticsearch indices based on the ?_index query parameter") {
     val work = workWith(
       canonicalId = "1234",
       title = "A wombat wallowing under a willow"
@@ -832,7 +824,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("should return a Bad Request error if asked for an invalid include") {
+  it("returns a Bad Request error if asked for an invalid include") {
     eventually {
       server.httpGet(
         path = s"/$apiPrefix/works?includes=foo",
@@ -842,8 +834,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it(
-    "should return a Bad Request error if asked for more than one invalid include") {
+  it("returns a Bad Request error if asked for more than one invalid include") {
     eventually {
       server.httpGet(
         path = s"/$apiPrefix/works?includes=foo,bar",
@@ -854,8 +845,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it(
-    "should return a Bad Request error if asked for a mixture of valid and invalid includes") {
+  it("returns a Bad Request error if asked for a mixture of valid and invalid includes") {
     eventually {
       server.httpGet(
         path = s"/$apiPrefix/works?includes=foo,identifiers,bar",
@@ -866,8 +856,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it(
-    "should return a Bad Request error if asked for an invalid include on an individual work") {
+  it("returns a Bad Request error if asked for an invalid include on an individual work") {
     eventually {
       server.httpGet(
         path = s"/$apiPrefix/works/nfdn7wac?includes=foo",
@@ -877,8 +866,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it(
-    "should include the thumbnail field if available and we use the thumbnail include") {
+  it("includes the thumbnail field if available and we use the thumbnail include") {
     val work = identifiedWorkWith(
       canonicalId = "1234",
       title = "A thorn in the thumb tells a traumatic tale",
@@ -916,7 +904,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("should not include the thumbnail if we omit the thumbnail include") {
+  it("does not include the thumbnail if we omit the thumbnail include") {
     val work = identifiedWorkWith(
       canonicalId = "5678",
       title = "An otter omitted from an occasion in Oslo",
@@ -953,7 +941,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("should return Not Found if you look up a non-existent index") {
+  it("returns Not Found if you look up a non-existent index") {
     eventually {
       server.httpGet(
         path = s"/$apiPrefix/works?_index=foobarbaz",
@@ -963,8 +951,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it(
-    "should return an Internal Server error if you try to search a malformed index") {
+  it("returns an Internal Server error if you try to search a malformed index") {
     // We need to do something that reliably triggers an internal exception
     // in the Elasticsearch handler.
     //
@@ -986,8 +973,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it(
-    "should return a Bad Request error if you try to page beyond the first 10000 works") {
+  it("returns a Bad Request error if you try to page beyond the first 10000 works") {
     val queries = List(
       "page=10000",
       "pageSize=100&page=101",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
@@ -25,6 +25,11 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "id": "${works(0).canonicalId}",
                           |     "title": "${works(0).title.get}",
                           |     "description": "${works(0).description.get}",
+                          |     "workType": {
+                          |       "id": "id",
+                          |       "label": "label",
+                          |       "type": "WorkType"
+                          |     },
                           |     "lettering": "${works(0).lettering.get}",
                           |     "createdDate": ${period(
                             works(0).createdDate.get)},
@@ -39,6 +44,11 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "id": "${works(1).canonicalId}",
                           |     "title": "${works(1).title.get}",
                           |     "description": "${works(1).description.get}",
+                          |     "workType": {
+                          |       "id": "id",
+                          |       "label": "label",
+                          |       "type": "WorkType"
+                          |     },
                           |     "lettering": "${works(1).lettering.get}",
                           |     "createdDate": ${period(
                             works(1).createdDate.get)},
@@ -53,6 +63,11 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "id": "${works(2).canonicalId}",
                           |     "title": "${works(2).title.get}",
                           |     "description": "${works(2).description.get}",
+                          |     "workType": {
+                          |       "id": "id",
+                          |       "label": "label",
+                          |       "type": "WorkType"
+                          |     },
                           |     "lettering": "${works(2).lettering.get}",
                           |     "createdDate": ${period(
                             works(2).createdDate.get)},
@@ -69,7 +84,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("should return a single work when requested with id") {
+   it("should return a single work when requested with id") {
     val work = workWith(
       canonicalId = canonicalId,
       title = title,
@@ -93,6 +108,11 @@ class ApiWorksTest extends ApiWorksTestBase {
                           | "id": "$canonicalId",
                           | "title": "$title",
                           | "description": "$description",
+                          | "workType": {
+                          |       "id": "id",
+                          |       "label": "label",
+                          |       "type": "WorkType"
+                          | },
                           | "lettering": "$lettering",
                           | "createdDate": ${period(work.createdDate.get)},
                           | "creators": [ ${agent(work.creators(0))} ],
@@ -258,6 +278,11 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "id": "${works(1).canonicalId}",
                           |     "title": "${works(1).title.get}",
                           |     "description": "${works(1).description.get}",
+                          |     "workType" : {
+                          |        "id" : "id",
+                          |        "label" : "label",
+                          |        "type" : "WorkType"
+                          |      },
                           |     "lettering": "${works(1).lettering.get}",
                           |     "createdDate": ${period(
                             works(1).createdDate.get)},
@@ -289,6 +314,11 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "id": "${works(0).canonicalId}",
                           |     "title": "${works(0).title.get}",
                           |     "description": "${works(0).description.get}",
+                          |     "workType" : {
+                          |        "id" : "id",
+                          |        "label" : "label",
+                          |        "type" : "WorkType"
+                          |      },
                           |     "lettering": "${works(0).lettering.get}",
                           |     "createdDate": ${period(
                             works(0).createdDate.get)},
@@ -320,6 +350,11 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "id": "${works(2).canonicalId}",
                           |     "title": "${works(2).title.get}",
                           |     "description": "${works(2).description.get}",
+                          |     "workType" : {
+                          |        "id" : "id",
+                          |        "label" : "label",
+                          |        "type" : "WorkType"
+                          |      },
                           |     "lettering": "${works(2).lettering.get}",
                           |     "createdDate": ${period(
                             works(2).createdDate.get)},

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
@@ -84,7 +84,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-   it("should return a single work when requested with id") {
+  it("should return a single work when requested with id") {
     val work = workWith(
       canonicalId = canonicalId,
       title = title,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
@@ -109,8 +109,8 @@ class ApiWorksTest extends ApiWorksTestBase {
                           | "title": "$title",
                           | "description": "$description",
                           | "workType": {
-                          |       "id": s"${workType.id}",
-                          |       "label": s"${workType.label}",
+                          |       "id": "${workType.id}",
+                          |       "label": "${workType.label}",
                           |       "type": "WorkType"
                           | },
                           | "lettering": "$lettering",
@@ -351,7 +351,7 @@ class ApiWorksTest extends ApiWorksTestBase {
                           |     "description": "${works(2).description.get}",
                           |     "workType" : {
                           |        "id" : "${works(2).workType.get.id}",
-                          |        "label" : "${works(2).workType.get.id}",
+                          |        "label" : "${works(2).workType.get.label}",
                           |        "type" : "WorkType"
                           |      },
                           |     "lettering": "${works(2).lettering.get}",
@@ -371,8 +371,7 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it(
-    "returns a BadRequest when malformed query parameters are presented") {
+  it("returns a BadRequest when malformed query parameters are presented") {
     server.httpGet(
       path = s"/$apiPrefix/works?pageSize=penguin",
       andExpect = Status.BadRequest,
@@ -582,7 +581,8 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("includes a list of identifiers on a list endpoint if we pass ?includes=identifiers") {
+  it(
+    "includes a list of identifiers on a list endpoint if we pass ?includes=identifiers") {
     val identifier1 = SourceIdentifier(
       identifierScheme = IdentifierSchemes.miroImageNumber,
       value = "Test1234"
@@ -644,7 +644,8 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("includes a list of identifiers on a single work endpoint if we pass ?includes=identifiers") {
+  it(
+    "includes a list of identifiers on a single work endpoint if we pass ?includes=identifiers") {
     val srcIdentifier = SourceIdentifier(
       identifierScheme = IdentifierSchemes.miroImageNumber,
       value = "Test1234"
@@ -678,7 +679,8 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("always includes 'identifiers' with the identifiers include, even if there are no identifiers") {
+  it(
+    "always includes 'identifiers' with the identifiers include, even if there are no identifiers") {
     val work = workWith(
       canonicalId = "a87na87",
       title = "Idling inkwells of indigo images",
@@ -708,7 +710,8 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("can look at different Elasticsearch indices based on the ?index query parameter") {
+  it(
+    "can look at different Elasticsearch indices based on the ?index query parameter") {
     val work = workWith(
       canonicalId = "1234",
       title = "A whale on a wave"
@@ -762,7 +765,8 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("can search different Elasticsearch indices based on the ?_index query parameter") {
+  it(
+    "can search different Elasticsearch indices based on the ?_index query parameter") {
     val work = workWith(
       canonicalId = "1234",
       title = "A wombat wallowing under a willow"
@@ -845,7 +849,8 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("returns a Bad Request error if asked for a mixture of valid and invalid includes") {
+  it(
+    "returns a Bad Request error if asked for a mixture of valid and invalid includes") {
     eventually {
       server.httpGet(
         path = s"/$apiPrefix/works?includes=foo,identifiers,bar",
@@ -856,7 +861,8 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("returns a Bad Request error if asked for an invalid include on an individual work") {
+  it(
+    "returns a Bad Request error if asked for an invalid include on an individual work") {
     eventually {
       server.httpGet(
         path = s"/$apiPrefix/works/nfdn7wac?includes=foo",
@@ -866,7 +872,8 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("includes the thumbnail field if available and we use the thumbnail include") {
+  it(
+    "includes the thumbnail field if available and we use the thumbnail include") {
     val work = identifiedWorkWith(
       canonicalId = "1234",
       title = "A thorn in the thumb tells a traumatic tale",
@@ -973,7 +980,8 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("returns a Bad Request error if you try to page beyond the first 10000 works") {
+  it(
+    "returns a Bad Request error if you try to page beyond the first 10000 works") {
     val queries = List(
       "page=10000",
       "pageSize=100&page=101",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestInvisible.scala
@@ -50,6 +50,11 @@ class ApiWorksTestInvisible extends ApiWorksTestBase {
           |     "id": "${works(0).canonicalId}",
           |     "title": "${works(0).title.get}",
           |     "description": "${works(0).description.get}",
+          |     "workType": {
+          |       "id": "id",
+          |       "label": "label",
+          |       "type": "WorkType"
+          |     },
           |     "lettering": "${works(0).lettering.get}",
           |     "createdDate": ${period(works(0).createdDate.get)},
           |     "creators": [ ${agent(works(0).creators(0))} ],
@@ -63,6 +68,11 @@ class ApiWorksTestInvisible extends ApiWorksTestBase {
           |     "id": "${works(1).canonicalId}",
           |     "title": "${works(1).title.get}",
           |     "description": "${works(1).description.get}",
+          |     "workType": {
+          |       "id": "id",
+          |       "label": "label",
+          |       "type": "WorkType"
+          |     },
           |     "lettering": "${works(1).lettering.get}",
           |     "createdDate": ${period(works(1).createdDate.get)},
           |     "creators": [ ${agent(works(1).creators(0))} ],

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestInvisible.scala
@@ -51,8 +51,8 @@ class ApiWorksTestInvisible extends ApiWorksTestBase {
           |     "title": "${works(0).title.get}",
           |     "description": "${works(0).description.get}",
           |     "workType": {
-          |       "id": "id",
-          |       "label": "label",
+          |       "id": "${works(0).workType.get.id}",
+          |       "label": "${works(0).workType.get.label}",
           |       "type": "WorkType"
           |     },
           |     "lettering": "${works(0).lettering.get}",
@@ -69,8 +69,8 @@ class ApiWorksTestInvisible extends ApiWorksTestBase {
           |     "title": "${works(1).title.get}",
           |     "description": "${works(1).description.get}",
           |     "workType": {
-          |       "id": "id",
-          |       "label": "label",
+          |       "id": "${works(1).workType.get.id}",
+          |       "label": "${works(1).workType.get.label}",
           |       "type": "WorkType"
           |     },
           |     "lettering": "${works(1).lettering.get}",

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraBibData.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraBibData.scala
@@ -1,6 +1,9 @@
 package uk.ac.wellcome.transformer.source
 
-import uk.ac.wellcome.transformer.source.sierra.{Country => SierraCountry, Language => SierraLanguage}
+import uk.ac.wellcome.transformer.source.sierra.{
+  Country => SierraCountry,
+  Language => SierraLanguage
+}
 
 case class SierraBibData(
   id: String,

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraBibData.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraBibData.scala
@@ -9,6 +9,7 @@ case class SierraBibData(
   suppressed: Boolean = false,
   country: Option[Country] = None,
   lang: Option[Language] = None,
+  materialType: Option[SierraMaterialType] = None,
   fixedFields: Map[String, FixedField] = Map(),
   varFields: List[VarField] = List()
 )

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraBibData.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraBibData.scala
@@ -1,14 +1,14 @@
 package uk.ac.wellcome.transformer.source
 
-import uk.ac.wellcome.transformer.source.sierra.{Country, Language}
+import uk.ac.wellcome.transformer.source.sierra.{Country => SierraCountry, Language => SierraLanguage}
 
 case class SierraBibData(
   id: String,
   title: Option[String] = None,
   deleted: Boolean = false,
   suppressed: Boolean = false,
-  country: Option[Country] = None,
-  lang: Option[Language] = None,
+  country: Option[SierraCountry] = None,
+  lang: Option[SierraLanguage] = None,
   materialType: Option[SierraMaterialType] = None,
   fixedFields: Map[String, FixedField] = Map(),
   varFields: List[VarField] = List()

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraMaterialType.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraMaterialType.scala
@@ -1,0 +1,3 @@
+package uk.ac.wellcome.transformer.source
+
+case class SierraMaterialType(code: String, value: String)

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
@@ -15,6 +15,7 @@ class SierraTransformableTransformer
     with SierraIdentifiers
     with SierraDescription
     with SierraPhysicalDescription
+    with SierraWorkType
     with SierraExtent
     with SierraItems
     with SierraLanguage
@@ -47,6 +48,7 @@ class SierraTransformableTransformer
               ),
               version = version,
               identifiers = getIdentifiers(sierraBibData),
+              workType = getWorkType(sierraBibData),
               description = getDescription(sierraBibData),
               physicalDescription = getPhysicalDescription(sierraBibData),
               extent = getExtent(sierraBibData),

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraWorkType.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraWorkType.scala
@@ -4,6 +4,22 @@ import uk.ac.wellcome.models.WorkType
 import uk.ac.wellcome.transformer.source.SierraBibData
 
 trait SierraWorkType {
+  
+  /* Populate wwork:workType. Rules:
+  *
+  * 1. For all bibliographic records use "materialType"
+  * 2. Platform "id" is populated from "code"
+  * 3. Platform "label" is populated from "value"
+  *
+  * Example:
+  *  "workType": {
+  *     "id": "e-book",
+  *     "type": "WorkType",
+  *     "label": "E-books"
+  *     },
+  *
+  * Note: will map to a controlled vocabulary terms in future
+  */
   def getWorkType(bibData: SierraBibData): Option[WorkType] =
     bibData.materialType.map { t =>
       WorkType(id = t.code, label = t.value)

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraWorkType.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraWorkType.scala
@@ -1,0 +1,11 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+import uk.ac.wellcome.models.WorkType
+import uk.ac.wellcome.transformer.source.SierraBibData
+
+trait SierraWorkType {
+  def getWorkType(bibData: SierraBibData): Option[WorkType] =
+    bibData.materialType.map { t =>
+      WorkType(id = t.code, label = t.value)
+    }
+}

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraWorkType.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraWorkType.scala
@@ -4,22 +4,22 @@ import uk.ac.wellcome.models.WorkType
 import uk.ac.wellcome.transformer.source.SierraBibData
 
 trait SierraWorkType {
-  
+
   /* Populate wwork:workType. Rules:
-  *
-  * 1. For all bibliographic records use "materialType"
-  * 2. Platform "id" is populated from "code"
-  * 3. Platform "label" is populated from "value"
-  *
-  * Example:
-  *  "workType": {
-  *     "id": "e-book",
-  *     "type": "WorkType",
-  *     "label": "E-books"
-  *     },
-  *
-  * Note: will map to a controlled vocabulary terms in future
-  */
+   *
+   * 1. For all bibliographic records use "materialType"
+   * 2. Platform "id" is populated from "code"
+   * 3. Platform "label" is populated from "value"
+   *
+   * Example:
+   *  "workType": {
+   *     "id": "e-book",
+   *     "type": "WorkType",
+   *     "label": "E-books"
+   *     },
+   *
+   * Note: will map to a controlled vocabulary terms in future
+   */
   def getWorkType(bibData: SierraBibData): Option[WorkType] =
     bibData.materialType.map { t =>
       WorkType(id = t.code, label = t.value)

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -498,7 +498,8 @@ class SierraTransformableTransformerTest
   it("includes the work type, if present") {
     val id = "6547529"
     val workTypeId = "xxx"
-    val workTypeValue = "A parchment of penguin pemmican pierced playfully with pencils."
+    val workTypeValue =
+      "A parchment of penguin pemmican pierced playfully with pencils."
 
     val workType = WorkType(
       id = workTypeId,
@@ -527,8 +528,7 @@ class SierraTransformableTransformerTest
       transformer.transform(sierraTransformable, version = 1)
     transformedSierraRecord.isSuccess shouldBe true
 
-    transformedSierraRecord.get.get.workType shouldBe Some(
-      workType)
+    transformedSierraRecord.get.get.workType shouldBe Some(workType)
   }
 
   it("uses the full Sierra system number as the source identifier") {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -495,6 +495,42 @@ class SierraTransformableTransformerTest
 
   }
 
+  it("includes the work type, if present") {
+    val id = "6547529"
+    val workTypeId = "xxx"
+    val workTypeValue = "A parchment of penguin pemmican pierced playfully with pencils."
+
+    val workType = WorkType(
+      id = workTypeId,
+      label = workTypeValue
+    )
+
+    val data =
+      s"""
+         | {
+         |   "id": "$id",
+         |   "title": "Doddering dinosaurs are daring in dance",
+         |    "materialType": {
+         |      "code": "$workTypeId",
+         |      "value": "$workTypeValue"
+         |    },
+         |   "varFields": []
+         | }
+      """.stripMargin
+
+    val sierraTransformable = SierraTransformable(
+      sourceId = id,
+      maybeBibData =
+        Some(SierraBibRecord(id = id, data = data, modifiedDate = now())))
+
+    val transformedSierraRecord =
+      transformer.transform(sierraTransformable, version = 1)
+    transformedSierraRecord.isSuccess shouldBe true
+
+    transformedSierraRecord.get.get.workType shouldBe Some(
+      workType)
+  }
+
   it("uses the full Sierra system number as the source identifier") {
     val id = "9000009"
     val sierraTransformable = SierraTransformable(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraWorkTypeTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraWorkTypeTest.scala
@@ -1,0 +1,34 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.WorkType
+import uk.ac.wellcome.transformer.source.{SierraBibData, SierraMaterialType}
+
+
+class SierraWorkTypeTest extends FunSpec with Matchers {
+
+  val transformer = new SierraWorkType {}
+
+  it("should extract WorkType from bib records") {
+
+    val workTypeId = "workTypeCode"
+    val sierraValue = "Sierra Material Type Label"
+
+    val bibData = SierraBibData(
+      id = "b1234567",
+      title = Some("A trifle of tangy tangerine tigers"),
+      materialType = Some(SierraMaterialType(
+        code = workTypeId,
+        value = sierraValue
+      ))
+    )
+
+    val expectedWorkType= WorkType(
+      id = workTypeId,
+      label = sierraValue
+    )
+
+    transformer.getWorkType(bibData = bibData) shouldBe Some(
+      expectedWorkType)
+  }
+}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraWorkTypeTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraWorkTypeTest.scala
@@ -4,7 +4,6 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.WorkType
 import uk.ac.wellcome.transformer.source.{SierraBibData, SierraMaterialType}
 
-
 class SierraWorkTypeTest extends FunSpec with Matchers {
 
   val transformer = new SierraWorkType {}
@@ -17,18 +16,18 @@ class SierraWorkTypeTest extends FunSpec with Matchers {
     val bibData = SierraBibData(
       id = "b1234567",
       title = Some("A trifle of tangy tangerine tigers"),
-      materialType = Some(SierraMaterialType(
-        code = workTypeId,
-        value = sierraValue
-      ))
+      materialType = Some(
+        SierraMaterialType(
+          code = workTypeId,
+          value = sierraValue
+        ))
     )
 
-    val expectedWorkType= WorkType(
+    val expectedWorkType = WorkType(
       id = workTypeId,
       label = sierraValue
     )
 
-    transformer.getWorkType(bibData = bibData) shouldBe Some(
-      expectedWorkType)
+    transformer.getWorkType(bibData = bibData) shouldBe Some(expectedWorkType)
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -8,6 +8,7 @@ trait Work extends Versioned with Identifiable {
   val sourceIdentifier: SourceIdentifier
   val version: Int
   val identifiers: List[SourceIdentifier]
+  val workType: Option[WorkType]
   val description: Option[String]
   val physicalDescription: Option[String]
   val extent: Option[String]
@@ -28,6 +29,7 @@ case class UnidentifiedWork(title: Option[String],
                             sourceIdentifier: SourceIdentifier,
                             version: Int,
                             identifiers: List[SourceIdentifier] = List(),
+                            workType: Option[WorkType] = None,
                             description: Option[String] = None,
                             physicalDescription: Option[String] = None,
                             extent: Option[String] = None,
@@ -51,6 +53,7 @@ case class IdentifiedWork(canonicalId: String,
                           sourceIdentifier: SourceIdentifier,
                           version: Int,
                           identifiers: List[SourceIdentifier] = List(),
+                          workType: Option[WorkType] = None,
                           description: Option[String] = None,
                           physicalDescription: Option[String] = None,
                           extent: Option[String] = None,

--- a/common/src/main/scala/uk/ac/wellcome/models/WorkType.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/WorkType.scala
@@ -1,0 +1,6 @@
+package uk.ac.wellcome.models
+
+case class WorkType(
+                     id: String,
+                     label: String,
+                     ontologyType: String = "WorkType")

--- a/common/src/main/scala/uk/ac/wellcome/models/WorkType.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/WorkType.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.models
 
-case class WorkType(
-                     id: String,
-                     label: String,
-                     ontologyType: String = "WorkType")
+case class WorkType(id: String,
+                    label: String,
+                    ontologyType: String = "WorkType")

--- a/common/src/test/scala/uk/ac/wellcome/models/IdentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/IdentifiedWorkTest.scala
@@ -48,6 +48,11 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |      "value": "value"
       |    }
       |  ],
+      |  "workType": {
+      |    "id": "id",
+      |    "label": "label",
+      |    "ontologyType" : "WorkType"
+      |  },
       |  "canonicalId": "canonicalId",
       |  "description": "description",
       |  "physicalDescription": "$physicalDescription",
@@ -156,6 +161,11 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
     label = "MIT Press"
   )
 
+  val workType = WorkType(
+    id = "id",
+    label = "label"
+  )
+
   val publishers = List(publisher)
 
   val identifiedWork = IdentifiedWork(
@@ -164,6 +174,7 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
     sourceIdentifier = identifier,
     version = 1,
     identifiers = List(identifier),
+    workType = Some(workType),
     description = Some("description"),
     physicalDescription = Some(physicalDescription),
     extent = Some(extent),

--- a/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
@@ -48,6 +48,11 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |      "value": "value"
       |    }
       |  ],
+      |  "workType": {
+      |    "id": "id",
+      |    "label": "label",
+      |    "ontologyType" : "WorkType"
+      |  },
       |  "description": "description",
       |  "physicalDescription": "$physicalDescription",
       |  "extent": "$extent",
@@ -156,11 +161,18 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
   )
 
   val publishers = List(publisher)
+
+  val workType = WorkType(
+    id = "id",
+    label = "label"
+  )
+
   val unidentifiedWork = UnidentifiedWork(
     title = Some("title"),
     sourceIdentifier = identifier,
     version = 1,
     identifiers = List(identifier),
+    workType = Some(workType),
     description = Some("description"),
     physicalDescription = Some(physicalDescription),
     extent = Some(extent),

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -88,7 +88,11 @@ case class DisplayWork(
   ) language: Option[DisplayLanguage] = None,
   visible: Boolean = true
 ) {
-  @ApiModelProperty(readOnly = true, value = "A broad, top-level description of the form of a work: namely, whether it is a printed book, archive, painting, photograph, moving image, etc.")
+  @ApiModelProperty(
+    readOnly = true,
+    value =
+      "A broad, top-level description of the form of a work: namely, whether it is a printed book, archive, painting, photograph, moving image, etc."
+  )
   @JsonProperty("type") val ontologyType: String = "Work"
 }
 

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -25,7 +25,7 @@ case class DisplayWork(
     value = "A description of specific physical characteristics of the work.") physicalDescription: Option[
     String] = None,
   @ApiModelProperty(
-    dataType = "List[uk.ac.wellcome.display.models.WorkType]",
+    dataType = "List[uk.ac.wellcome.display.models.DisplayWorkType]",
     value = "The type of work.") workType: Option[
     DisplayWorkType] = None,
   @ApiModelProperty(

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -88,7 +88,7 @@ case class DisplayWork(
   ) language: Option[DisplayLanguage] = None,
   visible: Boolean = true
 ) {
-  @ApiModelProperty(readOnly = true, value = "A type of thing")
+  @ApiModelProperty(readOnly = true, value = "A broad, top-level description of the form of a work: namely, whether it is a printed book, archive, painting, photograph, moving image, etc.")
   @JsonProperty("type") val ontologyType: String = "Work"
 }
 

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -26,8 +26,7 @@ case class DisplayWork(
     String] = None,
   @ApiModelProperty(
     dataType = "List[uk.ac.wellcome.display.models.DisplayWorkType]",
-    value = "The type of work.") workType: Option[
-    DisplayWorkType] = None,
+    value = "The type of work.") workType: Option[DisplayWorkType] = None,
   @ApiModelProperty(
     dataType = "String",
     value =

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -25,6 +25,10 @@ case class DisplayWork(
     value = "A description of specific physical characteristics of the work.") physicalDescription: Option[
     String] = None,
   @ApiModelProperty(
+    dataType = "List[uk.ac.wellcome.display.models.WorkType]",
+    value = "The type of work.") workType: Option[
+    DisplayWorkType] = None,
+  @ApiModelProperty(
     dataType = "String",
     value =
       "Number of physical pages, volumes, cassettes, total playing time, etc., of of each type of unit"
@@ -107,6 +111,7 @@ case object DisplayWork {
         if (includes.identifiers)
           Some(work.identifiers.map { DisplayIdentifier(_) })
         else None,
+      workType = work.workType.map { DisplayWorkType(_) },
       thumbnail =
         if (includes.thumbnail)
           work.thumbnail.map { DisplayLocation(_) } else None,

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWorkType.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWorkType.scala
@@ -5,8 +5,8 @@ import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.{Place, WorkType}
 
 @ApiModel(
-  value = "Place",
-  description = "A place"
+  value = "WorkType",
+  description = "A broad, top-level description of the form of a work: namely, whether it is a printed book, archive, painting, photograph, moving image, etc."
 )
 case class DisplayWorkType(
   @ApiModelProperty(

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWorkType.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWorkType.scala
@@ -1,5 +1,27 @@
 package uk.ac.wellcome.display.models
 
-class DisplayWorkType {
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.models.{Place, WorkType}
 
+@ApiModel(
+  value = "Place",
+  description = "A place"
+)
+case class DisplayWorkType (
+                         @ApiModelProperty(
+                           dataType = "String"
+                         ) id: String,
+                         @ApiModelProperty(
+                           dataType = "String"
+                         ) label: String
+                       ) {
+  @JsonProperty("type") val ontologyType: String = "WorkType"
+}
+
+case object DisplayWorkType {
+  def apply(workType: WorkType): DisplayWorkType = DisplayWorkType(
+    id = workType.id,
+    label = workType.label
+  )
 }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWorkType.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWorkType.scala
@@ -8,14 +8,14 @@ import uk.ac.wellcome.models.{Place, WorkType}
   value = "Place",
   description = "A place"
 )
-case class DisplayWorkType (
-                         @ApiModelProperty(
-                           dataType = "String"
-                         ) id: String,
-                         @ApiModelProperty(
-                           dataType = "String"
-                         ) label: String
-                       ) {
+case class DisplayWorkType(
+  @ApiModelProperty(
+    dataType = "String"
+  ) id: String,
+  @ApiModelProperty(
+    dataType = "String"
+  ) label: String
+) {
   @JsonProperty("type") val ontologyType: String = "WorkType"
 }
 

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWorkType.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWorkType.scala
@@ -1,0 +1,5 @@
+package uk.ac.wellcome.display.models
+
+class DisplayWorkType {
+
+}

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWorkType.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWorkType.scala
@@ -6,7 +6,8 @@ import uk.ac.wellcome.models.{Place, WorkType}
 
 @ApiModel(
   value = "WorkType",
-  description = "A broad, top-level description of the form of a work: namely, whether it is a printed book, archive, painting, photograph, moving image, etc."
+  description =
+    "A broad, top-level description of the form of a work: namely, whether it is a printed book, archive, painting, photograph, moving image, etc."
 )
 case class DisplayWorkType(
   @ApiModelProperty(

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/models/display/DisplayWorkTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/models/display/DisplayWorkTest.scala
@@ -151,6 +151,29 @@ class DisplayWorkTest extends FunSpec with Matchers {
     displayWork.physicalDescription shouldBe Some(physicalDescription)
   }
 
+  it("gets the workType from a Work") {
+    val workType = WorkType(
+      id = "id",
+      label = "Proud pooch pavement plops"
+    )
+
+    val expectedDisplayWork = DisplayWorkType(
+      id = workType.id,
+      label = workType.label
+    )
+
+    val work = IdentifiedWork(
+      title = Some("Moving a mighty mouse to Madagascar"),
+      canonicalId = "mtc2wvrg",
+      sourceIdentifier = sourceIdentifier,
+      workType = Some(workType),
+      version = 1
+    )
+
+    val displayWork = DisplayWork(work)
+    displayWork.workType shouldBe Some(expectedDisplayWork)
+  }
+
   it("gets the extent from a Work") {
     val extent = "Bound in boxes of bark"
 

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -41,6 +41,13 @@ class WorksIndex @Inject()(client: HttpClient,
       keywordField("value")
     )
 
+  val workType = objectField("workType")
+    .fields(
+      keywordField("ontologyType"),
+      keywordField("id"),
+      keywordField("label")
+    )
+
   def location(fieldName: String = "locations") =
     objectField(fieldName).fields(
       keywordField("type"),
@@ -90,6 +97,7 @@ class WorksIndex @Inject()(client: HttpClient,
       intField("version"),
       sourceIdentifier,
       identifiers,
+      workType,
       textField("title").fields(
         textField("english").analyzer(EnglishLanguageAnalyzer)),
       textField("description").fields(

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/ServerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/ServerTest.scala
@@ -14,7 +14,6 @@ class ServerTest
   it("it shows the healthcheck message") {
     withLocalS3Bucket { bucketName =>
       withLocalSqsQueue { queueUrl =>
-
         val flags = s3LocalFlags(bucketName) ++ sqsLocalFlags(queueUrl) ++ Map(
           "reader.resourceType" -> "bibs",
           "sierra.apiUrl" -> "http://localhost:8080",

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/ServerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/ServerTest.scala
@@ -2,18 +2,26 @@ package uk.ac.wellcome.platform.sierra_reader
 
 import com.twitter.finagle.http.Status._
 import com.twitter.inject.server.FeatureTest
+import org.scalatest.FunSpec
 import uk.ac.wellcome.test.fixtures.{S3, SqsFixtures}
 
 class ServerTest
-    extends FeatureTest
+    extends FunSpec
     with fixtures.Server
     with S3
     with SqsFixtures {
 
-  test("it shows the healthcheck message") {
+  it("it shows the healthcheck message") {
     withLocalS3Bucket { bucketName =>
       withLocalSqsQueue { queueUrl =>
-        val flags = s3LocalFlags(bucketName) ++ sqsLocalFlags(queueUrl)
+
+        val flags = s3LocalFlags(bucketName) ++ sqsLocalFlags(queueUrl) ++ Map(
+          "reader.resourceType" -> "bibs",
+          "sierra.apiUrl" -> "http://localhost:8080",
+          "sierra.oauthKey" -> "key",
+          "sierra.oauthSecret" -> "secret",
+          "sierra.fields" -> "updatedDate,deletedDate,deleted,suppressed,author,title"
+        )
 
         withServer(flags) { server =>
           server.httpGet(

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/SierraReaderFeatureTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/SierraReaderFeatureTest.scala
@@ -19,7 +19,6 @@ class SierraReaderFeatureTest
   it("reads bibs from Sierra and writes files to S3") {
     withLocalS3Bucket { bucketName =>
       withLocalSqsQueue { queueUrl =>
-
         val flags = s3LocalFlags(bucketName) ++ sqsLocalFlags(queueUrl) ++ Map(
           "reader.resourceType" -> "bibs",
           "sierra.apiUrl" -> "http://localhost:8080",

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/SierraReaderFeatureTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/SierraReaderFeatureTest.scala
@@ -19,7 +19,14 @@ class SierraReaderFeatureTest
   it("reads bibs from Sierra and writes files to S3") {
     withLocalS3Bucket { bucketName =>
       withLocalSqsQueue { queueUrl =>
-        val flags = s3LocalFlags(bucketName) ++ sqsLocalFlags(queueUrl)
+
+        val flags = s3LocalFlags(bucketName) ++ sqsLocalFlags(queueUrl) ++ Map(
+          "reader.resourceType" -> "bibs",
+          "sierra.apiUrl" -> "http://localhost:8080",
+          "sierra.oauthKey" -> "key",
+          "sierra.oauthSecret" -> "secret",
+          "sierra.fields" -> "updatedDate,deletedDate,deleted,suppressed,author,title"
+        )
 
         withServer(flags) { _ =>
           val message =

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlowTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlowTest.scala
@@ -15,7 +15,6 @@ import uk.ac.wellcome.test.utils.ExtendedPatience
 
 import scala.concurrent.ExecutionContextExecutor
 
-
 class SierraRecordWrapperFlowTest
     extends FunSpec
     with AkkaFixtures
@@ -24,10 +23,11 @@ class SierraRecordWrapperFlowTest
     with Matchers {
 
   private def withRecordWrapperFlow(
-    testWith: TestWith[(Flow[Json, SierraRecord, NotUsed], ActorSystem), Assertion]) = {
+    testWith: TestWith[(Flow[Json, SierraRecord, NotUsed], ActorSystem),
+                       Assertion]) = {
     withActorSystem { actorSystem =>
-
-      implicit val executionContext: ExecutionContextExecutor = actorSystem.dispatcher
+      implicit val executionContext: ExecutionContextExecutor =
+        actorSystem.dispatcher
 
       val wrapperFlow = SierraRecordWrapperFlow()
 
@@ -36,46 +36,48 @@ class SierraRecordWrapperFlowTest
   }
 
   it("creates a SierraRecord from a bib") {
-    withRecordWrapperFlow { case (wrapperFlow, actorSystem) =>
+    withRecordWrapperFlow {
+      case (wrapperFlow, actorSystem) =>
+        implicit val system: ActorSystem = actorSystem
+        implicit val materializer: Materializer =
+          ActorMaterializer()(actorSystem)
 
-      implicit val system: ActorSystem = actorSystem
-      implicit val materializer: Materializer = ActorMaterializer()(actorSystem)
-
-      val id = "100001"
-      val updatedDate = "2013-12-13T12:43:16Z"
-      val json = parse(s"""
+        val id = "100001"
+        val updatedDate = "2013-12-13T12:43:16Z"
+        val json = parse(s"""
         |{
         | "id": "$id",
         | "updatedDate": "$updatedDate"
         |}
       """.stripMargin).right.get
 
-      val expectedRecord = SierraRecord(
-        id = id,
-        data = json.noSpaces,
-        modifiedDate = updatedDate
-      )
+        val expectedRecord = SierraRecord(
+          id = id,
+          data = json.noSpaces,
+          modifiedDate = updatedDate
+        )
 
-      val futureRecord = Source
-        .single(json)
-        .via(wrapperFlow)
-        .runWith(Sink.head)
+        val futureRecord = Source
+          .single(json)
+          .via(wrapperFlow)
+          .runWith(Sink.head)
 
-      whenReady(futureRecord) { sierraRecord =>
-        sierraRecord shouldBe expectedRecord
-      }
+        whenReady(futureRecord) { sierraRecord =>
+          sierraRecord shouldBe expectedRecord
+        }
     }
   }
 
   it("creates a SierraRecord from an item") {
-    withRecordWrapperFlow { case (wrapperFlow, actorSystem) =>
+    withRecordWrapperFlow {
+      case (wrapperFlow, actorSystem) =>
+        implicit val system: ActorSystem = actorSystem
+        implicit val materializer: Materializer =
+          ActorMaterializer()(actorSystem)
 
-      implicit val system: ActorSystem = actorSystem
-      implicit val materializer: Materializer = ActorMaterializer()(actorSystem)
-
-      val id = "400004"
-      val updatedDate = "2014-04-14T14:14:14Z"
-      val json = parse(s"""
+        val id = "400004"
+        val updatedDate = "2014-04-14T14:14:14Z"
+        val json = parse(s"""
         |{
         | "id": "$id",
         | "updatedDate": "$updatedDate",
@@ -83,74 +85,76 @@ class SierraRecordWrapperFlowTest
         |}
       """.stripMargin).right.get
 
-      val expectedRecord = SierraRecord(
-        id = id,
-        data = json.noSpaces,
-        modifiedDate = updatedDate
-      )
+        val expectedRecord = SierraRecord(
+          id = id,
+          data = json.noSpaces,
+          modifiedDate = updatedDate
+        )
 
-      val futureRecord = Source
-        .single(json)
-        .via(wrapperFlow)
-        .runWith(Sink.head)
+        val futureRecord = Source
+          .single(json)
+          .via(wrapperFlow)
+          .runWith(Sink.head)
 
-      whenReady(futureRecord) { sierraRecord =>
-        sierraRecord shouldBe expectedRecord
-      }
+        whenReady(futureRecord) { sierraRecord =>
+          sierraRecord shouldBe expectedRecord
+        }
     }
   }
 
   it("is able to handle deleted bibs") {
-    withRecordWrapperFlow { case (wrapperFlow, actorSystem) =>
+    withRecordWrapperFlow {
+      case (wrapperFlow, actorSystem) =>
+        implicit val system: ActorSystem = actorSystem
+        implicit val materializer: Materializer =
+          ActorMaterializer()(actorSystem)
 
-      implicit val system: ActorSystem = actorSystem
-      implicit val materializer: Materializer = ActorMaterializer()(actorSystem)
-
-      val id = "1357947"
-      val deletedDate = "2014-01-31"
-      val json = parse(s"""{
+        val id = "1357947"
+        val deletedDate = "2014-01-31"
+        val json = parse(s"""{
                           |  "id" : "$id",
                           |  "deletedDate" : "$deletedDate",
                           |  "deleted" : true
                           |}""".stripMargin).right.get
 
-      val expectedRecord = SierraRecord(
-        id = id,
-        data = json.noSpaces,
-        modifiedDate = s"${deletedDate}T00:00:00Z"
-      )
+        val expectedRecord = SierraRecord(
+          id = id,
+          data = json.noSpaces,
+          modifiedDate = s"${deletedDate}T00:00:00Z"
+        )
 
-      val futureRecord = Source
-        .single(json)
-        .via(wrapperFlow)
-        .runWith(Sink.head)
+        val futureRecord = Source
+          .single(json)
+          .via(wrapperFlow)
+          .runWith(Sink.head)
 
-      whenReady(futureRecord) { sierraRecord =>
-        sierraRecord shouldBe expectedRecord
-      }
+        whenReady(futureRecord) { sierraRecord =>
+          sierraRecord shouldBe expectedRecord
+        }
     }
   }
 
   it("fails the stream if the record contains invalid JSON") {
-    withRecordWrapperFlow { case (wrapperFlow, actorSystem) =>
+    withRecordWrapperFlow {
+      case (wrapperFlow, actorSystem) =>
+        implicit val system: ActorSystem = actorSystem
+        implicit val materializer: Materializer =
+          ActorMaterializer()(actorSystem)
 
-      implicit val system: ActorSystem = actorSystem
-      implicit val materializer: Materializer = ActorMaterializer()(actorSystem)
-
-      val invalidSierraJson = parse(s"""{
+        val invalidSierraJson = parse(s"""{
         | "missing": ["id", "updatedDate"],
         | "reason": "This JSON will not pass!",
         |  "comment": "XML is coming!"
         |}""".stripMargin).right.get
 
-      val futureUnit = Source
-        .single(invalidSierraJson)
-        .via(wrapperFlow)
-        .runWith(Sink.head)
+        val futureUnit = Source
+          .single(invalidSierraJson)
+          .via(wrapperFlow)
+          .runWith(Sink.head)
 
-      whenReady(futureUnit.failed) { _ =>
-        true shouldBe true
-      }
+        whenReady(futureUnit.failed) { _ =>
+          true shouldBe true
+        }
     }
   }
 }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -25,7 +25,6 @@ import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
 
 import collection.JavaConversions._
 
-
 class SierraReaderWorkerServiceTest
     extends FunSpec
     with MockitoSugar
@@ -49,7 +48,9 @@ class SierraReaderWorkerServiceTest
       mockCloudWatch,
       ActorSystem())
 
-  case class FixtureParams(worker: SierraReaderWorkerService, queueUrl: String, bucketName: String)
+  case class FixtureParams(worker: SierraReaderWorkerService,
+                           queueUrl: String,
+                           bucketName: String)
 
   def withSierraReaderWorkerService(
     fields: String,
@@ -118,7 +119,8 @@ class SierraReaderWorkerServiceTest
         "windows_bibs_complete/2013-12-10T17-16-35Z__2013-12-13T21-34-35Z")
 
       eventually {
-        val objects = s3Client.listObjects(fixtures.bucketName).getObjectSummaries
+        val objects =
+          s3Client.listObjects(fixtures.bucketName).getObjectSummaries
 
         // there are 29 bib updates in the sierra wiremock so we expect 3 files
         objects.map { _.getKey() } shouldBe pageNames
@@ -161,7 +163,8 @@ class SierraReaderWorkerServiceTest
         "windows_items_complete/2013-12-10T17-16-35Z__2013-12-13T21-34-35Z")
 
       eventually {
-        val objects = s3Client.listObjects(fixtures.bucketName).getObjectSummaries
+        val objects =
+          s3Client.listObjects(fixtures.bucketName).getObjectSummaries
 
         // There are 157 item records in the Sierra wiremock so we expect 4 files
         objects.map { _.getKey() } shouldBe pageNames
@@ -223,7 +226,8 @@ class SierraReaderWorkerServiceTest
         "windows_items_complete/2013-12-10T17-16-35Z__2013-12-13T21-34-35Z")
 
       eventually {
-        val objects = s3Client.listObjects(fixtures.bucketName).getObjectSummaries
+        val objects =
+          s3Client.listObjects(fixtures.bucketName).getObjectSummaries
 
         // There are 157 item records in the Sierra wiremock so we expect 4 files
         objects.map { _.getKey() } shouldBe pageNames
@@ -239,7 +243,8 @@ class SierraReaderWorkerServiceTest
     }
   }
 
-  private def getRecordsFromS3(bucketName: String, key: String): List[SierraRecord] =
+  private def getRecordsFromS3(bucketName: String,
+                               key: String): List[SierraRecord] =
     fromJson[List[SierraRecord]](getContentFromS3(bucketName, key)).get
 
   it(

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -23,6 +23,9 @@ import scala.concurrent.duration._
 import org.scalatest.compatible.Assertion
 import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
 
+import collection.JavaConversions._
+
+
 class SierraReaderWorkerServiceTest
     extends FunSpec
     with MockitoSugar
@@ -46,7 +49,7 @@ class SierraReaderWorkerServiceTest
       mockCloudWatch,
       ActorSystem())
 
-  case class FixtureParams(worker: SierraReaderWorkerService, queueUrl: String)
+  case class FixtureParams(worker: SierraReaderWorkerService, queueUrl: String, bucketName: String)
 
   def withSierraReaderWorkerService(
     fields: String,
@@ -74,7 +77,7 @@ class SierraReaderWorkerServiceTest
           )
 
           try {
-            testWith(FixtureParams(worker, queueUrl))
+            testWith(FixtureParams(worker, queueUrl, bucketName))
           } finally {
             worker.stop()
           }
@@ -115,14 +118,14 @@ class SierraReaderWorkerServiceTest
         "windows_bibs_complete/2013-12-10T17-16-35Z__2013-12-13T21-34-35Z")
 
       eventually {
-        val objects = s3Client.listObjects(bucketName).getObjectSummaries
+        val objects = s3Client.listObjects(fixtures.bucketName).getObjectSummaries
 
         // there are 29 bib updates in the sierra wiremock so we expect 3 files
         objects.map { _.getKey() } shouldBe pageNames
 
-        getRecordsFromS3(pageNames(0)) should have size 10
-        getRecordsFromS3(pageNames(1)) should have size 10
-        getRecordsFromS3(pageNames(2)) should have size 9
+        getRecordsFromS3(fixtures.bucketName, pageNames(0)) should have size 10
+        getRecordsFromS3(fixtures.bucketName, pageNames(1)) should have size 10
+        getRecordsFromS3(fixtures.bucketName, pageNames(2)) should have size 9
       }
     }
   }
@@ -158,15 +161,15 @@ class SierraReaderWorkerServiceTest
         "windows_items_complete/2013-12-10T17-16-35Z__2013-12-13T21-34-35Z")
 
       eventually {
-        val objects = s3Client.listObjects(bucketName).getObjectSummaries
+        val objects = s3Client.listObjects(fixtures.bucketName).getObjectSummaries
 
         // There are 157 item records in the Sierra wiremock so we expect 4 files
         objects.map { _.getKey() } shouldBe pageNames
 
-        getRecordsFromS3(pageNames(0)) should have size 50
-        getRecordsFromS3(pageNames(1)) should have size 50
-        getRecordsFromS3(pageNames(2)) should have size 50
-        getRecordsFromS3(pageNames(3)) should have size 7
+        getRecordsFromS3(fixtures.bucketName, pageNames(0)) should have size 50
+        getRecordsFromS3(fixtures.bucketName, pageNames(1)) should have size 50
+        getRecordsFromS3(fixtures.bucketName, pageNames(2)) should have size 50
+        getRecordsFromS3(fixtures.bucketName, pageNames(3)) should have size 7
       }
     }
   }
@@ -180,9 +183,9 @@ class SierraReaderWorkerServiceTest
       val prefix = "records_items/2013-12-10T17-16-35Z__2013-12-13T21-34-35Z"
 
       // First we pre-populate S3 with files as if they'd come from a prior run of the reader.
-      s3Client.putObject(bucketName, s"$prefix/0000.json", "[]")
+      s3Client.putObject(fixtures.bucketName, s"$prefix/0000.json", "[]")
       s3Client.putObject(
-        bucketName,
+        fixtures.bucketName,
         s"$prefix/0001.json",
         """
           |[
@@ -220,23 +223,23 @@ class SierraReaderWorkerServiceTest
         "windows_items_complete/2013-12-10T17-16-35Z__2013-12-13T21-34-35Z")
 
       eventually {
-        val objects = s3Client.listObjects(bucketName).getObjectSummaries
+        val objects = s3Client.listObjects(fixtures.bucketName).getObjectSummaries
 
         // There are 157 item records in the Sierra wiremock so we expect 4 files
         objects.map { _.getKey() } shouldBe pageNames
 
         // These two files were pre-populated -- we check the reader hasn't overwritten these
-        getRecordsFromS3(pageNames(0)) should have size 0
-        getRecordsFromS3(pageNames(1)) should have size 1
+        getRecordsFromS3(fixtures.bucketName, pageNames(0)) should have size 0
+        getRecordsFromS3(fixtures.bucketName, pageNames(1)) should have size 1
 
         // We check the reader has filled these in correctly
-        getRecordsFromS3(pageNames(2)) should have size 50
-        getRecordsFromS3(pageNames(3)) should have size 7
+        getRecordsFromS3(fixtures.bucketName, pageNames(2)) should have size 50
+        getRecordsFromS3(fixtures.bucketName, pageNames(3)) should have size 7
       }
     }
   }
 
-  private def getRecordsFromS3(key: String): List[SierraRecord] =
+  private def getRecordsFromS3(bucketName: String, key: String): List[SierraRecord] =
     fromJson[List[SierraRecord]](getContentFromS3(bucketName, key)).get
 
   it(


### PR DESCRIPTION
### What is this PR trying to achieve?

Part of https://github.com/wellcometrust/platform/issues/1682. Resolves #787.

TODO: 
- [x] Update API tests

### Who is this change for?

🤘 ⭕️ 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.

Transformation checklist:

- [x] Added any new fields to Work/Item (and the unidentified/identified variants)
- [x] Update the JSON serialisation tests in [Un]IdentifiedWorkTest
- [x] Implemented the new transformation
- [x] Added any new fields to the Elasticsearch mapping
- [x] Updated the Display models in the API