### PR TITLE
Normalise fixture trait names

### DIFF
--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.models.{IdentifierSchemes, _}
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.test.fixtures.{MessageInfo, SnsFixtures, SqsFixtures}
+import uk.ac.wellcome.test.fixtures.{MessageInfo, SNS, SQS}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.utils.JsonUtil
 
@@ -13,8 +13,8 @@ import scala.collection.JavaConversions._
 
 class IdMinterFeatureTest
     extends FunSpec
-    with SqsFixtures
-    with SnsFixtures
+    with SQS
+    with SNS
     with fixtures.IdentifiersDatabase
     with fixtures.Server
     with ExtendedPatience

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/ServerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/ServerTest.scala
@@ -3,13 +3,13 @@ import com.twitter.finagle.http.Status._
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.server.FeatureTest
 import org.scalatest.FunSpec
-import uk.ac.wellcome.test.fixtures.{SnsFixtures, SqsFixtures}
+import uk.ac.wellcome.test.fixtures.{SNS, SQS}
 
 class ServerTest
     extends FunSpec
     with fixtures.Server
-    with SqsFixtures
-    with SnsFixtures
+    with SQS
+    with SNS
     with fixtures.IdentifiersDatabase {
 
   it("shows the healthcheck message") {

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
@@ -12,13 +12,13 @@ import uk.ac.wellcome.platform.idminter.database.{
   IdentifiersDao
 }
 import uk.ac.wellcome.platform.idminter.{fixtures, Server}
-import uk.ac.wellcome.test.fixtures.{SnsFixtures, SqsFixtures}
+import uk.ac.wellcome.test.fixtures.{SNS, SQS}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
 class IdMinterWorkerTest
     extends FunSpec
-    with SqsFixtures
-    with SnsFixtures
+    with SQS
+    with SNS
     with fixtures.IdentifiersDatabase
     with fixtures.Server
     with Eventually

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.models.{
   SourceIdentifier
 }
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.test.fixtures.SqsFixtures
+import uk.ac.wellcome.test.fixtures.SQS
 import uk.ac.wellcome.test.utils.JsonTestUtil
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
@@ -25,7 +25,7 @@ class IngestorFeatureTest
     with ScalaFutures
     with fixtures.Server
     with ElasticsearchFixtures
-    with SqsFixtures {
+    with SQS {
 
   val indexName = "works"
   val itemType = "work"

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
@@ -5,12 +5,12 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.test.fixtures.SqsFixtures
+import uk.ac.wellcome.test.fixtures.SQS
 
 class IngestorIndexTest
     extends FunSpec
     with fixtures.Server
-    with SqsFixtures
+    with SQS
     with Matchers
     with ScalaFutures
     with ElasticsearchFixtures {

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -21,7 +21,7 @@ import uk.ac.wellcome.models.{
   SourceIdentifier
 }
 import uk.ac.wellcome.sqs.SQSReader
-import uk.ac.wellcome.test.fixtures.SqsFixtures
+import uk.ac.wellcome.test.fixtures.SQS
 import uk.ac.wellcome.test.utils.JsonTestUtil
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -35,7 +35,7 @@ class IngestorWorkerServiceTest
     with MockitoSugar
     with JsonTestUtil
     with ElasticsearchFixtures
-    with SqsFixtures {
+    with SQS {
 
   val itemType = "work"
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.models.{
   SourceIdentifier,
   UnidentifiedWork
 }
-import uk.ac.wellcome.test.fixtures.{MessageInfo, S3, SnsFixtures, SqsFixtures}
+import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.transformer.utils.TransformableMessageUtils
 import uk.ac.wellcome.utils.JsonUtil
@@ -17,8 +17,8 @@ import uk.ac.wellcome.utils.JsonUtil._
 class CalmTransformerFeatureTest
     extends FunSpec
     with Matchers
-    with SqsFixtures
-    with SnsFixtures
+    with SQS
+    with SNS
     with S3
     with fixtures.Server
     with Eventually

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.models.{UnidentifiedWork}
 import uk.ac.wellcome.models.transformable.{MiroTransformable}
-import uk.ac.wellcome.test.fixtures.{S3, SnsFixtures, SqsFixtures}
+import uk.ac.wellcome.test.fixtures.{S3, SNS, SQS}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.test.fixtures.MessageInfo
 import uk.ac.wellcome.transformer.transformers.MiroTransformableWrapper
@@ -15,8 +15,8 @@ import uk.ac.wellcome.utils.JsonUtil
 class MiroTransformerFeatureTest
     extends FunSpec
     with Matchers
-    with SqsFixtures
-    with SnsFixtures
+    with SQS
+    with SNS
     with S3
     with fixtures.Server
     with Eventually

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.models.{
   SourceIdentifier,
   UnidentifiedWork
 }
-import uk.ac.wellcome.test.fixtures.{S3, SnsFixtures, SqsFixtures}
+import uk.ac.wellcome.test.fixtures.{S3, SNS, SQS}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.transformer.utils.TransformableMessageUtils
 import uk.ac.wellcome.utils.JsonUtil
@@ -18,8 +18,8 @@ import uk.ac.wellcome.utils.JsonUtil
 class SierraTransformerFeatureTest
     extends FunSpec
     with Matchers
-    with SqsFixtures
-    with SnsFixtures
+    with SQS
+    with SNS
     with S3
     with fixtures.Server
     with Eventually

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -21,7 +21,7 @@ import uk.ac.wellcome.models.{
   UnidentifiedWork
 }
 import uk.ac.wellcome.sns.{PublishAttempt, SNSWriter}
-import uk.ac.wellcome.test.fixtures.{S3, SnsFixtures, SqsFixtures, TestWith}
+import uk.ac.wellcome.test.fixtures.{S3, SNS, SQS, TestWith}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.transformer.utils.TransformableMessageUtils
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -34,8 +34,8 @@ import scala.concurrent.duration._
 class SQSMessageReceiverTest
     extends FunSpec
     with Matchers
-    with SqsFixtures
-    with SnsFixtures
+    with SQS
+    with SNS
     with S3
     with Eventually
     with ExtendedPatience

--- a/common/src/test/scala/uk/ac/wellcome/sns/SNSWriterTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sns/SNSWriterTest.scala
@@ -3,13 +3,13 @@ package uk.ac.wellcome.sns
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.aws.SNSConfig
-import uk.ac.wellcome.test.fixtures.SnsFixtures
+import uk.ac.wellcome.test.fixtures.SNS
 
 class SNSWriterTest
     extends FunSpec
     with ScalaFutures
     with Matchers
-    with SnsFixtures
+    with SNS
     with IntegrationPatience {
 
 //  val topicArn = createTopicAndReturnArn("test-topic-name")

--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
@@ -20,7 +20,7 @@ class SQSReaderTest
     with ScalaFutures
     with Eventually
     with ExtendedPatience
-    with SqsFixtures {
+    with SQS {
 
   def withSqsReader[R](queueUrl: String, maxMessages: Int)(
     testWith: TestWith[SQSReader, R]) = {

--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerTest.scala
@@ -21,8 +21,8 @@ class SQSWorkerTest
     extends FunSpec
     with MockitoSugar
     with Eventually
-    with AkkaFixtures
-    with SqsFixtures {
+    with Akka
+    with SQS {
 
   def withMockMetricSender[R](testWith: TestWith[MetricsSender, R]): R = {
     val metricsSender: MetricsSender = mock[MetricsSender]

--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerToDynamoTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerToDynamoTest.scala
@@ -30,8 +30,8 @@ class SQSWorkerToDynamoTest
     with Matchers
     with Eventually
     with ExtendedPatience
-    with AkkaFixtures
-    with SqsFixtures {
+    with Akka
+    with SQS {
 
   val mockPutMetricDataResult = mock[PutMetricDataResult]
   val mockCloudWatch = mock[AmazonCloudWatch]

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/Akka.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/Akka.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.test.fixtures
 import akka.actor.ActorSystem
 import org.scalatest.concurrent.Eventually
 
-trait AkkaFixtures extends Eventually {
+trait Akka extends Eventually {
 
   def withActorSystem[R](testWith: TestWith[ActorSystem, R]) = {
     val actorSystem = ActorSystem()
@@ -11,7 +11,8 @@ trait AkkaFixtures extends Eventually {
     try {
       testWith(actorSystem)
     } finally {
-      eventually { actorSystem.terminate() }
+      actorSystem.terminate()
+      eventually { actorSystem.whenTerminated }
     }
   }
 

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/SNS.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/SNS.scala
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 import scala.util.Random
 
-trait SnsFixtures {
+trait SNS {
 
   private val localSNSEndpointUrl = "http://localhost:9292"
 

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/SQS.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/SQS.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.models.aws.SQSMessage
 
 import scala.util.Try
 
-trait SqsFixtures {
+trait SQS {
 
   private val sqsEndpointUrl = "http://localhost:9324"
 

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/ServerTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/ServerTest.scala
@@ -11,8 +11,8 @@ import uk.ac.wellcome.test.utils.AmazonCloudWatchFlag
 class ServerTest
     extends FunSpec
     with AmazonCloudWatchFlag
-    with SqsFixtures
-    with SnsFixtures
+    with SQS
+    with SNS
     with S3
     with ScalaFutures {
 

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.platform.reindex_worker.models.{
   ReindexJob,
   ReindexRecord
 }
-import uk.ac.wellcome.test.fixtures.{LocalDynamoDb, SnsFixtures, SqsFixtures}
+import uk.ac.wellcome.test.fixtures.{LocalDynamoDb, SNS, SQS}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.utils.JsonUtil._
@@ -33,8 +33,8 @@ class ReindexerFeatureTest
     with ExtendedPatience
     with fixtures.Server
     with LocalDynamoDb[TestRecord]
-    with SnsFixtures
-    with SqsFixtures
+    with SNS
+    with SQS
     with ScalaFutures {
 
   override lazy val evidence: DynamoFormat[TestRecord] =

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.DynamoConfig
 import uk.ac.wellcome.platform.reindex_worker.TestRecord
 import uk.ac.wellcome.platform.reindex_worker.models.ReindexJob
-import uk.ac.wellcome.test.fixtures.{AkkaFixtures, LocalDynamoDb, TestWith}
+import uk.ac.wellcome.test.fixtures.{Akka, LocalDynamoDb, TestWith}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import scala.concurrent.duration._
 
@@ -21,7 +21,7 @@ class ReindexServiceTest
     extends FunSpec
     with ScalaFutures
     with Matchers
-    with AkkaFixtures
+    with Akka
     with LocalDynamoDb[TestRecord]
     with MockitoSugar
     with ExtendedPatience {

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -22,13 +22,7 @@ import uk.ac.wellcome.platform.reindex_worker.TestRecord
 import uk.ac.wellcome.platform.reindex_worker.models.ReindexJob
 import uk.ac.wellcome.sns.SNSWriter
 import uk.ac.wellcome.sqs.SQSReader
-import uk.ac.wellcome.test.fixtures.{
-  AkkaFixtures,
-  LocalDynamoDb,
-  SnsFixtures,
-  SqsFixtures,
-  TestWith
-}
+import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -39,10 +33,10 @@ class ReindexWorkerServiceTest
     extends FunSpec
     with Matchers
     with MockitoSugar
-    with AkkaFixtures
+    with Akka
     with LocalDynamoDb[TestRecord]
-    with SnsFixtures
-    with SqsFixtures
+    with SNS
+    with SQS
     with ScalaFutures {
 
   override lazy val evidence: DynamoFormat[TestRecord] =

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
@@ -4,14 +4,14 @@ import com.gu.scanamo.DynamoFormat
 import com.twitter.finagle.http.Status._
 import org.scalatest.FunSpec
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
-import uk.ac.wellcome.test.fixtures.{LocalDynamoDb, SqsFixtures}
+import uk.ac.wellcome.test.fixtures.{LocalDynamoDb, SQS}
 
 import uk.ac.wellcome.dynamo._
 
 class ServerTest
     extends FunSpec
     with LocalDynamoDb[SierraItemRecord]
-    with SqsFixtures
+    with SQS
     with fixtures.Server {
 
   override lazy val evidence = DynamoFormat[SierraItemRecord]

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
@@ -21,12 +21,12 @@ import uk.ac.wellcome.models.transformable.sierra.{
   SierraItemRecord,
   SierraRecord
 }
-import uk.ac.wellcome.test.fixtures.{LocalDynamoDb, SqsFixtures}
+import uk.ac.wellcome.test.fixtures.{LocalDynamoDb, SQS}
 
 class SierraItemsToDynamoFeatureTest
     extends FunSpec
     with LocalDynamoDb[SierraItemRecord]
-    with SqsFixtures
+    with SQS
     with fixtures.Server
     with Matchers
     with Eventually

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -22,24 +22,19 @@ import uk.ac.wellcome.utils.JsonUtil._
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.test.fixtures.{
-  AkkaFixtures,
-  LocalDynamoDb,
-  SqsFixtures,
-  TestWith
-}
+import uk.ac.wellcome.test.fixtures._
 
 import scala.concurrent.duration._
 
 class SierraItemsToDynamoWorkerServiceTest
     extends FunSpec
     with LocalDynamoDb[SierraItemRecord]
-    with SqsFixtures
+    with SQS
     with Matchers
     with Eventually
     with ExtendedPatience
     with MockitoSugar
-    with AkkaFixtures
+    with Akka
     with ScalaFutures {
 
   override lazy val evidence: DynamoFormat[SierraItemRecord] =

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/ServerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/ServerTest.scala
@@ -5,11 +5,7 @@ import com.twitter.inject.server.FeatureTest
 import org.scalatest.FunSpec
 import uk.ac.wellcome.test.fixtures.{S3, SQS}
 
-class ServerTest
-    extends FunSpec
-    with fixtures.Server
-    with S3
-    with SQS {
+class ServerTest extends FunSpec with fixtures.Server with S3 with SQS {
 
   it("it shows the healthcheck message") {
     withLocalS3Bucket { bucketName =>

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/ServerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/ServerTest.scala
@@ -3,13 +3,13 @@ package uk.ac.wellcome.platform.sierra_reader
 import com.twitter.finagle.http.Status._
 import com.twitter.inject.server.FeatureTest
 import org.scalatest.FunSpec
-import uk.ac.wellcome.test.fixtures.{S3, SqsFixtures}
+import uk.ac.wellcome.test.fixtures.{S3, SQS}
 
 class ServerTest
     extends FunSpec
     with fixtures.Server
     with S3
-    with SqsFixtures {
+    with SQS {
 
   it("it shows the healthcheck message") {
     withLocalS3Bucket { bucketName =>

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/SierraReaderFeatureTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/SierraReaderFeatureTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.sierra_reader
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.test.fixtures.{S3, SqsFixtures}
+import uk.ac.wellcome.test.fixtures.{S3, SQS}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.utils.JsonUtil._
 
@@ -11,7 +11,7 @@ class SierraReaderFeatureTest
     extends FunSpec
     with fixtures.Server
     with S3
-    with SqsFixtures
+    with SQS
     with Eventually
     with Matchers
     with ExtendedPatience {

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlowTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlowTest.scala
@@ -10,14 +10,14 @@ import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.transformable.sierra.SierraRecord
-import uk.ac.wellcome.test.fixtures.{AkkaFixtures, TestWith}
+import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
 import scala.concurrent.ExecutionContextExecutor
 
 class SierraRecordWrapperFlowTest
     extends FunSpec
-    with AkkaFixtures
+    with Akka
     with ScalaFutures
     with ExtendedPatience
     with Matchers {
@@ -38,7 +38,7 @@ class SierraRecordWrapperFlowTest
   it("creates a SierraRecord from a bib") {
     withRecordWrapperFlow {
       case (wrapperFlow, actorSystem) =>
-        implicit val system: ActorSystem = actorSystem
+        implicit val system = actorSystem
         implicit val materializer: Materializer =
           ActorMaterializer()(actorSystem)
 

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.models.aws.{SQSConfig, SQSMessage}
 import uk.ac.wellcome.sqs.SQSReader
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import org.scalatest.FunSpec
-import uk.ac.wellcome.test.fixtures.{AkkaFixtures, S3, SqsFixtures, TestWith}
+import uk.ac.wellcome.test.fixtures.{Akka, S3, SQS, TestWith}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import uk.ac.wellcome.utils.JsonUtil._
@@ -29,8 +29,8 @@ class SierraReaderWorkerServiceTest
     extends FunSpec
     with MockitoSugar
     with S3
-    with SqsFixtures
-    with AkkaFixtures
+    with SQS
+    with Akka
     with Eventually
     with Matchers
     with ExtendedPatience

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/sink/SequentialS3SinkTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/sink/SequentialS3SinkTest.scala
@@ -9,7 +9,7 @@ import io.circe.parser._
 import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
-import uk.ac.wellcome.test.fixtures.{AkkaFixtures, S3, TestWith}
+import uk.ac.wellcome.test.fixtures.{Akka, S3, TestWith}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
 import scala.collection.JavaConversions._
@@ -19,7 +19,7 @@ class SequentialS3SinkTest
     extends FunSpec
     with Matchers
     with S3
-    with AkkaFixtures
+    with Akka
     with BeforeAndAfterAll
     with ScalaFutures
     with ExtendedPatience {


### PR DESCRIPTION
### What is this PR trying to achieve?

Fixture traits had inconsistent naming schema (`S3` vs `AkkaFixture`). This normalises the naming conventions.