### PR TITLE
[WIP] Implement the ConvertorService

### DIFF
--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/models/CompletedConversionJob.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/models/CompletedConversionJob.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.snapshot_convertor.models
 
-case class CompletedConversionJob()
+import akka.http.scaladsl.model.Uri
 
-object CompletedConversionJob {
-  def apply(conversionJob: ConversionJob): CompletedConversionJob =
-    CompletedConversionJob()
-}
+case class CompletedConversionJob(
+  conversionJob: ConversionJob,
+  targetLocation: Uri
+)

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
@@ -1,18 +1,74 @@
 package uk.ac.wellcome.platform.snapshot_convertor.services
 
 import javax.inject.Inject
-
-import com.twitter.inject.Logging
-import uk.ac.wellcome.platform.snapshot_convertor.models.ConversionJob
-import uk.ac.wellcome.utils.GlobalExecutionContext.context
-
 import scala.concurrent.Future
+import scala.util.{Success, Failure}
 
-class ConvertorService @Inject()() extends Logging {
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.s3.scaladsl.{MultipartUploadResult, S3Client}
+import akka.stream.scaladsl.Sink
+import akka.util.ByteString
+import com.twitter.inject.Logging
+import com.twitter.inject.annotations.Flag
 
-  def runConversion(conversionJob: ConversionJob): Future[Unit] = {
+import uk.ac.wellcome.display.models.DisplayWork
+import uk.ac.wellcome.platform.snapshot_convertor.flow.{
+  ElasticsearchHitToDisplayWorkFlow,
+  StringToGzipFlow
+}
+import uk.ac.wellcome.platform.snapshot_convertor.models.ConversionJob
+import uk.ac.wellcome.platform.snapshot_convertor.source.S3Source
+import uk.ac.wellcome.utils.GlobalExecutionContext.context
+import uk.ac.wellcome.utils.JsonUtil._
+
+class ConvertorService @Inject()(actorSystem: ActorSystem, s3Client: S3Client, @Flag("aws.s3.endpoint") extends Logging {
+
+  implicit val materializer = ActorMaterializer()
+
+  def runConversion(conversionJob: ConversionJob): Future[CompletedConversionJob] = {
     info(s"ConvertorService running $conversionJob")
 
-    Future.failed(new RuntimeException("Not implemented!"))
+    val s3source = S3Source(
+      s3client = s3Client,
+      bucketName = conversionJob.bucketName,
+      key = conversionJob.objectKey
+    )
+
+    val displayWorks = s3source
+      .via(ElasticsearchHitToDisplayWorkFlow())
+
+    val jsonStrings = displayWorks
+      .map { displayWork: DisplayWork => toJson(displayWork) }
+      .map {
+        case Success(jsonString) => jsonString
+        case Failure(encodeError) => {
+          warn("Failed to convert $displayWork to string!", encodeError)
+          throw encodeError
+        }
+      }
+
+    val gzipContent = jsonStrings
+      .via{ StringToGzipFlow(_) }
+
+    val targetObjectKey = "target.txt.gz"
+
+    val s3Sink: Sink[ByteString, Future[MultipartUploadResult]] =
+      s3Client.multipartUpload(
+        bucket = conversionJob.bucketName,
+        key = targetObjectKey
+      )
+
+    val future = gzipContent
+      .runWith(s3Sink)
+
+    future.map { _ =>
+      val targetLocation = Uri(s"$s3endpoint/${conversionJob.bucketName}/$targetObjectKey")
+
+      CompletedConversionJob(
+        conversionJob = conversionJob,
+        targetLocation = targetLocation
+      )
+    }
   }
 }

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
@@ -22,9 +22,11 @@ import uk.ac.wellcome.platform.snapshot_convertor.source.S3Source
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil._
 
-class ConvertorService @Inject()(actorSystem: ActorSystem, s3Client: S3Client, @Flag("aws.s3.endpoint") extends Logging {
+class ConvertorService @Inject()(actorSystem: ActorSystem,
+                                 s3Client: S3Client,
+                                 @Flag("aws.s3.endpoint") s3Endpoint: String) extends Logging {
 
-  implicit val materializer = ActorMaterializer()
+  implicit val materializer = ActorMaterializer()(actorSystem)
 
   def runConversion(conversionJob: ConversionJob): Future[CompletedConversionJob] = {
     info(s"ConvertorService running $conversionJob")

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.snapshot_convertor.services
 
 import javax.inject.Inject
 import scala.concurrent.Future
-import scala.util.{Success, Failure}
+import scala.util.{Failure, Success}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
@@ -28,11 +28,13 @@ import uk.ac.wellcome.utils.JsonUtil._
 
 class ConvertorService @Inject()(actorSystem: ActorSystem,
                                  s3Client: S3Client,
-                                 @Flag("aws.s3.endpoint") s3Endpoint: String) extends Logging {
+                                 @Flag("aws.s3.endpoint") s3Endpoint: String)
+    extends Logging {
 
   implicit val materializer = ActorMaterializer()(actorSystem)
 
-  def runConversion(conversionJob: ConversionJob): Future[CompletedConversionJob] = {
+  def runConversion(
+    conversionJob: ConversionJob): Future[CompletedConversionJob] = {
     info(s"ConvertorService running $conversionJob")
 
     val s3source = S3Source(
@@ -45,7 +47,9 @@ class ConvertorService @Inject()(actorSystem: ActorSystem,
       .via(ElasticsearchHitToDisplayWorkFlow())
 
     val jsonStrings = displayWorks
-      .map { displayWork: DisplayWork => toJson(displayWork) }
+      .map { displayWork: DisplayWork =>
+        toJson(displayWork)
+      }
       .map {
         case Success(jsonString) => jsonString
         case Failure(encodeError) => {
@@ -69,7 +73,8 @@ class ConvertorService @Inject()(actorSystem: ActorSystem,
       .runWith(s3Sink)
 
     future.map { _ =>
-      val targetLocation = Uri(s"$s3Endpoint/${conversionJob.bucketName}/$targetObjectKey")
+      val targetLocation =
+        Uri(s"$s3Endpoint/${conversionJob.bucketName}/$targetObjectKey")
 
       CompletedConversionJob(
         conversionJob = conversionJob,

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/SnapshotConvertorWorkerService.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/SnapshotConvertorWorkerService.scala
@@ -26,7 +26,8 @@ class SnapshotConvertorWorkerService @Inject()(
   override def processMessage(message: SQSMessage): Future[Unit] =
     for {
       conversionJob <- Future.fromTry(fromJson[ConversionJob](message.body))
-      completedConversionJob <- convertorService.runConversion(conversionJob = conversionJob)
+      completedConversionJob <- convertorService.runConversion(
+        conversionJob = conversionJob)
       message <- Future.fromTry(toJson(completedConversionJob))
       _ <- snsWriter.writeMessage(
         subject = s"source: ${this.getClass.getSimpleName}.processMessage",

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/SnapshotConvertorWorkerService.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/SnapshotConvertorWorkerService.scala
@@ -26,8 +26,8 @@ class SnapshotConvertorWorkerService @Inject()(
   override def processMessage(message: SQSMessage): Future[Unit] =
     for {
       conversionJob <- Future.fromTry(fromJson[ConversionJob](message.body))
-      _ <- convertorService.runConversion(conversionJob = conversionJob)
-      message <- Future.fromTry(toJson(CompletedConversionJob(conversionJob)))
+      completedConversionJob <- convertorService.runConversion(conversionJob = conversionJob)
+      message <- Future.fromTry(toJson(completedConversionJob))
       _ <- snsWriter.writeMessage(
         subject = s"source: ${this.getClass.getSimpleName}.processMessage",
         message = message

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
@@ -9,9 +9,16 @@ import com.amazonaws.services.s3.model.GetObjectRequest
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.models.{IdentifiedWork, IdentifierSchemes, SourceIdentifier}
+import uk.ac.wellcome.models.{
+  IdentifiedWork,
+  IdentifierSchemes,
+  SourceIdentifier
+}
 import uk.ac.wellcome.platform.snapshot_convertor.fixtures.AkkaS3
-import uk.ac.wellcome.platform.snapshot_convertor.models.{CompletedConversionJob, ConversionJob}
+import uk.ac.wellcome.platform.snapshot_convertor.models.{
+  CompletedConversionJob,
+  ConversionJob
+}
 import uk.ac.wellcome.platform.snapshot_convertor.services.ConvertorService
 import uk.ac.wellcome.platform.snapshot_convertor.test.utils.GzipUtils
 import uk.ac.wellcome.test.fixtures._
@@ -39,7 +46,6 @@ class SnapshotConvertorFeatureTest
             bucketName)
 
           withServer(flags) { _ =>
-
             // Create a collection of works.  These three differ by version,
             // if not anything more interesting!
             val works = (1 to 3).map { version =>
@@ -56,7 +62,8 @@ class SnapshotConvertorFeatureTest
             }
 
             val elasticsearchJsons = works.map { work =>
-              s"""{"_index": "jett4fvw", "_type": "work", "_id": "${work.canonicalId}", "_score": 1, "_source": ${toJson(work).get}}"""
+              s"""{"_index": "jett4fvw", "_type": "work", "_id": "${work.canonicalId}", "_score": 1, "_source": ${toJson(
+                work).get}}"""
             }
             val content = elasticsearchJsons.mkString("\n")
 
@@ -78,8 +85,11 @@ class SnapshotConvertorFeatureTest
 
               eventually {
 
-                val downloadFile = File.createTempFile("convertorServiceTest", ".txt.gz")
-                s3Client.getObject(new GetObjectRequest(bucketName, "target.txt.gz"), downloadFile)
+                val downloadFile =
+                  File.createTempFile("convertorServiceTest", ".txt.gz")
+                s3Client.getObject(
+                  new GetObjectRequest(bucketName, "target.txt.gz"),
+                  downloadFile)
 
                 val contents = readGzipFile(downloadFile.getPath)
                 val expectedContents = works
@@ -92,7 +102,8 @@ class SnapshotConvertorFeatureTest
                 listMessagesReceivedFromSNS(topicArn) shouldBe List(
                   CompletedConversionJob(
                     conversionJob = conversionJob,
-                    targetLocation = s"http://localhost:33333/$bucketName/target.txt.gz"
+                    targetLocation =
+                      s"http://localhost:33333/$bucketName/target.txt.gz"
                   )
                 )
               }

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
@@ -1,0 +1,105 @@
+package uk.ac.wellcome.platform.snapshot_convertor
+
+import java.io.File
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.s3.scaladsl.S3Client
+import com.amazonaws.services.s3.model.GetObjectRequest
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.{Assertion, FunSpec, Matchers}
+import uk.ac.wellcome.models.aws.SQSMessage
+import uk.ac.wellcome.models.{IdentifiedWork, IdentifierSchemes, SourceIdentifier}
+import uk.ac.wellcome.platform.snapshot_convertor.fixtures.AkkaS3
+import uk.ac.wellcome.platform.snapshot_convertor.models.{CompletedConversionJob, ConversionJob}
+import uk.ac.wellcome.platform.snapshot_convertor.services.ConvertorService
+import uk.ac.wellcome.platform.snapshot_convertor.test.utils.GzipUtils
+import uk.ac.wellcome.test.fixtures._
+import uk.ac.wellcome.test.utils.ExtendedPatience
+import uk.ac.wellcome.utils.JsonUtil._
+
+class SnapshotConvertorFeatureTest
+    extends FunSpec
+    with Eventually
+    with Matchers
+    with Akka
+    with AkkaS3
+    with S3
+    with SNS
+    with SQS
+    with GzipUtils
+    with fixtures.Server
+    with ExtendedPatience {
+
+  it("completes a conversion successfully") {
+    withLocalSqsQueue { queueUrl =>
+      withLocalSnsTopic { topicArn =>
+        withLocalS3Bucket { bucketName =>
+          val flags = snsLocalFlags(topicArn) ++ sqsLocalFlags(queueUrl) ++ s3LocalFlags(
+            bucketName)
+
+          withServer(flags) { _ =>
+
+            // Create a collection of works.  These three differ by version,
+            // if not anything more interesting!
+            val works = (1 to 3).map { version =>
+              IdentifiedWork(
+                canonicalId = "rbfhv6b4",
+                title = Some("Rumblings from a rambunctious rodent"),
+                sourceIdentifier = SourceIdentifier(
+                  identifierScheme = IdentifierSchemes.miroImageNumber,
+                  ontologyType = "work",
+                  value = "R0060400"
+                ),
+                version = version
+              )
+            }
+
+            val elasticsearchJsons = works.map { work =>
+              s"""{"_index": "jett4fvw", "_type": "work", "_id": "${work.canonicalId}", "_score": 1, "_source": ${toJson(work).get}}"""
+            }
+            val content = elasticsearchJsons.mkString("\n")
+
+            withGzipCompressedS3Key(bucketName, content) { objectKey =>
+              val conversionJob = ConversionJob(
+                bucketName = bucketName,
+                objectKey = objectKey
+              )
+
+              val message = SQSMessage(
+                subject = Some("Sent from SnapshotConvertorFeatureTest"),
+                body = toJson(conversionJob).get,
+                messageType = "json",
+                topic = topicArn,
+                timestamp = "now"
+              )
+
+              sqsClient.sendMessage(queueUrl, toJson(message).get)
+
+              eventually {
+
+                val downloadFile = File.createTempFile("convertorServiceTest", ".txt.gz")
+                s3Client.getObject(new GetObjectRequest(bucketName, "target.txt.gz"), downloadFile)
+
+                val contents = readGzipFile(downloadFile.getPath)
+                val expectedContents = works
+                  .map { DisplayWork(_) }
+                  .map { toJson(_).get }
+                  .mkString("\n") + "\n"
+
+                contents shouldBe expectedContents
+
+                listMessagesReceivedFromSNS(topicArn) shouldBe List(
+                  CompletedConversionJob(
+                    conversionJob = conversionJob,
+                    targetLocation = s"http://localhost:33333/$bucketName/target.txt.gz"
+                  )
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
@@ -8,8 +8,10 @@ import akka.stream.alpakka.s3.scaladsl.S3Client
 import com.amazonaws.services.s3.model.GetObjectRequest
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{Assertion, FunSpec, Matchers}
+import uk.ac.wellcome.display.models.DisplayWork
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.models.{
+  AllWorksIncludes,
   IdentifiedWork,
   IdentifierSchemes,
   SourceIdentifier
@@ -93,7 +95,7 @@ class SnapshotConvertorFeatureTest
 
                 val contents = readGzipFile(downloadFile.getPath)
                 val expectedContents = works
-                  .map { DisplayWork(_) }
+                  .map { DisplayWork(_, includes = AllWorksIncludes()) }
                   .map { toJson(_).get }
                   .mkString("\n") + "\n"
 

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -1,0 +1,61 @@
+package uk.ac.wellcome.platform.snapshot_convertor.services
+
+import akka.stream.ActorMaterializer
+import org.scalatest.{Assertion, FunSpec, Matchers}
+import org.scalatest.concurrent.ScalaFutures
+import uk.ac.wellcome.models.{
+  IdentifiedWork,
+  IdentifierSchemes,
+  SourceIdentifier
+}
+import uk.ac.wellcome.platform.snapshot_convertor.fixtures.AkkaS3
+import uk.ac.wellcome.test.fixtures.{Akka, S3, TestWith}
+import uk.ac.wellcome.test.utils.ExtendedPatience
+
+class ConvertorServiceTest
+    extends FunSpec
+    with ScalaFutures
+    with Matchers
+    with Akka
+    with AkkaS3
+    with S3
+    with ExtendedPatience {
+
+  private def withConvertorService(bucketName: String)(
+    testWith: TestWith[ConvertorService, Assertion]) = {
+    withActorSystem { actorSystem =>
+      implicit val materializer = ActorMaterializer()(actorSystem)
+      withS3AkkaClient(actorSystem, materializer) { s3AkkaClient =>
+        val convertorService = new ConvertorService(
+          actorSystem = actorSystem,
+          s3Client = s3AkkaClient,
+          s3Endpoint = localS3EndpointUrl
+        )
+
+        testWith(convertorService)
+      }
+    }
+  }
+
+  it("completes a conversion successfully") {
+    withLocalS3Bucket { bucketName =>
+      withConvertorService { convertorService =>
+
+        // Create a collection of works.  These three differ by version,
+        // if not anything more interesting!
+        val works = (1 to 3).map { version =>
+          IdentifiedWork(
+            canonicalId = "t83tggem",
+            title = Some("Tired of troubling tests"),
+            sourceIdentifier = SourceIdentifier(
+              identifierScheme = IdentifierSchemes.miroImageNumber,
+              ontologyType = "work",
+              value = "T0083000"
+            ),
+            version = version
+          )
+        }
+      }
+    }
+  }
+}

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -10,6 +10,7 @@ import org.scalatest.{Assertion, FunSpec, Matchers}
 import org.scalatest.concurrent.ScalaFutures
 import uk.ac.wellcome.display.models.DisplayWork
 import uk.ac.wellcome.models.{
+  AllWorksIncludes,
   IdentifiedWork,
   IdentifierSchemes,
   SourceIdentifier
@@ -92,7 +93,7 @@ class ConvertorServiceTest
 
                   val contents = readGzipFile(downloadFile.getPath)
                   val expectedContents = works
-                    .map { DisplayWork(_) }
+                    .map { DisplayWork(_, includes = AllWorksIncludes()) }
                     .map { toJson(_).get }
                     .mkString("\n") + "\n"
 

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -1,21 +1,17 @@
 package uk.ac.wellcome.platform.snapshot_convertor.services
 
+import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import akka.stream.alpakka.s3.scaladsl.S3Client
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import org.scalatest.concurrent.ScalaFutures
-import uk.ac.wellcome.models.{
-  IdentifiedWork,
-  IdentifierSchemes,
-  SourceIdentifier
-}
+import uk.ac.wellcome.models.{IdentifiedWork, IdentifierSchemes, SourceIdentifier}
 import uk.ac.wellcome.platform.snapshot_convertor.fixtures.AkkaS3
-import uk.ac.wellcome.platform.snapshot_convertor.models.{
-  CompletedConversionJob,
-  ConversionJob
-}
+import uk.ac.wellcome.platform.snapshot_convertor.models.{CompletedConversionJob, ConversionJob}
 import uk.ac.wellcome.platform.snapshot_convertor.test.utils.GzipUtils
 import uk.ac.wellcome.test.fixtures.{Akka, S3, TestWith}
 import uk.ac.wellcome.test.utils.ExtendedPatience
+import uk.ac.wellcome.utils.JsonUtil._
 
 class ConvertorServiceTest
     extends FunSpec
@@ -27,62 +23,59 @@ class ConvertorServiceTest
     with GzipUtils
     with ExtendedPatience {
 
-  private def withConvertorService(bucketName: String)(
+  private def withConvertorService(bucketName: String, actorSystem: ActorSystem, s3AkkaClient: S3Client)(
     testWith: TestWith[ConvertorService, Assertion]) = {
-    withActorSystem { actorSystem =>
-      implicit val materializer = ActorMaterializer()(actorSystem)
-      withS3AkkaClient(actorSystem, materializer) { s3AkkaClient =>
-        val convertorService = new ConvertorService(
-          actorSystem = actorSystem,
-          s3Client = s3AkkaClient,
-          s3Endpoint = localS3EndpointUrl
-        )
+    val convertorService = new ConvertorService(
+      actorSystem = actorSystem,
+      s3Client = s3AkkaClient,
+      s3Endpoint = localS3EndpointUrl
+    )
 
-        testWith(convertorService)
-      }
-    }
+    testWith(convertorService)
   }
 
   it("completes a conversion successfully") {
     withLocalS3Bucket { bucketName =>
-      withConvertorService(bucketName) { convertorService =>
+      withActorSystem { actorSystem =>
+        implicit val materializer = ActorMaterializer()(actorSystem)
+        withS3AkkaClient(actorSystem, materializer) { s3AkkaClient =>
+          withConvertorService(bucketName, actorSystem, s3AkkaClient) { convertorService =>
 
-        // Create a collection of works.  These three differ by version,
-        // if not anything more interesting!
-        val works = (1 to 3).map { version =>
-          IdentifiedWork(
-            canonicalId = "rbfhv6b4",
-            title = Some("Rumblings from a rambunctious rodent"),
-            sourceIdentifier = SourceIdentifier(
-              identifierScheme = IdentifierSchemes.miroImageNumber,
-              ontologyType = "work",
-              value = "R0060400"
-            ),
-            version = version
-          )
-        }
+            // Create a collection of works.  These three differ by version,
+            // if not anything more interesting!
+            val works = (1 to 3).map { version =>
+              IdentifiedWork(
+                canonicalId = "rbfhv6b4",
+                title = Some("Rumblings from a rambunctious rodent"),
+                sourceIdentifier = SourceIdentifier(
+                  identifierScheme = IdentifierSchemes.miroImageNumber,
+                  ontologyType = "work",
+                  value = "R0060400"
+                ),
+                version = version
+              )
+            }
 
-        val elasticsearchJsons = works.map { work =>
-          s"""{"_index": "jett4fvw", "_type": "work", "_id": "${work.canonicalId}", "_score": 1, "_source": ${toJson(work).get}}"""
-        }
-        val content = elasticsearchJsons.mkString("\n")
+            val elasticsearchJsons = works.map { work =>
+              s"""{"_index": "jett4fvw", "_type": "work", "_id": "${work.canonicalId}", "_score": 1, "_source": ${toJson(work).get}}"""
+            }
+            val content = elasticsearchJsons.mkString("\n")
 
-        withGzipCompressedS3Key(bucketName, content) { objectKey =>
-          val conversionJob = ConversionJob(
-            bucketName = bucketName,
-            objectKey = objectKey
-          )
+            withGzipCompressedS3Key(bucketName, content) { objectKey =>
+              val conversionJob = ConversionJob(
+                bucketName = bucketName,
+                objectKey = objectKey
+              )
 
-          val future = convertorService.runConversion(conversionJob)
+              val future = convertorService.runConversion(conversionJob)
 
-          whenReady(future) { result =>
-
-
-
-            result shouldBe CompletedConversionJob(
-              conversionJob = conversionJob,
-              targetLocation = s"http://localhost:33333/$bucketName/target.txt.gz"
-            )
+              whenReady(future) { result =>
+                result shouldBe CompletedConversionJob(
+                  conversionJob = conversionJob,
+                  targetLocation = s"http://localhost:33333/$bucketName/target.txt.gz"
+                )
+              }
+            }
           }
         }
       }

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -9,9 +9,16 @@ import com.amazonaws.services.s3.model.GetObjectRequest
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import org.scalatest.concurrent.ScalaFutures
 import uk.ac.wellcome.display.models.DisplayWork
-import uk.ac.wellcome.models.{IdentifiedWork, IdentifierSchemes, SourceIdentifier}
+import uk.ac.wellcome.models.{
+  IdentifiedWork,
+  IdentifierSchemes,
+  SourceIdentifier
+}
 import uk.ac.wellcome.platform.snapshot_convertor.fixtures.AkkaS3
-import uk.ac.wellcome.platform.snapshot_convertor.models.{CompletedConversionJob, ConversionJob}
+import uk.ac.wellcome.platform.snapshot_convertor.models.{
+  CompletedConversionJob,
+  ConversionJob
+}
 import uk.ac.wellcome.platform.snapshot_convertor.test.utils.GzipUtils
 import uk.ac.wellcome.test.fixtures.{Akka, S3, TestWith}
 import uk.ac.wellcome.test.utils.ExtendedPatience
@@ -27,7 +34,9 @@ class ConvertorServiceTest
     with GzipUtils
     with ExtendedPatience {
 
-  private def withConvertorService(bucketName: String, actorSystem: ActorSystem, s3AkkaClient: S3Client)(
+  private def withConvertorService(bucketName: String,
+                                   actorSystem: ActorSystem,
+                                   s3AkkaClient: S3Client)(
     testWith: TestWith[ConvertorService, Assertion]) = {
     val convertorService = new ConvertorService(
       actorSystem = actorSystem,
@@ -43,55 +52,59 @@ class ConvertorServiceTest
       withActorSystem { actorSystem =>
         implicit val materializer = ActorMaterializer()(actorSystem)
         withS3AkkaClient(actorSystem, materializer) { s3AkkaClient =>
-          withConvertorService(bucketName, actorSystem, s3AkkaClient) { convertorService =>
-
-            // Create a collection of works.  These three differ by version,
-            // if not anything more interesting!
-            val works = (1 to 3).map { version =>
-              IdentifiedWork(
-                canonicalId = "rbfhv6b4",
-                title = Some("Rumblings from a rambunctious rodent"),
-                sourceIdentifier = SourceIdentifier(
-                  identifierScheme = IdentifierSchemes.miroImageNumber,
-                  ontologyType = "work",
-                  value = "R0060400"
-                ),
-                version = version
-              )
-            }
-
-            val elasticsearchJsons = works.map { work =>
-              s"""{"_index": "jett4fvw", "_type": "work", "_id": "${work.canonicalId}", "_score": 1, "_source": ${toJson(work).get}}"""
-            }
-            val content = elasticsearchJsons.mkString("\n")
-
-            withGzipCompressedS3Key(bucketName, content) { objectKey =>
-              val conversionJob = ConversionJob(
-                bucketName = bucketName,
-                objectKey = objectKey
-              )
-
-              val future = convertorService.runConversion(conversionJob)
-
-              whenReady(future) { result =>
-
-                val downloadFile = File.createTempFile("convertorServiceTest", ".txt.gz")
-                s3Client.getObject(new GetObjectRequest(bucketName, "target.txt.gz"), downloadFile)
-
-                val contents = readGzipFile(downloadFile.getPath)
-                val expectedContents = works
-                  .map { DisplayWork(_) }
-                  .map { toJson(_).get }
-                  .mkString("\n") + "\n"
-
-                contents shouldBe expectedContents
-
-                result shouldBe CompletedConversionJob(
-                  conversionJob = conversionJob,
-                  targetLocation = s"http://localhost:33333/$bucketName/target.txt.gz"
+          withConvertorService(bucketName, actorSystem, s3AkkaClient) {
+            convertorService =>
+              // Create a collection of works.  These three differ by version,
+              // if not anything more interesting!
+              val works = (1 to 3).map { version =>
+                IdentifiedWork(
+                  canonicalId = "rbfhv6b4",
+                  title = Some("Rumblings from a rambunctious rodent"),
+                  sourceIdentifier = SourceIdentifier(
+                    identifierScheme = IdentifierSchemes.miroImageNumber,
+                    ontologyType = "work",
+                    value = "R0060400"
+                  ),
+                  version = version
                 )
               }
-            }
+
+              val elasticsearchJsons = works.map { work =>
+                s"""{"_index": "jett4fvw", "_type": "work", "_id": "${work.canonicalId}", "_score": 1, "_source": ${toJson(
+                  work).get}}"""
+              }
+              val content = elasticsearchJsons.mkString("\n")
+
+              withGzipCompressedS3Key(bucketName, content) { objectKey =>
+                val conversionJob = ConversionJob(
+                  bucketName = bucketName,
+                  objectKey = objectKey
+                )
+
+                val future = convertorService.runConversion(conversionJob)
+
+                whenReady(future) { result =>
+                  val downloadFile =
+                    File.createTempFile("convertorServiceTest", ".txt.gz")
+                  s3Client.getObject(
+                    new GetObjectRequest(bucketName, "target.txt.gz"),
+                    downloadFile)
+
+                  val contents = readGzipFile(downloadFile.getPath)
+                  val expectedContents = works
+                    .map { DisplayWork(_) }
+                    .map { toJson(_).get }
+                    .mkString("\n") + "\n"
+
+                  contents shouldBe expectedContents
+
+                  result shouldBe CompletedConversionJob(
+                    conversionJob = conversionJob,
+                    targetLocation =
+                      s"http://localhost:33333/$bucketName/target.txt.gz"
+                  )
+                }
+              }
           }
         }
       }
@@ -103,17 +116,18 @@ class ConvertorServiceTest
       withActorSystem { actorSystem =>
         implicit val materializer = ActorMaterializer()(actorSystem)
         withS3AkkaClient(actorSystem, materializer) { s3AkkaClient =>
-          withConvertorService(bucketName, actorSystem, s3AkkaClient) { convertorService =>
-            val conversionJob = ConversionJob(
-              bucketName = bucketName,
-              objectKey = "doesnotexist.txt.gz"
-            )
+          withConvertorService(bucketName, actorSystem, s3AkkaClient) {
+            convertorService =>
+              val conversionJob = ConversionJob(
+                bucketName = bucketName,
+                objectKey = "doesnotexist.txt.gz"
+              )
 
-            val future = convertorService.runConversion(conversionJob)
+              val future = convertorService.runConversion(conversionJob)
 
-            whenReady(future.failed) { result =>
-              result shouldBe a[RuntimeException]
-            }
+              whenReady(future.failed) { result =>
+                result shouldBe a[RuntimeException]
+              }
           }
         }
       }
@@ -125,19 +139,23 @@ class ConvertorServiceTest
       withActorSystem { actorSystem =>
         implicit val materializer = ActorMaterializer()(actorSystem)
         withS3AkkaClient(actorSystem, materializer) { s3AkkaClient =>
-          withConvertorService(bucketName, actorSystem, s3AkkaClient) { convertorService =>
-            withGzipCompressedS3Key(bucketName, content = "This is not what snapshots look like") { objectKey =>
-              val conversionJob = ConversionJob(
-                bucketName = bucketName,
-                objectKey = objectKey
-              )
+          withConvertorService(bucketName, actorSystem, s3AkkaClient) {
+            convertorService =>
+              withGzipCompressedS3Key(
+                bucketName,
+                content = "This is not what snapshots look like") {
+                objectKey =>
+                  val conversionJob = ConversionJob(
+                    bucketName = bucketName,
+                    objectKey = objectKey
+                  )
 
-              val future = convertorService.runConversion(conversionJob)
+                  val future = convertorService.runConversion(conversionJob)
 
-              whenReady(future.failed) { result =>
-                result shouldBe a[RuntimeException]
+                  whenReady(future.failed) { result =>
+                    result shouldBe a[RuntimeException]
+                  }
               }
-            }
           }
         }
       }
@@ -149,40 +167,41 @@ class ConvertorServiceTest
       withActorSystem { actorSystem =>
         implicit val materializer = ActorMaterializer()(actorSystem)
         withS3AkkaClient(actorSystem, materializer) { s3AkkaClient =>
-          withConvertorService(bucketName, actorSystem, s3AkkaClient) { convertorService =>
-
-            // Create a collection of works.  These three differ by version,
-            // if not anything more interesting!
-            val works = (1 to 3).map { version =>
-              IdentifiedWork(
-                canonicalId = "h4dh3esm",
-                title = Some("Harrowing Henry is hardly heard from"),
-                sourceIdentifier = SourceIdentifier(
-                  identifierScheme = IdentifierSchemes.miroImageNumber,
-                  ontologyType = "work",
-                  value = "r4f2t3bf"
-                ),
-                version = version
-              )
-            }
-
-            val elasticsearchJsons = works.map { work =>
-              s"""{"_index": "jett4fvw", "_type": "work", "_id": "${work.canonicalId}", "_score": 1, "_source": ${toJson(work).get}}"""
-            }
-            val content = elasticsearchJsons.mkString("\n")
-
-            withGzipCompressedS3Key(bucketName, content) { objectKey =>
-              val conversionJob = ConversionJob(
-                bucketName = "wrongBukkit",
-                objectKey = objectKey
-              )
-
-              val future = convertorService.runConversion(conversionJob)
-
-              whenReady(future.failed) { result =>
-                result shouldBe a[RuntimeException]
+          withConvertorService(bucketName, actorSystem, s3AkkaClient) {
+            convertorService =>
+              // Create a collection of works.  These three differ by version,
+              // if not anything more interesting!
+              val works = (1 to 3).map { version =>
+                IdentifiedWork(
+                  canonicalId = "h4dh3esm",
+                  title = Some("Harrowing Henry is hardly heard from"),
+                  sourceIdentifier = SourceIdentifier(
+                    identifierScheme = IdentifierSchemes.miroImageNumber,
+                    ontologyType = "work",
+                    value = "r4f2t3bf"
+                  ),
+                  version = version
+                )
               }
-            }
+
+              val elasticsearchJsons = works.map { work =>
+                s"""{"_index": "jett4fvw", "_type": "work", "_id": "${work.canonicalId}", "_score": 1, "_source": ${toJson(
+                  work).get}}"""
+              }
+              val content = elasticsearchJsons.mkString("\n")
+
+              withGzipCompressedS3Key(bucketName, content) { objectKey =>
+                val conversionJob = ConversionJob(
+                  bucketName = "wrongBukkit",
+                  objectKey = objectKey
+                )
+
+                val future = convertorService.runConversion(conversionJob)
+
+                whenReady(future.failed) { result =>
+                  result shouldBe a[RuntimeException]
+                }
+              }
           }
         }
       }

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -9,6 +9,7 @@ import uk.ac.wellcome.models.{
   SourceIdentifier
 }
 import uk.ac.wellcome.platform.snapshot_convertor.fixtures.AkkaS3
+import uk.ac.wellcome.platform.snapshot_convertor.test.utils.GzipUtils
 import uk.ac.wellcome.test.fixtures.{Akka, S3, TestWith}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
@@ -19,6 +20,7 @@ class ConvertorServiceTest
     with Akka
     with AkkaS3
     with S3
+    with GzipUtils
     with ExtendedPatience {
 
   private def withConvertorService(bucketName: String)(
@@ -59,7 +61,8 @@ class ConvertorServiceTest
         val elasticsearchJsons = works.map { work =>
           s"""{"_index": "jett4fvw", "_type": "work", "_id": "${work.canonicalId}", "_score": 1, "_source": ${toJson(work).get}}"""
         }
-        contents = elasticsearchJsons.mkString("\n")
+        val content = elasticsearchJsons.mkString("\n")
+        val gzipContent = createGzipFile(content)
       }
     }
   }

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -45,16 +45,21 @@ class ConvertorServiceTest
         // if not anything more interesting!
         val works = (1 to 3).map { version =>
           IdentifiedWork(
-            canonicalId = "t83tggem",
-            title = Some("Tired of troubling tests"),
+            canonicalId = "rbfhv6b4",
+            title = Some("Rumblings from a rambunctious rodent"),
             sourceIdentifier = SourceIdentifier(
               identifierScheme = IdentifierSchemes.miroImageNumber,
               ontologyType = "work",
-              value = "T0083000"
+              value = "R0060400"
             ),
             version = version
           )
         }
+
+        val elasticsearchJsons = works.map { work =>
+          s"""{"_index": "jett4fvw", "_type": "work", "_id": "${work.canonicalId}", "_score": 1, "_source": ${toJson(work).get}}"""
+        }
+        contents = elasticsearchJsons.mkString("\n")
       }
     }
   }

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
@@ -34,19 +34,17 @@ class S3SourceTest
             "Cor! Countless copies of crying camels"
           )
 
-          val gzipFile = createGzipFile(expectedLines.mkString("\n"))
-          val key = "test001.txt.gz"
-          s3Client.putObject(bucketName, key, gzipFile)
+          withGzipCompressedS3Key(expectedLines.mkString("\n")) { key =>
+            val source = S3Source(
+              s3client = akkaS3client,
+              bucketName = bucketName,
+              key = key
+            )
 
-          val source = S3Source(
-            s3client = akkaS3client,
-            bucketName = bucketName,
-            key = key
-          )
-
-          val future = source.runWith(Sink.seq)
-          whenReady(future) { result =>
-            result.toList shouldBe expectedLines
+            val future = source.runWith(Sink.seq)
+            whenReady(future) { result =>
+              result.toList shouldBe expectedLines
+            }
           }
         }
       }

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
@@ -33,8 +33,9 @@ class S3SourceTest
             "Blimey! Blue bonobos with beachballs",
             "Cor! Countless copies of crying camels"
           )
+          val content = expectedLines.mkString("\n")
 
-          withGzipCompressedS3Key(expectedLines.mkString("\n")) { key =>
+          withGzipCompressedS3Key(bucketName, content) { key =>
             val source = S3Source(
               s3client = akkaS3client,
               bucketName = bucketName,

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
@@ -3,11 +3,10 @@ package uk.ac.wellcome.platform.snapshot_convertor.source
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Compression, Sink, Source}
 import akka.util.ByteString
-import java.io.{BufferedWriter, File, FileWriter}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import scala.sys.process._
 import uk.ac.wellcome.platform.snapshot_convertor.fixtures.AkkaS3
+import uk.ac.wellcome.platform.snapshot_convertor.test.utils.GzipUtils
 import uk.ac.wellcome.test.fixtures.Akka
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
@@ -19,7 +18,8 @@ class S3SourceTest
     with ScalaFutures
     with ExtendedPatience
     with Akka
-    with AkkaS3 {
+    with AkkaS3
+    with GzipUtils {
 
   it("reads a series of lines from S3") {
     withActorSystem { actorSystem =>
@@ -51,26 +51,5 @@ class S3SourceTest
         }
       }
     }
-  }
-
-  private def createGzipFile(content: String): File = {
-    val tmpfile = File.createTempFile("s3sourcetest", ".txt")
-
-    // Create a gzip-compressed file.  This is based on the shell commands
-    // that are used in the elasticdump container.
-    //
-    // The intention here is not to create a gzip-compressed file in
-    // the most "Scala-like" way, it's to create a file that closely
-    // matches what we'd get from an elasticdump in S3.
-    val bw = new BufferedWriter(new FileWriter(tmpfile))
-    bw.write(content)
-    bw.close()
-
-    // This performs "gzip foo.txt > foo.txt.gz" in a roundabout way.
-    // Because we're using the busybox version of gzip, it actually cleans
-    // up the old file and appends the .gz suffix for us.
-    s"gzip ${tmpfile.getPath}" !!
-
-    new File(s"${tmpfile.getPath}.gz")
   }
 }

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/test/utils/GzipUtils.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/test/utils/GzipUtils.scala
@@ -2,9 +2,23 @@ package uk.ac.wellcome.platform.snapshot_convertor.test.utils
 
 import java.io.{BufferedWriter, File, FileWriter}
 import scala.sys.process._
+import scala.util.Random
 
-trait GzipUtils {
-  def createGzipFile(content: String): File = {
+import org.scalatest.Assertion
+
+import uk.ac.wellcome.test.fixtures.{S3, TestWith}
+
+trait GzipUtils with S3 {
+  def withGzipCompressedS3Key(bucketName: String, content: String)(
+    testWith: TestWith[String, Assertion]) = {
+    val gzipContent = createGzipFile(content)
+    val key = (Random.alphanumeric take 10 mkString).toLowerCase
+    s3Client.putObject(bucketName, key, gzipFile)
+
+    testWith(key)
+  }
+
+  private def createGzipFile(content: String): File = {
     val tmpfile = File.createTempFile("s3sourcetest", ".txt")
 
     // Create a gzip-compressed file.  This is based on the shell commands

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/test/utils/GzipUtils.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/test/utils/GzipUtils.scala
@@ -1,0 +1,27 @@
+package uk.ac.wellcome.platform.snapshot_convertor.test.utils
+
+import java.io.{BufferedWriter, File, FileWriter}
+import scala.sys.process._
+
+trait GzipUtils {
+  def createGzipFile(content: String): File = {
+    val tmpfile = File.createTempFile("s3sourcetest", ".txt")
+
+    // Create a gzip-compressed file.  This is based on the shell commands
+    // that are used in the elasticdump container.
+    //
+    // The intention here is not to create a gzip-compressed file in
+    // the most "Scala-like" way, it's to create a file that closely
+    // matches what we'd get from an elasticdump in S3.
+    val bw = new BufferedWriter(new FileWriter(tmpfile))
+    bw.write(content)
+    bw.close()
+
+    // This performs "gzip foo.txt > foo.txt.gz" in a roundabout way.
+    // Because we're using the busybox version of gzip, it actually cleans
+    // up the old file and appends the .gz suffix for us.
+    s"gzip ${tmpfile.getPath}" !!
+
+    new File(s"${tmpfile.getPath}.gz")
+  }
+}

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/test/utils/GzipUtils.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/test/utils/GzipUtils.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.snapshot_convertor.test.utils
 
 import java.io.{BufferedWriter, File, FileWriter}
+import scala.io.Source.fromFile
 import scala.sys.process._
 import scala.util.Random
 
@@ -16,6 +17,15 @@ trait GzipUtils with S3 {
     s3Client.putObject(bucketName, key, gzipFile)
 
     testWith(key)
+  }
+
+  def readGzipFile(path: String): String = {
+    // The intention here isn't to read a gzip-compressed file in the most
+    // "Scala-like" way, it's to open the file in a way similar to the
+    // way our users are likely to use.
+    s"gunzip $path" !!
+
+    val fileContents = fromFile(path.replace(".gz", "")).mkString
   }
 
   private def createGzipFile(content: String): File = {

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/test/utils/GzipUtils.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/test/utils/GzipUtils.scala
@@ -12,8 +12,9 @@ import uk.ac.wellcome.test.fixtures.{S3, TestWith}
 trait GzipUtils extends S3 {
   def withGzipCompressedS3Key(bucketName: String, content: String)(
     testWith: TestWith[String, Assertion]) = {
-    val gzipContent = createGzipFile(content)
+    val gzipFile = createGzipFile(content)
     val key = (Random.alphanumeric take 10 mkString).toLowerCase
+
     s3Client.putObject(bucketName, key, gzipFile)
 
     testWith(key)
@@ -25,7 +26,7 @@ trait GzipUtils extends S3 {
     // way our users are likely to use.
     s"gunzip $path" !!
 
-    val fileContents = fromFile(path.replace(".gz", "")).mkString
+    fromFile(path.replace(".gz", "")).mkString
   }
 
   private def createGzipFile(content: String): File = {

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/test/utils/GzipUtils.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/test/utils/GzipUtils.scala
@@ -9,7 +9,7 @@ import org.scalatest.Assertion
 
 import uk.ac.wellcome.test.fixtures.{S3, TestWith}
 
-trait GzipUtils with S3 {
+trait GzipUtils extends S3 {
   def withGzipCompressedS3Key(bucketName: String, content: String)(
     testWith: TestWith[String, Assertion]) = {
     val gzipContent = createGzipFile(content)

--- a/data_api/snapshot_convertor/src/universal/conf/application.ini.template
+++ b/data_api/snapshot_convertor/src/universal/conf/application.ini.template
@@ -1,5 +1,3 @@
--aws.s3.sourceBucketName=${source_bucket_name}
--aws.s3.targetBucketName=${target_bucket_name}
 -aws.sns.topic.arn=${topic_arn}
 -aws.sqs.queue.url=${queue_url}
 -aws.metrics.namespace=${metrics_namespace}

--- a/data_api/terraform/service_elasticdump.tf
+++ b/data_api/terraform/service_elasticdump.tf
@@ -12,12 +12,12 @@ module "elasticdump" {
 
     sqs_queue_url = "${module.elasticdump_queue.id}"
     upload_bucket = "${aws_s3_bucket.private_data.id}"
-    es_username   = "${local.es_index}"
-    es_password   = "${local.es_port}"
+    es_username   = "${local.es_username}"
+    es_password   = "${local.es_name}"
     es_name       = "${local.es_name}"
     es_region     = "${local.es_region}"
-    es_port       = "${local.es_password}"
-    es_index      = "${local.es_username}"
+    es_port       = "${local.es_port}"
+    es_index      = "${local.es_index}"
   }
 
   env_vars_length = 9

--- a/data_api/terraform/service_elasticdump.tf
+++ b/data_api/terraform/service_elasticdump.tf
@@ -8,20 +8,22 @@ module "elasticdump" {
   release_id         = "${var.release_ids["elasticdump"]}"
 
   env_vars = {
+    AWS_DEFAULT_REGION = "${var.aws_region}"
+
     sqs_queue_url = "${module.elasticdump_queue.id}"
     upload_bucket = "${aws_s3_bucket.private_data.id}"
     es_username   = "${local.es_index}"
     es_password   = "${local.es_port}"
-    es_name       = "${local.es_region}"
-    es_region     = "${local.es_name}"
+    es_name       = "${local.es_name}"
+    es_region     = "${local.es_region}"
     es_port       = "${local.es_password}"
     es_index      = "${local.es_username}"
   }
 
+  env_vars_length = 9
+
   memory = 1024
   cpu    = 512
-
-  env_vars_length = 8
 
   cluster_name = "${module.data_api_cluster.cluster_name}"
   vpc_id       = "${module.vpc_data_api.vpc_id}"

--- a/data_api/terraform/snapshot_convertor_job_generator/iam_role_policy.tf
+++ b/data_api/terraform/snapshot_convertor_job_generator/iam_role_policy.tf
@@ -1,4 +1,4 @@
 resource "aws_iam_role_policy" "snapshot_scheduler_sns_publish" {
   role   = "${module.snapshot_convertor_job_generator_lambda.role_name}"
-  policy = "${module.scheduler_topic.publish_policy}"
+  policy = "${module.snapshot_convertor_topic.publish_policy}"
 }

--- a/data_api/terraform/snapshot_convertor_job_generator/triggers.tf
+++ b/data_api/terraform/snapshot_convertor_job_generator/triggers.tf
@@ -5,6 +5,5 @@ resource "aws_s3_bucket_notification" "private_data_bucket_notification" {
     lambda_function_arn = "${module.snapshot_convertor_job_generator_lambda.arn}"
     events              = ["s3:ObjectCreated:*"]
     filter_prefix       = "elasticdump/"
-    filter_suffix       = ".json"
   }
 }


### PR DESCRIPTION
This removes the ConvertorService from #1679, uses all the new flows and sources, and adds a bunch of tests around it. Plus moving some of the gzip-related code into a utility trait.

Not quite working yet (I think), but I think the mainline function is okay.