### PR TITLE
Test our Travis build scripts… in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,9 @@ env:
 
 jobs:
   include:
-    - env: TASK=travis-format
-      stage: format
+    - stage: quicktest
+      env: TASK=travis-format
+    - env: TASK=travistooling-test
 
     - stage: test
       env: TASK=sbt-common-test
@@ -105,7 +106,7 @@ jobs:
     # - env: TASK=monitoring-test
 
 stages:
-  - format
+  - quicktest
   - test
 
 # This has a Slack API token for posting messages about build failures to

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,14 @@ sbt-common-test:
 
 sbt-common-publish:
 	echo "Nothing to do!"
+
+
+travistooling-test:
+	$(ROOT)/docker_run.py -- \
+		--volume $(ROOT):/data \
+		wellcome/build_tooling \
+		coverage run --rcfile=travistooling/.coveragerc --module py.test travistooling/test_*.py
+	$(ROOT)/docker_run.py -- \
+		--volume $(ROOT):/data \
+		wellcome/build_tooling \
+		coverage report --rcfile=travistooling/.coveragerc

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,6 @@ travistooling-test:
 		--volume $(ROOT):/data \
 		wellcome/build_tooling \
 		coverage report --rcfile=travistooling/.coveragerc
+
+travistooling-publish:
+	echo "nothing to do!"

--- a/travistooling/.coveragerc
+++ b/travistooling/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+branch = True
+source = travistooling
+
+[report]
+fail_under = 100
+show_missing = True

--- a/travistooling/.coveragerc
+++ b/travistooling/.coveragerc
@@ -5,3 +5,5 @@ source = travistooling
 [report]
 fail_under = 100
 show_missing = True
+exclude_lines =
+    pragma: no cover

