### PR TITLE
Remove some stuff from the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,13 +95,14 @@ jobs:
     # Shared infra stack
     - env: TASK=shared_infra-test
 
-    # Loris stack
-    - env: TASK=loris-build
     # (not under active development)
+
+    # Loris stack
+    # - env: TASK=loris-build
     # - env: TASK=cache_cleaner-build
 
     # Monitoring stack
-    - env: TASK=monitoring-test
+    # - env: TASK=monitoring-test
 
 stages:
   - format

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,6 @@ jobs:
     - env: TASK=travis-format
       stage: format
 
-    # (not under active development)
-    # - env: TASK=nginx-build
-
     - stage: test
       env: TASK=sbt-common-test
     - env: TASK=sbt-display-test
@@ -96,6 +93,9 @@ jobs:
     - env: TASK=shared_infra-test
 
     # (not under active development)
+
+    # nginx stack
+    # - env: TASK=nginx-build
 
     # Loris stack
     # - env: TASK=loris-build

--- a/.travis/travistooling.py
+++ b/.travis/travistooling.py
@@ -137,6 +137,10 @@ def affects_tests(path, task):
                     (path, task))
                 return False
 
+    if path.startswith('.travis'):
+        print("~~~ All changes to the .travis directory are irrelevant")
+        return False
+
     # Otherwise, we were unable to decide if this change was important.
     # We assume that it is, so we'll run tests just in case.
     print("+++ Unable to decide if %s is significant, so assume it is" % path)


### PR DESCRIPTION
Travis has been getting slow again recently; this is an attempt at a cheap fix to make it a bit faster.