### PR TITLE
Account for at least once message delivery

### DIFF
--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
@@ -60,7 +60,7 @@ class SierraTransformerFeatureTest
           withServer(flags) { _ =>
             eventually {
               val snsMessages = listMessagesReceivedFromSNS(topicArn)
-              snsMessages should have size 1
+              snsMessages.size should be >= 1
 
               val sourceIdentifier = SourceIdentifier(
                 identifierScheme = IdentifierSchemes.sierraSystemNumber,
@@ -72,16 +72,18 @@ class SierraTransformerFeatureTest
                 value = id
               )
 
-              val actualWork =
-                JsonUtil
-                  .fromJson[UnidentifiedWork](snsMessages.head.message)
-                  .get
+              snsMessages.map { snsMessage =>
+                val actualWork =
+                  JsonUtil
+                    .fromJson[UnidentifiedWork](snsMessage.message)
+                    .get
 
-              actualWork.sourceIdentifier shouldBe sourceIdentifier
-              actualWork.title shouldBe Some(title)
-              actualWork.identifiers shouldBe List(
-                sourceIdentifier,
-                sierraIdentifier)
+                actualWork.sourceIdentifier shouldBe sourceIdentifier
+                actualWork.title shouldBe Some(title)
+                actualWork.identifiers shouldBe List(
+                  sourceIdentifier,
+                  sierraIdentifier)
+              }
             }
           }
         }


### PR DESCRIPTION
### What is this PR trying to achieve?

I've seen this transformer test behave unreliably even though it is isolated. It appears that elasticmq (the container providing FakeSQS) adheres to the same "at least once" delivery guarantee that SQS does. As a consequences messages may be delivered more than once (and this behaviour is _expected_) so the tests need to account for that.

This could also explain reliability issues elsewhere!

### Who is this change for?

🎲 👾 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.