### PR TITLE
api: don't return a 500 error on malformed identifiers

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -191,10 +191,12 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
           // In this case, we return a 400 Bad Request exception rather than bubbling
           // up as a 500 error.
           case exception: IllegalArgumentException =>
-            if (exception.getMessage.startsWith("Illegal character in path at index ")) {
+            if (exception.getMessage.startsWith(
+                  "Illegal character in path at index ")) {
               val result = Error(
                 variant = "http-400",
-                description = Some(s"Unrecognised character in identifier ${request.id}")
+                description =
+                  Some(s"Unrecognised character in identifier ${request.id}")
               )
               response.badRequest.json(
                 ResultResponse(

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -181,6 +181,29 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
             )
           }
         }
+        .recover {
+          // If a user tries to request an ID without escaping it correctly
+          // (e.g. "/works/work/zd224ncv]"), we get an IllegalArgumentException with
+          // the error:
+          //
+          //      Illegal character in path at index 20: /works/work/zd224ncv]
+          //
+          // In this case, we return a 400 Bad Request exception rather than bubbling
+          // up as a 500 error.
+          case exception: IllegalArgumentException =>
+            if (exception.getMessage.startsWith("Illegal character in path at index ")) {
+              val result = Error(
+                variant = "http-400",
+                description = Some(s"Unrecognised character in identifier ${request.id}")
+              )
+              response.badRequest.json(
+                ResultResponse(
+                  context = contextUri,
+                  result = DisplayError(result)
+                )
+              )
+            }
+        }
     }
 
   }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
@@ -975,6 +975,16 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
+  it("returns Not Found if you ask for a non-existent work") {
+    eventually {
+      server.httpGet(
+        path = s"/$apiPrefix/works/xhu96f9j",
+        andExpect = Status.NotFound,
+        withJsonBody = notFound("Work not found for identifier xhu96f9j")
+      )
+    }
+  }
+
   it("returns an Internal Server error if you try to search a malformed index") {
     // We need to do something that reliably triggers an internal exception
     // in the Elasticsearch handler.

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
@@ -985,6 +985,16 @@ class ApiWorksTest extends ApiWorksTestBase {
     }
   }
 
+  it("returns Bad Request if you ask for a malformed identifier") {
+    eventually {
+      server.httpGet(
+        path = s"/$apiPrefix/works/zd224ncv]",
+        andExpect = Status.BadRequest,
+        withJsonBody = badRequest("Unrecognised character in identifier zd224ncv]")
+      )
+    }
+  }
+
   it("returns an Internal Server error if you try to search a malformed index") {
     // We need to do something that reliably triggers an internal exception
     // in the Elasticsearch handler.

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTest.scala
@@ -990,7 +990,8 @@ class ApiWorksTest extends ApiWorksTestBase {
       server.httpGet(
         path = s"/$apiPrefix/works/zd224ncv]",
         andExpect = Status.BadRequest,
-        withJsonBody = badRequest("Unrecognised character in identifier zd224ncv]")
+        withJsonBody =
+          badRequest("Unrecognised character in identifier zd224ncv]")
       )
     }
   }


### PR DESCRIPTION
Resolves #1767. Requesting URLs like https://api.wellcomecollection.org/catalogue/v1/works/n76whrxq] (no escaping on the square bracket) causes the API to 500; this causes the API to 400 instead, which is slightly more graceful and helpful – and more importantly, doesn't trigger an alarm in Slack!

- [ ] Deployed new versions