### PR TITLE
common: LocalVHS and JsonTestUtil should be extended by Suite, not Matchers

### DIFF
--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalVersionedHybridStore.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalVersionedHybridStore.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.test.fixtures
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
 import io.circe.Encoder
-import org.scalatest.{Assertion, Matchers}
+import org.scalatest.{Assertion, Matchers, Suite}
 import uk.ac.wellcome.dynamo.VersionedDao
 import uk.ac.wellcome.models.aws.{DynamoConfig, S3Config}
 import uk.ac.wellcome.storage.{HybridRecord, VersionedHybridStore}
@@ -17,7 +17,7 @@ trait LocalVersionedHybridStore
     with S3
     with JsonTestUtil
     with Matchers
-    with ImplicitLogging {
+    with ImplicitLogging { this: Suite
 
   override lazy val evidence: DynamoFormat[HybridRecord] =
     DynamoFormat[HybridRecord]

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/JsonTestUtil.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/JsonTestUtil.scala
@@ -1,9 +1,9 @@
 package uk.ac.wellcome.test.utils
 
-import org.scalatest.Matchers
+import org.scalatest.{Matchers, Suite}
 import io.circe.parser._
 
-trait JsonTestUtil { this: Matchers =>
+trait JsonTestUtil extends Matchers { this: Suite =>
 
   def assertJsonStringsAreEqual(json1: String, json2: String) = {
     val tree1 = parse(json1).right.get


### PR DESCRIPTION
Snipped out as an easy standalone piece from #1856.