### PR TITLE
Replace DynamoInserter logic in sierra_items_to_dynamo

### DIFF
--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserter.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserter.scala
@@ -1,0 +1,29 @@
+package uk.ac.wellcome.platform.sierra_items_to_dynamo.services
+
+import com.google.inject.Inject
+import uk.ac.wellcome.dynamo.VersionedDao
+import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
+import uk.ac.wellcome.platform.sierra_items_to_dynamo.merger.SierraItemRecordMerger
+import uk.ac.wellcome.utils.GlobalExecutionContext._
+
+import uk.ac.wellcome.dynamo._
+
+import scala.concurrent.Future
+
+class DynamoInserter @Inject()(versionedDao: VersionedDao) {
+
+  def insertIntoDynamo(record: SierraItemRecord): Future[Unit] = {
+    versionedDao.getRecord[SierraItemRecord](record.id).flatMap {
+      case Some(existingRecord) =>
+        val mergedRecord = SierraItemRecordMerger
+          .mergeItems(existingRecord = existingRecord, updatedRecord = record)
+        if (mergedRecord != existingRecord) {
+          versionedDao.updateRecord(mergedRecord)
+        } else {
+          Future.successful(())
+        }
+      case None => versionedDao.updateRecord(record)
+    }
+  }
+
+}

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerService.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerService.scala
@@ -17,11 +17,11 @@ class SierraItemsToDynamoWorkerService @Inject()(
   reader: SQSReader,
   system: ActorSystem,
   metrics: MetricsSender,
-  versionedDao: VersionedDao
+  dynamoInserter: DynamoInserter
 ) extends SQSWorkerToDynamo[SierraRecord](reader, system, metrics) {
 
   override implicit val decoder = deriveDecoder[SierraRecord]
 
   override def store(record: SierraRecord): Future[Unit] =
-    versionedDao.updateRecord(record.toItemRecord.get)
+    dynamoInserter.insertIntoDynamo(record.toItemRecord.get)
 }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/DynamoInserterFixture.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/DynamoInserterFixture.scala
