### PR TITLE
The slow but steady drive for a sentient build system

### DIFF
--- a/.travis/parse_makefiles.py
+++ b/.travis/parse_makefiles.py
@@ -4,7 +4,7 @@ import collections
 import os
 
 Project = collections.namedtuple('Project',
-    ['type', 'exclusive_path']
+    ['name', 'type', 'exclusive_path']
 )
 
 
@@ -46,6 +46,7 @@ def _get_projects_from_makefile(root, path):
 
         for t in targets:
             yield Project(
+                name=t,
                 type=project_type,
                 exclusive_path=os.path.join(root, t)
             )

--- a/.travis/parse_makefiles.py
+++ b/.travis/parse_makefiles.py
@@ -1,0 +1,51 @@
+# -*- encoding: utf-8
+
+import collections
+import os
+
+Project = collections.namedtuple('Project',
+    ['type', 'exclusive_path']
+)
+
+
+def get_projects(repo):
+    for root, _, filenames in os.walk(repo):
+        if root == '.':
+            continue
+        for f in filenames:
+            if f == 'Makefile':
+                path = os.path.join(root, f)
+                for proj in _get_projects_from_makefile(root=root, path=path):
+                    yield proj
+
+
+def _get_projects_from_makefile(root, path):
+    contents = open(path).read()
+
+    # Newlines in Makefiles are escaped with backslashes
+    contents = contents.replace('\\\n', ' ')
+    lines = contents.splitlines()
+
+    for make_variable, project_type in [
+        ('SBT_APPS', 'sbt_app'),
+        ('ECS_TASKS', 'ecs_task'),
+        ('LAMBDAS', 'python_lambda'),
+    ]:
+        matching_lines = [l for l in lines if l.startswith(make_variable)]
+
+        if len(matching_lines) == 0:
+            continue
+        elif len(matching_lines) == 1:
+            # The line is 'SBT_APPS = foo bar baz', so we discard the first
+            # two terms in the line.
+            targets = matching_lines[0].split()[2:]
+        else:
+            raise RuntimeException(
+                "Too many %s variables in %s" % (make_variable, path)
+            )
+
+        for t in targets:
+            yield Project(
+                type=project_type,
+                exclusive_path=os.path.join(root, t)
+            )

--- a/.travis/parse_makefiles.py
+++ b/.travis/parse_makefiles.py
@@ -3,9 +3,7 @@
 import collections
 import os
 
-Project = collections.namedtuple('Project',
-    ['name', 'type', 'exclusive_path']
-)
+Project = collections.namedtuple('Project', ['name', 'type', 'exclusive_path'])
 
 
 def get_projects(repo):
@@ -40,7 +38,7 @@ def _get_projects_from_makefile(root, path):
             # two terms in the line.
             targets = matching_lines[0].split()[2:]
         else:
