### PR TITLE
Move WorksUtil and the JSON test helpers into the display library

### DIFF
--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -4,9 +4,8 @@ import com.sksamuel.elastic4s.http.search.SearchHit
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.IdentifiedWork
-import uk.ac.wellcome.platform.api.WorksUtil
 import uk.ac.wellcome.platform.api.fixtures.ElasticsearchServiceFixture
-import uk.ac.wellcome.display.models.{DisplayWork, WorksIncludes}
+import uk.ac.wellcome.display.models.{DisplayWork, WorksIncludes, WorksUtil}
 import uk.ac.wellcome.utils.JsonUtil._
 
 class ElasticsearchServiceTest

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.api.services
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.{IdentifierSchemes, SourceIdentifier}
-import uk.ac.wellcome.platform.api.WorksUtil
 import uk.ac.wellcome.platform.api.fixtures.{
   ElasticsearchServiceFixture,
   WorksServiceFixture
@@ -11,7 +10,8 @@ import uk.ac.wellcome.platform.api.fixtures.{
 import uk.ac.wellcome.display.models.{
   DisplayIdentifier,
   DisplayWork,
-  WorksIncludes
+  WorksIncludes,
+  WorksUtil
 }
 import uk.ac.wellcome.platform.api.models.DisplayResultList
 import uk.ac.wellcome.elasticsearch.test.utils.IndexedElasticSearchLocal

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -1,24 +1,20 @@
 package uk.ac.wellcome.platform.api.works
 
 import com.sksamuel.elastic4s.Indexable
-import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.server.FeatureTestMixin
 import org.scalatest.FunSpec
-import uk.ac.wellcome.models._
-import uk.ac.wellcome.platform.api.{Server, WorksUtil}
+import uk.ac.wellcome.display.models.{DisplayJacksonModuleTestBase, WorksUtil}
 import uk.ac.wellcome.elasticsearch.test.utils.IndexedElasticSearchLocal
+import uk.ac.wellcome.models._
+import uk.ac.wellcome.platform.api.Server
 import uk.ac.wellcome.utils.JsonUtil._
-import io.circe.parser._
-import cats.syntax.either._
-import io.circe.{Json, JsonObject}
-import io.circe.optics.JsonPath
-import io.circe.optics.JsonPath.root
 
-class ApiWorksTestBase
+trait ApiWorksTestBase
     extends FunSpec
     with FeatureTestMixin
     with IndexedElasticSearchLocal
+    with DisplayJacksonModuleTestBase
     with WorksUtil {
 
   val indexName = "works"
@@ -54,120 +50,6 @@ class ApiWorksTestBase
     |  "results": []
     |}""".stripMargin
 
-  def items(its: List[IdentifiedItem]) =
-    its
-      .map { it =>
-        s"""{
-          "id": "${it.canonicalId}",
-          "type": "${it.ontologyType}",
-          "locations": [
-            ${locations(it.locations)}
-          ]
-        }"""
-      }
-      .mkString(",")
-
-  def locations(locations: List[Location]) =
-    locations
-      .map { location(_) }
-      .mkString(",")
-
-  def location(loc: Location) = loc match {
-    case l: DigitalLocation => digitalLocation(l)
-    case l: PhysicalLocation => physicalLocation(l)
-  }
-
-  def digitalLocation(loc: DigitalLocation) =
-    s"""{
-      "type": "${loc.ontologyType}",
-      "locationType": "${loc.locationType}",
-      "url": "${loc.url}",
-      "license": ${license(loc.license)}
-    }"""
-
-  def physicalLocation(loc: PhysicalLocation) =
-    s"""
-       {
-        "type": "${loc.ontologyType}",
-        "locationType": "${loc.locationType}",
-        "label": "${loc.label}"
-       }
-     """
-
-  def license(license: License) =
-    s"""{
-      "label": "${license.label}",
-      "licenseType": "${license.licenseType}",
-      "type": "${license.ontologyType}",
-      "url": "${license.url}"
-    }"""
-
-  def identifier(identifier: SourceIdentifier) =
-    s"""{
-      "type": "Identifier",
-      "identifierScheme": "${identifier.identifierScheme}",
-      "value": "${identifier.value}"
-    }"""
-
-  def identifiedOrUnidentifiable[T](displayableAgent: Displayable[T],
-                                    f: T => String) =
-    displayableAgent match {
-      case Unidentifiable(ag) => f(ag)
-      case Identified(ag, id, identifiers) =>
-        val agent = parse(f(ag)).right.get.asObject.get
-        val identifiersJson = identifiers.map { sourceIdentifier =>
-          parse(identifier(sourceIdentifier)).right.get
-        }
-        val newJson = ("id", Json.fromString(id)) +: (
-          "identifiers",
-          Json.arr(identifiersJson: _*)) +: agent
-        Json.fromJsonObject(newJson).spaces2
-    }
-
-  def abstractAgent(ag: AbstractAgent) =
-    ag match {
-      case a: Agent => agent(a)
-      case o: Organisation => organisation(o)
-      case p: Person => person(p)
-    }
-
-  def person(p: Person) = {
-    s"""{
-        "type": "Person",
-        ${optionalString("prefix", p.prefix)},
-        ${optionalString("numeration", p.numeration)},
-        "label": "${p.label}"
-      }"""
-  }
-
-  def organisation(o: Organisation) = {
-    s"""{
-        "type": "Organisation",
-        "label": "${o.label}"
-      }"""
-  }
-
-  def agent(a: Agent) = {
-    s"""{
-        "type": "Agent",
-        "label": "${a.label}"
-      }"""
-  }
-
-  def optionalString(fieldName: String, maybeValue: Option[String]) =
-    maybeValue match {
-      case None => ""
-      case Some(p) =>
-        s"""
-           "$fieldName": "$p"
-         """
-    }
-
-  def period(p: Period) =
-    s"""{
-      "type": "Period",
-      "label": "${p.label}"
-    }"""
 
   def badRequest(description: String) =
     s"""{
@@ -178,19 +60,6 @@ class ApiWorksTestBase
       "label": "Bad Request",
       "description": "$description"
     }"""
-
-  def concept(con: AbstractConcept) =
-    s"""
-    {
-      "type": "${con.ontologyType}",
-      "label": "${con.label}"
-    }
-    """
-
-  def concepts(concepts: List[AbstractConcept]) =
-    concepts
-      .map { concept(_) }
-      .mkString(",")
 
   def resultList(pageSize: Int = 10,
                  totalPages: Int = 1,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -50,7 +50,6 @@ trait ApiWorksTestBase
     |  "results": []
     |}""".stripMargin
 
-
   def badRequest(description: String) =
     s"""{
       "@context": "https://localhost:8888/$apiPrefix/context.json",

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/JsonTestUtil.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/JsonTestUtil.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.test.utils
 import org.scalatest.Matchers
 import io.circe.parser._
 
-trait JsonTestUtil { this: Matchers =>
+trait JsonTestUtil extends Matchers {
 
   def assertJsonStringsAreEqual(json1: String, json2: String) = {
     val tree1 = parse(json1).right.get

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayJacksonModuleTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayJacksonModuleTest.scala
@@ -6,7 +6,11 @@ import org.scalatest.FunSpec
 import uk.ac.wellcome.display.modules.DisplayJacksonModule
 import uk.ac.wellcome.test.utils.JsonTestUtil
 
-class DisplayJacksonModuleTest extends FunSpec with DisplayJacksonModuleTestBase with JsonTestUtil with WorksUtil {
+class DisplayJacksonModuleTest
+    extends FunSpec
+    with DisplayJacksonModuleTestBase
+    with JsonTestUtil
+    with WorksUtil {
   val injector = Guice.createInjector(DisplayJacksonModule)
 
   val objectMapper = injector.getInstance(classOf[ObjectMapper])
@@ -39,8 +43,8 @@ class DisplayJacksonModuleTest extends FunSpec with DisplayJacksonModuleTestBase
        | "lettering": "$lettering",
        | "createdDate": ${period(work.createdDate.get)},
        | "creators": [ ${identifiedOrUnidentifiable(
-      work.creators(0),
-      abstractAgent)} ],
+                                  work.creators(0),
+                                  abstractAgent)} ],
        | "subjects": [ ],
        | "genres": [ ],
        | "publishers": [ ],

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayJacksonModuleTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayJacksonModuleTest.scala
@@ -1,0 +1,53 @@
+package uk.ac.wellcome.display.models
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.inject.Guice
+import org.scalatest.FunSpec
+import uk.ac.wellcome.display.modules.DisplayJacksonModule
+import uk.ac.wellcome.test.utils.JsonTestUtil
+
+class DisplayJacksonModuleTest extends FunSpec with DisplayJacksonModuleTestBase with JsonTestUtil with WorksUtil {
+  val injector = Guice.createInjector(DisplayJacksonModule)
+
+  val objectMapper = injector.getInstance(classOf[ObjectMapper])
+
+  it("should serialise a DisplayWork correctly") {
+
+    val work = workWith(
+      canonicalId = canonicalId,
+      title = title,
+      description = description,
+      lettering = lettering,
+      createdDate = period,
+      creator = agent,
+      items = List(defaultItem),
+      visible = true)
+
+    val actualJsonString = objectMapper.writeValueAsString(DisplayWork(work))
+
+    val expectedJsonString = s"""
+       |{
+       | "type": "Work",
+       | "id": "$canonicalId",
+       | "title": "$title",
+       | "description": "$description",
+       | "workType": {
+       |       "id": "${workType.id}",
+       |       "label": "${workType.label}",
+       |       "type": "WorkType"
+       | },
+       | "lettering": "$lettering",
+       | "createdDate": ${period(work.createdDate.get)},
+       | "creators": [ ${identifiedOrUnidentifiable(
+      work.creators(0),
+      abstractAgent)} ],
+       | "subjects": [ ],
+       | "genres": [ ],
+       | "publishers": [ ],
+       | "placesOfPublication": [ ]
+       |}
+          """.stripMargin
+
+    assertJsonStringsAreEqual(actualJsonString, expectedJsonString)
+  }
+}

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayJacksonModuleTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayJacksonModuleTestBase.scala
@@ -1,0 +1,139 @@
+package uk.ac.wellcome.display.models
+
+import io.circe.Json
+import io.circe.parser._
+import org.scalatest.Suite
+import uk.ac.wellcome.models._
+
+trait DisplayJacksonModuleTestBase {this: Suite =>
+
+  def items(its: List[IdentifiedItem]) =
+    its
+      .map { it =>
+        s"""{
+          "id": "${it.canonicalId}",
+          "type": "${it.ontologyType}",
+          "locations": [
+            ${locations(it.locations)}
+          ]
+        }"""
+      }
+      .mkString(",")
+
+  def locations(locations: List[Location]) =
+    locations
+      .map { location(_) }
+      .mkString(",")
+
+  def location(loc: Location) = loc match {
+    case l: DigitalLocation => digitalLocation(l)
+    case l: PhysicalLocation => physicalLocation(l)
+  }
+
+  def digitalLocation(loc: DigitalLocation) =
+    s"""{
+      "type": "${loc.ontologyType}",
+      "locationType": "${loc.locationType}",
+      "url": "${loc.url}",
+      "license": ${license(loc.license)}
+    }"""
+
+  def physicalLocation(loc: PhysicalLocation) =
+    s"""
+       {
+        "type": "${loc.ontologyType}",
+        "locationType": "${loc.locationType}",
+        "label": "${loc.label}"
+       }
+     """
+
+  def license(license: License) =
+    s"""{
+      "label": "${license.label}",
+      "licenseType": "${license.licenseType}",
+      "type": "${license.ontologyType}",
+      "url": "${license.url}"
+    }"""
+
+  def identifier(identifier: SourceIdentifier) =
+    s"""{
+      "type": "Identifier",
+      "identifierScheme": "${identifier.identifierScheme}",
+      "value": "${identifier.value}"
+    }"""
+
+  def identifiedOrUnidentifiable[T](displayableAgent: Displayable[T],
+                                    f: T => String) =
+    displayableAgent match {
+      case Unidentifiable(ag) => f(ag)
+      case Identified(ag, id, identifiers) =>
+        val agent = parse(f(ag)).right.get.asObject.get
+        val identifiersJson = identifiers.map { sourceIdentifier =>
+          parse(identifier(sourceIdentifier)).right.get
+        }
+        val newJson = ("id", Json.fromString(id)) +: (
+          "identifiers",
+          Json.arr(identifiersJson: _*)) +: agent
+        Json.fromJsonObject(newJson).spaces2
+    }
+
+  def abstractAgent(ag: AbstractAgent) =
+    ag match {
+      case a: Agent => agent(a)
+      case o: Organisation => organisation(o)
+      case p: Person => person(p)
+    }
+
+  def person(p: Person) = {
+    s"""{
+        "type": "Person",
+        ${optionalString("prefix", p.prefix)},
+        ${optionalString("numeration", p.numeration)},
+        "label": "${p.label}"
+      }"""
+  }
+
+  def organisation(o: Organisation) = {
+    s"""{
+        "type": "Organisation",
+        "label": "${o.label}"
+      }"""
+  }
+
+  def agent(a: Agent) = {
+    s"""{
+        "type": "Agent",
+        "label": "${a.label}"
+      }"""
+  }
+
+  def optionalString(fieldName: String, maybeValue: Option[String]) =
+    maybeValue match {
+      case None => ""
+      case Some(p) =>
+        s"""
+           "$fieldName": "$p"
+         """
+    }
+
+  def period(p: Period) =
+    s"""{
+      "type": "Period",
+      "label": "${p.label}"
+    }"""
+
+
+  def concept(con: AbstractConcept) =
+    s"""
+    {
+      "type": "${con.ontologyType}",
+      "label": "${con.label}"
+    }
+    """
+
+  def concepts(concepts: List[AbstractConcept]) =
+    concepts
+      .map { concept(_) }
+      .mkString(",")
+
+}

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayJacksonModuleTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayJacksonModuleTestBase.scala
@@ -69,12 +69,12 @@ trait DisplayJacksonModuleTestBase {this: Suite =>
   // unmodified.  In the second case, we modify the JSON to include
   // the "id" field and the "identifiers" field.
   //
-  def identifiedOrUnidentifiable[T](displayableAgent: Displayable[T],
-                                    f: T => String) =
-    displayableAgent match {
-      case Unidentifiable(ag) => f(ag)
+  def identifiedOrUnidentifiable[T](displayable: Displayable[T],
+                                    serialise: T => String) =
+    displayable match {
+      case Unidentifiable(ag) => serialise(ag)
       case Identified(ag, id, identifiers) =>
-        val agent = parse(f(ag)).right.get.asObject.get
+        val agent = parse(serialise(ag)).right.get.asObject.get
         val identifiersJson = identifiers.map { sourceIdentifier =>
           parse(identifier(sourceIdentifier)).right.get
         }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayJacksonModuleTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayJacksonModuleTestBase.scala
@@ -62,6 +62,13 @@ trait DisplayJacksonModuleTestBase {this: Suite =>
       "value": "${identifier.value}"
     }"""
 
+  // Some of our fields can be optionally identified (e.g. creators).
+  //
+  // Values in these fields are wrapped in either "Unidentifiable" or
+  // "Identified".  In the first case, we use the default serialisation
+  // unmodified.  In the second case, we modify the JSON to include
+  // the "id" field and the "identifiers" field.
+  //
   def identifiedOrUnidentifiable[T](displayableAgent: Displayable[T],
                                     f: T => String) =
     displayableAgent match {

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayJacksonModuleTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayJacksonModuleTestBase.scala
@@ -5,7 +5,7 @@ import io.circe.parser._
 import org.scalatest.Suite
 import uk.ac.wellcome.models._
 
-trait DisplayJacksonModuleTestBase {this: Suite =>
+trait DisplayJacksonModuleTestBase { this: Suite =>
 
   def items(its: List[IdentifiedItem]) =
     its
@@ -128,7 +128,6 @@ trait DisplayJacksonModuleTestBase {this: Suite =>
       "type": "Period",
       "label": "${p.label}"
     }"""
-
 
   def concept(con: AbstractConcept) =
     s"""

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/WorksUtil.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/WorksUtil.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.api
+package uk.ac.wellcome.display.models
 
 import uk.ac.wellcome.models._
 


### PR DESCRIPTION
Pulled out as a standalone piece from #1856. Mostly unmodified from the original patch, aside from the additional comment and new variable names in `identifiedOrUnidentifiable`.