### PR TITLE
Provide a convenience wrapper for getting all WorksIncludes

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/WorksIncludes.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/WorksIncludes.scala
@@ -51,6 +51,18 @@ case object WorksIncludes {
     }
 }
 
+/** Convenience wrapper that has every field on WorksIncludes set to true.
+  *
+  * We're piggybacking the string-parsing logic used for parsing includes from
+  * a URL query string.  This isn't especially neat, but it means it always
+  * stays up-to-date if/when we add new includes, and avoids the messiness of
+  * doing reflection.
+  */
+object AllWorksIncludes {
+  def apply(): WorksIncludes =
+    WorksIncludes(queryParam = WorksIncludes.recognisedIncludes.mkString(","))
+}
+
 class WorksIncludesDeserializer extends JsonDeserializer[WorksIncludes] {
   override def deserialize(p: JsonParser,
                            ctxt: DeserializationContext): WorksIncludes =

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlow.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlow.scala
@@ -6,7 +6,7 @@ import com.twitter.inject.Logging
 import io.circe.Decoder
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.display.models.DisplayWork
-import uk.ac.wellcome.models.{IdentifiedWork, WorksIncludes}
+import uk.ac.wellcome.models.{AllWorksIncludes, IdentifiedWork}
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.ExecutionContext
@@ -28,14 +28,6 @@ case class ElasticsearchHit(
   */
 object ElasticsearchHitToDisplayWorkFlow extends Logging {
 
-  // TODO: Can we get a convenience wrapper for WorksIncludes that just
-  // fills in everything?
-  val includes = WorksIncludes(
-    identifiers = true,
-    thumbnail = true,
-    items = true
-  )
-
   def apply()(implicit executionContext: ExecutionContext)
     : Flow[String, DisplayWork, NotUsed] =
     Flow.fromFunction({ line =>
@@ -48,6 +40,6 @@ object ElasticsearchHitToDisplayWorkFlow extends Logging {
       }
 
       val internalWork = hit.source
-      DisplayWork(internalWork, includes = includes)
+      DisplayWork(internalWork, includes = AllWorksIncludes())
     })
 }


### PR DESCRIPTION
It’s not the neatest thing ever, but it saves us having to remember to update it later, and avoids the murkiness of reflection.