### PR TITLE
Hiding the evidence

### DIFF
--- a/common/src/test/scala/uk/ac/wellcome/dynamo/VersionedDaoTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/dynamo/VersionedDaoTest.scala
@@ -38,8 +38,6 @@ class VersionedDaoTest
     with MockitoSugar
     with Matchers {
 
-  override lazy val evidence = DynamoFormat[TestVersioned]
-
   def withVersionedDao[R](testWith: TestWith[(VersionedDao, String), R]) {
     withLocalDynamoDbTable { tableName =>
       val config = DynamoConfig(tableName)

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalVersionedHybridStore.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalVersionedHybridStore.scala
@@ -18,9 +18,6 @@ trait LocalVersionedHybridStore
     with JsonTestUtil
     with Matchers {
 
-  override lazy val evidence: DynamoFormat[HybridRecord] =
-    DynamoFormat[HybridRecord]
-
   def withVersionedDao(tableName: String)(
     testWith: TestWith[VersionedDao, Assertion]) {
     val dao = new VersionedDao(

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.reindex_worker
 
-import com.gu.scanamo.{DynamoFormat, Scanamo}
+import com.gu.scanamo.Scanamo
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.Matchers
 import org.scalatest.FunSpec
@@ -36,9 +36,6 @@ class ReindexerFeatureTest
     with SNS
     with SQS
     with ScalaFutures {
-
-  override lazy val evidence: DynamoFormat[TestRecord] =
-    DynamoFormat[TestRecord]
 
   val currentVersion = 1
   val desiredVersion = 5

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.reindex_worker.services
 import akka.actor.ActorSystem
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException
-import com.gu.scanamo.{DynamoFormat, Scanamo}
+import com.gu.scanamo.Scanamo
 import org.scalatest.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
@@ -25,9 +25,6 @@ class ReindexServiceTest
     with LocalDynamoDb[TestRecord]
     with MockitoSugar
     with ExtendedPatience {
-
-  override lazy val evidence: DynamoFormat[TestRecord] =
-    DynamoFormat[TestRecord]
 
   val shardName = "shard"
   val currentVersion = 1

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.reindex_worker.services
 
 import akka.actor.ActorSystem
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
-import com.gu.scanamo.{DynamoFormat, Scanamo}
+import com.gu.scanamo.Scanamo
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest.Assertion
@@ -38,9 +38,6 @@ class ReindexWorkerServiceTest
     with SNS
     with SQS
     with ScalaFutures {
-
-  override lazy val evidence: DynamoFormat[TestRecord] =
-    DynamoFormat[TestRecord]
 
   def withReindexWorkerService(tableName: String, indexName: String)(
     testWith: TestWith[ReindexWorkerService, Assertion]) = {

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.sierra_bib_merger
 
-import com.gu.scanamo.DynamoFormat
 import com.twitter.finagle.http.Status._
 import org.scalatest.FunSpec
 import uk.ac.wellcome.storage.HybridRecord
@@ -12,9 +11,6 @@ class ServerTest
     with fixtures.Server
     with S3
     with SQS {
-
-  override lazy val evidence: DynamoFormat[HybridRecord] =
-    DynamoFormat[HybridRecord]
 
   it("shows the healthcheck message") {
     withLocalSqsQueue { queueUrl =>

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.sierra_item_merger
 
-import com.gu.scanamo.DynamoFormat
 import com.twitter.finagle.http.Status._
 import org.scalatest.FunSpec
 import uk.ac.wellcome.storage.HybridRecord
@@ -12,9 +11,6 @@ class ServerTest
     with fixtures.Server
     with S3
     with SQS {
-
-  override lazy val evidence: DynamoFormat[HybridRecord] =
-    DynamoFormat[HybridRecord]
 
   it("shows the healthcheck message") {
     withLocalSqsQueue { queueUrl =>

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.sierra_items_to_dynamo
 
-import com.gu.scanamo.DynamoFormat
 import com.twitter.finagle.http.Status._
 import org.scalatest.FunSpec
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
@@ -13,8 +12,6 @@ class ServerTest
     with LocalDynamoDb[SierraItemRecord]
     with SQS
     with fixtures.Server {
-
-  override lazy val evidence = DynamoFormat[SierraItemRecord]
 
   it("shows the healthcheck message") {
     withLocalDynamoDbTable { tableName =>

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.sierra_items_to_dynamo
 
 import java.time.Instant
 
-import com.gu.scanamo.{DynamoFormat, Scanamo}
+import com.gu.scanamo.Scanamo
 import com.gu.scanamo.syntax._
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.server.FeatureTestMixin
@@ -31,9 +31,6 @@ class SierraItemsToDynamoFeatureTest
     with Matchers
     with Eventually
     with ExtendedPatience {
-
-  override lazy val evidence: DynamoFormat[SierraItemRecord] =
-    DynamoFormat[SierraItemRecord]
 
   it("reads items from Sierra and adds them to DynamoDB") {
     withLocalDynamoDbTable { tableName =>

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model.PutMetricDataResult
-import com.gu.scanamo.{DynamoFormat, Scanamo}
+import com.gu.scanamo.Scanamo
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
@@ -36,9 +36,6 @@ class SierraItemsToDynamoWorkerServiceTest
     with MockitoSugar
     with Akka
     with ScalaFutures {
-
-  override lazy val evidence: DynamoFormat[SierraItemRecord] =
-    DynamoFormat[SierraItemRecord]
 
   case class ServiceFixtures(
     service: SierraItemsToDynamoWorkerService,


### PR DESCRIPTION
Picking up a review comment from #1764; these implicits are now defined in LocalDynamoDb, so we shouldn’t need to define them on individual test classes.