### PR TITLE
Fix the Sierra bib reader

### DIFF
--- a/sierra_adapter/build_windows.py
+++ b/sierra_adapter/build_windows.py
@@ -44,11 +44,13 @@ import math
 import boto3
 import docopt
 import maya
+import pytz
 import tqdm
 
 
 def generate_windows(start, end, minutes):
-    current = start
+    current = pytz.utc.localize(start)
+    end = pytz.utc.localize(end)
     while current <= end:
         yield {
             'start': current.isoformat(),

--- a/sierra_adapter/terraform/sierra_reader/service.tf
+++ b/sierra_adapter/terraform/sierra_reader/service.tf
@@ -43,5 +43,5 @@ module "sierra_reader_service" {
 
   enable_alb_alarm = false
 
-  max_capacity = 15
+  max_capacity = 4
 }


### PR DESCRIPTION
We’ve been having issues with the Sierra bib window losing records that are updated in the early morning hours; these are two fixes that should make that less likely, and make it easier to resolve when it happens.