### PR TITLE
Human-readable reports of file analysis in Travis

### DIFF
--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -20,7 +20,7 @@ from travistooling.decisions import (
     IgnoredPath,
     InsignificantFile,
     ScalaChangeAndIsScalaApp,
-    ScalaChangeAndScalaFree,
+    ScalaChangeAndNotScalaApp,
     SignificantFile,
     UnrecognisedFile
 )
@@ -79,7 +79,7 @@ def does_file_affect_build_job(path, task_name):
                 if project.type == 'sbt_app':
                     raise ScalaChangeAndIsScalaApp()
                 else:
-                    raise ScalaChangeAndScalaFree()
+                    raise ScalaChangeAndNotScalaApp()
 
     # If we can't decide if a file affects a build job, we assume it's
     # significant and run the job just-in-case.

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -36,15 +36,15 @@ def does_file_affect_build_job(path, task_name):
         task_name == 'travis-format' and
         path.endswith(('.scala', '.tf', '.py', '.json', '.ttl'))
     ):
-        raise KnownAffectsThisTask(path)
+        raise KnownAffectsThisTask()
 
     # These extensions and paths never have an effect on tests.
     if path.endswith(('.md', '.png', '.graffle', '.tf')):
-        raise IgnoredFileFormat(path)
+        raise IgnoredFileFormat()
 
     # These paths never have an effect on tests.
     if path in ['LICENSE', ] or path.startswith(('misc/', 'ontologies/')):
-        raise IgnoredPath(path)
+        raise IgnoredPath()
 
     # Some directories only affect one task.
     #
@@ -58,9 +58,9 @@ def does_file_affect_build_job(path, task_name):
     for dir_name, task_name_prefix in exclusive_directories.items():
         if path.startswith(dir_name):
             if task_name.startswith(task_name_prefix):
-                raise KnownAffectsThisTask(path)
+                raise KnownAffectsThisTask()
             else:
-                raise KnownDoesNotAffectThisTask(path)
+                raise KnownDoesNotAffectThisTask()
 
     # We have a couple of sbt common libs and files scattered around the
     # repository; changes to any of these don't affect non-sbt applications.
@@ -74,13 +74,13 @@ def does_file_affect_build_job(path, task_name):
         for project in PROJECTS:
             if task_name.startswith(project.name):
                 if project.type == 'sbt_app':
-                    raise KnownAffectsThisTask(path)
+                    raise KnownAffectsThisTask()
                 else:
-                    raise KnownDoesNotAffectThisTask(path)
+                    raise KnownDoesNotAffectThisTask()
 
     # If we can't decide if a file affects a build job, we assume it's
     # significant and run the job just-in-case.
-    raise UnrecognisedFile(path)
+    raise UnrecognisedFile()
 
 
 def should_run_job(changed_paths, task_name):

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -101,9 +101,9 @@ def should_run_job(changed_paths, task_name):
         try:
             does_file_affect_build_job(path=path, task_name=task_name)
         except InsignificantFile as err:
-            report[False][type(err)].add(path)
+            report[False][err.message].add(path)
         except SignificantFile as err:
