### PR TITLE
Remove the 'visible' field from DisplayWork

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -8,7 +8,7 @@ import com.twitter.inject.annotations.Flag
 import io.swagger.models.parameters.QueryParameter
 import io.swagger.models.properties.StringProperty
 import scala.collection.JavaConverters._
-import uk.ac.wellcome.models.{Error, WorksIncludes}
+import uk.ac.wellcome.models.{Error, IdentifiedWork, WorksIncludes}
 import uk.ac.wellcome.platform.api.ApiSwagger
 import uk.ac.wellcome.platform.api.models.{DisplayError, DisplayResultList}
 
@@ -146,18 +146,14 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
       worksService
         .findWorkById(canonicalId = request.id, index = request._index)
         .map {
-          case Some(work) =>
-            Some(DisplayWork(work = work, includes = includes))
-          case None => None
-        }
-        .map {
 
           // If the work is visible, we return the complete work.  If it's
           // present but hidden, we need to return an HTTP 410 Gone.
-          case Some(work: DisplayWork) =>
+          case Some(work: IdentifiedWork) =>
             if (work.visible) {
+              val result = DisplayWork(work = work, includes = includes)
               response.ok.json(
-                ResultResponse(context = contextUri, result = work))
+                ResultResponse(context = contextUri, result = result))
             } else {
               val result = Error(
                 variant = "http-410",

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -1,10 +1,9 @@
 package uk.ac.wellcome.display.models
 
-import com.fasterxml.jackson.annotation.{JsonIgnoreProperties, JsonProperty}
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.{IdentifiedWork, WorksIncludes}
 
-@JsonIgnoreProperties(Array("visible"))
 @ApiModel(
   value = "Work",
   description =

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -85,8 +85,7 @@ case class DisplayWork(
   @ApiModelProperty(
     dataType = "uk.ac.wellcome.display.models.DisplayLanguage",
     value = "Relates a work to its primary language."
-  ) language: Option[DisplayLanguage] = None,
-  visible: Boolean = true
+  ) language: Option[DisplayLanguage] = None
 ) {
   @ApiModelProperty(
     readOnly = true,
@@ -127,8 +126,7 @@ case object DisplayWork {
       publishers = work.publishers.map(DisplayAbstractAgent(_)),
       publicationDate = work.publicationDate.map { DisplayPeriod(_) },
       placesOfPublication = work.placesOfPublication.map { DisplayPlace(_) },
-      language = work.language.map { DisplayLanguage(_) },
-      visible = work.visible
+      language = work.language.map { DisplayLanguage(_) }
     )
   }
 


### PR DESCRIPTION
This is an internal-only field; it doesn't make sense to have it on the display model.