-            raise RuntimeException(
+            raise RuntimeError(
                 "Too many %s variables in %s" % (make_variable, path)
             )
 

--- a/.travis/travistooling.py
+++ b/.travis/travistooling.py
@@ -147,26 +147,13 @@ def affects_tests(path, task):
     # which doesn't use this sbt-common lib, we can ignore changes to it.
     #
     # The project directory and build.sbt are also Scala-specific.
-    sbt_free_tasks = (
-        'loris',
-        'monitoring',
-        'shared_infra',
-        's3_demultiplexer',
-        'sierra_window_generator',
-        'reindex_job_creator',
-        'complete_reindex',
-        'reindex_shard_generator',
-        'resharder',
-        'snapshot_scheduler',
-    )
-    if (
-        task.startswith(sbt_free_tasks) and
-        path.startswith(('common/', 'project/', 'build.sbt', 'sbt_common'))
-    ):
-        print(
-            "~~~ Ignoring %s; sbt-common changes don't affect %s tests" %
-            (path, task))
-        return False
+    if path.startswith(('common/', 'project/', 'build.sbt', 'sbt_common/')):
+        for project in get_projects(ROOT):
+            if project.type != 'sbt_app' and task.startswith(project.name):
+                print(
+                    "~~~ Ignoring %s; sbt-common changes don't affect %s tests" %
+                    (path, task))
+                return False
 
     # Otherwise, we were unable to decide if this change was important.
     # We assume that it is, so we'll run tests just in case.

--- a/.travis/travistooling.py
+++ b/.travis/travistooling.py
@@ -99,48 +99,30 @@ def affects_tests(path, task):
     # A number of Sierra-related tasks share code/Makefiles in the
     # sierra_adapter directory.  If we're definitely in a project which
     # has nothing to do with Sierra, we can ignore changes in this dir.
-    sierra_free_tasks = (
-        'loris',
-        'id_minter',
-        'ingestor',
-        'reindexer_worker',
-        'reindex_job_creator',
-        'complete_reindex',
-        'reindex_shard_generator',
-        'resharder',
-        'transformer',
-        'api',
-        'monitoring',
-        'shared_infra',
-        'nginx',
-        'snapshot_scheduler',
-        'sbt-display',
-        'sbt-common',
-    )
-    if (
-        task.startswith(sierra_free_tasks) and
-        path.startswith('sierra_adapter/')
-    ):
-        print(
-            "~~~ Ignoring %s; sierra_adapter changes don't affect %s tests" %
-            (path, task))
-        return False
+    if path.startswith('sierra_adapter/'):
+        for project in get_projects(ROOT):
+            if (
+                not project.exclusive_path.startswith('sierra_adapter/') and
+                task.startswith(project.name)
+            ):
+                print(
+                    "~~~ Ignoring %s; sbt-common changes don't affect %s tests" %
+                    (path, task))
+                return False
 
     # Within the sierra_adapter stack, there's an sbt common lib.  If we're
     # in a Sierra project that doesn't use sbt, we can ignore that too.
-    sbt_common_free_tasks = (
-        's3_demultiplexer',
-        'sierra_window_generator',
-        'snapshot_scheduler',
-    )
-    if (
-        task.startswith(sbt_common_free_tasks) and
-        path.startswith('sierra_adapter/common/')
-    ):
-        print(
-            "~~~ Ignoring %s; sierra-common changes don't affect %s tests" %
-            (path, task))
-        return False
+    if path.startswith('sierra_adapter/common'):
+        for project in get_projects(ROOT):
+            if (
+                project.type != 'sbt_app' and
+                task.startswith(project.name)
+            ):
+                assert project.exclusive_path.startswith('sierra_adapter/')
+                print(
+                    "~~~ Ignoring %s; sierra-common changes don't affect %s tests" %
+                    (path, task))
+                return False
 
     # The top-level common directory contains some Scala files which are
     # shared across multiple projects.  If we're definitely in a project

--- a/.travis/travistooling.py
+++ b/.travis/travistooling.py
@@ -7,6 +7,8 @@ import os
 import subprocess
 import sys
 
+from parse_makefiles import get_projects
+
 
 # Root of the Git repository
 ROOT = subprocess.check_output([
@@ -75,47 +77,24 @@ def affects_tests(path, task):
         print("~~~ %s is ignored because it's a Terraform file" % path)
         return False
 
-    # For each task, which directories only have an effect on this task?
+    # Some directories only affect one task.
     #
-    # For example, changes to the ``loris`` directory only have an effect
-    # on the ``loris`` task; in any other task changes to that directory
-    # can be ignored.
-    task_specific_directories = {
-        'loris': ['loris'],
-        'id_minter': ['catalogue_pipeline/id_minter'],
-        'ingestor': ['catalogue_pipeline/ingestor'],
-        'transformer': ['catalogue_pipeline/transformer'],
-        'api': ['catalogue_api'],
-        'monitoring': ['monitoring'],
-        'shared_infra': ['shared_infra'],
-        'nginx': ['nginx'],
-
-        'reindexer_worker': ['reindexer/reindexer_worker'],
-        'reindex_job_creator': ['reindexer/reindex_job_creator'],
-        'complete_reindex': ['reindexer/complete_reindex'],
-        'reindex_shard_generator': ['reindexer/reindex_shard_generator'],
-        'resharder': ['reindexer/resharder'],
-
-        's3_demultiplexer': ['sierra_adapter/s3_demultiplexer'],
-        'sierra_window_generator': ['sierra_adapter/sierra_window_generator'],
-        'sierra_reader': ['sierra_adapter/sierra_reader'],
-        'sierra_items_to_dynamo': ['sierra_adapter/sierra_items_to_dynamo'],
-        'sierra_bib_merger': ['sierra_adapter/sierra_bib_merger'],
-        'sierra_item_merger': ['sierra_adapter/sierra_item_merger'],
-
-        'snapshot_scheduler': ['data_api/snapshot_scheduler'],
+    # For example, the ``catalogue_api/api`` directory only contains code
+    # for the api Scala app, so changes in this directory cannot affect
+    # any other task.
+    exclusive_directories = {
+        t.exclusive_path: t.name for t in get_projects(ROOT)
     }
 
-    # If we have a change to a file which is specific to a particular task,
-    # but we're *not* in that task, this change is unimportant.
-    for prefix, directories in task_specific_directories.items():
-        if not task.startswith(prefix) and path.startswith(tuple(directories)):
-            print('~~~ Ignoring %s; it only affects %s tests' % (path, task))
-            return False
-
-        if task.startswith(prefix) and path.startswith(tuple(directories)):
-            print("+++ %s is definitely part of the %s tests" % (path, task))
-            return True
+    for dir_name, task_name in exclusive_directories.items():
+        if path.startswith(dir_name):
+            if task.startswith(task_name):
+                print(
+                    "+++ %s is definitely part of the %s tests" % (path, task))
+                return True
+            else:
+                print('~~~ Ignoring %s; it only affects %s tests' % (path, task_name))
+                return False
 
     # A number of Sierra-related tasks share code/Makefiles in the
     # sierra_adapter directory.  If we're definitely in a project which


### PR DESCRIPTION
It’s annoyed me for a while that `travistooling.py` has a hard-coded list of projects and their exclusive directories, especially because it’s just duplicating information in our Makefiles.

This patch teaches Travis to understand our Makefiles, work out whether a task is an SBT app, an ECS task or a Python Lambda, then feeds that information into decisions about whether to run tests or rebuild tasks.

This reduces the need for us to keep editing this file by hand, and should make builds more accurate (I found at least one bug in the existing hard-coded list while writing this).