### PR TITLE
snapshot_convertor: move the server fixture to a separate file

### DIFF
--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/ServerTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/ServerTest.scala
@@ -1,49 +1,24 @@
 package uk.ac.wellcome.platform.snapshot_convertor
 
 import com.twitter.finagle.http.Status.Ok
-import com.twitter.finatra.http.EmbeddedHttpServer
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.Matchers
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.FunSpec
-import uk.ac.wellcome.test.fixtures._
-import uk.ac.wellcome.test.utils.AmazonCloudWatchFlag
 
 class ServerTest
     extends FunSpec
-    with AmazonCloudWatchFlag
-    with SQS
-    with SNS
-    with S3
-    with ScalaFutures {
-
-  def withServer[R](queueUrl: String, topicArn: String, bucketName: String)(
-    testWith: TestWith[EmbeddedHttpServer, R]) = {
-    val server: EmbeddedHttpServer =
-      new EmbeddedHttpServer(
-        new Server(),
-        flags = snsLocalFlags(topicArn) ++ cloudWatchLocalEndpointFlag ++ sqsLocalFlags(
-          queueUrl) ++ s3LocalFlags(bucketName)
-      )
-
-    server.start()
-
-    try {
-      testWith(server)
-    } finally {
-      server.close()
-    }
-  }
+    with ScalaFutures
+    with fixtures.Server {
 
   it("shows the healthcheck message") {
     withLocalSqsQueue { queueUrl =>
       withLocalSnsTopic { topicArn =>
         withLocalS3Bucket { bucketName =>
-          withServer(queueUrl, topicArn, bucketName) { server =>
+          val flags = snsLocalFlags(topicArn) ++ sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucketName)
+          withServer(flags) { server =>
             server.httpGet(
               path = "/management/healthcheck",
               andExpect = Ok,
               withJsonBody = """{"message": "ok"}""")
-
           }
         }
       }

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/fixtures/Server.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/fixtures/Server.scala
@@ -1,0 +1,32 @@
+package uk.ac.wellcome.platform.snapshot_convertor.fixtures
+
+import com.twitter.finatra.http.EmbeddedHttpServer
+import org.scalatest.Suite
+import uk.ac.wellcome.platform.snapshot_convertor.{Server => AppServer}
+import uk.ac.wellcome.test.fixtures.TestWith
+import uk.ac.wellcome.test.utils.AmazonCloudWatchFlag
+
+trait Server extends AmazonCloudWatchFlag { this: Suite =>
+  def withServer[R](
+    flags: Map[String, String],
+    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer = identity
+  )(testWith: TestWith[EmbeddedHttpServer, R]) = {
+
+    val server: EmbeddedHttpServer = modifyServer(
+      new EmbeddedHttpServer(
+        new AppServer(),
+        flags = Map(
+          "aws.region" -> "localhost"
+        ) ++ flags ++ cloudWatchLocalEndpointFlag
+      )
+    )
+
+    server.start()
+
+    try {
+      testWith(server)
+    } finally {
+      server.close()
+    }
+  }
+}


### PR DESCRIPTION
Broken out of #1679 to reduce that diff further, and follows the pattern of our other applications.

This one is quite simple, so I’ll merge as soon as Travis goes green.