### PR TITLE
Break out the S3 reader as a separate component in the snapshot_convertor

### DIFF
--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/S3.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/S3.scala
@@ -7,19 +7,17 @@ import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import io.circe.Json
 import io.circe.parser.parse
 import org.apache.commons.io.IOUtils
-import org.scalatest.Matchers
-import org.scalatest.concurrent.Eventually
-import uk.ac.wellcome.test.utils.ExtendedPatience
 
 import scala.collection.JavaConversions._
 import scala.util.Random
 
 trait S3 {
 
-  private val localS3EndpointUrl = "http://localhost:33333"
+  protected val localS3EndpointUrl = "http://localhost:33333"
+  protected val regionName = "localhost"
 
-  private val accessKey = "accessKey1"
-  private val secretKey = "verySecretKey1"
+  protected val accessKey = "accessKey1"
+  protected val secretKey = "verySecretKey1"
 
   def s3LocalFlags(bucketName: String) = Map(
     "aws.s3.endpoint" -> localS3EndpointUrl,

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3Source.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3Source.scala
@@ -9,7 +9,7 @@ import akka.util.ByteString
   * source emits the (uncompressed) lines from that file, one line at a time.
   */
 object S3Source {
-  def apply(s3client: S3Client, bucketName: String, key: String): Source[String, NotUsed] = {
+  def apply(s3client: S3Client, bucketName: String, key: String): Source[String, Any] = {
     val (s3download: Source[ByteString, _], _) = s3client.download(bucket = bucketName, key = key)
 
     s3download

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3Source.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3Source.scala
@@ -9,14 +9,16 @@ import akka.util.ByteString
   * source emits the (uncompressed) lines from that file, one line at a time.
   */
 object S3Source {
-  def apply(s3client: S3Client, bucketName: String, key: String): Source[String, Any] = {
-    val (s3download: Source[ByteString, _], _) = s3client.download(bucket = bucketName, key = key)
+  def apply(s3client: S3Client,
+            bucketName: String,
+            key: String): Source[String, Any] = {
+    val (s3download: Source[ByteString, _], _) =
+      s3client.download(bucket = bucketName, key = key)
 
     s3download
       .via(Compression.gunzip())
       .via(Framing
-        .delimiter(ByteString("\n"), Int.MaxValue, allowTruncation = true)
-      )
+        .delimiter(ByteString("\n"), Int.MaxValue, allowTruncation = true))
       .map { _.utf8String }
   }
 }

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3Source.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3Source.scala
@@ -1,0 +1,22 @@
+package uk.ac.wellcome.platform.snapshot_convertor.source
+
+import akka.NotUsed
+import akka.stream.alpakka.s3.scaladsl.S3Client
+import akka.stream.scaladsl.{Compression, Framing, Source}
+import akka.util.ByteString
+
+/** Given an S3 bucket and key that point to a gzip-compressed file, this
+  * source emits the (uncompressed) lines from that file, one line at a time.
+  */
+object S3Source {
+  def apply(s3client: S3Client, bucketName: String, key: String): Source[String, NotUsed] = {
+    val (s3download: Source[ByteString, _], _) = s3client.download(bucket = bucketName, key = key)
+
+    s3download
+      .via(Compression.gunzip())
+      .via(Framing
+        .delimiter(ByteString("\n"), Int.MaxValue, allowTruncation = true)
+      )
+      .map { _.utf8String }
+  }
+}

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/fixtures/AkkaS3.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/fixtures/AkkaS3.scala
@@ -1,0 +1,32 @@
+package uk.ac.wellcome.platform.snapshot_convertor.fixtures
+
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import akka.stream.alpakka.s3.{MemoryBufferType, S3Settings}
+import akka.stream.alpakka.s3.scaladsl.S3Client
+import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.regions.AwsRegionProvider
+import uk.ac.wellcome.test.fixtures.{S3, TestWith}
+
+trait AkkaS3 extends S3 {
+
+  def withS3AkkaClient[R](actorSystem: ActorSystem,
+                          materializer: Materializer)(testWith: TestWith[S3Client, R]): R = {
+    val s3AkkaClient = new S3Client(
+      new S3Settings(
+        bufferType = MemoryBufferType,
+        proxy = None,
+        credentialsProvider = new AWSStaticCredentialsProvider(
+          new BasicAWSCredentials(accessKey, secretKey)
+        ),
+        s3RegionProvider = new AwsRegionProvider {
+          def getRegion: String = regionName
+        },
+        pathStyleAccess = true,
+        endpointUrl = Some(localS3EndpointUrl)
+      )
+    )(actorSystem, materializer)
+
+    testWith(s3AkkaClient)
+  }
+}

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/fixtures/AkkaS3.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/fixtures/AkkaS3.scala
@@ -10,8 +10,9 @@ import uk.ac.wellcome.test.fixtures.{S3, TestWith}
 
 trait AkkaS3 extends S3 {
 
-  def withS3AkkaClient[R](actorSystem: ActorSystem,
-                          materializer: Materializer)(testWith: TestWith[S3Client, R]): R = {
+  def withS3AkkaClient[R](
+    actorSystem: ActorSystem,
+    materializer: Materializer)(testWith: TestWith[S3Client, R]): R = {
     val s3AkkaClient = new S3Client(
       new S3Settings(
         bufferType = MemoryBufferType,

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
@@ -1,0 +1,60 @@
+package uk.ac.wellcome.platform.snapshot_convertor.source
+
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Compression, Sink, Source}
+import akka.util.ByteString
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.platform.snapshot_convertor.fixtures.AkkaS3
+import uk.ac.wellcome.test.fixtures.Akka
+
+import scala.concurrent.Future
+
+class S3SourceTest
+    extends FunSpec
+    with Matchers
+    with ScalaFutures
+    with Akka
+    with AkkaS3 {
+
+  it("reads a series of lines from S3") {
+    withActorSystem { actorSystem =>
+      implicit val system = actorSystem
+      implicit val materializer = ActorMaterializer()
+
+      withLocalS3Bucket { bucketName =>
+        withS3AkkaClient(actorSystem, materializer) { akkaS3client =>
+          val expectedLines = List(
+            "AARGH! An armada of alpaccas",
+            "Blimey! Blue bonobos with beachballs",
+            "Cor! Countless copies of crying camels"
+          )
+
+          val key = "test001.txt.gz"
+
+          whenReady(gzipContent(expectedLines.mkString("\n"))) { content =>
+            s3Client.putObject(bucketName, key, content)
+          }
+
+          val source = S3Source(
+            s3client = akkaS3client, bucketName = bucketName, key = key
+          )
+
+          val future = source.runWith(Sink.head)
+          whenReady(future) { result =>
+            result shouldBe expectedLines
+          }
+        }
+      }
+    }
+  }
+
+  private def gzipContent(content: String): Future[String] = {
+    Source
+      .single(content)
+      .map { ByteString(_) }
+      .via(Compression.gzip)
+      .map { _.utf8String }
+      .runWith(Sink.head)
+  }
+}

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
@@ -34,12 +34,15 @@ class S3SourceTest
 
           val key = "test001.txt.gz"
 
-          whenReady(gzipContent(materializer, expectedLines.mkString("\n"))) { content =>
-            s3Client.putObject(bucketName, key, content)
+          whenReady(gzipContent(materializer, expectedLines.mkString("\n"))) {
+            content =>
+              s3Client.putObject(bucketName, key, content)
           }
 
           val source = S3Source(
-            s3client = akkaS3client, bucketName = bucketName, key = key
+            s3client = akkaS3client,
+            bucketName = bucketName,
+            key = key
           )
 
           val future = source.runWith(Sink.head)
@@ -51,7 +54,8 @@ class S3SourceTest
     }
   }
 
-  private def gzipContent(actorMaterializer: ActorMaterializer, content: String): Future[String] = {
+  private def gzipContent(actorMaterializer: ActorMaterializer,
+                          content: String): Future[String] = {
     implicit val materializer: ActorMaterializer = actorMaterializer
 
     Source

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
@@ -44,9 +44,9 @@ class S3SourceTest
             key = key
           )
 
-          val future = source.runWith(Sink.head)
+          val future = source.runWith(Sink.seq)
           whenReady(future) { result =>
-            result shouldBe expectedLines.mkString("\n")
+            result.toList shouldBe expectedLines
           }
         }
       }

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
@@ -7,6 +7,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.snapshot_convertor.fixtures.AkkaS3
 import uk.ac.wellcome.test.fixtures.Akka
+import uk.ac.wellcome.test.utils.ExtendedPatience
 
 import scala.concurrent.Future
 
@@ -14,6 +15,7 @@ class S3SourceTest
     extends FunSpec
     with Matchers
     with ScalaFutures
+    with ExtendedPatience
     with Akka
     with AkkaS3 {
 
@@ -32,7 +34,7 @@ class S3SourceTest
 
           val key = "test001.txt.gz"
 
-          whenReady(gzipContent(expectedLines.mkString("\n"))) { content =>
+          whenReady(gzipContent(materializer, expectedLines.mkString("\n"))) { content =>
             s3Client.putObject(bucketName, key, content)
           }
 
@@ -49,7 +51,9 @@ class S3SourceTest
     }
   }
 
-  private def gzipContent(content: String): Future[String] = {
+  private def gzipContent(actorMaterializer: ActorMaterializer, content: String): Future[String] = {
+    implicit val materializer: ActorMaterializer = actorMaterializer
+
     Source
       .single(content)
       .map { ByteString(_) }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,6 +4,7 @@ object Dependencies {
 
   lazy val versions = new {
     val akka = "2.4.17"
+    val akkaStreamAlpakkaS3 = "0.17"
     val aws = "1.11.95"
     val apacheLogging = "2.8.2"
     val finatra = "2.8.0"
@@ -25,6 +26,11 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-actor" % versions.akka,
     "com.typesafe.akka" %% "akka-agent" % versions.akka,
     "com.typesafe.akka" %% "akka-stream" % versions.akka
+  )
+
+  val akkaStreamDependencies = Seq(
+    "com.typesafe.akka" %% "akka-stream" % versions.akka,
+    "com.lightbend.akka" %% "akka-stream-alpakka-s3" % versions.akkaStreamAlpakkaS3
   )
 
   val awsDependencies: Seq[ModuleID] = Seq(
@@ -114,7 +120,7 @@ object Dependencies {
 
   val reindexerDependencies: Seq[ModuleID] = commonDependencies
 
-  val snapshotConvertorDependencies: Seq[ModuleID] = commonDependencies
+  val snapshotConvertorDependencies = commonDependencies ++ akkaStreamDependencies
 
   val recorderDependencies: Seq[ModuleID] = Seq()
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,11 +28,6 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-stream" % versions.akka
   )
 
-  val akkaStreamDependencies = Seq(
-    "com.typesafe.akka" %% "akka-stream" % versions.akka,
-    "com.lightbend.akka" %% "akka-stream-alpakka-s3" % versions.akkaStreamAlpakkaS3
-  )
-
   val awsDependencies: Seq[ModuleID] = Seq(
     "com.amazonaws" % "aws-java-sdk" % versions.aws
   )
@@ -120,7 +115,9 @@ object Dependencies {
 
   val reindexerDependencies: Seq[ModuleID] = commonDependencies
 
-  val snapshotConvertorDependencies = commonDependencies ++ akkaStreamDependencies
+  val snapshotConvertorDependencies = commonDependencies ++ Seq(
+    "com.lightbend.akka" %% "akka-stream-alpakka-s3" % versions.akkaStreamAlpakkaS3
+  )
 
   val recorderDependencies: Seq[ModuleID] = Seq()
 


### PR DESCRIPTION
I discussed with @alicefuzier today; we both think this is another useful piece spun out of #1679. Tests are still failing at one point:

```
The future returned an exception of type: akka.stream.impl.io.ByteStringParser$ParsingException, with message: Parsing failed in step ReadHeaders. (S3SourceTest.scala:46)
```

I also want to dig into the gzipping in the tests, as I suspect there’s a more efficient approach than going via another Akka stream and dealing with futures for what should be an in-memory operation.