### PR TITLE
Better errors when trying to convert a Work to DisplayWork when visible=false

### DIFF
--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -100,6 +100,11 @@ case class DisplayWork(
 case object DisplayWork {
 
   def apply(work: IdentifiedWork, includes: WorksIncludes): DisplayWork = {
+
+    if (!work.visible) {
+      throw new RuntimeException(s"IdentifiedWork ${work.canonicalId} has visible=false, cannot be converted to DisplayWork")
+    }
+
     DisplayWork(
       id = work.canonicalId,
       title = work.title.get,

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -102,7 +102,8 @@ case object DisplayWork {
   def apply(work: IdentifiedWork, includes: WorksIncludes): DisplayWork = {
 
     if (!work.visible) {
-      throw new RuntimeException(s"IdentifiedWork ${work.canonicalId} has visible=false, cannot be converted to DisplayWork")
+      throw new RuntimeException(
+        s"IdentifiedWork ${work.canonicalId} has visible=false, cannot be converted to DisplayWork")
     }
 
     DisplayWork(

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
@@ -286,4 +286,20 @@ class DisplayWorkTest extends FunSpec with Matchers {
     displayLanguage.id shouldBe language.id
     displayLanguage.label shouldBe language.label
   }
+
+  it("gives a helpful error if you try to convert a work with visible=False") {
+    val work = IdentifiedWork(
+      canonicalId = "xpudrscx",
+      title = Some("Invisible igloos improve iguanas"),
+      sourceIdentifier = sourceIdentifier,
+      visible = false,
+      version = 1
+    )
+
+    val caught = intercept[RuntimeException] {
+      DisplayWork(work)
+    }
+
+    caught.getMessage shouldBe s"IdentifiedWork ${work.canonicalId} has visible=false, cannot be converted to DisplayWork"
+  }
 }


### PR DESCRIPTION
Per chat with @alicefuzier.

We may want to tighten this up with type-system rules for now, but this should at last make it easier to debug issues (such as the recent snapshot_convertor bug).