### PR TITLE
Add the transformation for language

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/Country.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/Country.scala
@@ -1,3 +1,0 @@
-package uk.ac.wellcome.transformer.source
-
-case class Country(code: String, name: String)

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraBibData.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraBibData.scala
@@ -1,11 +1,14 @@
 package uk.ac.wellcome.transformer.source
 
+import uk.ac.wellcome.transformer.source.sierra.{Country, Language}
+
 case class SierraBibData(
   id: String,
   title: Option[String],
   deleted: Boolean = false,
   suppressed: Boolean = false,
   country: Option[Country] = None,
+  lang: Option[Language] = None,
   fixedFields: Map[String, FixedField] = Map(),
   varFields: List[VarField] = List()
 )

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraBibData.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/SierraBibData.scala
@@ -4,7 +4,7 @@ import uk.ac.wellcome.transformer.source.sierra.{Country, Language}
 
 case class SierraBibData(
   id: String,
-  title: Option[String],
+  title: Option[String] = None,
   deleted: Boolean = false,
   suppressed: Boolean = false,
   country: Option[Country] = None,

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/sierra/Country.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/sierra/Country.scala
@@ -1,0 +1,5 @@
+package uk.ac.wellcome.transformer.source.sierra
+
+// Represents a Language object, as returned by the Sierra API.
+// https://techdocs.iii.com/sierraapi/Content/zReference/objects/bibObjectDescription.htm?Highlight=language
+case class Language(code: String, name: String)

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/sierra/Country.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/sierra/Country.scala
@@ -1,5 +1,3 @@
 package uk.ac.wellcome.transformer.source.sierra
 
-// Represents a Language object, as returned by the Sierra API.
-// https://techdocs.iii.com/sierraapi/Content/zReference/objects/bibObjectDescription.htm?Highlight=language
-case class Language(code: String, name: String)
+case class Country(code: String, name: String)

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/sierra/Language.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/sierra/Language.scala
@@ -1,0 +1,3 @@
+package uk.ac.wellcome.transformer.source.sierra
+
+case class Country(code: String, name: String)

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/sierra/Language.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/source/sierra/Language.scala
@@ -1,3 +1,5 @@
 package uk.ac.wellcome.transformer.source.sierra
 
-case class Country(code: String, name: String)
+// Represents a Language object, as returned by the Sierra API.
+// https://techdocs.iii.com/sierraapi/Content/zReference/objects/bibObjectDescription.htm?Highlight=language
+case class Language(code: String, name: String)

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformer.scala
@@ -17,6 +17,7 @@ class SierraTransformableTransformer
     with SierraPhysicalDescription
     with SierraExtent
     with SierraItems
+    with SierraLanguage
     with SierraLettering
     with SierraPublishers
     with SierraTitle
@@ -54,7 +55,8 @@ class SierraTransformableTransformer
               publishers = getPublishers(sierraBibData),
               visible = !(sierraBibData.deleted || sierraBibData.suppressed),
               publicationDate = getPublicationDate(sierraBibData),
-              placesOfPublication = getPlacesOfPublication(sierraBibData)
+              placesOfPublication = getPlacesOfPublication(sierraBibData),
+              language = getLanguage(sierraBibData)
             ))
         }
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLanguage.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLanguage.scala
@@ -1,0 +1,25 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+import uk.ac.wellcome.models.Language
+import uk.ac.wellcome.transformer.source.{MarcSubfield, SierraBibData}
+
+trait SierraLanguage {
+
+  // Populate wwork:language.
+  //
+  // We use the "lang" field, if present.
+  //
+  // Notes:
+  //
+  //  - "lang" is an optional field in the Sierra API.
+  //  - These are populated by ISO 639-2 language codes, but we treat them
+  //    as opaque identifiers for our purposes.
+  //
+  def getLanguage(bibData: SierraBibData): Option[Language] =
+    bibData.lang.map { lang =>
+      Language(
+        id = lang.code,
+        label = lang.name
+      )
+    }
+}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -518,4 +518,34 @@ class SierraTransformableTransformerTest
 
     transformedSierraRecord.get.get.sourceIdentifier
   }
