### PR TITLE
Add a script for building missing Sierra windows

### DIFF
--- a/sierra_adapter/build_missing_windows.py
+++ b/sierra_adapter/build_missing_windows.py
@@ -49,7 +49,7 @@ if __name__ == '__main__':
         report = build_report(bucket=BUCKET, resource_type=resource_type)
         for missing_window in get_missing_windows(report):
             client.publish(
-                TopicArn=f'arn:aws:sns:eu-west-1:760097843905:sierra_{resource}_windows',
-                Message=json.dumps(window),
+                TopicArn=f'arn:aws:sns:eu-west-1:760097843905:sierra_{resource_type}_windows',
+                Message=json.dumps(missing_window),
                 Subject=f'Window sent by {__file__}'
             )

--- a/sierra_adapter/build_missing_windows.py
+++ b/sierra_adapter/build_missing_windows.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+import collections
+
+
+def sliding_window(iterable):
+    """Returns a sliding window (of width 2) over data from the iterable."""
+    result = collections.deque([], maxlen=2)
+
+    for elem in iterable:
+        result.append(elem)
+        if len(result) == 2:
+            yield tuple(list(result))

--- a/sierra_adapter/build_missing_windows.py
+++ b/sierra_adapter/build_missing_windows.py
@@ -2,6 +2,9 @@
 # -*- encoding: utf-8 -*-
 
 import collections
+import datetime as dt
+
+from build_windows import generate_windows
 
 
 def sliding_window(iterable):
@@ -12,3 +15,24 @@ def sliding_window(iterable):
         result.append(elem)
         if len(result) == 2:
             yield tuple(list(result))
+
+
+def get_missing_windows(report):
+    """Given a report of saved Sierra windows, emit the gaps."""
+    # Suppose we get two windows:
+    #
+    #   (-- window_1 --)
+    #                       (-- window_2 --)
+    #
+    # We're missing any records created between the *end* of window_1
+    # and the *start* of window_2, so we use these as the basis for
+    # our new window.
+    for window_1, window_2 in sliding_window(report):
+        missing_start = window_1.end - dt.timedelta(seconds=1)
+        missing_end = window_2.start + dt.timedelta(seconds=1)
+
+        yield from generate_windows(
+            start=missing_start,
+            end=missing_end,
+            minutes=5
+        )

--- a/sierra_adapter/build_missing_windows.py
+++ b/sierra_adapter/build_missing_windows.py
@@ -31,7 +31,7 @@ def get_missing_windows(report):
     # We're missing any records created between the *end* of window_1
     # and the *start* of window_2, so we use these as the basis for
     # our new window.
-    for window_1, window_2 in sliding_window(report):
+    for (window_1, _), (window_2, _) in sliding_window(report):
         missing_start = window_1.end - dt.timedelta(seconds=1)
         missing_end = window_2.start + dt.timedelta(seconds=1)
 
@@ -43,11 +43,12 @@ def get_missing_windows(report):
 
 
 if __name__ == '__main__':
-    client = boto3.client('s3')
+    client = boto3.client('sns')
 
     for resource_type in ('bibs', 'items'):
         report = build_report(bucket=BUCKET, resource_type=resource_type)
         for missing_window in get_missing_windows(report):