-            report[True][type(err)].add(path)
+            report[True][err.message].add(path)
 
     return (
         bool(report[True]),

--- a/travistooling/decisions.py
+++ b/travistooling/decisions.py
@@ -5,11 +5,6 @@ class Decision(Exception):
     """
     The base class for all decisions.
     """
-    path = None
-
-    def __init__(self, path):
-        self.path == path
-        super(Decision, self).__init__()
 
 
 class SignificantFile(Decision):

--- a/travistooling/decisions.py
+++ b/travistooling/decisions.py
@@ -55,5 +55,5 @@ class ScalaChangeAndIsScalaApp(SignificantFile):
     message = 'Changes to Scala common libs affect Scala apps'
 
 
-class ScalaChangeAndScalaFree(InsignificantFile):
+class ScalaChangeAndNotScalaApp(InsignificantFile):
     message = 'Changes to Scala common libs are irrelevant to non-Scala apps'

--- a/travistooling/decisions.py
+++ b/travistooling/decisions.py
@@ -5,6 +5,7 @@ class Decision(Exception):
     """
     The base class for all decisions.
     """
+    message = None
 
 
 class SignificantFile(Decision):
@@ -22,30 +23,37 @@ class InsignificantFile(Decision):
 
 
 class UnrecognisedFile(SignificantFile):
-    """
-    We cannot determine if this file has an effect on the current build task.
-    """
+    message = 'Unrecognised file, so assuming significant'
 
 
 class IgnoredPath(InsignificantFile):
-    """
-    This path never has an effect on build tasks.
-    """
+    message = 'Path has no effect on build tasks'
 
 
-class IgnoredFileFormat(IgnoredPath):
-    """
-    This file format never has an effect on build tasks.
-    """
+class IgnoredFileFormat(InsignificantFile):
+    message = 'File format has no effect on build tasks'
 
 
-class KnownAffectsThisTask(SignificantFile):
-    """
-    This file has a known effect on this build task.
-    """
+class ExclusivelyAffectsThisTask(SignificantFile):
+    message = 'Path is an exclusive dependency of this build task'
 
 
-class KnownDoesNotAffectThisTask(InsignificantFile):
-    """
-    This file is known not to affect this build task.
-    """
+class ExclusivelyAffectsAnotherTask(InsignificantFile):
+    def __init__(self, other_task):
+        self.message = (
+            'Path is an exclusive dependency of a different build task (%s)' %
+            (other_task,)
+        )
+        super(ExclusivelyAffectsAnotherTask, self).__init__()
+
+
+class CheckedByTravisFormat(SignificantFile):
+    message = 'File format is checked by the travis-format task'
+
+
+class ScalaChangeAndIsScalaApp(SignificantFile):
+    message = 'Changes to Scala common libs affect Scala apps'
+
+
+class ScalaChangeAndScalaFree(InsignificantFile):
+    message = 'Changes to Scala common libs are irrelevant to non-Scala apps'

--- a/travistooling/reports.py
+++ b/travistooling/reports.py
@@ -14,7 +14,7 @@ def build_report_output(report, description='run tests'):
         if report[significance]:
             lines.append('## %s %s ##' % (prefix, description))
             for reason, affected_paths in report[significance].items():
-                lines.append('\n%s:' % reason.__name__)
+                lines.append('\n%s:' % reason)
                 for p in sorted(affected_paths):
                     lines.append(' - %s' % p)
 

--- a/travistooling/test_decisionmaker.py
+++ b/travistooling/test_decisionmaker.py
@@ -13,7 +13,7 @@ from travistooling.decisions import (
     IgnoredFileFormat,
     IgnoredPath,
     ScalaChangeAndIsScalaApp,
-    ScalaChangeAndScalaFree,
+    ScalaChangeAndNotScalaApp,
     UnrecognisedFile
 )
 
@@ -54,11 +54,11 @@ from travistooling.decisions import (
     ('catalogue_pipeline/ingestor/bar.scala', 'api-test', ExclusivelyAffectsAnotherTask, False),
 
     # Anything in the sierra_adapter directory/common lib
-    ('sierra_adapter/common/main.scala', 'loris-test', ScalaChangeAndScalaFree, False),
-    ('sierra_adapter/common/main.scala', 's3_demultiplexer-test', ScalaChangeAndScalaFree, False),
-    ('sierra_adapter/common/main.scala', 'sierra_window_generator-test', ScalaChangeAndScalaFree, False),
+    ('sierra_adapter/common/main.scala', 'loris-test', ScalaChangeAndNotScalaApp, False),
+    ('sierra_adapter/common/main.scala', 's3_demultiplexer-test', ScalaChangeAndNotScalaApp, False),
+    ('sierra_adapter/common/main.scala', 'sierra_window_generator-test', ScalaChangeAndNotScalaApp, False),
     ('sbt_common/display/model.scala', 'id_minter-test', ScalaChangeAndIsScalaApp, True),
-    ('sbt_common/display/model.scala', 'loris-publish', ScalaChangeAndScalaFree, False),
+    ('sbt_common/display/model.scala', 'loris-publish', ScalaChangeAndNotScalaApp, False),
     ('sbt_common/display/model.scala', 'sierra_adapter-publish', UnrecognisedFile, True),
 ])
 def test_does_file_affect_build_job(path, task_name, exc_class, is_significant):