+
+  it("uses the lang for the language field") {
+    val id = "1020201"
+    val sierraTransformable = SierraTransformable(
+      sourceId = id,
+      maybeBibData = Some(
+        SierraBibRecord(
+          id = id,
+          data = s"""{
+            "id": "$id",
+            "lang": {
+              "code": "fra",
+              "name": "French"
+            }
+          }""",
+          modifiedDate = now()
+        ))
+    )
+
+    val transformedSierraRecord =
+      transformer.transform(sierraTransformable, version = 1)
+    transformedSierraRecord.isSuccess shouldBe true
+
+    val expectedLanguage = Language(
+      id = "fra",
+      label = "French"
+    )
+
+    transformedSierraRecord.get.get.language.get shouldBe expectedLanguage
+  }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLanguageTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLanguageTest.scala
@@ -1,0 +1,36 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.Language
+import uk.ac.wellcome.transformer.source.SierraBibData
+import uk.ac.wellcome.transformer.source.sierra.{Language => SierraLanguage}
+import uk.ac.wellcome.test.utils.SierraData
+
+class SierraLanguageTest extends FunSpec with Matchers with SierraData {
+
+  val transformer = new SierraLanguage {}
+
+  it("ignores records which don't have a lang field") {
+    val bibData = SierraBibData(
+      id = "1000001",
+      lang = None
+    )
+
+    transformer.getLanguage(bibData = bibData) shouldBe None
+  }
+
+  it("picks up the language from the lang field") {
+    val bibData = SierraBibData(
+      id = "2000002",
+      lang = Some(SierraLanguage(
+        code = "eng",
+        name = "English"
+      ))
+    )
+
+    transformer.getLanguage(bibData = bibData) shouldBe Some(Language(
+      id = "eng",
+      label = "English"
+    ))
+  }
+}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLanguageTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLanguageTest.scala
@@ -22,15 +22,17 @@ class SierraLanguageTest extends FunSpec with Matchers with SierraData {
   it("picks up the language from the lang field") {
     val bibData = SierraBibData(
       id = "2000002",
-      lang = Some(SierraLanguage(
-        code = "eng",
-        name = "English"
-      ))
+      lang = Some(
+        SierraLanguage(
+          code = "eng",
+          name = "English"
+        ))
     )
 
-    transformer.getLanguage(bibData = bibData) shouldBe Some(Language(
-      id = "eng",
-      label = "English"
-    ))
+    transformer.getLanguage(bibData = bibData) shouldBe Some(
+      Language(
+        id = "eng",
+        label = "English"
+      ))
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLanguageTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLanguageTest.scala
@@ -3,7 +3,9 @@ package uk.ac.wellcome.transformer.transformers.sierra
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.Language
 import uk.ac.wellcome.transformer.source.SierraBibData
-import uk.ac.wellcome.transformer.source.sierra.{Language => SierraLanguage}
+import uk.ac.wellcome.transformer.source.sierra.{
+  Language => SierraLanguageField
+}
 import uk.ac.wellcome.test.utils.SierraData
 
 class SierraLanguageTest extends FunSpec with Matchers with SierraData {
@@ -23,7 +25,7 @@ class SierraLanguageTest extends FunSpec with Matchers with SierraData {
     val bibData = SierraBibData(
       id = "2000002",
       lang = Some(
-        SierraLanguage(
+        SierraLanguageField(
           code = "eng",
           name = "English"
         ))

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLetteringTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraLetteringTest.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.{Agent, Organisation}
 import uk.ac.wellcome.transformer.source.{
   MarcSubfield,
   SierraBibData,

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraPlaceOfPublicationTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraPlaceOfPublicationTest.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.transformer.transformers.sierra
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models._
 import uk.ac.wellcome.transformer.source.{
-  Country,
   MarcSubfield,
   SierraBibData,
   VarField

--- a/common/src/main/scala/uk/ac/wellcome/models/Language.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Language.scala
@@ -1,0 +1,7 @@
+package uk.ac.wellcome.models
+
+case class Language(
+  id: String,
+  label: String,
+  ontologyType: String = "Language"
+)

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -19,6 +19,7 @@ trait Work extends Versioned with Identifiable {
   val thumbnail: Option[Location]
   val publishers: List[AbstractAgent]
   val publicationDate: Option[Period]
+  val language: Option[Language]
   val visible: Boolean
   val ontologyType: String
 }
@@ -40,6 +41,7 @@ case class UnidentifiedWork(title: Option[String],
                             publishers: List[AbstractAgent] = Nil,
                             publicationDate: Option[Period] = None,
                             placesOfPublication: List[Place] = Nil,
+                            language: Option[Language] = None,
                             visible: Boolean = true,
                             ontologyType: String = "Work")
     extends Work
@@ -62,6 +64,7 @@ case class IdentifiedWork(canonicalId: String,
                           publishers: List[AbstractAgent] = Nil,
                           publicationDate: Option[Period] = None,
                           placesOfPublication: List[Place] = Nil,
+                          language: Option[Language] = None,
                           visible: Boolean = true,
                           ontologyType: String = "Work")
     extends Work

--- a/common/src/test/scala/uk/ac/wellcome/models/IdentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/IdentifiedWorkTest.scala
@@ -26,6 +26,13 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
   // seeing the quokka when exploring near Australia.
   val physicalDescription = "A kind of rat as big as a cat"
 
+  // wow very language such doge much javascript
+  // (In the future, everything will compile to JavaScript.)
+  val language = Language(
+    id = "dog",
+    label = "Dogescript"
+  )
+
   val identifiedWorkJson: String =
     s"""
       |{
@@ -117,6 +124,11 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |   "label": "Spain",
       |   "ontologyType": "Place"
       |  }],
+      |   "language": {
+      |     "id": "${language.id}",
+      |     "label": "${language.label}",
+      |     "ontologyType": "Language"
+      |   },
       |  "visible":true,
       |  "ontologyType": "Work"
       |}
@@ -164,7 +176,8 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
     items = List(item),
     publishers = publishers,
     publicationDate = Some(Period(publicationDate)),
-    placesOfPublication = List(Place(label = "Spain"))
+    placesOfPublication = List(Place(label = "Spain")),
+    language = Some(language)
   )
 
   it("should serialise an identified Item as Work") {

--- a/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/UnidentifiedWorkTest.scala
@@ -26,6 +26,13 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
   // for steam locomotives, reaching 126 mph.
   val publicationDate = "3 July 1938"
 
+  // Reskitkish is a fictional language from the "Wayfarers" series of novels,
+  // and requires large lungs to speak effectively.
+  val language = Language(
+    id = "res",
+    label = "Reskitkish"
+  )
+
   val unidentifiedWorkJson: String =
     s"""
       |{
@@ -118,6 +125,11 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |     "ontologyType": "Place"
       |   }
       |  ],
+      |   "language": {
+      |     "id": "${language.id}",
+      |     "label": "${language.label}",
+      |     "ontologyType": "Language"
+      |   },
       |  "ontologyType": "Work"
       |}
     """.stripMargin
@@ -161,7 +173,8 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
     items = List(item),
     publishers = publishers,
     publicationDate = Some(Period(publicationDate)),
-    placesOfPublication = List(Place("Madrid"))
+    placesOfPublication = List(Place("Madrid")),
+    language = Some(language)
   )
 
   it("should serialise an unidentified Work as JSON") {

--- a/ontologies/WIP/sierratransformable
+++ b/ontologies/WIP/sierratransformable
@@ -85,8 +85,8 @@
    */
 
    /* Populate wwork:language. Rules
-   * 
-   * 1. For all bibliographic records use "language"
+   *
+   * 1. For all bibliographic records use "lang"
    * 2. Platform "id" is populated from "code"
    * 3. Platform "label" is populated from "name"
    * 

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLanguage.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLanguage.scala
@@ -6,7 +6,8 @@ import uk.ac.wellcome.models.Language
 
 @ApiModel(
   value = "Language",
-  description = "A language recognised as one of those in the ISO 639-2 language codes."
+  description =
+    "A language recognised as one of those in the ISO 639-2 language codes."
 )
 case class DisplayLanguage(
   @ApiModelProperty(

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLanguage.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLanguage.scala
@@ -1,0 +1,28 @@
+package uk.ac.wellcome.display.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.models.Language
+
+@ApiModel(
+  value = "Language",
+  description = "A language recognised as one of those in the ISO 639-2 language codes."
+)
+case class DisplayLanguage(
+  @ApiModelProperty(
+    value = "An ISO 639-2 language code."
+  ) id: String,
+  @ApiModelProperty(
+    value = "The name of a language"
+  ) label: String
+) {
+  @ApiModelProperty(readOnly = true, value = "A type of thing")
+  @JsonProperty("type") val ontologyType: String = "Language"
+}
+
+case object DisplayLanguage {
+  def apply(language: Language): DisplayLanguage = DisplayLanguage(
+    id = language.id,
+    label = language.label
+  )
+}

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -79,6 +79,10 @@ case class DisplayWork(
     value =
       "Relates the publication of a work to a date when the work has been formally published."
   ) publicationDate: Option[DisplayPeriod] = None,
+  @ApiModelProperty(
+    dataType = "uk.ac.wellcome.display.models.DisplayLanguage",
+    value = "Relates a work to its primary language."
+  ) language: Option[DisplayLanguage] = None,
   visible: Boolean = true
 ) {
   @ApiModelProperty(readOnly = true, value = "A type of thing")
@@ -115,6 +119,7 @@ case object DisplayWork {
       publishers = work.publishers.map(DisplayAgent(_)),
       publicationDate = work.publicationDate.map { DisplayPeriod(_) },
       placesOfPublication = work.placesOfPublication.map { DisplayPlace(_) },
+      language = work.language.map { DisplayLanguage(_) },
       visible = work.visible
     )
   }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/models/display/DisplayWorkTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/models/display/DisplayWorkTest.scala
@@ -165,4 +165,24 @@ class DisplayWorkTest extends FunSpec with Matchers {
     val displayWork = DisplayWork(work)
     displayWork.extent shouldBe Some(extent)
   }
+
+  it("gets the language from a Work") {
+    val language = Language(
+      id = "bsl",
+      label = "British Sign Language"
+    )
+
+    val work = IdentifiedWork(
+      title = Some("A largesse of leaping Libyan lions"),
+      canonicalId = "lfk6nkje",
+      sourceIdentifier = sourceIdentifier,
+      language = Some(language),
+      version = 1
+    )
+
+    val displayWork = DisplayWork(work)
+    val displayLanguage = displayWork.language.get
+    displayLanguage.id shouldBe language.id
+    displayLanguage.label shouldBe language.label
+  }
 }

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -76,6 +76,12 @@ class WorksIndex @Inject()(client: HttpClient,
     keywordField("ontologyType")
   )
 
+  val language = objectField("language").fields(
+    keywordField("id"),
+    textField("language"),
+    keywordField("ontologyType")
+  )
+
   val rootIndexFields: Seq[FieldDefinition with Product with Serializable] =
     Seq(
       keywordField("canonicalId"),
@@ -102,6 +108,7 @@ class WorksIndex @Inject()(client: HttpClient,
       items,
       publishers,
       date("publicationDate"),
+      language,
       location("thumbnail")
     )
 


### PR DESCRIPTION
Add the transformation for language, per @silveroliver‘s notes. Related: #1682.

Transformation checklist:

- [x] Added any new fields to Work/Item (and the unidentified/identified variants)
- [x] Update the JSON serialisation tests in [Un]IdentifiedWorkTest
- [x] Implemented the new transformation
- [x] Added any new fields to the Elasticsearch mapping
- [x] Updated the Display models in the API
