### PR TITLE
Move WorksIncludes into the display-common lib

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
@@ -19,7 +19,7 @@ import uk.ac.wellcome.platform.api.finatra.exceptions.{
   ElasticsearchResponseExceptionMapper,
   GeneralExceptionMapper
 }
-import uk.ac.wellcome.models.WorksIncludesDeserializerModule
+import uk.ac.wellcome.display.models.WorksIncludesDeserializerModule
 
 object ServerMain extends Server
 object ApiSwagger extends Swagger

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -8,7 +8,8 @@ import com.twitter.inject.annotations.Flag
 import io.swagger.models.parameters.QueryParameter
 import io.swagger.models.properties.StringProperty
 import scala.collection.JavaConverters._
-import uk.ac.wellcome.models.{Error, IdentifiedWork, WorksIncludes}
+import uk.ac.wellcome.display.models.WorksIncludes
+import uk.ac.wellcome.models.{Error, IdentifiedWork}
 import uk.ac.wellcome.platform.api.ApiSwagger
 import uk.ac.wellcome.platform.api.models.{DisplayError, DisplayResultList}
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayResultList.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayResultList.scala
@@ -2,8 +2,7 @@ package uk.ac.wellcome.platform.api.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.WorksIncludes
-import uk.ac.wellcome.display.models.DisplayWork
+import uk.ac.wellcome.display.models.{DisplayWork, WorksIncludes}
 
 @ApiModel(
   value = "ResultList",

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.api.requests
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.request.{QueryParam, RouteParam}
 import com.twitter.finatra.validation.{Max, Min}
-import uk.ac.wellcome.models.WorksIncludes
+import uk.ac.wellcome.display.models.WorksIncludes
 
 sealed trait ApiRequest {
   val request: Request

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -6,8 +6,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.IdentifiedWork
 import uk.ac.wellcome.platform.api.WorksUtil
 import uk.ac.wellcome.platform.api.fixtures.ElasticsearchServiceFixture
-import uk.ac.wellcome.display.models.DisplayWork
-import uk.ac.wellcome.models.WorksIncludes
+import uk.ac.wellcome.display.models.{DisplayWork, WorksIncludes}
 import uk.ac.wellcome.utils.JsonUtil._
 
 class ElasticsearchServiceTest

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -8,8 +8,11 @@ import uk.ac.wellcome.platform.api.fixtures.{
   ElasticsearchServiceFixture,
   WorksServiceFixture
 }
-import uk.ac.wellcome.models.WorksIncludes
-import uk.ac.wellcome.display.models.{DisplayIdentifier, DisplayWork}
+import uk.ac.wellcome.display.models.{
+  DisplayIdentifier,
+  DisplayWork,
+  WorksIncludes
+}
 import uk.ac.wellcome.platform.api.models.DisplayResultList
 import uk.ac.wellcome.elasticsearch.test.utils.IndexedElasticSearchLocal
 

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlow.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlow.scala
@@ -4,8 +4,8 @@ import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import com.twitter.inject.Logging
 import io.circe.generic.extras.JsonKey
-import uk.ac.wellcome.display.models.DisplayWork
-import uk.ac.wellcome.models.{AllWorksIncludes, IdentifiedWork}
+import uk.ac.wellcome.display.models.{AllWorksIncludes, DisplayWork}
+import uk.ac.wellcome.models.IdentifiedWork
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.ExecutionContext

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlowTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/ElasticsearchHitToDisplayWorkFlowTest.scala
@@ -5,13 +5,12 @@ import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.scaladsl.{Sink, Source}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.display.models.DisplayWork
+import uk.ac.wellcome.display.models.{AllWorksIncludes, DisplayWork}
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.{
   IdentifiedWork,
   IdentifierSchemes,
-  SourceIdentifier,
-  WorksIncludes
+  SourceIdentifier
 }
 import uk.ac.wellcome.test.fixtures.Akka
 import uk.ac.wellcome.test.utils.ExtendedPatience
@@ -25,12 +24,6 @@ class ElasticsearchHitToDisplayWorkFlowTest
     with Akka
     with ScalaFutures
     with ExtendedPatience {
-
-  val includes = WorksIncludes(
-    identifiers = true,
-    thumbnail = true,
-    items = true
-  )
 
   it("creates a DisplayWork from a single hit") {
     withActorSystem { actorSystem =>
@@ -67,7 +60,7 @@ class ElasticsearchHitToDisplayWorkFlowTest
         .runWith(Sink.head)
 
       whenReady(futureDisplayWork) { displayWork =>
-        displayWork shouldBe DisplayWork(work, includes = includes)
+        displayWork shouldBe DisplayWork(work, includes = AllWorksIncludes())
       }
     }
   }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.display.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.{IdentifiedWork, WorksIncludes}
+import uk.ac.wellcome.models.IdentifiedWork
 
 @ApiModel(
   value = "Work",

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/WorksIncludes.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/WorksIncludes.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.models
+package uk.ac.wellcome.display.models
 
 import com.fasterxml.jackson.core.{JsonParser, JsonProcessingException}
 import com.fasterxml.jackson.databind.module.SimpleModule

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/WorksIncludesTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/WorksIncludesTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.models
+package uk.ac.wellcome.display.models
 
 import org.scalatest.{FunSpec, Matchers}
 


### PR DESCRIPTION
This model is only used when creating DisplayWork, so it makes more sense for it to live in the display library.