@@ -78,7 +78,7 @@ def test_should_not_run_job_with_no_relevant_changes():
         task_name='loris-test'
     )
     assert result == (False, {
-        False: {ScalaChangeAndScalaFree.message: set(['sierra_adapter/common/main.scala'])},
+        False: {ScalaChangeAndNotScalaApp.message: set(['sierra_adapter/common/main.scala'])},
         True: {}
     })
 
@@ -92,6 +92,6 @@ def test_should_run_job_with_relevant_changes():
         task_name='loris-test'
     )
     assert result == (True, {
-        False: {ScalaChangeAndScalaFree.message: set(['sierra_adapter/common/main.scala'])},
+        False: {ScalaChangeAndNotScalaApp.message: set(['sierra_adapter/common/main.scala'])},
         True: {ExclusivelyAffectsThisTask.message: set(['loris/loris/Dockerfile'])}
     })

--- a/travistooling/test_decisionmaker.py
+++ b/travistooling/test_decisionmaker.py
@@ -78,7 +78,7 @@ def test_should_not_run_job_with_no_relevant_changes():
         task_name='loris-test'
     )
     assert result == (False, {
-        False: {ScalaChangeAndScalaFree: set(['sierra_adapter/common/main.scala'])},
+        False: {ScalaChangeAndScalaFree.message: set(['sierra_adapter/common/main.scala'])},
         True: {}
     })
 
@@ -92,6 +92,6 @@ def test_should_run_job_with_relevant_changes():
         task_name='loris-test'
     )
     assert result == (True, {
-        False: {ScalaChangeAndScalaFree: set(['sierra_adapter/common/main.scala'])},
-        True: {ExclusivelyAffectsThisTask: set(['loris/loris/Dockerfile'])}
+        False: {ScalaChangeAndScalaFree.message: set(['sierra_adapter/common/main.scala'])},
+        True: {ExclusivelyAffectsThisTask.message: set(['loris/loris/Dockerfile'])}
     })

