### PR TITLE
Implement the snapshot convertor logic as a flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,6 +72,7 @@ lazy val sierra_item_merger = doSharedSierraSetup(project, "sierra_adapter/sierr
   .settings(libraryDependencies ++= Dependencies.sierraItemMergerDependencies)
 
 lazy val snapshot_convertor = doSharedSetup(project, "data_api/snapshot_convertor")
+  .dependsOn(common_display % "compile->compile;test->test")
   .settings(libraryDependencies ++= Dependencies.snapshotConvertorDependencies)
 
 lazy val root = (project in file("."))

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlow.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlow.scala
@@ -1,0 +1,62 @@
+package uk.ac.wellcome.platform.snapshot_convertor.flow
+
+import akka.NotUsed
+import akka.stream.scaladsl.Flow
+import com.twitter.inject.Logging
+import io.circe.generic.extras.Configuration
+import uk.ac.wellcome.display.models.DisplayWork
+import uk.ac.wellcome.models.{IdentifiedWork, WorksIncludes}
+import uk.ac.wellcome.utils.JsonUtil._
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+/** Converts lines from an Elasticsearch snapshot into DisplayWorks.
+  *
+  * The Elasticsearch snapshot in S3 has JSON blobs, one per line, which
+  * contain the internal Elasticsearch results.  This flow receives a line
+  * at a time, and converts it to the corresponding DisplayWork.
+  */
+object ElasticsearchHitToDisplayWorkFlow extends Logging {
+
+  case class ElasticsearchHit(
+    index: String,
+    documentType: String,
+    id: String,
+    score: Int,
+    source: IdentifiedWork
+  )
+
+  implicit val config: Configuration = Configuration.default.copy(
+    transformMemberNames = {
+      case "index" => "_index"
+      case "documentType" => "_type"
+      case "id" => "_id"
+      case "score" => "_score"
+      case "source" => "_source"
+      case other => other
+    }
+  )
+
+  // TODO: Can we get a convenience wrapper for WorksIncludes that just
+  // fills in everything?
+  val includes = WorksIncludes(
+    identifiers = true,
+    thumbnail = true,
+    items = true
+  )
+
+  def apply()(implicit executionContext: ExecutionContext): Flow[String, DisplayWork, NotUsed] =
+    Flow.fromFunction({ line =>
+      val hit = fromJson[ElasticsearchHit](line) match {
+        case Success(hit) => hit
+        case Failure(parseFailure) => {
+          warn("Failed to parse work metadata!", parseFailure)
+          throw parseFailure
+        }
+      }
+
+      val internalWork = hit.source
+      DisplayWork(internalWork, includes = includes)
+    })
+}

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlow.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlow.scala
@@ -36,7 +36,8 @@ object ElasticsearchHitToDisplayWorkFlow extends Logging {
     items = true
   )
 
-  def apply()(implicit executionContext: ExecutionContext): Flow[String, DisplayWork, NotUsed] =
+  def apply()(implicit executionContext: ExecutionContext)
+    : Flow[String, DisplayWork, NotUsed] =
     Flow.fromFunction({ line =>
       val hit = fromJson[ElasticsearchHit](line) match {
         case Success(h: ElasticsearchHit) => h

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlow.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlow.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.snapshot_convertor.flow
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import com.twitter.inject.Logging
+import io.circe.Decoder
 import io.circe.generic.extras.Configuration
 import uk.ac.wellcome.display.models.DisplayWork
 import uk.ac.wellcome.models.{IdentifiedWork, WorksIncludes}
@@ -46,10 +47,12 @@ object ElasticsearchHitToDisplayWorkFlow extends Logging {
     items = true
   )
 
+  implicit val decoder: Decoder[ElasticsearchHit] = Decoder[ElasticsearchHit]
+
   def apply()(implicit executionContext: ExecutionContext): Flow[String, DisplayWork, NotUsed] =
     Flow.fromFunction({ line =>
       val hit = fromJson[ElasticsearchHit](line) match {
-        case Success(hit) => hit
+        case Success(hit: ElasticsearchHit) => hit
         case Failure(parseFailure) => {
           warn("Failed to parse work metadata!", parseFailure)
           throw parseFailure

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlowTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlowTest.scala
@@ -7,7 +7,12 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models.DisplayWork
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.models.{IdentifiedWork, IdentifierSchemes, SourceIdentifier, WorksIncludes}
+import uk.ac.wellcome.models.{
+  IdentifiedWork,
+  IdentifierSchemes,
+  SourceIdentifier,
+  WorksIncludes
+}
 import uk.ac.wellcome.test.fixtures.AkkaFixtures
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.utils.JsonUtil._

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlowTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlowTest.scala
@@ -1,0 +1,158 @@
+package uk.ac.wellcome.platform.snapshot_convertor.flow
+
+import akka.actor.ActorSystem
+import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.scaladsl.{Sink, Source}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.display.models.DisplayWork
+import uk.ac.wellcome.models.{IdentifiedWork, IdentifierSchemes, SourceIdentifier, WorksIncludes}
+import uk.ac.wellcome.test.fixtures.AkkaFixtures
+import uk.ac.wellcome.test.utils.ExtendedPatience
+import uk.ac.wellcome.utils.JsonUtil._
+
+import scala.concurrent.{ExecutionContextExecutor, Future}
+
+class ElasticsearchHitToDisplayWorkFlowTest
+    extends FunSpec
+    with Matchers
+    with AkkaFixtures
+    with ScalaFutures
+    with ExtendedPatience {
+
+  val includes = WorksIncludes(
+    identifiers = true,
+    thumbnail = true,
+    items = true
+  )
+
+  it("creates a DisplayWork from a single hit") {
+    withActorSystem { actorSystem =>
+      implicit val executionContext: ExecutionContextExecutor =
+        actorSystem.dispatcher
+      implicit val system: ActorSystem = actorSystem
+      implicit val materializer: Materializer =
+        ActorMaterializer()(actorSystem)
+
+      val flow = ElasticsearchHitToDisplayWorkFlow()
+
+      val work = IdentifiedWork(
+        canonicalId = "t83tggem",
+        title = Some("Tired of troubling tests"),
+        sourceIdentifier = SourceIdentifier(
+          identifierScheme = IdentifierSchemes.miroImageNumber,
+          ontologyType = "work",
+          value = "T0083000"
+        ),
+        version = 1
+      )
+
+      val elasticsearchHitJson = s"""{
+        "_index": "zagbdjgf",
+        "_type": "work",
+        "_id": "${work.canonicalId}",
+        "_score": 1,
+        "_source": ${toJson(work).get}
+      }"""
+
+      val futureDisplayWork: Future[DisplayWork] = Source
+        .single(elasticsearchHitJson)
+        .via(flow)
+        .runWith(Sink.head)
+
+      whenReady(futureDisplayWork) { displayWork =>
+        displayWork shouldBe DisplayWork(work, includes = includes)
+      }
+    }
+  }
+  //
+  // it("creates a SierraRecord from an item") {
+  //   withRecordWrapperFlow {
+  //     case (wrapperFlow, actorSystem) =>
+  //       implicit val system: ActorSystem = actorSystem
+  //       implicit val materializer: Materializer =
+  //         ActorMaterializer()(actorSystem)
+  //
+  //       val id = "400004"
+  //       val updatedDate = "2014-04-14T14:14:14Z"
+  //       val json = parse(s"""
+  //       |{
+  //       | "id": "$id",
+  //       | "updatedDate": "$updatedDate",
+  //       | "bibIds": ["4", "44", "444", "4444"]
+  //       |}
+  //     """.stripMargin).right.get
+  //
+  //       val expectedRecord = SierraRecord(
+  //         id = id,
+  //         data = json.noSpaces,
+  //         modifiedDate = updatedDate
+  //       )
+  //
+  //       val futureRecord = Source
+  //         .single(json)
+  //         .via(wrapperFlow)
+  //         .runWith(Sink.head)
+  //
+  //       whenReady(futureRecord) { sierraRecord =>
+  //         sierraRecord shouldBe expectedRecord
+  //       }
+  //   }
+  // }
+  //
+  // it("is able to handle deleted bibs") {
+  //   withRecordWrapperFlow {
+  //     case (wrapperFlow, actorSystem) =>
+  //       implicit val system: ActorSystem = actorSystem
+  //       implicit val materializer: Materializer =
+  //         ActorMaterializer()(actorSystem)
+  //
+  //       val id = "1357947"
+  //       val deletedDate = "2014-01-31"
+  //       val json = parse(s"""{
+  //                         |  "id" : "$id",
+  //                         |  "deletedDate" : "$deletedDate",
+  //                         |  "deleted" : true
+  //                         |}""".stripMargin).right.get
+  //
+  //       val expectedRecord = SierraRecord(
+  //         id = id,
+  //         data = json.noSpaces,
+  //         modifiedDate = s"${deletedDate}T00:00:00Z"
+  //       )
+  //
+  //       val futureRecord = Source
+  //         .single(json)
+  //         .via(wrapperFlow)
+  //         .runWith(Sink.head)
+  //
+  //       whenReady(futureRecord) { sierraRecord =>
+  //         sierraRecord shouldBe expectedRecord
+  //       }
+  //   }
+  // }
+  //
+  // it("fails the stream if the record contains invalid JSON") {
+  //   withRecordWrapperFlow {
+  //     case (wrapperFlow, actorSystem) =>
+  //       implicit val system: ActorSystem = actorSystem
+  //       implicit val materializer: Materializer =
+  //         ActorMaterializer()(actorSystem)
+  //
+  //       val invalidSierraJson = parse(s"""{
+  //       | "missing": ["id", "updatedDate"],
+  //       | "reason": "This JSON will not pass!",
+  //       |  "comment": "XML is coming!"
+  //       |}""".stripMargin).right.get
+  //
+  //       val futureUnit = Source
+  //         .single(invalidSierraJson)
+  //         .via(wrapperFlow)
+  //         .runWith(Sink.head)
+  //
+  //       whenReady(futureUnit.failed) { _ =>
+  //         true shouldBe true
+  //       }
+  //   }
+  // }
+}

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlowTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlowTest.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.models.{
   SourceIdentifier,
   WorksIncludes
 }
-import uk.ac.wellcome.test.fixtures.AkkaFixtures
+import uk.ac.wellcome.test.fixtures.Akka
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.utils.JsonUtil._
 
@@ -22,7 +22,7 @@ import scala.concurrent.{ExecutionContextExecutor, Future}
 class ElasticsearchHitToDisplayWorkFlowTest
     extends FunSpec
     with Matchers
-    with AkkaFixtures
+    with Akka
     with ScalaFutures
     with ExtendedPatience {
 


### PR DESCRIPTION
An attempt to break up #1679.

This implements some of the logic for #1679, but as its own flow so we can test it separately, and reduce the size of that PR as we try to debug it.