### PR TITLE
Isolate the reindex worker test

### DIFF
--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
@@ -24,7 +24,6 @@ class SQSReaderTest
 
   def withSqsReader[R](queueUrl: String, maxMessages: Int)(
     testWith: TestWith[SQSReader, R]) = {
-    sqsClient.setQueueAttributes(queueUrl, Map("VisibilityTimeout" -> "1"))
     val sqsConfig = SQSConfig(queueUrl, waitTime = 20 seconds, maxMessages)
     val sqsReader = new SQSReader(sqsClient, sqsConfig)
 

--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerTest.scala
@@ -40,7 +40,6 @@ class SQSWorkerTest
   def withSqsWorker[R](actors: ActorSystem,
                        metrics: MetricsSender,
                        queueUrl: String)(testWith: TestWith[SQSWorker, R]) = {
-    sqsClient.setQueueAttributes(queueUrl, Map("VisibilityTimeout" -> "0"))
     val sqsReader = new SQSReader(sqsClient, SQSConfig(queueUrl, 1.second, 1))
 
     val testWorker =

--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerToDynamoTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerToDynamoTest.scala
@@ -96,8 +96,6 @@ class SQSWorkerToDynamoTest
     testWith: TestWith[(TestWorker, String), R]) = {
     withActorSystem { system =>
       withLocalSqsQueue { queueUrl =>
-        sqsClient.setQueueAttributes(queueUrl, Map("VisibilityTimeout" -> "0"))
-
         val worker = testWorkFactory(queueUrl, system)
 
         try {

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalDynamoDb.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalDynamoDb.scala
@@ -15,18 +15,6 @@ trait LocalDynamoDb[T <: Versioned with Id] extends DynamoDBLocalClients {
 
   case class FixtureParams(tableName: String, indexName: String)
 
-  def withLocalDynamoDbTable[R](testWith: TestWith[String, R]): R = {
-    val tableName = Random.alphanumeric.take(10).mkString
-    val indexName = Random.alphanumeric.take(10).mkString
-
-    try {
-      createTable(tableName, indexName)
-      testWith(tableName)
-    } finally {
-      deleteAllTables()
-    }
-  }
-
   def withLocalDynamoDbTableAndIndex[R](
     testWith: TestWith[FixtureParams, R]): R = {
     val tableName = Random.alphanumeric.take(10).mkString
@@ -37,6 +25,12 @@ trait LocalDynamoDb[T <: Versioned with Id] extends DynamoDBLocalClients {
       testWith(FixtureParams(tableName, indexName))
     } finally {
       deleteAllTables()
+    }
+  }
+
+  def withLocalDynamoDbTable[R](testWith: TestWith[String, R]): R = {
+    withLocalDynamoDbTableAndIndex { fixtures =>
+      testWith(fixtures.tableName)
     }
   }
 

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalDynamoDb.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalDynamoDb.scala
@@ -13,6 +13,8 @@ trait LocalDynamoDb[T <: Versioned with Id] extends DynamoDBLocalClients {
 
   implicit val evidence: DynamoFormat[T]
 
+  case class FixtureParams(tableName: String, indexName: String)
+
   def withLocalDynamoDbTable[R](testWith: TestWith[String, R]): R = {
     val tableName = Random.alphanumeric.take(10).mkString
     val indexName = Random.alphanumeric.take(10).mkString
@@ -20,6 +22,19 @@ trait LocalDynamoDb[T <: Versioned with Id] extends DynamoDBLocalClients {
     try {
       createTable(tableName, indexName)
       testWith(tableName)
+    } finally {
+      deleteAllTables()
+    }
+  }
+
+  def withLocalDynamoDbTableAndIndex[R](
+      testWith: TestWith[FixtureParams, R]): R = {
+    val tableName = Random.alphanumeric.take(10).mkString
+    val indexName = Random.alphanumeric.take(10).mkString
+
+    try {
+      createTable(tableName, indexName)
+      testWith(FixtureParams(tableName, indexName))
     } finally {
       deleteAllTables()
     }

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalDynamoDb.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalDynamoDb.scala
@@ -28,7 +28,7 @@ trait LocalDynamoDb[T <: Versioned with Id] extends DynamoDBLocalClients {
   }
 
   def withLocalDynamoDbTableAndIndex[R](
-      testWith: TestWith[FixtureParams, R]): R = {
+    testWith: TestWith[FixtureParams, R]): R = {
     val tableName = Random.alphanumeric.take(10).mkString
     val indexName = Random.alphanumeric.take(10).mkString
 

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/DynamoDBLocalClients.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/DynamoDBLocalClients.scala
@@ -17,9 +17,10 @@ trait DynamoDBLocalClients {
   private val accessKey = "access"
   private val secretKey = "secret"
 
-  val dynamoDbLocalEndpointFlags: Map[String, String] =
+  def dynamoDbLocalEndpointFlags(tableName: String) =
     Map(
       "aws.region" -> "localhost",
+      "aws.dynamo.tableName" -> tableName,
       "aws.dynamoDb.endpoint" -> dynamoDBEndPoint,
       "aws.dynamoDb.accessKey" -> accessKey,
       "aws.dynamoDb.secretKey" -> secretKey

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/Server.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/Server.scala
@@ -31,6 +31,8 @@ class Server extends HttpServer {
     AkkaModule
   )
 
+  flag[String]("aws.dynamo.indexName", "reindexTracker", "Name of the reindex tracker GSI")
+
   override def configureHttp(router: HttpRouter) {
     router
       .filter[CommonFilters]

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/Server.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/Server.scala
@@ -31,7 +31,10 @@ class Server extends HttpServer {
     AkkaModule
   )
 
-  flag[String]("aws.dynamo.indexName", "reindexTracker", "Name of the reindex tracker GSI")
+  flag[String](
+    "aws.dynamo.indexName",
+    "reindexTracker",
+    "Name of the reindex tracker GSI")
 
   override def configureHttp(router: HttpRouter) {
     router

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
@@ -8,6 +8,7 @@ import com.gu.scanamo.query._
 import com.gu.scanamo.syntax._
 import com.gu.scanamo.{Scanamo, _}
 import com.twitter.inject.Logging
+import com.twitter.inject.annotations.Flag
 import uk.ac.wellcome.dynamo.VersionedDao
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
@@ -24,7 +25,7 @@ class ReindexService @Inject()(dynamoDBClient: AmazonDynamoDB,
                                metricsSender: MetricsSender,
                                versionedDao: VersionedDao,
                                dynamoConfig: DynamoConfig,
-                               indexName: String = "reindexTracker")
+                               @Flag("aws.dynamo.indexName") indexName: String)
     extends Logging {
 
   def runReindex(reindexJob: ReindexJob): Future[List[Unit]] = {
@@ -32,7 +33,6 @@ class ReindexService @Inject()(dynamoDBClient: AmazonDynamoDB,
 
     val table = Table[ReindexRecord](dynamoConfig.table)
 
-    // TODO: The name of the GSI should be a config flag.
     val index = table.index(indexName)
 
     // We start by querying DynamoDB for every record in the reindex shard

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
@@ -23,7 +23,8 @@ import scala.concurrent.Future
 class ReindexService @Inject()(dynamoDBClient: AmazonDynamoDB,
                                metricsSender: MetricsSender,
                                versionedDao: VersionedDao,
-                               dynamoConfig: DynamoConfig)
+                               dynamoConfig: DynamoConfig,
+                               indexName: String = "reindexTracker")
     extends Logging {
 
   def runReindex(reindexJob: ReindexJob): Future[List[Unit]] = {
@@ -32,7 +33,7 @@ class ReindexService @Inject()(dynamoDBClient: AmazonDynamoDB,
     val table = Table[ReindexRecord](dynamoConfig.table)
 
     // TODO: The name of the GSI should be a config flag.
-    val index = table.index("reindexTracker")
+    val index = table.index(indexName)
 
     // We start by querying DynamoDB for every record in the reindex shard
     // that has an out-of-date reindexVersion.  If a shard was especially

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
@@ -45,7 +45,8 @@ class ReindexerFeatureTest
 
   val shardName = "shard"
 
-  private def createReindexableData(queueUrl: String, tableName: String): List[ReindexRecord] = {
+  private def createReindexableData(queueUrl: String,
+                                    tableName: String): List[ReindexRecord] = {
     val numberOfRecords = 4
 
     val testRecords = (1 to numberOfRecords).map(i => {
@@ -95,10 +96,14 @@ class ReindexerFeatureTest
           val tableName = fixtures.tableName
           val indexName = fixtures.indexName
 
-          val flags: Map[String, String] = snsLocalFlags(topicArn) ++ dynamoDbLocalEndpointFlags(tableName) ++ sqsLocalFlags(queueUrl) ++ Map("aws.dynamo.indexName" -> indexName)
+          val flags
+            : Map[String, String] = snsLocalFlags(topicArn) ++ dynamoDbLocalEndpointFlags(
+            tableName) ++ sqsLocalFlags(queueUrl) ++ Map(
+            "aws.dynamo.indexName" -> indexName)
 
           withServer(flags) { _ =>
-            val expectedRecords = createReindexableData(queueUrl = queueUrl, tableName = tableName)
+            val expectedRecords =
+              createReindexableData(queueUrl = queueUrl, tableName = tableName)
 
             eventually {
               val actualRecords =
@@ -121,10 +126,14 @@ class ReindexerFeatureTest
           val tableName = fixtures.tableName
           val indexName = fixtures.indexName
 
-          val flags: Map[String, String] = snsLocalFlags(topicArn) ++ dynamoDbLocalEndpointFlags(tableName) ++ sqsLocalFlags(queueUrl) ++ Map("aws.dynamo.indexName" -> indexName)
+          val flags
+            : Map[String, String] = snsLocalFlags(topicArn) ++ dynamoDbLocalEndpointFlags(
+            tableName) ++ sqsLocalFlags(queueUrl) ++ Map(
+            "aws.dynamo.indexName" -> indexName)
 
           withServer(flags) { _ =>
-            val expectedRecords = createReindexableData(queueUrl = queueUrl, tableName = tableName)
+            val expectedRecords =
+              createReindexableData(queueUrl = queueUrl, tableName = tableName)
 
             val expectedMessage = CompletedReindexJob(
               shardId = shardName,
@@ -155,10 +164,14 @@ class ReindexerFeatureTest
           val tableName = fixtures.tableName
           val indexName = fixtures.indexName
 
-          val flags: Map[String, String] = snsLocalFlags(topicArn) ++ dynamoDbLocalEndpointFlags("non_existent_table") ++ sqsLocalFlags(queueUrl) ++ Map("aws.dynamo.indexName" -> indexName)
+          val flags
+            : Map[String, String] = snsLocalFlags(topicArn) ++ dynamoDbLocalEndpointFlags(
+            "non_existent_table") ++ sqsLocalFlags(queueUrl) ++ Map(
+            "aws.dynamo.indexName" -> indexName)
 
           withServer(flags) { _ =>
-            val expectedRecords = createReindexableData(queueUrl = queueUrl, tableName = tableName)
+            val expectedRecords =
+              createReindexableData(queueUrl = queueUrl, tableName = tableName)
 
             // We wait some time to ensure that the message is not processed
             Thread.sleep(5000)

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
@@ -1,11 +1,9 @@
 package uk.ac.wellcome.platform.reindex_worker
 
 import com.gu.scanamo.{DynamoFormat, Scanamo}
-import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.Matchers
 import org.scalatest.FunSpec
-import uk.ac.wellcome.locals.DynamoDBLocal
 import uk.ac.wellcome.models.{Id, Versioned}
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.platform.reindex_worker.models.{
@@ -13,7 +11,7 @@ import uk.ac.wellcome.platform.reindex_worker.models.{
   ReindexJob,
   ReindexRecord
 }
-import uk.ac.wellcome.test.fixtures._
+import uk.ac.wellcome.test.fixtures.{LocalDynamoDb, SnsFixtures, SqsFixtures}
 import uk.ac.wellcome.test.utils.AmazonCloudWatchFlag
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.utils.JsonUtil._
@@ -32,63 +30,21 @@ class ReindexerFeatureTest
     extends FunSpec
     with Matchers
     with Eventually
-    with DynamoDBLocal[TestRecord]
-    with AmazonCloudWatchFlag
-    with SqsFixtures
+    with fixtures.Server
+    with LocalDynamoDb[TestRecord]
     with SnsFixtures
+    with SqsFixtures
     with ScalaFutures {
 
   override lazy val evidence: DynamoFormat[TestRecord] =
     DynamoFormat[TestRecord]
-
-  override lazy val tableName: String = "table"
-
-  def withServer[R](queueUrl: String, topicArn: String)(
-    testWith: TestWith[EmbeddedHttpServer, R]) = {
-    val server: EmbeddedHttpServer =
-      new EmbeddedHttpServer(
-        new Server(),
-        flags = Map(
-          "aws.dynamo.tableName" -> tableName
-        ) ++ snsLocalFlags(topicArn) ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags ++ sqsLocalFlags(
-          queueUrl)
-      )
-
-    server.start()
-
-    try {
-      testWith(server)
-    } finally {
-      server.close()
-    }
-  }
-
-  def withBadServer[R](queueUrl: String, topicArn: String)(
-    testWith: TestWith[EmbeddedHttpServer, R]) = {
-    val server: EmbeddedHttpServer =
-      new EmbeddedHttpServer(
-        new Server(),
-        flags = Map(
-          "aws.dynamo.tableName" -> "not_a_real_table"
-        ) ++ snsLocalFlags(topicArn) ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags ++ sqsLocalFlags(
-          queueUrl)
-      )
-
-    server.start()
-
-    try {
-      testWith(server)
-    } finally {
-      server.close()
-    }
-  }
 
   val currentVersion = 1
   val desiredVersion = 5
 
   val shardName = "shard"
 
-  private def createReindexableData(queueUrl: String): List[ReindexRecord] = {
+  private def createReindexableData(queueUrl: String, tableName: String): List[ReindexRecord] = {
     val numberOfRecords = 4
 
     val testRecords = (1 to numberOfRecords).map(i => {
@@ -134,18 +90,24 @@ class ReindexerFeatureTest
   it("increases the reindexVersion on every record that needs a reindex") {
     withLocalSqsQueue { queueUrl =>
       withLocalSnsTopic { topicArn =>
-        withServer(queueUrl, topicArn) { server =>
-          val expectedRecords = createReindexableData(queueUrl)
+        withLocalDynamoDbTableAndIndex { fixtures =>
+          val tableName = fixtures.tableName
+          val indexName = fixtures.indexName
 
-          eventually {
-            val actualRecords =
-              Scanamo
-                .scan[ReindexRecord](dynamoDbClient)(tableName)
-                .map(_.right.get)
+          val flags: Map[String, String] = snsLocalFlags(topicArn) ++ dynamoDbLocalEndpointFlags(tableName) ++ sqsLocalFlags(queueUrl) ++ Map("aws.dynamo.indexName" -> indexName)
 
-            actualRecords should contain theSameElementsAs expectedRecords
+          withServer(flags) { _ =>
+            val expectedRecords = createReindexableData(queueUrl = queueUrl, tableName = tableName)
+
+            eventually {
+              val actualRecords =
+                Scanamo
+                  .scan[ReindexRecord](dynamoDbClient)(tableName)
+                  .map(_.right.get)
+
+              actualRecords should contain theSameElementsAs expectedRecords
+            }
           }
-
         }
       }
     }
@@ -154,26 +116,31 @@ class ReindexerFeatureTest
   it("sends an SNS notice for a completed reindex") {
     withLocalSqsQueue { queueUrl =>
       withLocalSnsTopic { topicArn =>
-        withServer(queueUrl, topicArn) { server =>
-          val expectedRecords = createReindexableData(queueUrl)
+        withLocalDynamoDbTableAndIndex { fixtures =>
+          val tableName = fixtures.tableName
+          val indexName = fixtures.indexName
 
-          val expectedMessage = CompletedReindexJob(
-            shardId = shardName,
-            completedReindexVersion = desiredVersion
-          )
+          val flags: Map[String, String] = snsLocalFlags(topicArn) ++ dynamoDbLocalEndpointFlags(tableName) ++ sqsLocalFlags(queueUrl) ++ Map("aws.dynamo.indexName" -> indexName)
 
-          eventually {
+          withServer(flags) { _ =>
+            val expectedRecords = createReindexableData(queueUrl = queueUrl, tableName = tableName)
 
-            val messages = listMessagesReceivedFromSNS(topicArn)
+            val expectedMessage = CompletedReindexJob(
+              shardId = shardName,
+              completedReindexVersion = desiredVersion
+            )
 
-            messages should have size 1
+            eventually {
+              val messages = listMessagesReceivedFromSNS(topicArn)
 
-            JsonUtil
-              .fromJson[CompletedReindexJob](
-                messages.head.message
-              )
-              .get shouldBe expectedMessage
+              messages should have size 1
 
+              JsonUtil
+                .fromJson[CompletedReindexJob](
+                  messages.head.message
+                )
+                .get shouldBe expectedMessage
+            }
           }
         }
       }
@@ -183,14 +150,21 @@ class ReindexerFeatureTest
   it("does not send a message if it cannot complete a reindex") {
     withLocalSqsQueue { queueUrl =>
       withLocalSnsTopic { topicArn =>
-        withBadServer(queueUrl, topicArn) { server =>
-          val expectedRecords = createReindexableData(queueUrl)
+        withLocalDynamoDbTableAndIndex { fixtures =>
+          val tableName = fixtures.tableName
+          val indexName = fixtures.indexName
 
-          // We wait some time to ensure that the message is not processed
-          Thread.sleep(5000)
+          val flags: Map[String, String] = snsLocalFlags(topicArn) ++ dynamoDbLocalEndpointFlags("non_existent_table") ++ sqsLocalFlags(queueUrl) ++ Map("aws.dynamo.indexName" -> indexName)
 
-          val messages = listMessagesReceivedFromSNS(topicArn)
-          messages should have size 0
+          withServer(flags) { _ =>
+            val expectedRecords = createReindexableData(queueUrl = queueUrl, tableName = tableName)
+
+            // We wait some time to ensure that the message is not processed
+            Thread.sleep(5000)
+
+            val messages = listMessagesReceivedFromSNS(topicArn)
+            messages should have size 0
+          }
         }
       }
     }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
@@ -135,10 +135,6 @@ class ReindexerFeatureTest
     withLocalSqsQueue { queueUrl =>
       withLocalSnsTopic { topicArn =>
         withServer(queueUrl, topicArn) { server =>
-          sqsClient.setQueueAttributes(
-            queueUrl,
-            Map("VisibilityTimeout" -> "1"))
-
           val expectedRecords = createReindexableData(queueUrl)
 
           eventually {
@@ -159,10 +155,6 @@ class ReindexerFeatureTest
     withLocalSqsQueue { queueUrl =>
       withLocalSnsTopic { topicArn =>
         withServer(queueUrl, topicArn) { server =>
-          sqsClient.setQueueAttributes(
-            queueUrl,
-            Map("VisibilityTimeout" -> "1"))
-
           val expectedRecords = createReindexableData(queueUrl)
 
           val expectedMessage = CompletedReindexJob(
@@ -192,10 +184,6 @@ class ReindexerFeatureTest
     withLocalSqsQueue { queueUrl =>
       withLocalSnsTopic { topicArn =>
         withBadServer(queueUrl, topicArn) { server =>
-          sqsClient.setQueueAttributes(
-            queueUrl,
-            Map("VisibilityTimeout" -> "1"))
-
           val expectedRecords = createReindexableData(queueUrl)
 
           // We wait some time to ensure that the message is not processed

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.platform.reindex_worker.models.{
   ReindexRecord
 }
 import uk.ac.wellcome.test.fixtures.{LocalDynamoDb, SnsFixtures, SqsFixtures}
-import uk.ac.wellcome.test.utils.AmazonCloudWatchFlag
+import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.utils.JsonUtil._
 import scala.collection.JavaConversions._
@@ -30,6 +30,7 @@ class ReindexerFeatureTest
     extends FunSpec
     with Matchers
     with Eventually
+    with ExtendedPatience
     with fixtures.Server
     with LocalDynamoDb[TestRecord]
     with SnsFixtures

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/fixtures/Server.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/fixtures/Server.scala
@@ -1,0 +1,32 @@
+package uk.ac.wellcome.platform.reindex_worker.fixtures
+
+import com.twitter.finatra.http.EmbeddedHttpServer
+import org.scalatest.Suite
+import uk.ac.wellcome.platform.reindex_worker.{Server => AppServer}
+import uk.ac.wellcome.test.fixtures.TestWith
+import uk.ac.wellcome.test.utils.AmazonCloudWatchFlag
+
+trait Server extends AmazonCloudWatchFlag { this: Suite =>
+  def withServer[R](
+    flags: Map[String, String],
+    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer = identity
+  )(testWith: TestWith[EmbeddedHttpServer, R]) = {
+
+    val server: EmbeddedHttpServer = modifyServer(
+      new EmbeddedHttpServer(
+        new AppServer(),
+        flags = Map(
+          "aws.region" -> "localhost"
+        ) ++ flags ++ cloudWatchLocalEndpointFlag
+      )
+    )
+
+    server.start()
+
+    try {
+      testWith(server)
+    } finally {
+      server.close()
+    }
+  }
+}

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
@@ -46,7 +46,7 @@ class ReindexServiceTest
       withActorSystem { actorSystem =>
 
         val metricsSender = new MetricsSender(
-          namespace = "reindexer-tests",
+          namespace = "reindex-service-test",
           interval = 100 milliseconds,
           amazonCloudWatch = mock[AmazonCloudWatch],
           actorSystem = actorSystem

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
@@ -59,7 +59,8 @@ class ReindexServiceTest
             metricsSender = metricsSender,
             versionedDao = new VersionedDao(
               dynamoDbClient = dynamoDbClient,
-              DynamoConfig(tableName))
+              DynamoConfig(tableName)),
+            indexName = indexName
           )
 
         testWith(reindexService)

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
@@ -27,8 +27,6 @@ class ReindexServiceTest
   override lazy val evidence: DynamoFormat[TestRecord] =
     DynamoFormat[TestRecord]
 
-  override lazy val tableName: String = "table"
-
   val metricsSender: MetricsSender =
     new MetricsSender(
       namespace = "reindexer-tests",

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -10,7 +10,6 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.dynamo.VersionedDao
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.locals.DynamoDBLocal
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.{
   DynamoConfig,
@@ -22,7 +21,12 @@ import uk.ac.wellcome.platform.reindex_worker.TestRecord
 import uk.ac.wellcome.platform.reindex_worker.models.ReindexJob
 import uk.ac.wellcome.sns.SNSWriter
 import uk.ac.wellcome.sqs.SQSReader
-import uk.ac.wellcome.test.utils.{SNSLocal, SQSLocal}
+import uk.ac.wellcome.test.fixtures.{
+  AkkaFixtures,
+  LocalDynamoDb,
+  SnsFixtures,
+  SqsFixtures
+}
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -32,91 +36,82 @@ import scala.concurrent.duration._
 class ReindexWorkerServiceTest
     extends FunSpec
     with Matchers
-    with DynamoDBLocal[TestRecord]
     with MockitoSugar
-    with SNSLocal
-    with SQSLocal
+    with AkkaFixtures
+    with LocalDynamoDb
+    with SnsFixtures
+    with SqsFixtures
     with ScalaFutures {
-
-  val actorSystem = ActorSystem()
-
-  val metricsSender: MetricsSender =
-    new MetricsSender(
-      namespace = "reindexer-tests",
-      100 milliseconds,
-      mock[AmazonCloudWatch],
-      actorSystem)
-
-  override lazy val tableName = "table"
 
   override lazy val evidence: DynamoFormat[TestRecord] =
     DynamoFormat[TestRecord]
 
-  val queueUrl = createQueueAndReturnUrl("reindex-worker-service-test-q")
-  val topicArn = createTopicAndReturnArn("reindex-worker-service-test-topic")
-
   it("returns a successful Future if the reindex completes correctly") {
-    withReindexWorkerService { service =>
-      val reindexJob = ReindexJob(
-        shardId = "sierra/123",
-        desiredVersion = 6
-      )
-
-      val testRecord = TestRecord(
-        id = "id/111",
-        version = 1,
-        someData = "A dire daliance directly dancing due down.",
-        reindexShard = reindexJob.shardId,
-        reindexVersion = reindexJob.desiredVersion - 1
-      )
-
-      Scanamo.put(dynamoDbClient)(tableName)(testRecord)
-
-      val expectedRecords = List(
-        testRecord.copy(
-          version = testRecord.version + 1,
-          reindexVersion = reindexJob.desiredVersion
+    withLocalDynamoDbTable { tableName =>
+      withReindexWorkerService(tableName) { service =>
+        val reindexJob = ReindexJob(
+          shardId = "sierra/123",
+          desiredVersion = 6
         )
-      )
 
-      val sqsMessage = SQSMessage(
-        subject = None,
-        body = toJson(reindexJob).get,
-        topic = "topic",
-        messageType = "message",
-        timestamp = "now"
-      )
+        val testRecord = TestRecord(
+          id = "id/111",
+          version = 1,
+          someData = "A dire daliance directly dancing due down.",
+          reindexShard = reindexJob.shardId,
+          reindexVersion = reindexJob.desiredVersion - 1
+        )
 
-      val future = service.processMessage(message = sqsMessage)
+        Scanamo.put(dynamoDbClient)(tableName)(testRecord)
 
-      whenReady(future) { _ =>
-        val actualRecords: List[TestRecord] =
-          Scanamo.scan[TestRecord](dynamoDbClient)(tableName).map(_.right.get)
+        val expectedRecords = List(
+          testRecord.copy(
+            version = testRecord.version + 1,
+            reindexVersion = reindexJob.desiredVersion
+          )
+        )
 
-        actualRecords shouldBe expectedRecords
+        val sqsMessage = SQSMessage(
+          subject = None,
+          body = toJson(reindexJob).get,
+          topic = "topic",
+          messageType = "message",
+          timestamp = "now"
+        )
+
+        val future = service.processMessage(message = sqsMessage)
+
+        whenReady(future) { _ =>
+          val actualRecords: List[TestRecord] =
+            Scanamo.scan[TestRecord](dynamoDbClient)(tableName).map(_.right.get)
+
+          actualRecords shouldBe expectedRecords
+        }
       }
     }
   }
 
   it(
     "returns a failed Future if it cannot parse the SQS message as a ReindexJob") {
-    withReindexWorkerService { service =>
-      val sqsMessage = SQSMessage(
-        subject = None,
-        body = "<xml>What is JSON.</xl?>",
-        topic = "topic",
-        messageType = "message",
-        timestamp = "now"
-      )
+    withLocalDynamoDbTable { tableName =>
+      withReindexWorkerService(tableName) { service =>
+        val sqsMessage = SQSMessage(
+          subject = None,
+          body = "<xml>What is JSON.</xl?>",
+          topic = "topic",
+          messageType = "message",
+          timestamp = "now"
+        )
 
-      val service = reindexWorkerService()
+        val service = reindexWorkerService()
 
-      val future = service.processMessage(message = sqsMessage)
+        val future = service.processMessage(message = sqsMessage)
 
-      whenReady(future.failed) { result =>
-        result shouldBe a[GracefulFailureException]
-        result.getMessage should include(
-          "expected json value got < (line 1, column 1)")
+        whenReady(future.failed) { result =>
+          result shouldBe a[GracefulFailureException]
+          result.getMessage should include(
+            "expected json value got < (line 1, column 1)")
+        }
       }
     }
   }
@@ -166,6 +161,7 @@ class ReindexWorkerServiceTest
   }
 
   def withReindexWorkerService(
+      tableName: String,
       testWith: TestWith[ReindexWorkerService, Assertion]) = {
     withActorSystem { actorSystem =>
 
@@ -176,41 +172,39 @@ class ReindexWorkerServiceTest
         actorSystem = actorSystem
       )
 
-      withLocalDynamoDbTable { tableName =>
-        withLocalSqsQueue { queueUrl =>
-          withLocalTopicArn { topicArn =>
+      withLocalSqsQueue { queueUrl =>
+        withLocalTopicArn { topicArn =>
 
-            val workerService = new ReindexWorkerService(
-              targetService = new ReindexService(
-                dynamoDBClient = dynamoDbClient,
-                metricsSender = metricsSender,
-                versionedDao = new VersionedDao(
-                  dynamoDbClient = dynamoDbClient,
-                  dynamoConfig = DynamoConfig(table = dynamoTableName)
-                ),
+          val workerService = new ReindexWorkerService(
+            targetService = new ReindexService(
+              dynamoDBClient = dynamoDbClient,
+              metricsSender = metricsSender,
+              versionedDao = new VersionedDao(
+                dynamoDbClient = dynamoDbClient,
                 dynamoConfig = DynamoConfig(table = dynamoTableName)
               ),
-              reader = new SQSReader(
-                sqsClient = sqsClient,
-                sqsConfig = SQSConfig(
-                  queueUrl = queueUrl,
-                  waitTime = 1 second,
-                  maxMessages = 1
-                )
-              ),
-              snsWriter = new SNSWriter(
-                snsClient = snsClient,
-                snsConfig = SNSConfig(topicArn = topicArn)
-              ),
-              system = actorSystem,
-              metrics = metricsSender
-            )
+              dynamoConfig = DynamoConfig(table = dynamoTableName)
+            ),
+            reader = new SQSReader(
+              sqsClient = sqsClient,
+              sqsConfig = SQSConfig(
+                queueUrl = queueUrl,
+                waitTime = 1 second,
+                maxMessages = 1
+              )
+            ),
+            snsWriter = new SNSWriter(
+              snsClient = snsClient,
+              snsConfig = SNSConfig(topicArn = topicArn)
+            ),
+            system = actorSystem,
+            metrics = metricsSender
+          )
 
-            try {
-              testWith(FixtureParams(worker, queueUrl))
-            } finally {
-              worker.stop()
-            }
+          try {
+            testWith(FixtureParams(worker, queueUrl))
+          } finally {
+            worker.stop()
           }
         }
       }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -49,8 +49,10 @@ class ReindexWorkerServiceTest
     DynamoFormat[TestRecord]
 
   it("returns a successful Future if the reindex completes correctly") {
-    withLocalDynamoDbTable { tableName =>
-      withReindexWorkerService(tableName) { service =>
+    withLocalDynamoDbTableAndIndex { fixtures =>
+      val tableName = fixtures.tableName
+      val indexName = fixtures.indexName
+      withReindexWorkerService(tableName, indexName) { service =>
         val reindexJob = ReindexJob(
           shardId = "sierra/123",
           desiredVersion = 6
@@ -95,8 +97,10 @@ class ReindexWorkerServiceTest
 
   it(
     "returns a failed Future if it cannot parse the SQS message as a ReindexJob") {
-    withLocalDynamoDbTable { tableName =>
-      withReindexWorkerService(tableName) { service =>
+    withLocalDynamoDbTableAndIndex { fixtures =>
+      val tableName = fixtures.tableName
+      val indexName = fixtures.indexName
+      withReindexWorkerService(tableName, indexName) { service =>
         val sqsMessage = SQSMessage(
           subject = None,
           body = "<xml>What is JSON.</xl?>",
@@ -160,7 +164,7 @@ class ReindexWorkerServiceTest
     }
   }
 
-  def withReindexWorkerService(tableName: String)(
+  def withReindexWorkerService(tableName: String, indexName: String)(
       testWith: TestWith[ReindexWorkerService, Assertion]) = {
     withActorSystem { actorSystem =>
 

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -49,9 +49,8 @@ class ReindexWorkerServiceTest
     DynamoFormat[TestRecord]
 
   def withReindexWorkerService(tableName: String, indexName: String)(
-      testWith: TestWith[ReindexWorkerService, Assertion]) = {
+    testWith: TestWith[ReindexWorkerService, Assertion]) = {
     withActorSystem { actorSystem =>
-
       val metricsSender = new MetricsSender(
         namespace = "reindex-worker-service-test",
         flushInterval = 100 milliseconds,
@@ -61,7 +60,6 @@ class ReindexWorkerServiceTest
 
       withLocalSqsQueue { queueUrl =>
         withLocalSnsTopic { topicArn =>
-
           val workerService = new ReindexWorkerService(
             targetService = new ReindexService(
               dynamoDBClient = dynamoDbClient,
@@ -138,7 +136,9 @@ class ReindexWorkerServiceTest
 
         whenReady(future) { _ =>
           val actualRecords: List[TestRecord] =
-            Scanamo.scan[TestRecord](dynamoDbClient)(tableName).map(_.right.get)
+            Scanamo
+              .scan[TestRecord](dynamoDbClient)(tableName)
+              .map(_.right.get)
 
           actualRecords shouldBe expectedRecords
         }
@@ -173,7 +173,6 @@ class ReindexWorkerServiceTest
 
   it("returns a failed Future if the reindex job fails") {
     withActorSystem { actorSystem =>
-
       val metricsSender = new MetricsSender(
         namespace = "reindex-worker-service-test",
         flushInterval = 100 milliseconds,

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
@@ -24,7 +24,8 @@ class ServerTest
     new Server(),
     flags = Map(
       "aws.sqs.queue.url" -> queueUrl
-    ) ++ s3LocalFlags ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags("serverTestTable")
+    ) ++ s3LocalFlags ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags(
+      "serverTestTable")
   )
 
   test("it shows the healthcheck message") {

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
@@ -23,9 +23,8 @@ class ServerTest
   val server = new EmbeddedHttpServer(
     new Server(),
     flags = Map(
-      "aws.dynamo.tableName" -> "serverTestTable",
       "aws.sqs.queue.url" -> queueUrl
-    ) ++ s3LocalFlags ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
+    ) ++ s3LocalFlags ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags("serverTestTable")
   )
 
   test("it shows the healthcheck message") {

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -43,7 +43,8 @@ class SierraBibMergerFeatureTest
       "aws.sqs.queue.url" -> queueUrl,
       "aws.sqs.waitTime" -> "1",
       "aws.s3.bucketName" -> bucketName
-    ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags(tableName) ++ s3LocalFlags
+    ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags(
+      tableName) ++ s3LocalFlags
   )
 
   def bibRecordString(id: String,

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -42,9 +42,8 @@ class SierraBibMergerFeatureTest
     flags = Map(
       "aws.sqs.queue.url" -> queueUrl,
       "aws.sqs.waitTime" -> "1",
-      "aws.s3.bucketName" -> bucketName,
-      "aws.dynamo.tableName" -> tableName
-    ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags ++ s3LocalFlags
+      "aws.s3.bucketName" -> bucketName
+    ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags(tableName) ++ s3LocalFlags
   )
 
   def bibRecordString(id: String,

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
@@ -23,9 +23,8 @@ class ServerTest
   val server = new EmbeddedHttpServer(
     new Server(),
     flags = Map(
-      "aws.dynamo.tableName" -> "serverTest",
       "aws.sqs.queue.url" -> queueUrl
-    ) ++ s3LocalFlags ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
+    ) ++ s3LocalFlags ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags("serverTest")
   )
 
   test("it shows the healthcheck message") {

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
@@ -24,7 +24,8 @@ class ServerTest
     new Server(),
     flags = Map(
       "aws.sqs.queue.url" -> queueUrl
-    ) ++ s3LocalFlags ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags("serverTest")
+    ) ++ s3LocalFlags ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags(
+      "serverTest")
   )
 
   test("it shows the healthcheck message") {

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
@@ -23,7 +23,8 @@ class SierraItemMergerFeatureTest
       "aws.sqs.queue.url" -> queueUrl,
       "aws.sqs.waitTime" -> "1",
       "aws.s3.bucketName" -> bucketName
-    ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags(tableName) ++ s3LocalFlags
+    ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags(
+      tableName) ++ s3LocalFlags
   )
 
   it("stores an item from SQS") {

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
@@ -22,9 +22,8 @@ class SierraItemMergerFeatureTest
     flags = Map(
       "aws.sqs.queue.url" -> queueUrl,
       "aws.sqs.waitTime" -> "1",
-      "aws.s3.bucketName" -> bucketName,
-      "aws.dynamo.tableName" -> tableName
-    ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags ++ s3LocalFlags
+      "aws.s3.bucketName" -> bucketName
+    ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags(tableName) ++ s3LocalFlags
   )
 
   it("stores an item from SQS") {

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
@@ -21,7 +21,8 @@ class ServerTest
     new Server(),
     flags = Map(
       "aws.sqs.queue.url" -> queueUrl
-    ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags("serverTestTable")
+    ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags(
+      "serverTestTable")
   )
 
   test("it shows the healthcheck message") {

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
@@ -20,9 +20,8 @@ class ServerTest
   val server = new EmbeddedHttpServer(
     new Server(),
     flags = Map(
-      "aws.dynamo.tableName" -> "serverTestTable",
       "aws.sqs.queue.url" -> queueUrl
-    ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
+    ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags("serverTestTable")
   )
 
   test("it shows the healthcheck message") {

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
@@ -36,7 +36,8 @@ class SierraItemsToDynamoFeatureTest
     Map(
       "aws.sqs.queue.url" -> queueUrl,
       "aws.sqs.waitTime" -> "1"
-    ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags(tableName)
+    ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags(
+      tableName)
   )
 
   it("reads items from Sierra and adds them to DynamoDB") {

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
@@ -35,9 +35,8 @@ class SierraItemsToDynamoFeatureTest
     new Server(),
     Map(
       "aws.sqs.queue.url" -> queueUrl,
-      "aws.sqs.waitTime" -> "1",
-      "aws.dynamo.tableName" -> tableName
-    ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
+      "aws.sqs.waitTime" -> "1"
+    ) ++ sqsLocalFlags ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags(tableName)
   )
 
   it("reads items from Sierra and adds them to DynamoDB") {


### PR DESCRIPTION
This started as another piece of #1643, but the reindex is rather fiddly. So this patch *also*:

* Makes the GSI name a configurable flag to the reindexer (as our fixture generates it randomly)
* Makes the DynamoDB config flags a method on the fixture, so you *have* to supply a table name

WIP because I want to double-check everything before sending it round for review, but it should be passing all tests.