### PR TITLE
Remove spaces from code identifiers

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCreators.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCreators.scala
@@ -12,8 +12,6 @@ trait SierraCreators extends MarcUtils {
    * . For "100" type as "Person" populate "prefix" from 100 subfield c and "numeration" from b
    * . For "110" type as "Organisation"
    * . If subfield 0 contains a value use it to populate "identifiers". The "identifierScheme" will be lc-names.
-   * For now we are only removing leading and trailing spaces in identifiers.
-   * TODO: Figure out if we have to normalise further.
    */
   def getCreators(
     bibData: SierraBibData): List[MaybeDisplayable[AbstractAgent]] = {
@@ -55,6 +53,10 @@ trait SierraCreators extends MarcUtils {
     persons ++ organisations
   }
 
+  /**
+    * Identifier codes contain inconsistent spacing as in " nr 82270463" vs "nr 82270463"
+    * vs " nr82270463" and so on. We remove all spaces so that all of the above reduce to "nr82270463"
+    */
   private def getIdentifierCodes(subfields: List[MarcSubfield]) = {
     subfields.collect {
       case MarcSubfield("0", content) => content.replaceAll("\\s", "")

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCreators.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCreators.scala
@@ -30,9 +30,7 @@ trait SierraCreators extends MarcUtils {
           val prefixes = subfields.collect {
             case MarcSubfield("c", content) => content
           }
-          val codes = subfields.collect {
-            case MarcSubfield("0", content) => content
-          }
+          val codes = getIdentifierCodes(subfields)
           val prefixString =
             if (prefixes.isEmpty) None else Some(prefixes.mkString(" "))
 
@@ -49,14 +47,18 @@ trait SierraCreators extends MarcUtils {
         val name = subfields.collectFirst {
           case MarcSubfield("a", content) => content
         }
-        val codes = subfields.collect {
-          case MarcSubfield("0", content) => content
-        }
+        val codes = getIdentifierCodes(subfields)
         val organisation = Organisation(name.get)
         identify(codes, organisation, "Organisation")
       }
 
     persons ++ organisations
+  }
+
+  private def getIdentifierCodes(subfields: List[MarcSubfield]) = {
+    subfields.collect {
+      case MarcSubfield("0", content) => content.replaceAll("\\s", "")
+    }
   }
 
   private def identify(codes: List[String],
@@ -68,7 +70,7 @@ trait SierraCreators extends MarcUtils {
         val sourceIdentifier = SourceIdentifier(
           identifierScheme = IdentifierSchemes.libraryOfCongressNames,
           ontologyType = ontologyType,
-          value = code.trim)
+          value = code)
         Identifiable(agent, sourceIdentifier, List(sourceIdentifier))
       case _ =>
         throw new RuntimeException(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCreatorsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraCreatorsTest.scala
@@ -149,13 +149,10 @@ class SierraCreatorsTest extends FunSpec with Matchers {
       List(sourceIdentifier))
   }
 
-  // TODO: find out the identifiers normalisation rules
-  // This is ignored until we get better information as to
-  // how we want to clean the identifiers data
-  ignore("normalises the creator identifier marcTag 100 0") {
+  it("removes spaces from the creator identifier marcTag 100 0") {
     val name = "The Luggage"
     val code = "n 123456"
-    val cleanedCode = "123456"
+    val cleanedCode = "n123456"
 
     val bibData = SierraBibData(
       id = "1234567",
@@ -176,7 +173,7 @@ class SierraCreatorsTest extends FunSpec with Matchers {
     val sourceIdentifier = SourceIdentifier(
       IdentifierSchemes.libraryOfCongressNames,
       "Person",
-      code.trim)
+      cleanedCode)
     creators should contain only Identifiable(
       Person(label = name),
       sourceIdentifier = sourceIdentifier,


### PR DESCRIPTION
This should help clear the transformer DLQ. I see a lot of failures like this one ```java.lang.RuntimeException: Multiple identifiers in subfield $0: List(n 82270463 , n 82270463)```. This is due to the transformer finding more than one distinct identifier code for a creator, but these aren't actually distinct after normalisation, so they should pass transformation once this change is in
### Who is this change for?
🛋 ⛓ 