--- a/travistooling/test_decisionmaker.py
+++ b/travistooling/test_decisionmaker.py
@@ -7,20 +7,23 @@ from travistooling.decisionmaker import (
     should_run_job
 )
 from travistooling.decisions import (
+    CheckedByTravisFormat,
+    ExclusivelyAffectsAnotherTask,
+    ExclusivelyAffectsThisTask,
     IgnoredFileFormat,
     IgnoredPath,
-    KnownAffectsThisTask,
-    KnownDoesNotAffectThisTask,
+    ScalaChangeAndIsScalaApp,
+    ScalaChangeAndScalaFree,
     UnrecognisedFile
 )
 
 
 @pytest.mark.parametrize('path, task_name, exc_class, is_significant', [
     # Travis format task
-    ('misc/myscript.py', 'travis-format', KnownAffectsThisTask, True),
-    ('ontologies/item.ttl', 'travis-format', KnownAffectsThisTask, True),
-    ('main.tf', 'travis-format', KnownAffectsThisTask, True),
-    ('example.json', 'travis-format', KnownAffectsThisTask, True),
+    ('misc/myscript.py', 'travis-format', CheckedByTravisFormat, True),
+    ('ontologies/item.ttl', 'travis-format', CheckedByTravisFormat, True),
+    ('main.tf', 'travis-format', CheckedByTravisFormat, True),
+    ('example.json', 'travis-format', CheckedByTravisFormat, True),
     ('README.md', 'travis-format', IgnoredFileFormat, False),
 
     # Unrecognised filenames fall through to being significant, regardless
@@ -45,17 +48,17 @@ from travistooling.decisions import (
     ('ontologies/work.ttl', 'monitoring-publish', IgnoredPath, False),
 
     # Changes that belong exclusively to a single task
-    ('loris/loris/Dockerfile', 'loris-build', KnownAffectsThisTask, True),
-    ('loris/loris/Dockerfile', 'ingestor-test', KnownDoesNotAffectThisTask, False),
-    ('sierra_adapter/sierra_reader/foo.scala', 'sierra_reader-publish', KnownAffectsThisTask, True),
-    ('catalogue_pipeline/ingestor/bar.scala', 'api-test', KnownDoesNotAffectThisTask, False),
+    ('loris/loris/Dockerfile', 'loris-build', ExclusivelyAffectsThisTask, True),
+    ('loris/loris/Dockerfile', 'ingestor-test', ExclusivelyAffectsAnotherTask, False),
+    ('sierra_adapter/sierra_reader/foo.scala', 'sierra_reader-publish', ExclusivelyAffectsThisTask, True),
+    ('catalogue_pipeline/ingestor/bar.scala', 'api-test', ExclusivelyAffectsAnotherTask, False),
 
     # Anything in the sierra_adapter directory/common lib
-    ('sierra_adapter/common/main.scala', 'loris-test', KnownDoesNotAffectThisTask, False),
-    ('sierra_adapter/common/main.scala', 's3_demultiplexer-test', KnownDoesNotAffectThisTask, False),
-    ('sierra_adapter/common/main.scala', 'sierra_window_generator-test', KnownDoesNotAffectThisTask, False),
-    ('sbt_common/display/model.scala', 'id_minter-test', KnownAffectsThisTask, True),
-    ('sbt_common/display/model.scala', 'loris-publish', KnownDoesNotAffectThisTask, False),
+    ('sierra_adapter/common/main.scala', 'loris-test', ScalaChangeAndScalaFree, False),
+    ('sierra_adapter/common/main.scala', 's3_demultiplexer-test', ScalaChangeAndScalaFree, False),
+    ('sierra_adapter/common/main.scala', 'sierra_window_generator-test', ScalaChangeAndScalaFree, False),
+    ('sbt_common/display/model.scala', 'id_minter-test', ScalaChangeAndIsScalaApp, True),
+    ('sbt_common/display/model.scala', 'loris-publish', ScalaChangeAndScalaFree, False),
     ('sbt_common/display/model.scala', 'sierra_adapter-publish', UnrecognisedFile, True),
 ])
 def test_does_file_affect_build_job(path, task_name, exc_class, is_significant):
@@ -75,7 +78,7 @@ def test_should_not_run_job_with_no_relevant_changes():
         task_name='loris-test'
     )
     assert result == (False, {
-        False: {KnownDoesNotAffectThisTask: set(['sierra_adapter/common/main.scala'])},
+        False: {ScalaChangeAndScalaFree: set(['sierra_adapter/common/main.scala'])},
         True: {}
     })
 
@@ -89,6 +92,6 @@ def test_should_run_job_with_relevant_changes():
         task_name='loris-test'
     )
     assert result == (True, {
-        False: {KnownDoesNotAffectThisTask: set(['sierra_adapter/common/main.scala'])},
-        True: {KnownAffectsThisTask: set(['loris/loris/Dockerfile'])}
+        False: {ScalaChangeAndScalaFree: set(['sierra_adapter/common/main.scala'])},
+        True: {ExclusivelyAffectsThisTask: set(['loris/loris/Dockerfile'])}
     })

--- a/travistooling/test_reports.py
+++ b/travistooling/test_reports.py
@@ -3,7 +3,7 @@
 from travistooling.decisions import (
     ExclusivelyAffectsThisTask,
     IgnoredPath,
-    ScalaChangeAndScalaFree,
+    ScalaChangeAndNotScalaApp,
 )
 from travistooling.reports import build_report_output
 
@@ -15,7 +15,7 @@ def test_build_complete_report():
         },
         False: {
             IgnoredPath.message: set(['README.md', 'LICENSE']),
-            ScalaChangeAndScalaFree.message: set(['main.scala']),
+            ScalaChangeAndNotScalaApp.message: set(['main.scala']),
         },
     }
     assert build_report_output(report) == """
@@ -41,7 +41,7 @@ def test_report_only_includes_relevant_sections():
         True: {},
         False: {
             IgnoredPath.message: set(['README.md', 'LICENSE']),
-            ScalaChangeAndScalaFree.message: set(['main.scala']),
+            ScalaChangeAndNotScalaApp.message: set(['main.scala']),
         },
     }
     assert build_report_output(report) == """