+            print(missing_window)
             client.publish(
                 TopicArn=f'arn:aws:sns:eu-west-1:760097843905:sierra_{resource_type}_windows',
                 Message=json.dumps(missing_window),

--- a/sierra_adapter/build_windows.py
+++ b/sierra_adapter/build_windows.py
@@ -46,15 +46,6 @@ import docopt
 import maya
 import tqdm
 
-args = docopt.docopt(__doc__)
-
-start = maya.parse(args['--start']).datetime()
-end = maya.parse(args['--end']).datetime()
-minutes = int(args['--window_length'] or 30)
-resource = args['--resource']
-
-assert resource in ('bibs', 'items')
-
 
 def generate_windows(start, end, minutes):
     current = start
@@ -66,14 +57,24 @@ def generate_windows(start, end, minutes):
         current += dt.timedelta(minutes=minutes - 1)
 
 
-client = boto3.client('sns')
+if __name__ == '__main__':
+    args = docopt.docopt(__doc__)
 
-for window in tqdm.tqdm(
-    generate_windows(start, end, minutes),
-    total=math.ceil((end - start).total_seconds() / 60 / (minutes - 1))
-):
-    client.publish(
-        TopicArn=f'arn:aws:sns:eu-west-1:760097843905:sierra_{resource}_windows',
-        Message=json.dumps(window),
-        Subject=f'Window sent by {__file__}'
-    )
+    start = maya.parse(args['--start']).datetime()
+    end = maya.parse(args['--end']).datetime()
+    minutes = int(args['--window_length'] or 30)
+    resource = args['--resource']
+
+    assert resource in ('bibs', 'items')
+
+    client = boto3.client('sns')
+
+    for window in tqdm.tqdm(
+        generate_windows(start, end, minutes),
+        total=math.ceil((end - start).total_seconds() / 60 / (minutes - 1))
+    ):
+        client.publish(
+            TopicArn=f'arn:aws:sns:eu-west-1:760097843905:sierra_{resource}_windows',
+            Message=json.dumps(window),
+            Subject=f'Window sent by {__file__}'
+        )

--- a/sierra_adapter/report_adapter_progress.py
+++ b/sierra_adapter/report_adapter_progress.py
@@ -6,6 +6,7 @@ Report the progress of the Sierra adapter.
 
 import datetime as dt
 import os
+import sys
 
 import attr
 import boto3
@@ -193,3 +194,10 @@ if __name__ == '__main__':
             print(f'{iv.start.isoformat()} -- {iv.end.isoformat()}')
 
         print('')
+
+    print('')
+    print('-' * 79)
+    print('')
+    print('If there are gaps in the report, you can build new windows for the readers:')
+    print('')
+    print(f'$ python {sys.argv[0].replace("report_adapter_progress.py", "build_missing_windows.py")}')

--- a/sierra_adapter/report_adapter_progress.py
+++ b/sierra_adapter/report_adapter_progress.py
@@ -49,11 +49,22 @@ def get_matching_s3_keys(bucket, prefix=''):
             break
 
 
-@attr.s
+@attr.s(repr=False)
 class Interval:
     start = attr.ib()
     end = attr.ib()
     key = attr.ib()
+
+    def __repr__(self):
+        return f'%s(start=%r, end=%r, key=%r)' % (
+            type(self).__name__,
+            self.start.isoformat(),
+            self.end.isoformat(),
+            self.key
+        )
+
+    def __str__(self):
+        return repr(self)
 
 
 def get_intervals(keys):

--- a/sierra_adapter/test_build_missing_windows.py
+++ b/sierra_adapter/test_build_missing_windows.py
@@ -1,0 +1,18 @@
+# -*- encoding: utf-8
+
+from build_missing_windows import sliding_window
+
+
+def test_sliding_window():
+    res = sliding_window(range(10))
+    assert list(res) == [
+        (0, 1),
+        (1, 2),
+        (2, 3),
+        (3, 4),
+        (4, 5),
+        (5, 6),
+        (6, 7),
+        (7, 8),
+        (8, 9),
+    ]

--- a/sierra_adapter/test_build_missing_windows.py
+++ b/sierra_adapter/test_build_missing_windows.py
@@ -1,6 +1,9 @@
 # -*- encoding: utf-8
 
-from build_missing_windows import sliding_window
+import datetime as dt
+
+from build_missing_windows import get_missing_windows, sliding_window
+from report_adapter_progress import Interval
 
 
 def test_sliding_window():
@@ -15,4 +18,44 @@ def test_sliding_window():
         (6, 7),
         (7, 8),
         (8, 9),
+    ]
+
+
+def test_missing_windows():
+    report = [
+        Interval(
+            start = dt.datetime(2000, 1, 1, 12, 0, 0),
+            end   = dt.datetime(2000, 1, 1, 13, 0, 0),
+            key   = 'report1.txt'
+        ),
+        Interval(
+            start = dt.datetime(2000, 1, 1, 13, 7, 0),
+            end   = dt.datetime(2000, 1, 1, 13, 18, 0),
+            key   = 'report1.txt'
+        ),
+        Interval(
+            start = dt.datetime(2000, 1, 1, 13, 25, 0),
+            end   = dt.datetime(2000, 1, 1, 13, 40, 0),
+            key   = 'report1.txt'
+        ),
+    ]
+
+    res = get_missing_windows(report)
+    assert list(res) == [
+        {
+            'start': dt.datetime(2000, 1, 1, 12, 59, 59).isoformat(),
+            'end':   dt.datetime(2000, 1, 1, 13, 4, 59).isoformat(),
+        },
+        {
+            'start': dt.datetime(2000, 1, 1, 13, 3, 59).isoformat(),
+            'end':   dt.datetime(2000, 1, 1, 13, 8, 59).isoformat(),
+        },
+        {
+            'start': dt.datetime(2000, 1, 1, 13, 17, 59).isoformat(),
+            'end':   dt.datetime(2000, 1, 1, 13, 22, 59).isoformat(),
+        },
+        {
+            'start': dt.datetime(2000, 1, 1, 13, 21, 59).isoformat(),
+            'end':   dt.datetime(2000, 1, 1, 13, 26, 59).isoformat(),
+        },
     ]

