### PR TITLE
Add iam:GetUser permissions to Travis

### DIFF
--- a/shared_infra/iam_policy_document.tf
+++ b/shared_infra/iam_policy_document.tf
@@ -58,6 +58,16 @@ data "aws_iam_policy_document" "travis_permissions" {
       "*",
     ]
   }
+
+  statement {
+    actions = [
+      "iam:GetUser",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "s3_alb_logs" {


### PR DESCRIPTION
These are required for Travis to post an SNS notification when it completes a build.