--- a/travistooling/test_reports.py
+++ b/travistooling/test_reports.py
@@ -11,28 +11,28 @@ from travistooling.reports import build_report_output
 def test_build_complete_report():
     report = {
         True: {
-            ExclusivelyAffectsThisTask: set(['foo/bar.txt', 'foo/baz.txt']),
+            ExclusivelyAffectsThisTask.message: set(['foo/bar.txt', 'foo/baz.txt']),
         },
         False: {
-            IgnoredPath: set(['README.md', 'LICENSE']),
-            ScalaChangeAndScalaFree: set(['main.scala']),
+            IgnoredPath.message: set(['README.md', 'LICENSE']),
+            ScalaChangeAndScalaFree.message: set(['main.scala']),
         },
     }
     assert build_report_output(report) == """
 ## Reasons to run tests ##
 
-ExclusivelyAffectsThisTask:
+Path is an exclusive dependency of this build task:
  - foo/bar.txt
  - foo/baz.txt
 
 
 ## Reasons not to run tests ##
 
-IgnoredPath:
+Path has no effect on build tasks:
  - LICENSE
  - README.md
 
-ScalaChangeAndScalaFree:
+Changes to Scala common libs are irrelevant to non-Scala apps:
  - main.scala""".strip()
 
 
@@ -40,16 +40,16 @@ def test_report_only_includes_relevant_sections():
     report = {
         True: {},
         False: {
-            IgnoredPath: set(['README.md', 'LICENSE']),
-            ScalaChangeAndScalaFree: set(['main.scala']),
+            IgnoredPath.message: set(['README.md', 'LICENSE']),
+            ScalaChangeAndScalaFree.message: set(['main.scala']),
         },
     }
     assert build_report_output(report) == """
 ## Reasons not to run tests ##
 
-IgnoredPath:
+Path has no effect on build tasks:
  - LICENSE
  - README.md
 
-ScalaChangeAndScalaFree:
+Changes to Scala common libs are irrelevant to non-Scala apps:
  - main.scala""".strip()

--- a/travistooling/test_reports.py
+++ b/travistooling/test_reports.py
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8
 
 from travistooling.decisions import (
-    KnownAffectsThisTask,
-    KnownDoesNotAffectThisTask,
+    ExclusivelyAffectsThisTask,
     IgnoredPath,
+    ScalaChangeAndScalaFree,
 )
 from travistooling.reports import build_report_output
 
@@ -11,17 +11,17 @@ from travistooling.reports import build_report_output
 def test_build_complete_report():
     report = {
         True: {
-            KnownAffectsThisTask: set(['foo/bar.txt', 'foo/baz.txt']),
+            ExclusivelyAffectsThisTask: set(['foo/bar.txt', 'foo/baz.txt']),
         },
         False: {
             IgnoredPath: set(['README.md', 'LICENSE']),
-            KnownDoesNotAffectThisTask: set(['main.scala']),
+            ScalaChangeAndScalaFree: set(['main.scala']),
         },
     }
     assert build_report_output(report) == """
 ## Reasons to run tests ##
 
-KnownAffectsThisTask:
+ExclusivelyAffectsThisTask:
  - foo/bar.txt
  - foo/baz.txt
 
@@ -32,7 +32,7 @@ IgnoredPath:
  - LICENSE
  - README.md
 
-KnownDoesNotAffectThisTask:
+ScalaChangeAndScalaFree:
  - main.scala""".strip()
 
 
@@ -41,7 +41,7 @@ def test_report_only_includes_relevant_sections():
         True: {},
         False: {
             IgnoredPath: set(['README.md', 'LICENSE']),
-            KnownDoesNotAffectThisTask: set(['main.scala']),
+            ScalaChangeAndScalaFree: set(['main.scala']),
         },
     }
     assert build_report_output(report) == """
@@ -51,5 +51,5 @@ IgnoredPath:
  - LICENSE
  - README.md
 
-KnownDoesNotAffectThisTask:
+ScalaChangeAndScalaFree:
  - main.scala""".strip()


### PR DESCRIPTION
Another chunk of build tooling before I switch everything over to the new system. This one improves the reports you get explaining file decisions. For example:

```
## Reasons to run tests ##

Path is an exclusive dependency of this build task:
 - foo/bar.txt
 - foo/baz.txt


## Reasons not to run tests ##

Path has no effect on build tasks:
 - LICENSE
 - README.md

Changes to Scala common libs are irrelevant to non-Scala apps:
 - main.scala
```