--- a/sierra_adapter/test_build_missing_windows.py
+++ b/sierra_adapter/test_build_missing_windows.py
@@ -24,38 +24,38 @@ def test_sliding_window():
 def test_missing_windows():
     report = [
         Interval(
-            start = dt.datetime(2000, 1, 1, 12, 0, 0),
-            end   = dt.datetime(2000, 1, 1, 13, 0, 0),
-            key   = 'report1.txt'
+            start = dt.datetime(2000, 1, 1, 12, 0, 0),   # noqa
+            end   = dt.datetime(2000, 1, 1, 13, 0, 0),   # noqa
+            key='report1.txt'
         ),
         Interval(
-            start = dt.datetime(2000, 1, 1, 13, 7, 0),
-            end   = dt.datetime(2000, 1, 1, 13, 18, 0),
-            key   = 'report1.txt'
+            start = dt.datetime(2000, 1, 1, 13, 7, 0),   # noqa
+            end   = dt.datetime(2000, 1, 1, 13, 18, 0),  # noqa
+            key='report2.txt'
         ),
         Interval(
-            start = dt.datetime(2000, 1, 1, 13, 25, 0),
-            end   = dt.datetime(2000, 1, 1, 13, 40, 0),
-            key   = 'report1.txt'
+            start = dt.datetime(2000, 1, 1, 13, 25, 0),  # noqa
+            end   = dt.datetime(2000, 1, 1, 13, 40, 0),  # noqa
+            key='report3.txt'
         ),
-    ]
+    ]  # noqa
 
     res = get_missing_windows(report)
     assert list(res) == [
         {
             'start': dt.datetime(2000, 1, 1, 12, 59, 59).isoformat(),
-            'end':   dt.datetime(2000, 1, 1, 13, 4, 59).isoformat(),
+            'end':   dt.datetime(2000, 1, 1, 13, 4, 59).isoformat(),  # noqa
         },
         {
             'start': dt.datetime(2000, 1, 1, 13, 3, 59).isoformat(),
-            'end':   dt.datetime(2000, 1, 1, 13, 8, 59).isoformat(),
+            'end':   dt.datetime(2000, 1, 1, 13, 8, 59).isoformat(),  # noqa
         },
         {
             'start': dt.datetime(2000, 1, 1, 13, 17, 59).isoformat(),
-            'end':   dt.datetime(2000, 1, 1, 13, 22, 59).isoformat(),
+            'end':   dt.datetime(2000, 1, 1, 13, 22, 59).isoformat(),  # noqa
         },
         {
             'start': dt.datetime(2000, 1, 1, 13, 21, 59).isoformat(),
-            'end':   dt.datetime(2000, 1, 1, 13, 26, 59).isoformat(),
+            'end':   dt.datetime(2000, 1, 1, 13, 26, 59).isoformat(),  # noqa
         },
     ]


### PR DESCRIPTION
We have a script that reports the progress of the Sierra readers. Here’s what it gives right now:

```
===============================================================================
bibs windows
===============================================================================
2003-05-01T00:00:00 -- 2018-03-21T01:01:21.623690
2018-03-21T01:16:21.106866 -- 2018-03-26T00:46:21.204226
2018-03-26T03:01:22.002300 -- 2018-03-26T03:31:22.002300
2018-03-26T03:46:21.204819 -- 2018-03-26T23:46:21.488942
2018-03-27T04:01:21.561623 -- 2018-03-27T23:46:21.613291
2018-03-28T04:46:21.093863 -- 2018-03-29T00:01:21.702079
2018-03-29T04:16:21.198954 -- 2018-03-29T23:31:21.532529
2018-03-30T04:16:21.535243 -- 2018-03-30T23:46:21.649179
2018-03-31T04:16:21.259113 -- 2018-03-31T23:46:21.349198
2018-04-01T04:31:21.229935 -- 2018-04-01T23:46:21.975208
2018-04-02T04:16:21.406527 -- 2018-04-02T23:31:21.159546
2018-04-03T04:31:20.993826 -- 2018-04-03T11:46:20.942273


===============================================================================
items windows
===============================================================================
1999-11-01T00:00:00 -- 2018-04-03T11:58:52.082699
```

This is annoying because I can see there are gaps in the bibs we've saved, but I have to manually run `build_windows.py` multiple times to create new windows. BOR-ING.

This PR adds a new script which uses the report to build the missing windows and post jobs to SNS, thus saving us a bit of hassle and making it easier to fill in gaps.

The presence of the new script is advertised in the report output, like so:

```
-------------------------------------------------------------------------------

If there are gaps in the report, you can build new windows for the readers:

$ python sierra_adapter/build_missing_windows.py
```