### PR TITLE
Clean up IdentifierSchemes.scala

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/IdentifierSchemes.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/IdentifierSchemes.scala
@@ -8,15 +8,6 @@ import cats.syntax.either._
   *  the strings that will be presented to users of the API.
   */
 object IdentifierSchemes extends Logging {
-  private final val knownIdentifierSchemes = Seq(
-    miroImageNumber,
-    miroLibraryReference,
-    calmPlaceholder,
-    calmAltRefNo,
-    sierraSystemNumber,
-    sierraIdentifier,
-    marcCountries)
-
   sealed trait IdentifierScheme
 
   // Corresponds to the image number in Miro, e.g. V00127563.
@@ -59,6 +50,15 @@ object IdentifierSchemes extends Logging {
   case object marcCountries extends IdentifierScheme {
     override def toString: String = "marc-countries"
   }
+
+  private final val knownIdentifierSchemes = Seq(
+    miroImageNumber,
+    miroLibraryReference,
+    calmPlaceholder,
+    calmAltRefNo,
+    sierraSystemNumber,
+    sierraIdentifier,
+    marcCountries)
 
   private def createIdentifierScheme(
     identifierScheme: String): IdentifierSchemes.IdentifierScheme = {

--- a/common/src/main/scala/uk/ac/wellcome/models/IdentifierSchemes.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/IdentifierSchemes.scala
@@ -8,7 +8,7 @@ import cats.syntax.either._
   *  the strings that will be presented to users of the API.
   */
 object IdentifierSchemes extends Logging {
-  final val identifierSchemes = Seq(
+  private final val knownIdentifierSchemes = Seq(
     miroImageNumber,
     miroLibraryReference,
     calmPlaceholder,
@@ -60,28 +60,16 @@ object IdentifierSchemes extends Logging {
     override def toString: String = "marc-countries"
   }
 
-  def createIdentifierScheme(
+  private def createIdentifierScheme(
     identifierScheme: String): IdentifierSchemes.IdentifierScheme = {
-    identifierScheme match {
-      case s: String if s == IdentifierSchemes.miroImageNumber.toString =>
-        IdentifierSchemes.miroImageNumber
-      case s: String if s == IdentifierSchemes.sierraSystemNumber.toString =>
-        IdentifierSchemes.sierraSystemNumber
-      case s: String if s == IdentifierSchemes.sierraIdentifier.toString =>
-        IdentifierSchemes.sierraIdentifier
-      case s: String if s == IdentifierSchemes.calmAltRefNo.toString =>
-        IdentifierSchemes.calmAltRefNo
-      case s: String if s == IdentifierSchemes.calmPlaceholder.toString =>
-        IdentifierSchemes.calmPlaceholder
-      case s: String if s == IdentifierSchemes.miroLibraryReference.toString =>
-        IdentifierSchemes.miroLibraryReference
-      case s: String if s == IdentifierSchemes.marcCountries.toString =>
-        IdentifierSchemes.marcCountries
-      case identifierScheme =>
-        val errorMessage = s"$identifierScheme is not a valid identifierScheme"
-        error(errorMessage)
-        throw new Exception(errorMessage)
-    }
+      knownIdentifierSchemes
+        .filter { _.toString == identifierScheme }
+        .headOption
+        .getOrElse {
+          val errorMessage = s"$identifierScheme is not a valid identifierScheme"
+          error(errorMessage)
+          throw new Exception(errorMessage)
+        }
   }
 
   implicit val identifierSchemesDecoder

--- a/common/src/main/scala/uk/ac/wellcome/models/IdentifierSchemes.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/IdentifierSchemes.scala
@@ -1,35 +1,8 @@
 package uk.ac.wellcome.models
 
-import com.fasterxml.jackson.core.{JsonGenerator, JsonParser}
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.annotation.{
-  JsonDeserialize,
-  JsonSerialize
-}
 import com.twitter.inject.Logging
 import io.circe.{Decoder, Encoder, HCursor, Json}
 import cats.syntax.either._
-
-class IdentifierSchemeDeserialiser
-    extends JsonDeserializer[IdentifierSchemes.IdentifierScheme] {
-
-  override def deserialize(
-    p: JsonParser,
-    ctxt: DeserializationContext): IdentifierSchemes.IdentifierScheme = {
-    val node: JsonNode = p.getCodec.readTree(p)
-    val identifierScheme = node.asText()
-    IdentifierSchemes.createIdentifierScheme(identifierScheme)
-  }
-}
-
-class IdentifierSchemeSerialiser
-    extends JsonSerializer[IdentifierSchemes.IdentifierScheme] {
-  override def serialize(value: IdentifierSchemes.IdentifierScheme,
-                         gen: JsonGenerator,
-                         serializers: SerializerProvider): Unit = {
-    gen.writeString(value.toString)
-  }
-}
 
 /** This is the canonical version of our identifier schemes.  This contains
   *  the strings that will be presented to users of the API.
@@ -41,11 +14,11 @@ object IdentifierSchemes extends Logging {
     calmPlaceholder,
     calmAltRefNo,
     sierraSystemNumber,
+    sierraIdentifier,
     marcCountries)
 
-  @JsonDeserialize(using = classOf[IdentifierSchemeDeserialiser])
-  @JsonSerialize(using = classOf[IdentifierSchemeSerialiser])
   sealed trait IdentifierScheme
+
   // Corresponds to the image number in Miro, e.g. V00127563.
   case object miroImageNumber extends IdentifierScheme {
     override def toString: String = "miro-image-number"

--- a/common/src/main/scala/uk/ac/wellcome/models/IdentifierSchemes.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/IdentifierSchemes.scala
@@ -62,14 +62,14 @@ object IdentifierSchemes extends Logging {
 
   private def createIdentifierScheme(
     identifierScheme: String): IdentifierSchemes.IdentifierScheme = {
-      knownIdentifierSchemes
-        .filter { _.toString == identifierScheme }
-        .headOption
-        .getOrElse {
-          val errorMessage = s"$identifierScheme is not a valid identifierScheme"
-          error(errorMessage)
-          throw new Exception(errorMessage)
-        }
+    knownIdentifierSchemes
+      .filter { _.toString == identifierScheme }
+      .headOption
+      .getOrElse {
+        val errorMessage = s"$identifierScheme is not a valid identifierScheme"
+        error(errorMessage)
+        throw new Exception(errorMessage)
+      }
   }
 
   implicit val identifierSchemesDecoder

--- a/common/src/test/scala/uk/ac/wellcome/models/IdentifierSchemesTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/IdentifierSchemesTest.scala
@@ -7,7 +7,8 @@ import uk.ac.wellcome.test.utils.JsonTestUtil
 class IdentifierSchemesTest extends FunSpec with Matchers with JsonTestUtil {
 
   it("serialises a known identifier scheme to JSON") {
-    val data: Map[String, IdentifierSchemes.IdentifierScheme] = Map("scheme" -> IdentifierSchemes.miroImageNumber)
+    val data: Map[String, IdentifierSchemes.IdentifierScheme] =
+      Map("scheme" -> IdentifierSchemes.miroImageNumber)
     val expectedJsonString = """{"scheme": "miro-image-number"}"""
     val actualJsonString = toJson(data).get
 
@@ -17,7 +18,8 @@ class IdentifierSchemesTest extends FunSpec with Matchers with JsonTestUtil {
   it("deserialises a known identifier scheme from JSON") {
     val jsonString = """{"scheme": "sierra-identifier"}"""
     val expectedData = Map("scheme" -> IdentifierSchemes.sierraIdentifier)
-    val actualData = fromJson[Map[String, IdentifierSchemes.IdentifierScheme]](jsonString).get
+    val actualData =
+      fromJson[Map[String, IdentifierSchemes.IdentifierScheme]](jsonString).get
 
     actualData shouldBe expectedData
   }

--- a/common/src/test/scala/uk/ac/wellcome/models/IdentifierSchemesTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/IdentifierSchemesTest.scala
@@ -1,0 +1,34 @@
+package uk.ac.wellcome.models
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.utils.JsonUtil._
+import uk.ac.wellcome.test.utils.JsonTestUtil
+
+class IdentifierSchemesTest extends FunSpec with Matchers with JsonTestUtil {
+
+  it("serialises a known identifier scheme to JSON") {
+    val data: Map[String, IdentifierSchemes.IdentifierScheme] = Map("scheme" -> IdentifierSchemes.miroImageNumber)
+    val expectedJsonString = """{"scheme": "miro-image-number"}"""
+    val actualJsonString = toJson(data).get
+
+    assertJsonStringsAreEqual(expectedJsonString, actualJsonString)
+  }
+
+  it("deserialises a known identifier scheme from JSON") {
+    val jsonString = """{"scheme": "sierra-identifier"}"""
+    val expectedData = Map("scheme" -> IdentifierSchemes.sierraIdentifier)
+    val actualData = fromJson[Map[String, IdentifierSchemes.IdentifierScheme]](jsonString).get
+
+    actualData shouldBe expectedData
+  }
+
+  it("throws an error if asked to deserialise an unknown identifier scheme") {
+    val jsonString = """{"scheme": "unknown-identifier-scheme"}"""
+
+    val caught = intercept[Exception] {
+      fromJson[Map[String, IdentifierSchemes.IdentifierScheme]](jsonString)
+    }
+
+    caught.getMessage shouldEqual "unknown-identifier-scheme is not a valid identifierScheme"
+  }
+}

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayIdentifier.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayIdentifier.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.display.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models._
+import uk.ac.wellcome.models.SourceIdentifier
 
 @ApiModel(
   value = "Identifier",
@@ -11,7 +11,7 @@ import uk.ac.wellcome.models._
 )
 case class DisplayIdentifier(
   @ApiModelProperty(value =
-    "Relates a Identifier to a particular authoritative source identifier scheme: for example, if the identifier is MS.49 this property might indicate that this identifier has its origins in the Wellcome Library's CALM archive management system.") identifierScheme: IdentifierSchemes.IdentifierScheme,
+    "Relates a Identifier to a particular authoritative source identifier scheme: for example, if the identifier is MS.49 this property might indicate that this identifier has its origins in the Wellcome Library's CALM archive management system.") identifierScheme: String,
   @ApiModelProperty(value = "The value of the thing. e.g. an identifier") value: String) {
   @ApiModelProperty(readOnly = true, value = "A type of thing")
   @JsonProperty("type") val ontologyType: String = "Identifier"
@@ -20,6 +20,6 @@ case class DisplayIdentifier(
 object DisplayIdentifier {
   def apply(sourceIdentifier: SourceIdentifier): DisplayIdentifier =
     DisplayIdentifier(
-      identifierScheme = sourceIdentifier.identifierScheme,
+      identifierScheme = sourceIdentifier.identifierScheme.toString,
       value = sourceIdentifier.value)
 }


### PR DESCRIPTION
While staring at IdentifierSchemes.scala right now, I spotted some things we could simplify.

* Get rid of the Jackson-related code – Jackson never uses this internal model
* Add some tests for this model
* Simplify the horrible switch statement used for JSON deserialisation
* Reduce the number of places where you need to define a new identifier