@@ -1,0 +1,29 @@
+package uk.ac.wellcome.platform.sierra_items_to_dynamo.fixtures
+
+import com.gu.scanamo.DynamoFormat
+import uk.ac.wellcome.dynamo.VersionedDao
+import uk.ac.wellcome.models.aws.DynamoConfig
+import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
+import uk.ac.wellcome.platform.sierra_items_to_dynamo.services.DynamoInserter
+import uk.ac.wellcome.test.fixtures.{LocalDynamoDb, TestWith}
+
+import uk.ac.wellcome.dynamo._
+
+trait DynamoInserterFixture extends LocalDynamoDb[SierraItemRecord] {
+  override lazy val evidence: DynamoFormat[SierraItemRecord] =
+    DynamoFormat[SierraItemRecord]
+
+  def withDynamoInserter[R](
+                             testWith: TestWith[(String, DynamoInserter), R]): Unit = {
+    withLocalDynamoDbTable { tableName =>
+      val dynamoInserter = new DynamoInserter(
+        new VersionedDao(
+          dynamoDbClient,
+          dynamoConfig = DynamoConfig(tableName)
+        )
+      )
+
+      testWith((tableName, dynamoInserter))
+    }
+  }
+}

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/DynamoInserterFixture.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/DynamoInserterFixture.scala
@@ -14,7 +14,7 @@ trait DynamoInserterFixture extends LocalDynamoDb[SierraItemRecord] {
     DynamoFormat[SierraItemRecord]
 
   def withDynamoInserter[R](
-                             testWith: TestWith[(String, DynamoInserter), R]): Unit = {
+    testWith: TestWith[(String, DynamoInserter), R]): Unit = {
     withLocalDynamoDbTable { tableName =>
       val dynamoInserter = new DynamoInserter(
         new VersionedDao(

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
@@ -97,8 +97,7 @@ class SierraItemRecordMergerTest extends FunSpec with Matchers {
     mergedRecord.unlinkedBibIds shouldBe List("3")
   }
 
-  it(
-    "should return the existing record unchanged if the update has an older date") {
+  it("returns the existing record unchanged if the update has an older date") {
     val existingRecord = sierraItemRecord(
       bibIds = List("1", "2", "3"),
       modifiedDate = "2017-01-01T00:00:00Z",

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
@@ -1,0 +1,370 @@
+package uk.ac.wellcome.platform.sierra_items_to_dynamo.services
+
+import java.time.Instant
+
+import com.gu.scanamo.{DynamoFormat, Scanamo}
+import com.gu.scanamo.syntax._
+import io.circe.parser.parse
+import org.mockito.Matchers.any
+import org.mockito.Mockito
+import org.mockito.Mockito.{verify, when}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.aws.{DynamoConfig, SQSConfig}
+import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
+import uk.ac.wellcome.dynamo._
+import uk.ac.wellcome.test.fixtures.{LocalDynamoDb, TestWith}
+
+import scala.concurrent.Future
+import uk.ac.wellcome.test.utils.ExtendedPatience
+import uk.ac.wellcome.type_classes.{IdGetter, VersionGetter, VersionUpdater}
+
+class DynamoInserterTest
+    extends FunSpec
+    with Matchers
+    with LocalDynamoDb[SierraItemRecord]
+    with ScalaFutures
+    with MockitoSugar
+    with ExtendedPatience {
+
+  override lazy val evidence: DynamoFormat[SierraItemRecord] =
+    DynamoFormat[SierraItemRecord]
+
+  def withDynamoInserter[R](
+    testWith: TestWith[(String, DynamoInserter), R]): Unit = {
+    withLocalDynamoDbTable { tableName =>
+      val dynamoInserter = new DynamoInserter(
+        new VersionedDao(
+          dynamoDbClient,
+          dynamoConfig = DynamoConfig(tableName)
+        )
+      )
+
+      testWith((tableName, dynamoInserter))
+    }
+  }
+
+  it("ingests a json item into DynamoDB") {
+    withDynamoInserter {
+      case (tableName, dynamoInserter) =>
+        val id = "100001"
+        val updatedDate = "2013-12-13T12:43:16Z"
+
+        val record = SierraItemRecord(
+          id = s"$id",
+          data = parse(s"""
+             |{
+             | "id": "$id",
+             | "updatedDate": "$updatedDate",
+             | "bibIds": ["1556974"]
+             |}
+      """.stripMargin).right.get.noSpaces,
+          modifiedDate = updatedDate,
+          bibIds = List("1556974")
+        )
+
+        val futureUnit = dynamoInserter.insertIntoDynamo(record)
+
+        whenReady(futureUnit) { _ =>
+          Scanamo.get[SierraItemRecord](dynamoDbClient)(tableName)(
+            'id -> s"$id") shouldBe Some(Right(record.copy(version = 1)))
+        }
+    }
+  }
+
+  it("does not overwrite new data with old data") {
+    withDynamoInserter {
+      case (tableName, dynamoInserter) =>
+        val id = "200002"
+        val oldUpdatedDate = "2001-01-01T00:00:01Z"
+        val newUpdatedDate = "2017-12-12T23:59:59Z"
+
+        val newRecord = SierraItemRecord(
+          id = s"$id",
+          modifiedDate = newUpdatedDate,
+          data =
+            s"""{"id": "$id", "updatedDate": "$newUpdatedDate", "comment": "I am a shiny new record", "bibIds": ["1556974"]}""",
+          bibIds = List("1556974")
+        )
+        Scanamo.put(dynamoDbClient)(tableName)(newRecord)
+
+        val oldRecord = SierraItemRecord(
+          id = id,
+          data = s"""
+             |{
+             |  "id": "$id",
+             |  "updatedDate": "$oldUpdatedDate",
+             |  "comment": "I am an old record",
+             |  "bibIds": ["00000"]
+             |}
+       """.stripMargin,
+          modifiedDate = oldUpdatedDate,
+          bibIds = List("00000")
+        )
+
+        val futureUnit = dynamoInserter.insertIntoDynamo(oldRecord)
+        whenReady(futureUnit) { _ =>
+          Scanamo.get[SierraItemRecord](dynamoDbClient)(tableName)(
+            'id -> s"$id") shouldBe Some(Right(newRecord))
+        }
+    }
+  }
+
+  it("overwrites old data with new data") {
+    withDynamoInserter {
+      case (tableName, dynamoInserter) =>
+        val id = "300003"
+        val oldUpdatedDate = "2001-01-01T01:01:01Z"
+        val newUpdatedDate = "2011-11-11T11:11:11Z"
+
+        val oldRecord = SierraItemRecord(
+          id = s"$id",
+          modifiedDate = Instant.parse(oldUpdatedDate),
+          data =
+            s"""{"id": "$id", "updatedDate": "$oldUpdatedDate", "comment": "Legacy line of lamentable leopards", "bibIds": ["1556974"]}""",
+          bibIds = List("1556974"),
+          version = 1
+        )
+        Scanamo.put(dynamoDbClient)(tableName)(oldRecord)
+
+        val newRecord = SierraItemRecord(
+          id = s"$id",
+          modifiedDate = newUpdatedDate,
+          data = s"""
+             |{
+             |  "id": "$id",
+             |  "updatedDate": "$newUpdatedDate",
+             |  "comment": "Nice! New notes about narwhals in November",
+             |  "bibIds": ["1556974", "11111"]
+             |}
+       """.stripMargin,
+          bibIds = List("1556974", "11111")
+        )
+
+        val futureUnit = dynamoInserter.insertIntoDynamo(newRecord)
+
+        whenReady(futureUnit) { _ =>
+          Scanamo.get[SierraItemRecord](dynamoDbClient)(tableName)(
+            'id -> s"$id") shouldBe Some(Right(newRecord.copy(version = 2)))
+        }
+    }
+  }
+
+  it("records unlinked bibIds") {
+    withDynamoInserter {
+      case (tableName, dynamoInserter) =>
+        val id = "300003"
+        val oldUpdatedDate = "2001-01-01T01:01:01Z"
+        val newUpdatedDate = "2011-11-11T11:11:11Z"
+
+        val oldRecord = SierraItemRecord(
+          id = s"$id",
+          modifiedDate = oldUpdatedDate,
+          data =
+            s"""{"id": "$id", "updatedDate": "$oldUpdatedDate", "bibIds": ["b1", "b2", "b3"]}""",
+          bibIds = List("b1", "b2", "b3")
+        )
+        Scanamo.put(dynamoDbClient)(tableName)(oldRecord)
+
+        val newRecord = SierraItemRecord(
+          id = s"$id",
+          modifiedDate = newUpdatedDate,
+          data = s"""
+             |{
+             |  "id": "$id",
+             |  "updatedDate": "$newUpdatedDate",
+             |  "bibIds": ["b1", "b2"]
+             |}
+       """.stripMargin,
+          bibIds = List("b1", "b2")
+        )
+
+        val futureUnit = dynamoInserter.insertIntoDynamo(newRecord)
+
+        whenReady(futureUnit) { _ =>
+          Scanamo.get[SierraItemRecord](dynamoDbClient)(tableName)(
+            'id -> s"$id") shouldBe Some(
+            Right(newRecord.copy(version = 1, unlinkedBibIds = List("b3"))))
+        }
+    }
+  }
+
+  it("adds new bibIds and records unlinked bibIds in the same update") {
+    withDynamoInserter {
+      case (tableName, dynamoInserter) =>
+        val id = "300003"
+        val oldUpdatedDate = "2001-01-01T01:01:01Z"
+        val newUpdatedDate = "2011-11-11T11:11:11Z"
+
+        val oldRecord = SierraItemRecord(
+          id = s"$id",
+          modifiedDate = oldUpdatedDate,
+          data =
+            s"""{"id": "$id", "updatedDate": "$oldUpdatedDate", "bibIds": ["b1", "b2", "b3"]}""",
+          bibIds = List("b1", "b2", "b3")
+        )
+        Scanamo.put(dynamoDbClient)(tableName)(oldRecord)
+
+        val newRecord = SierraItemRecord(
+          id = s"$id",
+          modifiedDate = newUpdatedDate,
+          data = s"""
+             |{
+             |  "id": "$id",
+             |  "updatedDate": "$newUpdatedDate",
+             |  "bibIds": ["b2", "b3", "b4"]
+             |}
+       """.stripMargin,
+          bibIds = List("b2", "b3", "b4")
+        )
+
+        val futureUnit = dynamoInserter.insertIntoDynamo(newRecord)
+
+        whenReady(futureUnit) { _ =>
+          Scanamo.get[SierraItemRecord](dynamoDbClient)(tableName)(
+            'id -> s"$id") shouldBe Some(
+            Right(newRecord.copy(version = 1, unlinkedBibIds = List("b1"))))
+        }
+    }
+  }
+
+  it("preserves existing unlinked bibIds in DynamoDB") {
+    withDynamoInserter {
+      case (tableName, dynamoInserter) =>
+        val id = "300003"
+        val oldUpdatedDate = "2001-01-01T01:01:01Z"
+        val newUpdatedDate = "2011-11-11T11:11:11Z"
+
+        val oldRecord = SierraItemRecord(
+          id = s"$id",
+          modifiedDate = oldUpdatedDate,
+          data =
+            s"""{"id": "$id", "updatedDate": "$oldUpdatedDate", "bibIds": ["b1" ,"b2", "b3"]}""",
+          bibIds = List("b1", "b2", "b3"),
+          unlinkedBibIds = List("b5")
+        )
+
+        Scanamo.put(dynamoDbClient)(tableName)(oldRecord)
+
+        val newRecord = SierraItemRecord(
+          id = s"$id",
+          modifiedDate = newUpdatedDate,
+          data = s"""
+             |{
+             |  "id": "$id",
+             |  "updatedDate": "$newUpdatedDate",
+             |  "bibIds": ["b2", "b3", "b4"]
+             |}
+       """.stripMargin,
+          bibIds = List("b2", "b3", "b4")
+        )
+
+        val futureUnit = dynamoInserter.insertIntoDynamo(newRecord)
+
+        whenReady(futureUnit) { _ =>
+          Scanamo.get[SierraItemRecord](dynamoDbClient)(tableName)(
+            'id -> s"$id") shouldBe Some(
+            Right(
+              newRecord.copy(version = 1, unlinkedBibIds = List("b5", "b1"))))
+        }
+    }
+  }
+
+  it("fails if a dao returns an error when updating an item") {
+
+    val record =
+      SierraItemRecord("500005", "{}", "2005-05-05T05:05:05Z", bibIds = List())
+
+    val mockedDao = mock[VersionedDao]
+    val expectedException = new RuntimeException("AAAAAARGH!")
+
+    when(
+      mockedDao.getRecord[SierraItemRecord](any[String])(
+        any[DynamoFormat[SierraItemRecord]]))
+      .thenReturn(Future.successful(Some(
+        SierraItemRecord(id = "500005", "{}", "2001-01-01T00:00:00Z", List()))))
+
+    when(
+      mockedDao.updateRecord(any[SierraItemRecord])(
+        any[DynamoFormat[SierraItemRecord]],
+        any[VersionUpdater[SierraItemRecord]],
+        any[IdGetter[SierraItemRecord]],
+        any[VersionGetter[SierraItemRecord]],
+        any[UpdateExpressionGenerator[SierraItemRecord]]
+      ))
+      .thenThrow(expectedException)
+
+    val dynamoInserter = new DynamoInserter(mockedDao)
+
+    val futureUnit = dynamoInserter.insertIntoDynamo(record)
+    whenReady(futureUnit.failed) { ex =>
+      ex shouldBe expectedException
+    }
+  }
+
+  it("fails if the dao returns an error when getting an item") {
+    val record =
+      SierraItemRecord("500005", "{}", "2005-05-05T05:05:05Z", bibIds = List())
+
+    val mockedDao = mock[VersionedDao]
+
+
+    val expectedException = new RuntimeException("BLAAAAARGH!")
+
+    when(mockedDao.getRecord(any[String])(any[DynamoFormat[SierraItemRecord]]))
+      .thenReturn(Future.failed(expectedException))
+
+    val dynamoInserter = new DynamoInserter(mockedDao)
+    val futureUnit = dynamoInserter.insertIntoDynamo(record)
+
+    whenReady(futureUnit.failed) { ex =>
+      ex shouldBe expectedException
+    }
+  }
+
+  it("does not insert an item into DynamoDb if it's not changed") {
+    val id = "100001"
+    val updatedDate = "2013-12-13T12:43:16Z"
+
+    val record = SierraItemRecord(
+      id = id,
+      data = s"""
+                                                     |{
+                                                     | "id": "$id",
+                                                     | "updatedDate": "$updatedDate",
+                                                     | "bibIds": ["1556974"]
+                                                     |}
+      """.stripMargin,
+      modifiedDate = updatedDate,
+      bibIds = List("1556974")
+    )
+
+    val newUpdatedDate = "2014-12-13T12:43:16Z"
+    val newRecord = SierraItemRecord(
+      id = s"$id",
+      modifiedDate = newUpdatedDate,
+      data =
+        s"""{"id": "$id", "updatedDate": "$newUpdatedDate", "comment": "I am a shiny new record", "bibIds": ["1556974", "1556975"]}""",
+      bibIds = List("1556974")
+    )
+
+    val mockedDao = mock[VersionedDao]
+
+    when(mockedDao.getRecord(any[String])(any[DynamoFormat[SierraItemRecord]]))
+      .thenReturn(Future.successful(Some(newRecord)))
+
+    val dynamoInserter = new DynamoInserter(mockedDao)
+    val futureUnit = dynamoInserter.insertIntoDynamo(record)
+
+    whenReady(futureUnit) { _ =>
+      verify(mockedDao, Mockito.never()).updateRecord(any[SierraItemRecord])(
+        any[DynamoFormat[SierraItemRecord]],
+        any[VersionUpdater[SierraItemRecord]],
+        any[IdGetter[SierraItemRecord]],
+        any[VersionGetter[SierraItemRecord]],
+        any[UpdateExpressionGenerator[SierraItemRecord]]
+      )
+    }
+  }
+}

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
@@ -11,10 +11,9 @@ import org.mockito.Mockito.{verify, when}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.aws.{DynamoConfig, SQSConfig}
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 import uk.ac.wellcome.dynamo._
-import uk.ac.wellcome.test.fixtures.{LocalDynamoDb, TestWith}
+import uk.ac.wellcome.platform.sierra_items_to_dynamo.fixtures.DynamoInserterFixture
 
 import scala.concurrent.Future
 import uk.ac.wellcome.test.utils.ExtendedPatience
@@ -23,27 +22,10 @@ import uk.ac.wellcome.type_classes.{IdGetter, VersionGetter, VersionUpdater}
 class DynamoInserterTest
     extends FunSpec
     with Matchers
-    with LocalDynamoDb[SierraItemRecord]
+    with DynamoInserterFixture
     with ScalaFutures
     with MockitoSugar
     with ExtendedPatience {
-
-  override lazy val evidence: DynamoFormat[SierraItemRecord] =
-    DynamoFormat[SierraItemRecord]
-
-  def withDynamoInserter[R](
-    testWith: TestWith[(String, DynamoInserter), R]): Unit = {
-    withLocalDynamoDbTable { tableName =>
-      val dynamoInserter = new DynamoInserter(
-        new VersionedDao(
-          dynamoDbClient,
-          dynamoConfig = DynamoConfig(tableName)
-        )
-      )
-
-      testWith((tableName, dynamoInserter))
-    }
-  }
 
   it("ingests a json item into DynamoDB") {
     withDynamoInserter {

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
@@ -264,8 +264,14 @@ class DynamoInserterTest
     when(
       mockedDao.getRecord[SierraItemRecord](any[String])(
         any[DynamoFormat[SierraItemRecord]]))
-      .thenReturn(Future.successful(Some(
-        SierraItemRecord(id = "500005", "{}", "2001-01-01T00:00:00Z", List()))))
+      .thenReturn(
+        Future.successful(
+          Some(
+            SierraItemRecord(
+              id = "500005",
+              "{}",
+              "2001-01-01T00:00:00Z",
+              List()))))
 
     when(
       mockedDao.updateRecord(any[SierraItemRecord])(
@@ -290,7 +296,6 @@ class DynamoInserterTest
       SierraItemRecord("500005", "{}", "2005-05-05T05:05:05Z", bibIds = List())
 
     val mockedDao = mock[VersionedDao]
-
 
     val expectedException = new RuntimeException("BLAAAAARGH!")
 

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -13,7 +13,10 @@ import uk.ac.wellcome.models.aws.{DynamoConfig, SQSConfig, SQSMessage}
 import uk.ac.wellcome.sqs.SQSReader
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.dynamo._
-import uk.ac.wellcome.models.transformable.sierra.{SierraItemRecord, SierraRecord}
+import uk.ac.wellcome.models.transformable.sierra.{
+  SierraItemRecord,
+  SierraRecord
+}
 import com.gu.scanamo.syntax._
 import uk.ac.wellcome.utils.JsonUtil._
 import org.mockito.Matchers.any
@@ -28,14 +31,14 @@ import scala.concurrent.duration._
 
 class SierraItemsToDynamoWorkerServiceTest
     extends FunSpec
-      with DynamoInserterFixture
-      with SQS
-      with Matchers
-      with Eventually
-      with ExtendedPatience
-      with MockitoSugar
-      with Akka
-      with ScalaFutures {
+    with DynamoInserterFixture
+    with SQS
+    with Matchers
+    with Eventually
+    with ExtendedPatience
+    with MockitoSugar
+    with Akka
+    with ScalaFutures {
 
   override lazy val evidence: DynamoFormat[SierraItemRecord] =
     DynamoFormat[SierraItemRecord]
@@ -70,10 +73,11 @@ class SierraItemsToDynamoWorkerServiceTest
                   new SQSReader(sqsClient, SQSConfig(queueUrl, 1.second, 1)),
                 system = actorSystem,
                 metrics = mockMetrics,
-                dynamoInserter = new DynamoInserter(new VersionedDao(
-                  dynamoDbClient = dynamoDbClient,
-                  dynamoConfig = DynamoConfig(tableName)
-                ))
+                dynamoInserter = new DynamoInserter(
+                  new VersionedDao(
+                    dynamoDbClient = dynamoDbClient,
+                    dynamoConfig = DynamoConfig(tableName)
+                  ))
               )
 
             testWith(
@@ -119,12 +123,12 @@ class SierraItemsToDynamoWorkerServiceTest
       )
 
       val sqsMessage = SQSMessage(
-          Some("subject"),
-          toJson(record2).get,
-          "topic",
-          "messageType",
-          "timestamp"
-        )
+        Some("subject"),
+        toJson(record2).get,
+        "topic",
+        "messageType",
+        "timestamp"
+      )
 
       sqsClient.sendMessage(fixtures.queueUrl, toJson(sqsMessage).get)
 
@@ -132,8 +136,8 @@ class SierraItemsToDynamoWorkerServiceTest
       val expectedUnlinkedBibIds = List("1", "2")
 
       val expectedRecord = SierraItemRecordMerger.mergeItems(
-              existingRecord = record1,
-              updatedRecord = record2.toItemRecord.get
+        existingRecord = record1,
+        updatedRecord = record2.toItemRecord.get
       )
 
       val expectedData = expectedRecord.data
@@ -147,13 +151,13 @@ class SierraItemsToDynamoWorkerServiceTest
 
         scanamoResult shouldBe defined
         scanamoResult.get shouldBe Right(
-          SierraItemRecord(id = id,
+          SierraItemRecord(
+            id = id,
             data = expectedData,
             modifiedDate = modifiedDate2,
             bibIds = expectedBibIds,
             unlinkedBibIds = expectedUnlinkedBibIds,
-            version = 1
-          ))
+            version = 1))
       }
     }
   }
@@ -181,10 +185,10 @@ class SierraItemsToDynamoWorkerServiceTest
     }
   }
 
-  private def sierraRecordData(bibIds: List[String] = List(),
-                               unlinkedBibIds: List[String] = List(),
-                               modifiedDate: String = "2001-01-01T01:01:01Z"
-                          ): String = {
+  private def sierraRecordData(
+    bibIds: List[String] = List(),
+    unlinkedBibIds: List[String] = List(),
+    modifiedDate: String = "2001-01-01T01:01:01Z"): String = {
 
     val sierraItemRecord = SierraItemRecord(
       id = s"i111",


### PR DESCRIPTION
### What is this PR trying to achieve?

The `DynamoInserter` was removed in a previous change but is required to properly ingest item changes. This PR replaces the `DynamoInserter` and updates tests to ensure it cannot be removed by accident in the future.

### Who is this change for?

🌾 🍑 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.