### PR TITLE
post_to_slack: allow non-integer thresholds in CloudWatch alarms

### DIFF
--- a/monitoring/post_to_slack/src/cloudwatch_alarms.py
+++ b/monitoring/post_to_slack/src/cloudwatch_alarms.py
@@ -18,7 +18,7 @@ THRESHOLD_RE = re.compile(
     r'\[(?P<actual_value>\d+)\.0 \((?P<date>\d{2}/\d{2}/\d{2} \d{2}:\d{2}:\d{2})\)\] '
     r'was '
     r'(?P<operator>(?:greater|less) than(?: or equal to)?) '
-    r'the threshold \((?P<desired_value>\d+)\.0\).'
+    r'the threshold \((?P<desired_value>\d+\.\d+)\).'
 )
 
 # We may also get a message of the form:
@@ -32,13 +32,24 @@ MISSING_DATE_RE = re.compile(
 )
 
 
+def _parse_numeral(xs):
+    if xs is None:
+        return None
+
+    value = float(xs)
+    if value.is_integer():
+        return int(value)
+    else:
+        return value
+
+
 @attr.s
 class ThresholdMessage:
     """Holds information about a "threshold crossed" message."""
     is_breaching = attr.ib()
 
-    actual_value = attr.ib(converter=lambda v: int(v) if v is not None else None)
-    desired_value = attr.ib(converter=lambda v: int(v) if v is not None else None)
+    actual_value = attr.ib(converter=_parse_numeral)
+    desired_value = attr.ib(converter=_parse_numeral)
 
     # Datetime strings in alarms are of the form DD/MM/YY HH:MM:SS.
     # For example: "03/02/18 16:13:00" or "05/02/18 06:38:00".

--- a/monitoring/post_to_slack/src/test_cloudwatch_alarms.py
+++ b/monitoring/post_to_slack/src/test_cloudwatch_alarms.py
@@ -21,6 +21,7 @@ class TestThresholdMessage:
         ('Threshold Crossed: 1 datapoint [1.0 (05/02/18 06:28:00)] was greater than the threshold (1.0).', 1),
         ('Threshold Crossed: 1 datapoint [1.0 (05/02/18 06:28:00)] was greater than the threshold (12.0).', 12),
         ('Threshold Crossed: 1 datapoint [1.0 (05/02/18 06:28:00)] was greater than the threshold (0.0).', 0),
+        ('Threshold Crossed: 1 datapoint [1.0 (06/04/18 13:26:00)] was less than the threshold (1.5).', 1.5),
     ])
     def test_desired_value(self, message, desired_value):
         t = ThresholdMessage.from_message(message)

--- a/monitoring/post_to_slack/src/test_cloudwatch_alarms.py
+++ b/monitoring/post_to_slack/src/test_cloudwatch_alarms.py
@@ -57,7 +57,7 @@ class TestThresholdMessage:
         ('Threshold Crossed: 1 datapoint [1.0 (05/02/18 06:28:00)] was greater than the threshold (1.0).', False),
         ('Threshold Crossed: no datapoints were received for 1 period and 1 missing datapoint was treated as [Breaching].', True),
     ])
-    def test_is_breaking(self, message, is_breaching):
+    def test_is_breaching(self, message, is_breaching):
         t = ThresholdMessage.from_message(message)
         assert t.is_breaching == is_breaching
 


### PR DESCRIPTION
Fixes the bug that just appeared in #platform-alterations:

![screen shot 2018-04-06 at 14 46 52](https://user-images.githubusercontent.com/301220/38424567-615d827e-39a9-11e8-84de-b6d92b526653.png)
