### PR TITLE
data_api: redirect the root of data.wc.org to developers.wc.org

### DIFF
--- a/data_api/terraform/cloudfront.tf
+++ b/data_api/terraform/cloudfront.tf
@@ -14,6 +14,8 @@ resource "aws_cloudfront_distribution" "data_api" {
   enabled         = true
   is_ipv6_enabled = true
 
+  default_root_object = "index.html"
+
   aliases = ["data.wellcomecollection.org"]
 
   default_cache_behavior {

--- a/data_api/terraform/data_wc_index.html
+++ b/data_api/terraform/data_wc_index.html
@@ -1,12 +1,12 @@
 <html>
   <head>
-    <meta http-equiv="refresh" content="0; url=https://developers.wellcomecollection.org/" />
+    <meta http-equiv="refresh" content="0; url=https://developers.wellcomecollection.org/datasets/" />
     <script type="text/javascript">
-      window.location.href = "https://developers.wellcomecollection.org/"
+      window.location.href = "https://developers.wellcomecollection.org/datasets/"
     </script>
   </head>
   <body>
     Welcome to data.wellcomecollection.org!
-    The docs are at <a href="https://developers.wellcomecollection.org/">
+    The docs for our data sets are at <a href="https://developers.wellcomecollection.org/datasets/">
   </body>
 </html>

--- a/data_api/terraform/data_wc_index.html
+++ b/data_api/terraform/data_wc_index.html
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=https://developers.wellcomecollection.org/" />
+    <script type="text/javascript">
+      window.location.href = "https://developers.wellcomecollection.org/"
+    </script>
+  </head>
+  <body>
+    Welcome to data.wellcomecollection.org!
+    The docs are at <a href="https://developers.wellcomecollection.org/">
+  </body>
+</html>

--- a/data_api/terraform/s3.tf
+++ b/data_api/terraform/s3.tf
@@ -51,3 +51,13 @@ resource "aws_s3_bucket_notification" "private_data_bucket_notification" {
     filter_prefix       = "elasticdump/"
   }
 }
+
+# This file is served from the root of data.wellcomecollection.org.
+resource "aws_s3_bucket_object" "index_page" {
+  bucket = "${aws_s3_bucket.public_data.id}"
+  key    = "index.html"
+  source = "data_wc_index.html"
+  etag   = "${md5(file("data_wc_index.html"))}"
+
+  content_type = "text/html"
+}


### PR DESCRIPTION
When you visit data.wellcomecollection.org, rather than getting an ugly S3 error, you now get redirected to developers.wellcomecollection.org. When we write more specific docs for the snapshot service, we can modify the redirect to point there instead.

I’d like reviews from:

* @wellcometrust/platform-devs for the Terraform change
* @jtweed to confirm this is the correct behaviour

This change is already applied.

For #1778.