### PR TITLE
Expire CloudFront logs after 30 days

### DIFF
--- a/loris/terraform/s3.tf
+++ b/loris/terraform/s3.tf
@@ -10,6 +10,15 @@ resource "aws_s3_bucket" "wellcomecollection-miro-images-public" {
   lifecycle {
     prevent_destroy = true
   }
+
+  lifecycle_rule {
+    id      = "expire_cloudfront_logs"
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
 }
 
 resource "aws_s3_bucket" "cloudfront_logs" {


### PR DESCRIPTION
Resolves #1730.

### What is this PR trying to achieve?

Auto-expire CloudFront logs, which contain user IP addresses and thus count as PII for the purposes of DPA/GDPR. We shouldn’t be keeping them forever – they’re useful for the occasional bit of debugging, but not critical information.

Note that we already had a similar expiry policy for our ALB logs:

https://github.com/wellcometrust/platform/blob/611c58c1ae9649efa1a7e0485ca1b2650094b4b7/shared_infra/s3.tf#L38-L45

so this just brings the two buckets into line.

### Who is this change for?

The lawyers, who want to be happy that we’re GDPR-compliant.

Also our S3 bill. Although they’re gulfed by the cost of assets, an ever-growing collection of files in the Standard storage tier isn’t free either.

### Have the following been considered/are they needed?

- [x] Run `terraform apply`.