### PR TITLE
Increase the default number of messages read for all applications

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/SQSConfigModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/SQSConfigModule.scala
@@ -16,7 +16,7 @@ object SQSConfigModule extends TwitterModule {
     20,
     "Time to wait (in seconds) for a message to arrive on the queue before returning")
   val maxMessages =
-    flag("aws.sqs.maxMessages", 1, "Maximum number of SQS messages to return")
+    flag("aws.sqs.maxMessages", 10, "Maximum number of SQS messages to return")
 
   @Singleton
   @Provides


### PR DESCRIPTION
Apparently, the id minter is not the only service being a bit slow. All of them read 1 message per second so they sit idle most of the time
🏷 ◾️ 