### PR TITLE
snapshot_convertor: create the AkkaS3 client and module

### DIFF
--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/Server.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/Server.scala
@@ -2,11 +2,18 @@ package uk.ac.wellcome.platform.snapshot_convertor
 
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.HttpServer
-import com.twitter.finatra.http.filters.{CommonFilters, LoggingMDCFilter, TraceIdMDCFilter}
+import com.twitter.finatra.http.filters.{
+  CommonFilters,
+  LoggingMDCFilter,
+  TraceIdMDCFilter
+}
 import com.twitter.finatra.http.routing.HttpRouter
 import uk.ac.wellcome.finatra.controllers.ManagementController
 import uk.ac.wellcome.finatra.modules._
-import uk.ac.wellcome.platform.snapshot_convertor.modules.{AkkaS3ClientModule, SnapshotConvertorWorkerModule}
+import uk.ac.wellcome.platform.snapshot_convertor.modules.{
+  AkkaS3ClientModule,
+  SnapshotConvertorWorkerModule
+}
 
 object ServerMain extends Server
 

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/Server.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/Server.scala
@@ -2,15 +2,11 @@ package uk.ac.wellcome.platform.snapshot_convertor
 
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.HttpServer
-import com.twitter.finatra.http.filters.{
-  CommonFilters,
-  LoggingMDCFilter,
-  TraceIdMDCFilter
-}
+import com.twitter.finatra.http.filters.{CommonFilters, LoggingMDCFilter, TraceIdMDCFilter}
 import com.twitter.finatra.http.routing.HttpRouter
 import uk.ac.wellcome.finatra.controllers.ManagementController
 import uk.ac.wellcome.finatra.modules._
-import uk.ac.wellcome.platform.snapshot_convertor.modules.SnapshotConvertorWorkerModule
+import uk.ac.wellcome.platform.snapshot_convertor.modules.{AkkaS3ClientModule, SnapshotConvertorWorkerModule}
 
 object ServerMain extends Server
 
@@ -25,7 +21,7 @@ class Server extends HttpServer {
     SQSConfigModule,
     SNSClientModule,
     SNSConfigModule,
-    S3ClientModule,
+    AkkaS3ClientModule,
     S3ConfigModule,
     SnapshotConvertorWorkerModule,
     AkkaModule

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/modules/AkkaS3ClientModule.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/modules/AkkaS3ClientModule.scala
@@ -6,7 +6,12 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.s3.{MemoryBufferType, S3Settings}
 import akka.stream.alpakka.s3.scaladsl.S3Client
-import com.amazonaws.auth.{AWSCredentialsProvider, AWSStaticCredentialsProvider, BasicAWSCredentials, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.auth.{
+  AWSCredentialsProvider,
+  AWSStaticCredentialsProvider,
+  BasicAWSCredentials,
+  DefaultAWSCredentialsProviderChain
+}
 import com.amazonaws.regions.AwsRegionProvider
 import com.google.inject.Provides
 import com.twitter.inject.TwitterModule

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/modules/AkkaS3ClientModule.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/modules/AkkaS3ClientModule.scala
@@ -1,0 +1,70 @@
+package uk.ac.wellcome.platform.snapshot_convertor.modules
+
+import javax.inject.Singleton
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.s3.{MemoryBufferType, S3Settings}
+import akka.stream.alpakka.s3.scaladsl.S3Client
+import com.amazonaws.auth.{AWSCredentialsProvider, AWSStaticCredentialsProvider, BasicAWSCredentials, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.regions.AwsRegionProvider
+import com.google.inject.Provides
+import com.twitter.inject.TwitterModule
+import uk.ac.wellcome.models.aws.AWSConfig
+
+object AkkaS3ClientModule extends TwitterModule {
+  val s3Endpoint = flag[String](
+    "aws.s3.endpoint",
+    "",
+    "Endpoint of AWS S3. The region will be used if the endpoint is not provided")
+  private val accessKey =
+    flag[String]("aws.s3.accessKey", "", "AccessKey to access S3")
+  private val secretKey =
+    flag[String]("aws.s3.secretKey", "", "SecretKey to access S3")
+
+  def akkaS3Settings(credentialsProvider: AWSCredentialsProvider,
+                     regionProvider: AwsRegionProvider,
+                     endpointUrl: Option[String]): S3Settings =
+    new S3Settings(
+      bufferType = MemoryBufferType,
+      proxy = None,
+      credentialsProvider = credentialsProvider,
+      s3RegionProvider = regionProvider,
+      pathStyleAccess = true,
+      endpointUrl = endpointUrl
+    )
+
+  @Singleton
+  @Provides
+  def providesAkkaS3Client(awsConfig: AWSConfig,
+                           actorSystem: ActorSystem): S3Client = {
+    val regionProvider =
+      new AwsRegionProvider {
+        def getRegion: String = awsConfig.region
+      }
+
+    val credentialsProvider = if (s3Endpoint().isEmpty) {
+      DefaultAWSCredentialsProviderChain.getInstance()
+    } else {
+      new AWSStaticCredentialsProvider(
+        new BasicAWSCredentials(accessKey(), secretKey())
+      )
+    }
+
+    val actorMaterializer = ActorMaterializer()(actorSystem)
+    val endpointUrl = if (s3Endpoint().isEmpty) {
+      None
+    } else {
+      Some(s3Endpoint())
+    }
+
+    val settings = akkaS3Settings(
+      credentialsProvider = credentialsProvider,
+      regionProvider = regionProvider,
+      endpointUrl = endpointUrl
+    )
+
+    logger.debug(s"creating S3 Akka client with settings=[$settings]")
+    new S3Client(settings)(actorSystem, actorMaterializer)
+  }
+}

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/fixtures/AkkaS3.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/fixtures/AkkaS3.scala
@@ -25,7 +25,8 @@ trait AkkaS3 extends S3 {
       endpointUrl = Some(localS3EndpointUrl)
     )
 
-    val s3AkkaClient = new S3Client(s3Settings = s3Settings)(actorSystem, materializer)
+    val s3AkkaClient =
+      new S3Client(s3Settings = s3Settings)(actorSystem, materializer)
 
     testWith(s3AkkaClient)
   }


### PR DESCRIPTION
Another piece extracting from #1679 for easy review.

For now this lives in the snapshot_convertor application rather than common to avoid making alpakka-streams-s3 a dependency of our common lib.

I’ve also moved the creation of settings into a method which can be shared with the AkkaS3 fixture, as an inconsistency was the source of a hard-to-find bug when Ricardo was working on this.