### PR TITLE
Isolate some of the API tests

### DIFF
--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -2,24 +2,10 @@ package uk.ac.wellcome.platform.api
 
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.twitter.finagle.http.{Response, Status}
-import com.twitter.finatra.http.EmbeddedHttpServer
-import com.twitter.inject.server.FeatureTestMixin
-import org.scalatest.FunSpec
+import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.IdentifiedWork
 
-class ApiSwaggerTest extends FunSpec with FeatureTestMixin {
-
-  implicit val jsonMapper = IdentifiedWork
-  override val server =
-    new EmbeddedHttpServer(
-      new Server,
-      flags = Map(
-        "api.host" -> "test.host",
-        "api.scheme" -> "http",
-        "api.version" -> "v99",
-        "api.name" -> "test"
-      )
-    )
+class ApiSwaggerTest extends FunSpec with Matchers with fixtures.Server {
 
   it("should return a valid JSON response") {
     val tree = readTree("/test/v99/swagger.json")
@@ -36,10 +22,21 @@ class ApiSwaggerTest extends FunSpec with FeatureTestMixin {
   }
 
   def readTree(path: String): JsonNode = {
-    val response: Response = server.httpGet(
-      path = path,
-      andExpect = Status.Ok
+    val flags = Map(
+      "api.host" -> "test.host",
+      "api.scheme" -> "http",
+      "api.version" -> "v99",
+      "api.name" -> "test"
     )
+
+    implicit val jsonMapper = IdentifiedWork
+
+    val response: Response = withServer(flags) { server =>
+      server.httpGet(
+        path = path,
+        andExpect = Status.Ok
+      )
+    }
 
     val mapper = new ObjectMapper()
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ElasticsearchService.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ElasticsearchService.scala
@@ -1,0 +1,19 @@
+package uk.ac.wellcome.platform.api.fixtures
+
+import org.scalatest.{Assertion, Suite}
+import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
+import uk.ac.wellcome.platform.api.services.ElasticSearchService
+import uk.ac.wellcome.test.fixtures.TestWith
+
+trait ElasticsearchService
+    extends ElasticsearchFixtures { this: Suite =>
+  def withElasticSearchService(indexName: String, itemType: String)(
+      testWith: TestWith[ElasticSearchService, Assertion]) = {
+    val searchService = new ElasticSearchService(
+      defaultIndex = indexName,
+      documentType = itemType,
+      elasticClient = elasticClient
+    )
+    testWith(searchService)
+  }
+}

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ElasticsearchServiceFixture.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ElasticsearchServiceFixture.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.platform.api.services.ElasticSearchService
 import uk.ac.wellcome.test.fixtures.TestWith
 
-trait ElasticsearchService
+trait ElasticsearchServiceFixture
     extends ElasticsearchFixtures { this: Suite =>
   def withElasticSearchService(indexName: String, itemType: String)(
       testWith: TestWith[ElasticSearchService, Assertion]) = {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ElasticsearchServiceFixture.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ElasticsearchServiceFixture.scala
@@ -5,10 +5,10 @@ import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.platform.api.services.ElasticSearchService
 import uk.ac.wellcome.test.fixtures.TestWith
 
-trait ElasticsearchServiceFixture
-    extends ElasticsearchFixtures { this: Suite =>
+trait ElasticsearchServiceFixture extends ElasticsearchFixtures {
+  this: Suite =>
   def withElasticSearchService(indexName: String, itemType: String)(
-      testWith: TestWith[ElasticSearchService, Assertion]) = {
+    testWith: TestWith[ElasticSearchService, Assertion]) = {
     val searchService = new ElasticSearchService(
       defaultIndex = indexName,
       documentType = itemType,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/Server.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/Server.scala
@@ -1,0 +1,29 @@
+package uk.ac.wellcome.platform.api.fixtures
+
+import com.twitter.finatra.http.EmbeddedHttpServer
+import org.scalatest.Suite
+import uk.ac.wellcome.platform.api.{Server => AppServer}
+import uk.ac.wellcome.test.fixtures.TestWith
+
+trait Server { this: Suite =>
+  def withServer[R](
+    flags: Map[String, String],
+    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer = identity
+  )(testWith: TestWith[EmbeddedHttpServer, R]) = {
+
+    val server: EmbeddedHttpServer = modifyServer(
+      new EmbeddedHttpServer(
+        new AppServer(),
+        flags = flags
+      )
+    )
+
+    server.start()
+
+    try {
+      testWith(server)
+    } finally {
+      server.close()
+    }
+  }
+}

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/WorksServiceFixture.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/WorksServiceFixture.scala
@@ -1,0 +1,19 @@
+package uk.ac.wellcome.platform.api.fixtures
+
+import org.scalatest.{Assertion, Suite}
+import uk.ac.wellcome.platform.api.services.{
+  ElasticSearchService,
+  WorksService
+}
+import uk.ac.wellcome.test.fixtures.TestWith
+
+trait WorksServiceFixture { this: Suite =>
+  def withWorksService(searchService: ElasticSearchService)(
+      testWith: TestWith[WorksService, Assertion]) = {
+    val worksService = new WorksService(
+      defaultPageSize = 10,
+      searchService = searchService
+    )
+    testWith(worksService)
+  }
+}

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/WorksServiceFixture.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/WorksServiceFixture.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.test.fixtures.TestWith
 
 trait WorksServiceFixture { this: Suite =>
   def withWorksService(searchService: ElasticSearchService)(
-      testWith: TestWith[WorksService, Assertion]) = {
+    testWith: TestWith[WorksService, Assertion]) = {
     val worksService = new WorksService(
       defaultPageSize = 10,
       searchService = searchService

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -5,14 +5,14 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.IdentifiedWork
 import uk.ac.wellcome.platform.api.WorksUtil
-import uk.ac.wellcome.platform.api.fixtures
+import uk.ac.wellcome.platform.api.fixtures.ElasticsearchServiceFixture
 import uk.ac.wellcome.display.models.DisplayWork
 import uk.ac.wellcome.models.WorksIncludes
 import uk.ac.wellcome.utils.JsonUtil._
 
 class ElasticsearchServiceTest
     extends FunSpec
-    with fixtures.ElasticsearchService
+    with ElasticsearchServiceFixture
     with Matchers
     with ScalaFutures
     with WorksUtil {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -43,9 +43,9 @@ class ElasticsearchServiceTest
         expectedWorks = List(work3, work2, work1).map { DisplayWork(_) }
       )
 
-      // TODO: canonicalID is the only user-defined field that we can sort on.
-      // When we have other fields we can sort on, we should extend this test
-      // for different sort orders.
+    // TODO: canonicalID is the only user-defined field that we can sort on.
+    // When we have other fields we can sort on, we should extend this test
+    // for different sort orders.
     }
   }
 
@@ -129,8 +129,7 @@ class ElasticsearchServiceTest
     }
   }
 
-  private def populateElasticsearch(
-    indexName: String): List[DisplayWork] = {
+  private def populateElasticsearch(indexName: String): List[DisplayWork] = {
     val works = createWorks(10)
     insertIntoElasticsearch(indexName, itemType, works: _*)
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -2,33 +2,22 @@ package uk.ac.wellcome.platform.api.services
 
 import com.sksamuel.elastic4s.http.search.SearchHit
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{Assertion, FunSpec, Matchers}
+import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.IdentifiedWork
 import uk.ac.wellcome.platform.api.WorksUtil
+import uk.ac.wellcome.platform.api.fixtures
 import uk.ac.wellcome.display.models.DisplayWork
 import uk.ac.wellcome.models.WorksIncludes
-import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.test.fixtures.TestWith
 import uk.ac.wellcome.utils.JsonUtil._
 
 class ElasticsearchServiceTest
     extends FunSpec
-    with ElasticsearchFixtures
+    with fixtures.ElasticsearchService
     with Matchers
     with ScalaFutures
     with WorksUtil {
 
   val itemType = "work"
-
-  private def withElasticSearchService(indexName: String, itemType: String)(
-    testWith: TestWith[ElasticSearchService, Assertion]) = {
-      val searchService = new ElasticSearchService(
-        defaultIndex = indexName,
-        documentType = itemType,
-        elasticClient = elasticClient
-      )
-      testWith(searchService)
-    }
 
   it("should sort results from Elasticsearch in the correct order") {
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -2,147 +2,177 @@ package uk.ac.wellcome.platform.api.services
 
 import com.sksamuel.elastic4s.http.search.SearchHit
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.models.IdentifiedWork
 import uk.ac.wellcome.platform.api.WorksUtil
-import uk.ac.wellcome.models.WorksIncludes
 import uk.ac.wellcome.display.models.DisplayWork
-import uk.ac.wellcome.elasticsearch.test.utils.IndexedElasticSearchLocal
+import uk.ac.wellcome.models.WorksIncludes
+import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
+import uk.ac.wellcome.test.fixtures.TestWith
 import uk.ac.wellcome.utils.JsonUtil._
 
 class ElasticsearchServiceTest
     extends FunSpec
-    with IndexedElasticSearchLocal
+    with ElasticsearchFixtures
     with Matchers
     with ScalaFutures
     with WorksUtil {
 
-  val indexName = "works"
   val itemType = "work"
 
-  val searchService =
-    new ElasticSearchService(indexName, itemType, elasticClient)
+  private def withElasticSearchService(indexName: String, itemType: String)(
+    testWith: TestWith[ElasticSearchService, Assertion]) = {
+      val searchService = new ElasticSearchService(
+        defaultIndex = indexName,
+        documentType = itemType,
+        elasticClient = elasticClient
+      )
+      testWith(searchService)
+    }
 
   it("should sort results from Elasticsearch in the correct order") {
-    val work1 = workWith(
-      canonicalId = "000Z",
-      title = "Amid an Aegean"
-    )
-    val work2 = workWith(
-      canonicalId = "000Y",
-      title = "Before a Bengal"
-    )
-    val work3 = workWith(
-      canonicalId = "000X",
-      title = "Circling a Cheetah"
-    )
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      val work1 = workWith(
+        canonicalId = "000Z",
+        title = "Amid an Aegean"
+      )
+      val work2 = workWith(
+        canonicalId = "000Y",
+        title = "Before a Bengal"
+      )
+      val work3 = workWith(
+        canonicalId = "000X",
+        title = "Circling a Cheetah"
+      )
 
-    insertIntoElasticSearch(work1, work2, work3)
+      insertIntoElasticsearch(indexName, itemType, work1, work2, work3)
 
-    assertSliceIsCorrect(
-      limit = 3,
-      from = 0,
-      expectedWorks = List(work3, work2, work1).map { DisplayWork(_) }
-    )
+      assertSliceIsCorrect(
+        indexName = indexName,
+        limit = 3,
+        from = 0,
+        expectedWorks = List(work3, work2, work1).map { DisplayWork(_) }
+      )
 
-    // TODO: canonicalID is the only user-defined field that we can sort on.
-    // When we have other fields we can sort on, we should extend this test
-    // for different sort orders.
+      // TODO: canonicalID is the only user-defined field that we can sort on.
+      // When we have other fields we can sort on, we should extend this test
+      // for different sort orders.
+    }
   }
 
   it("should return everything if we ask for a limit > result size") {
-    val displayWorks = populateElasticsearch()
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      val displayWorks = populateElasticsearch(indexName)
 
-    assertSliceIsCorrect(
-      limit = displayWorks.length + 1,
-      from = 0,
-      expectedWorks = displayWorks
-    )
+      assertSliceIsCorrect(
+        indexName = indexName,
+        limit = displayWorks.length + 1,
+        from = 0,
+        expectedWorks = displayWorks
+      )
+    }
   }
 
   it("should return a page from the beginning of the result set") {
-    val displayWorks = populateElasticsearch()
-    assertSliceIsCorrect(
-      limit = 4,
-      from = 0,
-      expectedWorks = displayWorks.slice(0, 4)
-    )
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      val displayWorks = populateElasticsearch(indexName)
+      assertSliceIsCorrect(
+        indexName = indexName,
+        limit = 4,
+        from = 0,
+        expectedWorks = displayWorks.slice(0, 4)
+      )
+    }
   }
 
   it("should return a page from halfway through the result set") {
-    val displayWorks = populateElasticsearch()
-    assertSliceIsCorrect(
-      limit = 4,
-      from = 3,
-      expectedWorks = displayWorks.slice(3, 7)
-    )
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      val displayWorks = populateElasticsearch(indexName)
+      assertSliceIsCorrect(
+        indexName = indexName,
+        limit = 4,
+        from = 3,
+        expectedWorks = displayWorks.slice(3, 7)
+      )
+    }
   }
 
   it("should return a page from the end of the result set") {
-    val displayWorks = populateElasticsearch()
-    assertSliceIsCorrect(
-      limit = 7,
-      from = 5,
-      expectedWorks = displayWorks.slice(5, 10)
-    )
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      val displayWorks = populateElasticsearch(indexName)
+      assertSliceIsCorrect(
+        indexName = indexName,
+        limit = 7,
+        from = 5,
+        expectedWorks = displayWorks.slice(5, 10)
+      )
+    }
   }
 
   it("should return an empty page if asked for a limit > result size") {
-    val displayWorks = populateElasticsearch()
-    assertSliceIsCorrect(
-      limit = 10,
-      from = displayWorks.length * 2,
-      expectedWorks = List()
-    )
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      val displayWorks = populateElasticsearch(indexName)
+      assertSliceIsCorrect(
+        indexName = indexName,
+        limit = 10,
+        from = displayWorks.length * 2,
+        expectedWorks = List()
+      )
+    }
   }
 
   it("should not list works that have visible=false") {
-    val visibleWorks = createWorks(count = 8, visible = true)
-    val invisibleWorks = createWorks(count = 2, start = 9, visible = false)
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      val visibleWorks = createWorks(count = 8, visible = true)
+      val invisibleWorks = createWorks(count = 2, start = 9, visible = false)
 
-    val works = visibleWorks ++ invisibleWorks
-    insertIntoElasticSearch(works: _*)
+      val works = visibleWorks ++ invisibleWorks
+      insertIntoElasticsearch(indexName, itemType, works: _*)
 
-    val displayWorks = toDisplayWorks(visibleWorks)
+      val displayWorks = toDisplayWorks(visibleWorks)
 
-    assertSliceIsCorrect(
-      limit = 10,
-      from = 0,
-      expectedWorks = displayWorks
-    )
+      assertSliceIsCorrect(
+        indexName = indexName,
+        limit = 10,
+        from = 0,
+        expectedWorks = displayWorks
+      )
+    }
   }
 
   private def populateElasticsearch(
-    worksIncludes: WorksIncludes = WorksIncludes()): List[DisplayWork] = {
+    indexName: String): List[DisplayWork] = {
     val works = createWorks(10)
-    insertIntoElasticSearch(works: _*)
+    insertIntoElasticsearch(indexName, itemType, works: _*)
 
-    toDisplayWorks(works, worksIncludes = worksIncludes)
+    toDisplayWorks(works)
   }
 
-  private def toDisplayWorks(
-    works: Seq[IdentifiedWork],
-    worksIncludes: WorksIncludes = WorksIncludes()): List[DisplayWork] =
-    works.map(DisplayWork(_, worksIncludes)).sortBy(_.id).toList
+  private def toDisplayWorks(works: Seq[IdentifiedWork]): List[DisplayWork] =
+    works.map(DisplayWork(_)).sortBy(_.id).toList
 
   private def assertSliceIsCorrect(
+    indexName: String,
     limit: Int,
     from: Int,
     expectedWorks: List[DisplayWork]
   ) = {
-    val searchResultFuture = searchService.listResults(
-      sortByField = "canonicalId",
-      limit = limit,
-      from = from
-    )
-    whenReady(searchResultFuture) { result =>
-      result.hits should have size expectedWorks.length
-      val returnedWorks = result.hits.hits
-        .map { h: SearchHit =>
-          jsonToIdentifiedWork(h.sourceAsString)
+    withElasticSearchService(indexName = indexName, itemType = itemType) {
+      searchService =>
+        val searchResultFuture = searchService.listResults(
+          sortByField = "canonicalId",
+          limit = limit,
+          from = from
+        )
+        whenReady(searchResultFuture) { result =>
+          result.hits should have size expectedWorks.length
+          val returnedWorks = result.hits.hits
+            .map { h: SearchHit =>
+              jsonToIdentifiedWork(h.sourceAsString)
+            }
+            .map { DisplayWork(_) }
+          returnedWorks.toList shouldBe expectedWorks
         }
-        .map { DisplayWork(_) }
-      returnedWorks.toList shouldBe expectedWorks
     }
   }
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -28,24 +28,24 @@ class WorksServiceTest
   it("should return the records in Elasticsearch") {
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
       withElasticSearchService(indexName = indexName, itemType = itemType) {
-          searchService =>
-        withWorksService(searchService) { worksService =>
-          val works = createWorks(2)
+        searchService =>
+          withWorksService(searchService) { worksService =>
+            val works = createWorks(2)
 
-          insertIntoElasticsearch(indexName, itemType, works: _*)
+            insertIntoElasticsearch(indexName, itemType, works: _*)
 
-          val future = worksService.listWorks()
+            val future = worksService.listWorks()
 
-          whenReady(future) { resultList =>
-            resultList.results should have size 2
-            resultList.results.head shouldBe DisplayWork(
-              works(0).canonicalId,
-              works(0).title.get)
-            resultList.results.tail.head shouldBe DisplayWork(
-              works(1).canonicalId,
-              works(1).title.get)
+            whenReady(future) { resultList =>
+              resultList.results should have size 2
+              resultList.results.head shouldBe DisplayWork(
+                works(0).canonicalId,
+                works(0).title.get)
+              resultList.results.tail.head shouldBe DisplayWork(
+                works(1).canonicalId,
+                works(1).title.get)
+            }
           }
-        }
       }
     }
   }
@@ -53,19 +53,20 @@ class WorksServiceTest
   it("should get a DisplayWork by id") {
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
       withElasticSearchService(indexName = indexName, itemType = itemType) {
-          searchService =>
-        withWorksService(searchService) { worksService =>
-          val works = createWorks(1)
+        searchService =>
+          withWorksService(searchService) { worksService =>
+            val works = createWorks(1)
 
-          insertIntoElasticsearch(indexName, itemType, works: _*)
+            insertIntoElasticsearch(indexName, itemType, works: _*)
 
-          val recordsFuture = worksService.findWorkById(works.head.canonicalId)
+            val recordsFuture =
+              worksService.findWorkById(works.head.canonicalId)
 
-          whenReady(recordsFuture) { records =>
-            records.isDefined shouldBe true
-            records.get shouldBe works.head
+            whenReady(recordsFuture) { records =>
+              records.isDefined shouldBe true
+              records.get shouldBe works.head
+            }
           }
-        }
       }
     }
   }
@@ -73,31 +74,31 @@ class WorksServiceTest
   it("should only find results that match a query if doing a full-text search") {
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
       withElasticSearchService(indexName = indexName, itemType = itemType) {
-          searchService =>
-        withWorksService(searchService) { worksService =>
-          val workDodo = workWith(
-            canonicalId = "1234",
-            title = "A drawing of a dodo"
-          )
-          val workMouse = workWith(
-            canonicalId = "5678",
-            title = "A mezzotint of a mouse"
-          )
+        searchService =>
+          withWorksService(searchService) { worksService =>
+            val workDodo = workWith(
+              canonicalId = "1234",
+              title = "A drawing of a dodo"
+            )
+            val workMouse = workWith(
+              canonicalId = "5678",
+              title = "A mezzotint of a mouse"
+            )
 
-          insertIntoElasticsearch(indexName, itemType, workDodo, workMouse)
+            insertIntoElasticsearch(indexName, itemType, workDodo, workMouse)
 
-          val searchForCat = worksService.searchWorks("cat")
+            val searchForCat = worksService.searchWorks("cat")
 
-          whenReady(searchForCat) { works =>
-            works.results should have size 0
+            whenReady(searchForCat) { works =>
+              works.results should have size 0
+            }
+
+            val searchForDodo = worksService.searchWorks("dodo")
+            whenReady(searchForDodo) { works =>
+              works.results should have size 1
+              works.results.head shouldBe workDodo
+            }
           }
-
-          val searchForDodo = worksService.searchWorks("dodo")
-          whenReady(searchForDodo) { works =>
-            works.results should have size 1
-            works.results.head shouldBe workDodo
-          }
-        }
       }
     }
   }
@@ -105,14 +106,14 @@ class WorksServiceTest
   it("should return a future of None if it cannot get a record by id") {
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
       withElasticSearchService(indexName = indexName, itemType = itemType) {
-          searchService =>
-        withWorksService(searchService) { worksService =>
-          val recordsFuture = worksService.findWorkById("1234")
+        searchService =>
+          withWorksService(searchService) { worksService =>
+            val recordsFuture = worksService.findWorkById("1234")
 
-          whenReady(recordsFuture) { record =>
-            record shouldBe None
+            whenReady(recordsFuture) { record =>
+              record shouldBe None
+            }
           }
-        }
       }
     }
   }
@@ -120,14 +121,14 @@ class WorksServiceTest
   it("should return 0 pages when no results are available") {
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
       withElasticSearchService(indexName = indexName, itemType = itemType) {
-          searchService =>
-        withWorksService(searchService) { worksService =>
-          val displayWorksFuture = worksService.listWorks(pageSize = 10)
+        searchService =>
+          withWorksService(searchService) { worksService =>
+            val displayWorksFuture = worksService.listWorks(pageSize = 10)
 
-          whenReady(displayWorksFuture) { works =>
-            works.totalResults shouldBe 0
+            whenReady(displayWorksFuture) { works =>
+              works.totalResults shouldBe 0
+            }
           }
-        }
       }
     }
   }
@@ -136,19 +137,19 @@ class WorksServiceTest
     "should return an empty result set when asked for a page that does not exist") {
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
       withElasticSearchService(indexName = indexName, itemType = itemType) {
-          searchService =>
-        withWorksService(searchService) { worksService =>
-          val works = createWorks(3)
+        searchService =>
+          withWorksService(searchService) { worksService =>
+            val works = createWorks(3)
 
-          insertIntoElasticsearch(indexName, itemType, works: _*)
+            insertIntoElasticsearch(indexName, itemType, works: _*)
 
-          val displayWorksFuture =
-            worksService.listWorks(pageSize = 1, pageNumber = 4)
+            val displayWorksFuture =
+              worksService.listWorks(pageSize = 1, pageNumber = 4)
 
-          whenReady(displayWorksFuture) { receivedWorks =>
-            receivedWorks.results shouldBe empty
+            whenReady(displayWorksFuture) { receivedWorks =>
+              receivedWorks.results shouldBe empty
+            }
           }
-        }
       }
     }
   }
@@ -157,23 +158,23 @@ class WorksServiceTest
     "should not throw an exception if passed an invalid query string for full-text search") {
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
       withElasticSearchService(indexName = indexName, itemType = itemType) {
-          searchService =>
-        withWorksService(searchService) { worksService =>
-          val workEmu = workWith(
-            canonicalId = "1234",
-            title = "An etching of an emu"
-          )
-          insertIntoElasticsearch(indexName, itemType, workEmu)
+        searchService =>
+          withWorksService(searchService) { worksService =>
+            val workEmu = workWith(
+              canonicalId = "1234",
+              title = "An etching of an emu"
+            )
+            insertIntoElasticsearch(indexName, itemType, workEmu)
 
-          val searchForEmu = worksService.searchWorks(
-            "emu \"unmatched quotes are a lexical error in the Elasticsearch parser"
-          )
+            val searchForEmu = worksService.searchWorks(
+              "emu \"unmatched quotes are a lexical error in the Elasticsearch parser"
+            )
 
-          whenReady(searchForEmu) { works =>
-            works.results should have size 1
-            works.results.head shouldBe workEmu
+            whenReady(searchForEmu) { works =>
+              works.results should have size 1
+              works.results.head shouldBe workEmu
+            }
           }
-        }
       }
     }
   }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -37,13 +37,7 @@ class WorksServiceTest
             val future = worksService.listWorks()
 
             whenReady(future) { resultList =>
-              resultList.results should have size 2
-              resultList.results.head shouldBe DisplayWork(
-                works(0).canonicalId,
-                works(0).title.get)
-              resultList.results.tail.head shouldBe DisplayWork(
-                works(1).canonicalId,
-                works(1).title.get)
+              resultList.results shouldBe works
             }
           }
       }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -37,15 +37,13 @@ class WorksServiceTest
           val future = worksService.listWorks()
 
           whenReady(future) { resultList =>
-            resultList.results.map { displayWork =>
-              displayWork.results should have size 2
-              displayWork.results.head shouldBe DisplayWork(
-                works(0).canonicalId,
-                works(0).title.get)
-              displayWork.results.tail.head shouldBe DisplayWork(
-                works(1).canonicalId,
-                works(1).title.get)
-            }
+            resultList.results should have size 2
+            resultList.results.head shouldBe DisplayWork(
+              works(0).canonicalId,
+              works(0).title.get)
+            resultList.results.tail.head shouldBe DisplayWork(
+              works(1).canonicalId,
+              works(1).title.get)
           }
         }
       }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -4,6 +4,10 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier}
 import uk.ac.wellcome.platform.api.WorksUtil
+import uk.ac.wellcome.platform.api.fixtures.{
+  ElasticsearchServiceFixture,
+  WorksServiceFixture
+}
 import uk.ac.wellcome.models.WorksIncludes
 import uk.ac.wellcome.display.models.{DisplayIdentifier, DisplayWork}
 import uk.ac.wellcome.platform.api.models.DisplayResultList
@@ -13,121 +17,166 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class WorksServiceTest
     extends FunSpec
-    with IndexedElasticSearchLocal
+    with ElasticsearchServiceFixture
+    with WorksServiceFixture
     with Matchers
     with ScalaFutures
     with WorksUtil {
 
-  val indexName = "works"
   val itemType = "work"
 
-  val searchService =
-    new ElasticSearchService(indexName, itemType, elasticClient)
-
-  val worksService =
-    new WorksService(10, searchService)
-
   it("should return the records in Elasticsearch") {
-    val works = createWorks(2)
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withElasticSearchService(indexName = indexName, itemType = itemType) {
+          searchService =>
+        withWorksService(searchService) { worksService =>
+          val works = createWorks(2)
 
-    insertIntoElasticSearch(works: _*)
+          insertIntoElasticsearch(indexName, itemType, works: _*)
 
-    val displayWorksFuture = worksService.listWorks()
+          val future = worksService.listWorks()
 
-    displayWorksFuture map { displayWork =>
-      displayWork.results should have size 2
-      displayWork.results.head shouldBe DisplayWork(
-        works(0).canonicalId,
-        works(0).title.get)
-      displayWork.results.tail.head shouldBe DisplayWork(
-        works(1).canonicalId,
-        works(1).title.get)
+          whenReady(future) { resultList =>
+            resultList.results.map { displayWork =>
+              displayWork.results should have size 2
+              displayWork.results.head shouldBe DisplayWork(
+                works(0).canonicalId,
+                works(0).title.get)
+              displayWork.results.tail.head shouldBe DisplayWork(
+                works(1).canonicalId,
+                works(1).title.get)
+            }
+          }
+        }
+      }
     }
   }
 
   it("should get a DisplayWork by id") {
-    val works = createWorks(1)
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withElasticSearchService(indexName = indexName, itemType = itemType) {
+          searchService =>
+        withWorksService(searchService) { worksService =>
+          val works = createWorks(1)
 
-    insertIntoElasticSearch(works: _*)
+          insertIntoElasticsearch(indexName, itemType, works: _*)
 
-    val recordsFuture = worksService.findWorkById(works.head.canonicalId)
+          val recordsFuture = worksService.findWorkById(works.head.canonicalId)
 
-    whenReady(recordsFuture) { records =>
-      records.isDefined shouldBe true
-      records.get shouldBe works.head
+          whenReady(recordsFuture) { records =>
+            records.isDefined shouldBe true
+            records.get shouldBe works.head
+          }
+        }
+      }
     }
   }
 
   it("should only find results that match a query if doing a full-text search") {
-    val workDodo = workWith(
-      canonicalId = "1234",
-      title = "A drawing of a dodo"
-    )
-    val workMouse = workWith(
-      canonicalId = "5678",
-      title = "A mezzotint of a mouse"
-    )
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withElasticSearchService(indexName = indexName, itemType = itemType) {
+          searchService =>
+        withWorksService(searchService) { worksService =>
+          val workDodo = workWith(
+            canonicalId = "1234",
+            title = "A drawing of a dodo"
+          )
+          val workMouse = workWith(
+            canonicalId = "5678",
+            title = "A mezzotint of a mouse"
+          )
 
-    insertIntoElasticSearch(workDodo, workMouse)
+          insertIntoElasticsearch(indexName, itemType, workDodo, workMouse)
 
-    val searchForCat = worksService.searchWorks("cat")
+          val searchForCat = worksService.searchWorks("cat")
 
-    whenReady(searchForCat) { works =>
-      works.results should have size 0
-    }
+          whenReady(searchForCat) { works =>
+            works.results should have size 0
+          }
 
-    val searchForDodo = worksService.searchWorks("dodo")
-    whenReady(searchForDodo) { works =>
-      works.results should have size 1
-      works.results.head shouldBe workDodo
+          val searchForDodo = worksService.searchWorks("dodo")
+          whenReady(searchForDodo) { works =>
+            works.results should have size 1
+            works.results.head shouldBe workDodo
+          }
+        }
+      }
     }
   }
 
   it("should return a future of None if it cannot get a record by id") {
-    val recordsFuture = worksService.findWorkById("1234")
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withElasticSearchService(indexName = indexName, itemType = itemType) {
+          searchService =>
+        withWorksService(searchService) { worksService =>
+          val recordsFuture = worksService.findWorkById("1234")
 
-    whenReady(recordsFuture) { record =>
-      record shouldBe None
+          whenReady(recordsFuture) { record =>
+            record shouldBe None
+          }
+        }
+      }
     }
   }
 
   it("should return 0 pages when no results are available") {
-    val displayWorksFuture = worksService.listWorks(pageSize = 10)
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withElasticSearchService(indexName = indexName, itemType = itemType) {
+          searchService =>
+        withWorksService(searchService) { worksService =>
+          val displayWorksFuture = worksService.listWorks(pageSize = 10)
 
-    whenReady(displayWorksFuture) { works =>
-      works.totalResults shouldBe 0
+          whenReady(displayWorksFuture) { works =>
+            works.totalResults shouldBe 0
+          }
+        }
+      }
     }
   }
 
   it(
     "should return an empty result set when asked for a page that does not exist") {
-    val works = createWorks(3)
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withElasticSearchService(indexName = indexName, itemType = itemType) {
+          searchService =>
+        withWorksService(searchService) { worksService =>
+          val works = createWorks(3)
 
-    insertIntoElasticSearch(works: _*)
+          insertIntoElasticsearch(indexName, itemType, works: _*)
 
-    val displayWorksFuture =
-      worksService.listWorks(pageSize = 1, pageNumber = 4)
+          val displayWorksFuture =
+            worksService.listWorks(pageSize = 1, pageNumber = 4)
 
-    whenReady(displayWorksFuture) { receivedWorks =>
-      receivedWorks.results shouldBe empty
+          whenReady(displayWorksFuture) { receivedWorks =>
+            receivedWorks.results shouldBe empty
+          }
+        }
+      }
     }
   }
 
   it(
     "should not throw an exception if passed an invalid query string for full-text search") {
-    val workEmu = workWith(
-      canonicalId = "1234",
-      title = "An etching of an emu"
-    )
-    insertIntoElasticSearch(workEmu)
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withElasticSearchService(indexName = indexName, itemType = itemType) {
+          searchService =>
+        withWorksService(searchService) { worksService =>
+          val workEmu = workWith(
+            canonicalId = "1234",
+            title = "An etching of an emu"
+          )
+          insertIntoElasticsearch(indexName, itemType, workEmu)
 
-    val searchForEmu = worksService.searchWorks(
-      "emu \"unmatched quotes are a lexical error in the Elasticsearch parser"
-    )
+          val searchForEmu = worksService.searchWorks(
+            "emu \"unmatched quotes are a lexical error in the Elasticsearch parser"
+          )
 
-    whenReady(searchForEmu) { works =>
-      works.results should have size 1
-      works.results.head shouldBe workEmu
+          whenReady(searchForEmu) { works =>
+            works.results should have size 1
+            works.results.head shouldBe workEmu
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Another piece towards #1643.

The ApiWorksTest classes might need some extra thought – each test would need a server fixture, and maybe we want to reduce those tests and push the checks elsewhere – so I’ve skipped them for now.