### PR TITLE
snapshot_convertor: Add a flow for converting Strings into gzip-compressed bundles

### DIFF
--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlow.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlow.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.snapshot_convertor.flow
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import com.twitter.inject.Logging
-import io.circe.Decoder
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.display.models.DisplayWork
 import uk.ac.wellcome.models.{IdentifiedWork, WorksIncludes}

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/StringToGzipFlow.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/StringToGzipFlow.scala
@@ -1,0 +1,20 @@
+package uk.ac.wellcome.platform.snapshot_convertor.flow
+
+import akka.NotUsed
+import akka.stream.scaladsl.{Compression, Flow}
+import akka.util.ByteString
+import com.twitter.inject.Logging
+
+import scala.concurrent.ExecutionContext
+
+/** Converts instances of String into gzip-compressed ByteString.
+  *
+  * This is used to prepare the gzip file we uploaded to S3.
+  */
+object StringToGzipFlow extends Logging {
+
+  def apply()(implicit executionContext: ExecutionContext): Flow[String, ByteString, NotUsed] =
+    Flow[String]
+      .map { ByteString(_) }
+      .via(Compression.gzip)
+}

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/StringToGzipFlow.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/StringToGzipFlow.scala
@@ -15,6 +15,7 @@ object StringToGzipFlow extends Logging {
 
   def apply()(implicit executionContext: ExecutionContext): Flow[String, ByteString, NotUsed] =
     Flow[String]
+      .map { _ + "\n" }
       .map { ByteString(_) }
       .via(Compression.gzip)
 }

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/StringToGzipFlow.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/StringToGzipFlow.scala
@@ -13,7 +13,8 @@ import scala.concurrent.ExecutionContext
   */
 object StringToGzipFlow extends Logging {
 
-  def apply()(implicit executionContext: ExecutionContext): Flow[String, ByteString, NotUsed] =
+  def apply()(implicit executionContext: ExecutionContext)
+    : Flow[String, ByteString, NotUsed] =
     Flow[String]
       .map { _ + "\n" }
       .map { ByteString(_) }

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/StringToGzipFlowTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/StringToGzipFlowTest.scala
@@ -54,13 +54,13 @@ class StringToGzipFlowTest
         .runWith(fileSink)
 
       whenReady(future) { _ =>
-
         // Unzip the file, then open it and check it contains the strings
         // we'd expect.  This is the Busybox version of gzip, which strips
         // the .gz from the filename.
         s"gunzip ${tmpfile.getPath}" !!
 
-        val fileContents = fromFile(tmpfile.getPath.replace(".txt.gz", ".txt")).mkString
+        val fileContents =
+          fromFile(tmpfile.getPath.replace(".txt.gz", ".txt")).mkString
 
         // Files have a trailing newline
         val expectedContents = expectedLines.mkString("\n") + "\n"

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/StringToGzipFlowTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/StringToGzipFlowTest.scala
@@ -63,7 +63,11 @@ class StringToGzipFlowTest
         s"gunzip ${tmpfile.getPath}" !!
 
         val fileContents = fromFile(tmpfile.getPath.replace(".txt.gz", ".txt")).mkString
-        fileContents shouldBe expectedLines.mkString("\n")
+
+        // Files have a trailing newline
+        val expectedContents = expectedLines.mkString("\n") + "\n"
+
+        fileContents shouldBe expectedContents
       }
     }
   }

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/StringToGzipFlowTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/StringToGzipFlowTest.scala
@@ -4,15 +4,13 @@ import java.io.File
 import java.nio.file.Paths
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.Uri.Path
-import akka.stream.scaladsl.{FileIO, Flow, Keep, RunnableGraph, Sink, Source}
+import akka.stream.scaladsl.{FileIO, Flow, Keep, Sink, Source}
 import akka.stream.{ActorMaterializer, IOResult, Materializer}
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import scala.io.Source.fromFile
 import uk.ac.wellcome.test.fixtures.Akka
-import uk.ac.wellcome.test.utils.ExtendedPatience
 
 import scala.sys.process._
 import scala.concurrent.{ExecutionContextExecutor, Future}

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/StringToGzipFlowTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/StringToGzipFlowTest.scala
@@ -1,0 +1,70 @@
+package uk.ac.wellcome.platform.snapshot_convertor.flow
+
+import java.io.File
+import java.nio.file.Paths
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.Uri.Path
+import akka.stream.scaladsl.{FileIO, Flow, Keep, RunnableGraph, Sink, Source}
+import akka.stream.{ActorMaterializer, IOResult, Materializer}
+import akka.util.ByteString
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FunSpec, Matchers}
+import scala.io.Source.fromFile
+import uk.ac.wellcome.test.fixtures.Akka
+import uk.ac.wellcome.test.utils.ExtendedPatience
+
+import scala.sys.process._
+import scala.concurrent.{ExecutionContextExecutor, Future}
+
+class StringToGzipFlowTest
+    extends FunSpec
+    with Matchers
+    with Akka
+    with ScalaFutures {
+
+  it("produces a gzip-compressed file from the lines") {
+    withActorSystem { actorSystem =>
+      implicit val executionContext: ExecutionContextExecutor =
+        actorSystem.dispatcher
+      implicit val system: ActorSystem = actorSystem
+      implicit val materializer: Materializer =
+        ActorMaterializer()(actorSystem)
+
+      val flow = StringToGzipFlow()
+
+      val expectedLines = List(
+        "Amber avocados age admirably",
+        "Bronze bananas barely bounce",
+        "Cerise coconuts craftily curl"
+      )
+
+      val source = Source(expectedLines)
+
+      // This code dumps the gzip contents to a gzip file, then unpacks them
+      // using a shell command.
+      //
+      // The intention here isn't to read a gzip-compressed file in the most
+      // "Scala-like" way, it's to open the file in a way similar to the
+      // way our users are likely to use.
+      val tmpfile = File.createTempFile("stringToGzipFlowTest", ".txt.gz")
+      val fileSink: Sink[ByteString, Future[IOResult]] = Flow[ByteString]
+        .toMat(FileIO.toPath(Paths.get(tmpfile.getPath)))(Keep.right)
+
+      val future: Future[IOResult] = source
+        .via(flow)
+        .runWith(fileSink)
+
+      whenReady(future) { _ =>
+
+        // Unzip the file, then open it and check it contains the strings
+        // we'd expect.  This is the Busybox version of gzip, which strips
+        // the .gz from the filename.
+        s"gunzip ${tmpfile.getPath}" !!
+
+        val fileContents = fromFile(tmpfile.getPath.replace(".txt.gz", ".txt")).mkString
+        fileContents shouldBe expectedLines.mkString("\n")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Another flow pulled out of #1679. I believe this is the final flow we need, and then I’ll go back and fit these into the previous PR.

Note this found a bug in the original code – in particular, we weren’t adding newlines in the final output, so every document would be squished onto a single line!