--- a/travistooling/__init__.py
+++ b/travistooling/__init__.py
@@ -1,0 +1,8 @@
+# -*- encoding: utf-8
+
+import subprocess
+
+
+# Root of the Git repository
+ROOT = subprocess.check_output([
+    'git', 'rev-parse', '--show-toplevel']).decode('ascii').strip()

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -18,25 +18,20 @@ from travistooling.decisions import (
 
 
 def does_file_affect_build_job(path, job_name):
+    # Catch all the common file types that we care about for travis-format.
+    if (
+        job_name == 'travis-format' and
+        path.endswith(('.scala', '.tf', '.py', '.json', '.ttl'))
+    ):
+        raise KnownAffectsTask(path)
+
     # These extensions and paths never have an effect on tests.
-    if path.endswith(('.md', '.png', '.graffle')):
+    if path.endswith(('.md', '.png', '.graffle', '.tf')):
         raise IgnoredFileFormat(path)
 
-    if path.endswith('.tf'):
-        if job_name != 'travis-format':
-            raise IgnoredFileFormat(path)
-        else:
-            raise KnownAffectsTask(path)
-
     # These paths never have an effect on tests.
-    if path in ['LICENSE',] or path.startswith('misc/'):
+    if path in ['LICENSE',] or path.startswith(('misc/', 'ontologies/')):
         raise IgnoredPath(path)
-
-    if path.startswith('ontologies/'):
-        if job_name != 'travis-format':
-            raise IgnoredPath(path)
-        else:
-            raise KnownAffectsTask(path)
 
     # If we can't decide if a file affects a build job, we assume it's
     # significant and run the job just-in-case.

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -9,10 +9,14 @@ going up.  This file contains the logic for answering the question:
 
 """
 
-from travistooling.decisions import UnrecognisedFile
+from travistooling.decisions import IgnoredFileFormat, UnrecognisedFile
 
 
 def does_file_affect_build_job(path, job_name):
+    # These extensions and paths never have an effect on tests.
+    if path.endswith(('.md', '.png', '.graffle')) or path == 'LICENSE':
+        raise IgnoredFileFormat(path)
+
     # If we can't decide if a file affects a build job, we assume it's
     # significant and run the job just-in-case.
-    raise UnrecognisedFile(path=path)
+    raise UnrecognisedFile(path)

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -9,12 +9,19 @@ going up.  This file contains the logic for answering the question:
 
 """
 
+from travistooling import ROOT
 from travistooling.decisions import (
     IgnoredFileFormat,
     IgnoredPath,
     KnownAffectsTask,
     UnrecognisedFile
 )
+from travistooling.parse_makefiles import get_projects
+
+
+# Cache the Makefile information in a global variable, so we only have to
+# load it once.
+PROJECTS = list(get_projects(ROOT))
 
 
 def does_file_affect_build_job(path, job_name):

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -9,13 +9,21 @@ going up.  This file contains the logic for answering the question:
 
 """
 
-from travistooling.decisions import IgnoredFileFormat, UnrecognisedFile
+from travistooling.decisions import (
+    IgnoredFileFormat,
+    IgnoredPath,
+    UnrecognisedFile
+)
 
 
 def does_file_affect_build_job(path, job_name):
     # These extensions and paths never have an effect on tests.
-    if path.endswith(('.md', '.png', '.graffle')) or path == 'LICENSE':
+    if path.endswith(('.md', '.png', '.graffle')):
         raise IgnoredFileFormat(path)
+
+    # These paths never have an effect on tests.
+    if path in ['LICENSE',]:
+        raise IgnoredPath(path)
 
     # If we can't decide if a file affects a build job, we assume it's
     # significant and run the job just-in-case.

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -12,6 +12,7 @@ going up.  This file contains the logic for answering the question:
 from travistooling.decisions import (
     IgnoredFileFormat,
     IgnoredPath,
+    KnownAffectsTask,
     UnrecognisedFile
 )
 
@@ -21,9 +22,21 @@ def does_file_affect_build_job(path, job_name):
     if path.endswith(('.md', '.png', '.graffle')):
         raise IgnoredFileFormat(path)
 
+    if path.endswith('.tf'):
+        if job_name != 'travis-format':
+            raise IgnoredFileFormat(path)
+        else:
+            raise KnownAffectsTask(path)
+
     # These paths never have an effect on tests.
-    if path in ['LICENSE',]:
+    if path in ['LICENSE',] or path.startswith('misc/'):
         raise IgnoredPath(path)
+
+    if path.startswith('ontologies/'):
+        if job_name != 'travis-format':
+            raise IgnoredPath(path)
+        else:
+            raise KnownAffectsTask(path)
 
     # If we can't decide if a file affects a build job, we assume it's
     # significant and run the job just-in-case.

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -40,7 +40,7 @@ def does_file_affect_build_job(path, job_name):
         raise IgnoredFileFormat(path)
 
     # These paths never have an effect on tests.
-    if path in ['LICENSE',] or path.startswith(('misc/', 'ontologies/')):
+    if path in ['LICENSE', ] or path.startswith(('misc/', 'ontologies/')):
         raise IgnoredPath(path)
 
     # Some directories only affect one task.

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -1,0 +1,18 @@
+# -*- encoding: utf-8
+"""
+An important part of our Travis setup is that we skip build jobs where
+possible, as this means we can merge pull requests more quickly.
+A full build can take nearly two hours across 25 tasks, and that keeps
+going up.  This file contains the logic for answering the question:
+
+    Does file X affect build job Y?
+
+"""
+
+from travistooling.decisions import UnrecognisedFile
+
+
+def does_file_affect_build_job(path, job_name):
+    # If we can't decide if a file affects a build job, we assume it's
+    # significant and run the job just-in-case.
+    raise UnrecognisedFile(path=path)

--- a/travistooling/decisions.py
+++ b/travistooling/decisions.py
@@ -1,6 +1,9 @@
 # -*- encoding: utf-8
 
 class Decision(Exception):
+    """
+    The base class for all decisions.
+    """
     path = None
 
     def __init__(self, path):
@@ -9,12 +12,28 @@ class Decision(Exception):
 
 
 class SignificantFile(Decision):
+    """
+    This file might an effect on the outcome of the current build job.
+    """
     is_significant = True
 
 
 class InsignificantFile(Decision):
+    """
+    This file does not have an effect on the outcome of the current build job.
+    """
     is_significant = False
 
 
 class UnrecognisedFile(SignificantFile):
+    """
+    We cannot determine if this file has an effect on the current build job.
+    """
+    pass
+
+
+class IgnoredFileFormat(InsignificantFile):
+    """
+    This file format never has an effect on build jobs.
+    """
     pass

--- a/travistooling/decisions.py
+++ b/travistooling/decisions.py
@@ -1,0 +1,20 @@
+# -*- encoding: utf-8
+
+class Decision(Exception):
+    path = None
+
+    def __init__(self, path):
+        self.path == path
+        super(Decision, self).__init__()
+
+
+class SignificantFile(Decision):
+    is_significant = True
+
+
+class InsignificantFile(Decision):
+    is_significant = False
+
+
+class UnrecognisedFile(SignificantFile):
+    pass

--- a/travistooling/decisions.py
+++ b/travistooling/decisions.py
@@ -46,8 +46,15 @@ class IgnoredFileFormat(IgnoredPath):
     pass
 
 
-class KnownAffectsTask(SignificantFile):
+class KnownAffectsThisJob(SignificantFile):
     """
-    This file has a known effect on the outcome of the current build job.
+    This file has a known effect on this build job.
+    """
+    pass
+
+
+class KnownDoesNotAffectThisJob(InsignificantFile):
+    """
+    This file is known not to affect this build job.
     """
     pass

--- a/travistooling/decisions.py
+++ b/travistooling/decisions.py
@@ -37,3 +37,10 @@ class IgnoredFileFormat(InsignificantFile):
     This file format never has an effect on build jobs.
     """
     pass
+
+
+class IgnoredPath(InsignificantFile):
+    """
+    This path never has an effect on build jobs.
+    """
+    pass

--- a/travistooling/decisions.py
+++ b/travistooling/decisions.py
@@ -32,16 +32,16 @@ class UnrecognisedFile(SignificantFile):
     pass
 
 
-class IgnoredFileFormat(InsignificantFile):
+class IgnoredPath(InsignificantFile):
     """
-    This file format never has an effect on build jobs.
+    This path never has an effect on build jobs.
     """
     pass
 
 
-class IgnoredPath(InsignificantFile):
+class IgnoredFileFormat(IgnoredPath):
     """
-    This path never has an effect on build jobs.
+    This file format never has an effect on build jobs.
     """
     pass
 

--- a/travistooling/decisions.py
+++ b/travistooling/decisions.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8
 
+
 class Decision(Exception):
     """
     The base class for all decisions.

--- a/travistooling/decisions.py
+++ b/travistooling/decisions.py
@@ -44,3 +44,10 @@ class IgnoredPath(InsignificantFile):
     This path never has an effect on build jobs.
     """
     pass
+
+
+class KnownAffectsTask(SignificantFile):
+    """
+    This file has a known effect on the outcome of the current build job.
+    """
+    pass

--- a/travistooling/decisions.py
+++ b/travistooling/decisions.py
@@ -29,32 +29,27 @@ class UnrecognisedFile(SignificantFile):
     """
     We cannot determine if this file has an effect on the current build job.
     """
-    pass
 
 
 class IgnoredPath(InsignificantFile):
     """
     This path never has an effect on build jobs.
     """
-    pass
 
 
 class IgnoredFileFormat(IgnoredPath):
     """
     This file format never has an effect on build jobs.
     """
-    pass
 
 
 class KnownAffectsThisJob(SignificantFile):
     """
     This file has a known effect on this build job.
     """
-    pass
 
 
 class KnownDoesNotAffectThisJob(InsignificantFile):
     """
     This file is known not to affect this build job.
     """
-    pass

--- a/travistooling/parse_makefiles.py
+++ b/travistooling/parse_makefiles.py
@@ -1,0 +1,53 @@
+# -*- encoding: utf-8
+
+import collections
+import os
+
+Project = collections.namedtuple('Project', ['name', 'type', 'exclusive_path'])
+
+
+def get_projects(repo):
+    for root, _, filenames in os.walk(repo):
+        if any(
+            dirname in root
+            for dirname in ('.terraform', 'target', 'node_modules')
+        ):
+            continue
+        for f in filenames:
+            if f == 'Makefile':
+                path = os.path.join(root, f)
+                for proj in _get_projects_from_makefile(root=root, path=path):
+                    yield proj
+
+
+def _get_projects_from_makefile(root, path):
+    contents = open(path).read()
+
+    # Newlines in Makefiles are escaped with backslashes
+    contents = contents.replace('\\\n', ' ')
+    lines = contents.splitlines()
+
+    for make_variable, project_type in [
+        ('SBT_APPS', 'sbt_app'),
+        ('ECS_TASKS', 'ecs_task'),
+        ('LAMBDAS', 'python_lambda'),
+    ]:
+        matching_lines = [l for l in lines if l.startswith(make_variable)]
+
+        if len(matching_lines) == 0:
+            continue
+        elif len(matching_lines) == 1:
+            # The line is 'SBT_APPS = foo bar baz', so we discard the first
+            # two terms in the line.
+            targets = matching_lines[0].split()[2:]
+        else:  # pragma: no cover
+            raise RuntimeError(
+                "Too many %s variables in %s" % (make_variable, path)
+            )
+
+        for t in targets:
+            yield Project(
+                name=t,
+                type=project_type,
+                exclusive_path=os.path.join(root, t)
+            )

--- a/travistooling/test_decisionmaker.py
+++ b/travistooling/test_decisionmaker.py
@@ -3,7 +3,11 @@
 import pytest
 
 from travistooling.decisionmaker import does_file_affect_build_job
-from travistooling.decisions import IgnoredFileFormat, UnrecognisedFile
+from travistooling.decisions import (
+    IgnoredFileFormat,
+    IgnoredPath,
+    UnrecognisedFile
+)
 
 
 @pytest.mark.parametrize('path, job_name, exc_class, is_significant', [
@@ -17,7 +21,11 @@ from travistooling.decisions import IgnoredFileFormat, UnrecognisedFile
     ('foo.md', 'ingestor-build', IgnoredFileFormat, False),
     ('image.png', 'reindex_worker-test', IgnoredFileFormat, False),
     ('ontology.graffle', 'nginx-test', IgnoredFileFormat, False),
-    ('LICENSE', 'travistooling-test', IgnoredFileFormat, False),
+
+    # Certain paths are always insignificant.
+    ('LICENSE', 'travistooling-test', IgnoredPath, False),
+    ('misc/myscript.py', 'sierra_reader-build', IgnoredPath, False),
+    ('ontologies/work.ttl', 'monitoring-publish', IgnoredPath, False),
 ])
 def test_does_file_affect_build_job(path, job_name, exc_class, is_significant):
     with pytest.raises(exc_class) as err:

--- a/travistooling/test_decisionmaker.py
+++ b/travistooling/test_decisionmaker.py
@@ -16,4 +16,4 @@ from travistooling.decisions import UnrecognisedFile
 def test_does_file_affect_build_job(path, job_name, exc_class, is_significant):
     with pytest.raises(exc_class) as err:
         does_file_affect_build_job(path=path, job_name=job_name)
-        assert err.is_significant == is_significant
+    assert err.value.is_significant == is_significant

--- a/travistooling/test_decisionmaker.py
+++ b/travistooling/test_decisionmaker.py
@@ -3,7 +3,7 @@
 import pytest
 
 from travistooling.decisionmaker import does_file_affect_build_job
-from travistooling.decisions import UnrecognisedFile
+from travistooling.decisions import IgnoredFileFormat, UnrecognisedFile
 
 
 @pytest.mark.parametrize('path, job_name, exc_class, is_significant', [
@@ -12,6 +12,12 @@ from travistooling.decisions import UnrecognisedFile
     ('foo.txt', 'loris-build', UnrecognisedFile, True),
     ('foo.txt', 'api-test', UnrecognisedFile, True),
     ('foo.txt', 'snapshot_convertor-publish', UnrecognisedFile, True),
+
+    # Certain file formats are always excluded.
+    ('foo.md', 'ingestor-build', IgnoredFileFormat, False),
+    ('image.png', 'reindex_worker-test', IgnoredFileFormat, False),
+    ('ontology.graffle', 'nginx-test', IgnoredFileFormat, False),
+    ('LICENSE', 'travistooling-test', IgnoredFileFormat, False),
 ])
 def test_does_file_affect_build_job(path, job_name, exc_class, is_significant):
     with pytest.raises(exc_class) as err:

--- a/travistooling/test_decisionmaker.py
+++ b/travistooling/test_decisionmaker.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8
+
+import pytest
+
+from travistooling.decisionmaker import does_file_affect_build_job
+from travistooling.decisions import UnrecognisedFile
+
+
+@pytest.mark.parametrize('path, job_name, exc_class, is_significant', [
+    # Unrecognised filenames fall through to being significant, regardless
+    # of the build job.
+    ('foo.txt', 'loris-build', UnrecognisedFile, True),
+    ('foo.txt', 'api-test', UnrecognisedFile, True),
+    ('foo.txt', 'snapshot_convertor-publish', UnrecognisedFile, True),
+])
+def test_does_file_affect_build_job(path, job_name, exc_class, is_significant):
+    with pytest.raises(exc_class) as err:
+        does_file_affect_build_job(path=path, job_name=job_name)
+        assert err.is_significant == is_significant

--- a/travistooling/test_decisionmaker.py
+++ b/travistooling/test_decisionmaker.py
@@ -12,6 +12,13 @@ from travistooling.decisions import (
 
 
 @pytest.mark.parametrize('path, job_name, exc_class, is_significant', [
+    # Travis format task
+    ('misc/myscript.py', 'travis-format', KnownAffectsTask, True),
+    ('ontologies/item.ttl', 'travis-format', KnownAffectsTask, True),
+    ('main.tf', 'travis-format', KnownAffectsTask, True),
+    ('example.json', 'travis-format', KnownAffectsTask, True),
+    ('README.md', 'travis-format', IgnoredFileFormat, False),
+
     # Unrecognised filenames fall through to being significant, regardless
     # of the build job.
     ('foo.txt', 'loris-build', UnrecognisedFile, True),
@@ -24,16 +31,13 @@ from travistooling.decisions import (
     ('ontology.graffle', 'nginx-test', IgnoredFileFormat, False),
 
     # Terraform files are significant, but only in the travis-format task
-    ('main.tf', 'travis-format', KnownAffectsTask, True),
     ('s3.tf', 'elasticdump-test', IgnoredFileFormat, False),
 
     # Certain paths are always insignificant.
     ('LICENSE', 'travistooling-test', IgnoredPath, False),
 
     # Ontology/misc are significant, but only in the travis-format task
-    ('misc/myscript.py', 'travis-format', KnownAffectsTask, True),
     ('misc/myscript.py', 'sierra_reader-build', IgnoredPath, False),
-    ('ontologies/item.ttl', 'travis-format', KnownAffectsTask, True),
     ('ontologies/work.ttl', 'monitoring-publish', IgnoredPath, False),
 ])
 def test_does_file_affect_build_job(path, job_name, exc_class, is_significant):

--- a/travistooling/test_decisionmaker.py
+++ b/travistooling/test_decisionmaker.py
@@ -6,6 +6,7 @@ from travistooling.decisionmaker import does_file_affect_build_job
 from travistooling.decisions import (
     IgnoredFileFormat,
     IgnoredPath,
+    KnownAffectsTask,
     UnrecognisedFile
 )
 
@@ -22,9 +23,17 @@ from travistooling.decisions import (
     ('image.png', 'reindex_worker-test', IgnoredFileFormat, False),
     ('ontology.graffle', 'nginx-test', IgnoredFileFormat, False),
 
+    # Terraform files are significant, but only in the travis-format task
+    ('main.tf', 'travis-format', KnownAffectsTask, True),
+    ('s3.tf', 'elasticdump-test', IgnoredFileFormat, False),
+
     # Certain paths are always insignificant.
     ('LICENSE', 'travistooling-test', IgnoredPath, False),
+
+    # Ontology/misc are significant, but only in the travis-format task
+    ('misc/myscript.py', 'travis-format', KnownAffectsTask, True),
     ('misc/myscript.py', 'sierra_reader-build', IgnoredPath, False),
+    ('ontologies/item.ttl', 'travis-format', KnownAffectsTask, True),
     ('ontologies/work.ttl', 'monitoring-publish', IgnoredPath, False),
 ])
 def test_does_file_affect_build_job(path, job_name, exc_class, is_significant):


### PR DESCRIPTION
~[This is all @DRMaciver’s fault](https://twitter.com/DRMacIver/status/982175697601945602).~

A first step towards #1735. This reflects the fact that our Travis build scripts have become pretty complicated, and should be properly tested like the rest of our infrastructure code. None of the new code is used yet, merely tested – swapping out the mainline Travis for this refactored version will be a separate PR.