### PR TITLE
Freeze the V1 DisplayWork model

### DIFF
--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
@@ -1,0 +1,145 @@
+package uk.ac.wellcome.display.models.v1
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.display.models._
+import uk.ac.wellcome.models.IdentifiedWork
+
+@ApiModel(
+  value = "Work",
+  description =
+    "An individual work such as a text, archive item or picture; or a grouping of individual works (so, for instance, an archive collection counts as a work, as do all the series and individual files within it).  Each work may exist in multiple instances (e.g. copies of the same book).  N.B. this is not synonymous with \\\"work\\\" as that is understood in the International Federation of Library Associations and Institutions' Functional Requirements for Bibliographic Records model (FRBR) but represents something lower down the FRBR hierarchy, namely manifestation. Groups of related items are also included as works because they have similar properties to the individual ones."
+)
+case class DisplayWorkV1(
+  @ApiModelProperty(
+    readOnly = true,
+    value = "The canonical identifier given to a thing.") id: String,
+  @ApiModelProperty(value =
+    "The title or other short label of a work, including labels not present in the actual work or item but applied by the cataloguer for the purposes of search or description.") title: String,
+  @ApiModelProperty(
+    dataType = "String",
+    value = "A description given to a thing.") description: Option[String] =
+    None,
+  @ApiModelProperty(
+    dataType = "String",
+    value = "A description of specific physical characteristics of the work.") physicalDescription: Option[
+    String] = None,
+  @ApiModelProperty(
+    dataType = "List[uk.ac.wellcome.display.models.DisplayWorkType]",
+    value = "The type of work.") workType: Option[DisplayWorkType] = None,
+  @ApiModelProperty(
+    dataType = "String",
+    value =
+      "Number of physical pages, volumes, cassettes, total playing time, etc., of of each type of unit"
+  ) extent: Option[String] = None,
+  @ApiModelProperty(
+    dataType = "String",
+    value = "Recording written text on a (usually visual) work.") lettering: Option[
+    String] = None,
+  @ApiModelProperty(
+    dataType = "uk.ac.wellcome.display.models.DisplayPeriod",
+    value =
+      "Relates the creation of a work to a date, when the date of creation does not cover a range."
+  ) createdDate: Option[DisplayPeriod] = None,
+  @ApiModelProperty(
+    dataType = "List[uk.ac.wellcome.display.models.DisplayAbstractAgent]",
+    value =
+      "Relates a work to its author, compiler, editor, artist or other entity responsible for its coming into existence in the form that it has."
+  ) creators: List[DisplayAbstractAgent] = List(),
+  @ApiModelProperty(
+    dataType = "List[uk.ac.wellcome.display.models.DisplayIdentifier]",
+    value =
+      "Relates the item to a unique system-generated identifier that governs interaction between systems and is regarded as canonical within the Wellcome data ecosystem."
+  ) identifiers: Option[List[DisplayIdentifier]] = None,
+  @ApiModelProperty(
+    dataType = "uk.ac.wellcome.display.models.DisplayConcept",
+    value =
+      "Relates a work to the general thesaurus-based concept that describes the work's content."
+  ) subjects: List[DisplayConcept] = List(),
+  @ApiModelProperty(
+    dataType = "uk.ac.wellcome.display.models.DisplayConcept",
+    value = "Relates a work to the genre that describes the work's content.") genres: List[
+    DisplayConcept] = List(),
+  @ApiModelProperty(
+    dataType = "uk.ac.wellcome.display.models.DisplayLocation",
+    value =
+      "Relates any thing to the location of a representative thumbnail image"
+  ) thumbnail: Option[DisplayLocation] = None,
+  @ApiModelProperty(
+    dataType = "List[uk.ac.wellcome.display.models.DisplayItem]",
+    value = "List of items related to this work."
+  ) items: Option[List[DisplayItem]] = None,
+  @ApiModelProperty(
+    dataType = "List[uk.ac.wellcome.display.models.DisplayAbstractAgent]",
+    value = "Relates a published work to its publisher."
+  ) publishers: List[DisplayAbstractAgent] = List(),
+  @ApiModelProperty(
+    dataType = "List[uk.ac.wellcome.display.models.DisplayPlace]",
+    value = "Show a list of places of publication."
+  ) placesOfPublication: List[DisplayPlace] = List(),
+  @ApiModelProperty(
+    dataType = "uk.ac.wellcome.display.models.DisplayPeriod",
+    value =
+      "Relates the publication of a work to a date when the work has been formally published."
+  ) publicationDate: Option[DisplayPeriod] = None,
+  @ApiModelProperty(
+    dataType = "uk.ac.wellcome.display.models.DisplayLanguage",
+    value = "Relates a work to its primary language."
+  ) language: Option[DisplayLanguage] = None,
+  @ApiModelProperty(
+    dataType = "String"
+  ) dimensions: Option[String] = None
+) {
+  @ApiModelProperty(
+    readOnly = true,
+    value =
+      "A broad, top-level description of the form of a work: namely, whether it is a printed book, archive, painting, photograph, moving image, etc."
+  )
+  @JsonProperty("type") val ontologyType: String = "Work"
+}
+
+case object DisplayWorkV1 {
+
+  def apply(work: IdentifiedWork, includes: WorksIncludes): DisplayWorkV1 = {
+
+    if (!work.visible) {
+      throw new RuntimeException(
+        s"IdentifiedWork ${work.canonicalId} has visible=false, cannot be converted to DisplayWork")
+    }
+
+    DisplayWorkV1(
+      id = work.canonicalId,
+      title = work.title.get,
+      description = work.description,
+      physicalDescription = work.physicalDescription,
+      extent = work.extent,
+      lettering = work.lettering,
+      createdDate = work.createdDate.map { DisplayPeriod(_) },
+      creators = work.creators.map { DisplayAbstractAgent(_) },
+      subjects = work.subjects.map { DisplayConcept(_) },
+      genres = work.genres.map { DisplayConcept(_) },
+      identifiers =
+        if (includes.identifiers)
+          Some(work.identifiers.map { DisplayIdentifier(_) })
+        else None,
+      workType = work.workType.map { DisplayWorkType(_) },
+      thumbnail =
+        if (includes.thumbnail)
+          work.thumbnail.map { DisplayLocation(_) } else None,
+      items =
+        if (includes.items)
+          Some(work.items.map {
+            DisplayItem(_, includesIdentifiers = includes.identifiers)
+          })
+        else None,
+      publishers = work.publishers.map(DisplayAbstractAgent(_)),
+      publicationDate = work.publicationDate.map { DisplayPeriod(_) },
+      placesOfPublication = work.placesOfPublication.map { DisplayPlace(_) },
+      language = work.language.map { DisplayLanguage(_) },
+      dimensions = work.dimensions
+    )
+  }
+
+  def apply(work: IdentifiedWork): DisplayWork =
+    DisplayWork(work = work, includes = WorksIncludes())
+}

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -1,0 +1,573 @@
+package uk.ac.wellcome.display.models.v1
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.inject.Guice
+import org.scalatest.FunSpec
+import uk.ac.wellcome.display.models.{DisplaySerialisationTestBase, WorksIncludes, WorksUtil}
+import uk.ac.wellcome.display.modules.DisplayJacksonModule
+import uk.ac.wellcome.models._
+import uk.ac.wellcome.test.utils.JsonTestUtil
+
+class DisplayWorkV1SerialisationTest
+    extends FunSpec
+    with DisplaySerialisationTestBase
+    with JsonTestUtil
+    with WorksUtil {
+  val injector = Guice.createInjector(DisplayJacksonModule)
+
+  val objectMapper = injector.getInstance(classOf[ObjectMapper])
+
+  it("serialises a DisplayWorkV1 correctly") {
+
+    val work = workWith(
+      canonicalId = canonicalId,
+      title = title,
+      description = description,
+      lettering = lettering,
+      createdDate = period,
+      creator = agent,
+      items = List(defaultItem),
+      visible = true)
+
+    val actualJsonString = objectMapper.writeValueAsString(DisplayWorkV1(work))
+
+    val expectedJsonString = s"""
+       |{
+       | "type": "Work",
+       | "id": "$canonicalId",
+       | "title": "$title",
+       | "description": "$description",
+       | "workType": {
+       |       "id": "${workType.id}",
+       |       "label": "${workType.label}",
+       |       "type": "WorkType"
+       | },
+       | "lettering": "$lettering",
+       | "createdDate": ${period(work.createdDate.get)},
+       | "creators": [ ${identifiedOrUnidentifiable(
+                                  work.creators(0),
+                                  abstractAgent)} ],
+       | "subjects": [ ],
+       | "genres": [ ],
+       | "publishers": [ ],
+       | "placesOfPublication": [ ]
+       |}
+          """.stripMargin
+
+    assertJsonStringsAreEqual(actualJsonString, expectedJsonString)
+  }
+
+  it("renders an item if the items include is present") {
+    val work = workWith(
+      canonicalId = "b4heraz7",
+      title = "Inside an irate igloo",
+      items = List(
+        itemWith(
+          canonicalId = "c3a599u5",
+          identifier = defaultItemSourceIdentifier,
+          location = defaultLocation
+        )
+      )
+    )
+
+    val actualJson = objectMapper.writeValueAsString(
+      DisplayWorkV1(work, WorksIncludes(items = true)))
+    val expectedJson = s"""
+                          |{
+                          | "type": "Work",
+                          | "id": "${work.canonicalId}",
+                          | "title": "${work.title.get}",
+                          | "creators": [ ],
+                          | "items": [ ${items(work.items)} ],
+                          | "subjects": [ ],
+                          | "genres": [ ],
+                          | "publishers": [ ],
+                          | "placesOfPublication": [ ]
+                          |}
+          """.stripMargin
+
+    assertJsonStringsAreEqual(actualJson, expectedJson)
+  }
+
+  it("includes 'items' if the items include is present, even with no items") {
+    val work = workWith(
+      canonicalId = "dgdb712",
+      title = "Without windows or wind or washing-up liquid",
+      items = List()
+    )
+    val actualJson = objectMapper.writeValueAsString(
+      DisplayWorkV1(work, WorksIncludes(items = true)))
+    val expectedJson = s"""
+                          |{
+                          | "type": "Work",
+                          | "id": "${work.canonicalId}",
+                          | "title": "${work.title.get}",
+                          | "creators": [ ],
+                          | "items": [ ],
+                          | "subjects": [ ],
+                          | "genres": [ ],
+                          | "publishers": [ ],
+                          | "placesOfPublication": [ ]
+                          |}
+          """.stripMargin
+
+    assertJsonStringsAreEqual(actualJson, expectedJson)
+  }
+
+  it("includes credit information in DisplayWorkV1 serialisation") {
+    val location = DigitalLocation(
+      locationType = "thumbnail-image",
+      url = "",
+      credit = Some("Wellcome Collection"),
+      license = License_CCBY
+    )
+    val item = IdentifiedItem(
+      canonicalId = "chu27a8",
+      sourceIdentifier = sourceIdentifier,
+      identifiers = List(),
+      locations = List(location)
+    )
+    val workWithCopyright = IdentifiedWork(
+      title = Some("A scarf on a squirrel"),
+      sourceIdentifier = sourceIdentifier,
+      version = 1,
+      canonicalId = "yxh928a",
+      items = List(item))
+
+    val actualJson = objectMapper.writeValueAsString(
+      DisplayWorkV1(workWithCopyright, WorksIncludes(items = true)))
+    val expectedJson = s"""{
+                          |     "type": "Work",
+                          |     "id": "${workWithCopyright.canonicalId}",
+                          |     "title": "${workWithCopyright.title.get}",
+                          |     "creators": [ ],
+                          |     "subjects": [ ],
+                          |     "genres": [ ],
+                          |     "publishers": [ ],
+                          |     "placesOfPublication": [ ],
+                          |     "items": [
+                          |       {
+                          |         "id": "${item.canonicalId}",
+                          |         "type": "${item.ontologyType}",
+                          |         "locations": [
+                          |           {
+                          |             "type": "${location.ontologyType}",
+                          |             "url": "",
+                          |             "locationType": "${location.locationType}",
+                          |             "license": ${license(location.license)},
+                          |             "credit": "${location.credit.get}"
+                          |           }
+                          |         ]
+                          |       }
+                          |     ]
+                          |   }""".stripMargin
+
+    assertJsonStringsAreEqual(actualJson, expectedJson)
+  }
+
+  it("includes subject information in DisplayWorkV1 serialisation") {
+    val workWithSubjects = IdentifiedWork(
+      title = Some("A seal selling seaweed sandwiches in Scotland"),
+      sourceIdentifier = sourceIdentifier,
+      version = 1,
+      identifiers = List(),
+      canonicalId = "test_subject1",
+      subjects = List(Concept("fish"), Concept("gardening"))
+    )
+    val actualJson =
+      objectMapper.writeValueAsString(DisplayWorkV1(workWithSubjects))
+    val expectedJson = s"""{
+                          |     "type": "Work",
+                          |     "id": "${workWithSubjects.canonicalId}",
+                          |     "title": "${workWithSubjects.title.get}",
+                          |     "creators": [],
+                          |     "subjects": [ ${concepts(
+                            workWithSubjects.subjects)} ],
+                          |     "genres": [ ],
+                          |     "publishers": [ ],
+                          |     "placesOfPublication": [ ]
+                          |   }""".stripMargin
+
+    assertJsonStringsAreEqual(actualJson, expectedJson)
+  }
+
+  it("includes genre information in DisplayWorkV1 serialisation") {
+    val workWithSubjects = IdentifiedWork(
+      title = Some("A guppy in a greenhouse"),
+      sourceIdentifier = sourceIdentifier,
+      version = 1,
+      identifiers = List(),
+      canonicalId = "test_subject1",
+      genres = List(Concept("woodwork"), Concept("etching"))
+    )
+    val actualJson =
+      objectMapper.writeValueAsString(DisplayWorkV1(workWithSubjects))
+    val expectedJson = s"""
+                          |{
+                          |     "type": "Work",
+                          |     "id": "${workWithSubjects.canonicalId}",
+                          |     "title": "${workWithSubjects.title.get}",
+                          |     "creators": [],
+                          |     "subjects": [ ],
+                          |     "genres": [ ${concepts(workWithSubjects.genres)} ],
+                          |     "publishers": [ ],
+                          |     "placesOfPublication": [ ]
+                          |   }""".stripMargin
+
+    assertJsonStringsAreEqual(actualJson, expectedJson)
+
+  }
+
+  it(
+    "includes a list of identifiers on DisplayWorkV1") {
+    val srcIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.miroImageNumber,
+      ontologyType = "Work",
+      value = "Test1234"
+    )
+    val work = workWith(
+      canonicalId = "1234",
+      title = "An insect huddled in an igloo",
+      identifiers = List(srcIdentifier)
+    )
+    val actualJson = objectMapper.writeValueAsString(DisplayWorkV1(work, WorksIncludes(identifiers = true)))
+    val expectedJson = s"""
+                          |{
+                          | "type": "Work",
+                          | "id": "${work.canonicalId}",
+                          | "title": "${work.title.get}",
+                          | "creators": [ ],
+                          | "identifiers": [ ${identifier(srcIdentifier)} ],
+                          | "subjects": [ ],
+                          | "genres": [ ],
+                          | "publishers": [ ],
+                          | "placesOfPublication": [ ]
+                          |}
+          """.stripMargin
+      assertJsonStringsAreEqual(actualJson, expectedJson)
+  }
+
+  it(
+    "always includes 'identifiers' with the identifiers include, even if there are no identifiers") {
+    val work = workWith(
+      canonicalId = "a87na87",
+      title = "Idling inkwells of indigo images",
+      identifiers = List()
+    )
+    val actualJson = objectMapper.writeValueAsString(DisplayWorkV1(work, WorksIncludes(identifiers = true)))
+    val expectedJson = s"""
+                          |{
+                          | "type": "Work",
+                          | "id": "${work.canonicalId}",
+                          | "title": "${work.title.get}",
+                          | "creators": [ ],
+                          | "identifiers": [ ],
+                          | "subjects": [ ],
+                          | "genres": [ ],
+                          | "publishers": [ ],
+                          | "placesOfPublication": [ ]
+                          |}
+          """.stripMargin
+    assertJsonStringsAreEqual(actualJson, expectedJson)
+  }
+
+  it(
+    "includes the thumbnail field if available and we use the thumbnail include") {
+    val work = identifiedWorkWith(
+      canonicalId = "1234",
+      title = "A thorn in the thumb tells a traumatic tale",
+      thumbnail = DigitalLocation(
+        locationType = "thumbnail-image",
+        url = "https://iiif.example.org/1234/default.jpg",
+        license = License_CCBY
+      )
+    )
+    val actualJson = objectMapper.writeValueAsString(DisplayWorkV1(work, WorksIncludes(thumbnail = true)))
+    val expectedJson = s"""
+                          |   {
+                          |     "type": "Work",
+                          |     "id": "${work.canonicalId}",
+                          |     "title": "${work.title.get}",
+                          |     "creators": [ ],
+                          |     "subjects": [ ],
+                          |     "genres": [ ],
+                          |     "publishers": [ ],
+                          |     "placesOfPublication": [ ],
+                          |     "thumbnail": ${location(work.thumbnail.get)}
+                          |   }
+          """.stripMargin
+
+    assertJsonStringsAreEqual(actualJson, expectedJson)
+  }
+
+  describe("creators") {
+    it("serialises creators with a mixture of agents/organisations/persons") {
+      val work = IdentifiedWork(
+        canonicalId = "v9w6cz66",
+        sourceIdentifier = sourceIdentifier,
+        version = 1,
+        title = Some("Vultures vying for victory"),
+        creators = List(
+          Unidentifiable(Agent("Vivian Violet")),
+          Unidentifiable(Organisation("Verily Volumes")),
+          Unidentifiable(
+            Person(
+              label = "Havelock Vetinari",
+              prefix = Some("Lord Patrician"),
+              numeration = Some("I")))
+        )
+      )
+      val displayWork = DisplayWorkV1(work)
+
+      val actualJson = objectMapper.writeValueAsString(displayWork)
+      val expectedJson = s"""
+        |{
+        |  "type": "Work",
+        |  "id": "${work.canonicalId}",
+        |  "title": "${work.title.get}",
+        |  "creators": [
+        |    ${identifiedOrUnidentifiable(work.creators(0), abstractAgent)},
+        |    ${identifiedOrUnidentifiable(work.creators(1), abstractAgent)},
+        |    ${identifiedOrUnidentifiable(work.creators(2), abstractAgent)}
+        |  ],
+        |  "subjects": [ ],
+        |  "genres": [ ],
+        |  "publishers": [],
+        |  "placesOfPublication": [ ]
+        |}""".stripMargin
+
+      assertJsonStringsAreEqual(actualJson, expectedJson)
+    }
+
+    it("serialises identified creators") {
+      val work = IdentifiedWork(
+        canonicalId = "v9w6cz66",
+        sourceIdentifier = sourceIdentifier,
+        version = 1,
+        title = Some("Vultures vying for victory"),
+        creators = List(
+          Identified(
+            Person(
+              label = "Havelock Vetinari",
+              prefix = Some("Lord Patrician"),
+              numeration = Some("I")),
+            canonicalId = "hgfedcba",
+            identifiers = List(
+              SourceIdentifier(
+                IdentifierSchemes.libraryOfCongressNames,
+                ontologyType = "Organisation",
+                value = "hv"))
+          ),
+          Identified(
+            Organisation(label = "Unseen University"),
+            canonicalId = "abcdefgh",
+            identifiers = List(
+              SourceIdentifier(
+                IdentifierSchemes.libraryOfCongressNames,
+                ontologyType = "Organisation",
+                value = "uu"))
+          ),
+          Identified(
+            Agent(label = "The Librarian"),
+            canonicalId = "blahbluh",
+            identifiers = List(
+              SourceIdentifier(
+                IdentifierSchemes.libraryOfCongressNames,
+                ontologyType = "Organisation",
+                value = "uu"))
+          )
+        )
+      )
+      val displayWork = DisplayWorkV1(work)
+
+      val actualJson = objectMapper.writeValueAsString(displayWork)
+      val expectedJson = s"""
+                             |{
+                             |  "type": "Work",
+                             |  "id": "${work.canonicalId}",
+                             |  "title": "${work.title.get}",
+                             |  "creators": [
+                             |    ${identifiedOrUnidentifiable(work.creators(0), abstractAgent)},
+                             |    ${identifiedOrUnidentifiable(work.creators(1), abstractAgent)},
+                             |    ${identifiedOrUnidentifiable(work.creators(2), abstractAgent)}
+                             |  ],
+                             |  "subjects": [ ],
+                             |  "genres": [ ],
+                             |  "publishers": [],
+                             |  "placesOfPublication": [ ]
+                             |}""".stripMargin
+
+      assertJsonStringsAreEqual(actualJson, expectedJson)
+    }
+  }
+
+  describe("locations") {
+    it("serialises a physical location correctly") {
+      val physicalLocation = PhysicalLocation(
+        locationType = "smeg",
+        label = "a stack of slick slimes"
+      )
+
+      val work = IdentifiedWork(
+        canonicalId = "zm9q6c6h",
+        sourceIdentifier = sourceIdentifier,
+        version = 1,
+        title = Some("A zoo of zebras doing zumba"),
+        items = List(
+          IdentifiedItem(
+            canonicalId = "mhberjwy7",
+            sourceIdentifier = sourceIdentifier,
+            locations = List(physicalLocation)
+          )
+        )
+      )
+      val displayWork = DisplayWorkV1(work, includes = WorksIncludes(items = true))
+
+      val actualJson = objectMapper.writeValueAsString(displayWork)
+      val expectedJson = s"""
+                             |{
+                             |  "type": "Work",
+                             |  "id": "${work.canonicalId}",
+                             |  "title": "${work.title.get}",
+                             |  "creators": [ ],
+                             |  "items": [ ${items(work.items)} ],
+                             |  "subjects": [ ],
+                             |  "genres": [ ],
+                             |  "publishers": [],
+                             |  "placesOfPublication": [ ]
+                             |}""".stripMargin
+
+      assertJsonStringsAreEqual(actualJson, expectedJson)
+    }
+  }
+
+  describe("place of publication") {
+    it("serialises the placesOfPublication field") {
+      val work = IdentifiedWork(
+        canonicalId = "avfpwgrr",
+        sourceIdentifier = sourceIdentifier,
+        title = Some("Ahoy!  Armoured angelfish are attacking the armada!"),
+        placesOfPublication = List(Place("Durmstrang")),
+        version = 1
+      )
+      val displayWork = DisplayWorkV1(work)
+
+      val actualJson = objectMapper.writeValueAsString(displayWork)
+      val expectedJson = s"""
+                             |{
+                             |  "type": "Work",
+                             |  "id": "${work.canonicalId}",
+                             |  "title": "${work.title.get}",
+                             |  "creators": [ ],
+                             |  "subjects": [ ],
+                             |  "genres": [ ],
+                             |  "publishers": [],
+                             |  "placesOfPublication": [
+                             |    {
+                             |      "label": "${work.placesOfPublication.head.label}",
+                             |      "type": "Place"
+                             |    }
+                             |  ]
+                             |
+                             |}""".stripMargin
+
+      assertJsonStringsAreEqual(actualJson, expectedJson)
+    }
+  }
+
+  describe("publication date") {
+    it("omits the publicationDate field if it is empty") {
+      val work = IdentifiedWork(
+        canonicalId = "arfj5cj4",
+        sourceIdentifier = sourceIdentifier,
+        title = Some("Asking aging armadillos for another appraisal"),
+        publicationDate = None,
+        version = 1
+      )
+      val displayWork = DisplayWorkV1(work)
+
+      val actualJson = objectMapper.writeValueAsString(displayWork)
+      val expectedJson = s"""
+                            |{
+                            |  "type": "Work",
+                            |  "id": "${work.canonicalId}",
+                            |  "title": "${work.title.get}",
+                            |  "creators": [ ],
+                            |  "subjects": [ ],
+                            |  "genres": [ ],
+                            |  "publishers": [],
+                            |  "placesOfPublication": [ ]
+                            |}""".stripMargin
+
+      assertJsonStringsAreEqual(actualJson, expectedJson)
+    }
+
+    it("includes the publicationDate field if it is present on the Work") {
+      val work = IdentifiedWork(
+        canonicalId = "avfpwgrr",
+        sourceIdentifier = sourceIdentifier,
+        title = Some("Ahoy!  Armoured angelfish are attacking the armada!"),
+        publicationDate = Some(Period("1923")),
+        version = 1
+      )
+      val displayWork = DisplayWorkV1(work)
+
+      val actualJson = objectMapper.writeValueAsString(displayWork)
+      val expectedJson = s"""
+                            |{
+                            |  "type": "Work",
+                            |  "id": "${work.canonicalId}",
+                            |  "title": "${work.title.get}",
+                            |  "creators": [ ],
+                            |  "subjects": [ ],
+                            |  "genres": [ ],
+                            |  "publishers": [],
+                            |  "publicationDate": ${period(work.publicationDate.get)},
+                            |  "placesOfPublication": [ ]
+                            |}""".stripMargin
+
+      assertJsonStringsAreEqual(actualJson, expectedJson)
+    }
+  }
+
+  describe("publishers") {
+    it(
+      "includes the publishers field with a mixture of agents/organisations/persons") {
+      val work = IdentifiedWork(
+        canonicalId = "v9w6cz66",
+        sourceIdentifier = sourceIdentifier,
+        version = 1,
+        title = Some("Vultures vying for victory"),
+        publishers = List(
+          Unidentifiable(Agent("Vivian Violet")),
+          Unidentifiable(Organisation("Verily Volumes")),
+          Unidentifiable(
+            Person(
+              label = "Havelock Vetinari",
+              prefix = Some("Lord Patrician"),
+              numeration = Some("I")))
+        )
+      )
+      val displayWork = DisplayWorkV1(work)
+
+      val actualJson = objectMapper.writeValueAsString(displayWork)
+      val expectedJson = s"""
+                            |{
+                            |  "type": "Work",
+                            |  "id": "${work.canonicalId}",
+                            |  "title": "${work.title.get}",
+                            |  "creators": [ ],
+                            |  "subjects": [ ],
+                            |  "genres": [ ],
+                            |  "publishers": [
+                            |    ${identifiedOrUnidentifiable(work.publishers(0), abstractAgent)},
+                            |    ${identifiedOrUnidentifiable(work.publishers(1), abstractAgent)},
+                            |    ${identifiedOrUnidentifiable(work.publishers(2), abstractAgent)}
+                            |  ],
+                            |  "placesOfPublication": [ ]
+                            |}""".stripMargin
+
+      assertJsonStringsAreEqual(actualJson, expectedJson)
+    }
+  }
+}

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -1,0 +1,306 @@
+package uk.ac.wellcome.display.models.v1
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.display.models._
+import uk.ac.wellcome.models._
+
+class DisplayWorkV1Test extends FunSpec with Matchers {
+
+  it("correctly parses a Work without any items") {
+    val work = IdentifiedWork(
+      title = Some("An irritating imp is immune from items"),
+      sourceIdentifier = sourceIdentifier,
+      version = 1,
+      identifiers = List(sourceIdentifier),
+      canonicalId = "abcdef12"
+    )
+
+    val displayWork = DisplayWorkV1(
+      work = work,
+      includes = WorksIncludes(items = true)
+    )
+    displayWork.items shouldBe Some(List())
+  }
+
+  it("correctly parses items on a work") {
+    val item = IdentifiedItem(
+      canonicalId = "c3a599u5",
+      sourceIdentifier = sourceIdentifier,
+      identifiers = List(sourceIdentifier),
+      locations = List()
+    )
+    val work = IdentifiedWork(
+      title = Some("Inside an irate igloo"),
+      sourceIdentifier = sourceIdentifier,
+      version = 1,
+      identifiers = List(sourceIdentifier),
+      canonicalId = "b4heraz7",
+      items = List(item)
+    )
+
+    val displayWork = DisplayWorkV1(
+      work = work,
+      includes = WorksIncludes(items = true)
+    )
+    val displayItem = displayWork.items.get.head
+    displayItem.id shouldBe item.canonicalId
+  }
+
+  val sourceIdentifier = SourceIdentifier(
+    identifierScheme = IdentifierSchemes.sierraSystemNumber,
+    ontologyType = "Work",
+    value = "b1234567"
+  )
+
+  it("correctly parses a work without any identifiers") {
+    val work = IdentifiedWork(
+      title = Some("An irascible iguana invites impudence"),
+      sourceIdentifier = sourceIdentifier,
+      version = 1,
+      identifiers = Nil,
+      canonicalId = "xtsx8hwk")
+
+    val displayWork = DisplayWorkV1(
+      work = work,
+      includes = WorksIncludes(identifiers = true)
+    )
+    displayWork.identifiers shouldBe Some(List())
+  }
+
+  describe("publishers") {
+    it("parses a work without any publishers") {
+      val work = IdentifiedWork(
+        title = Some("A goading giraffe is galling"),
+        sourceIdentifier = sourceIdentifier,
+        version = 1,
+        identifiers = Nil,
+        canonicalId = "gsfmhw7v",
+        publishers = List()
+      )
+
+      val displayWork = DisplayWorkV1(work)
+      displayWork.publishers shouldBe List()
+    }
+
+    it("parses a work with agent publishers") {
+      val work = IdentifiedWork(
+        title = Some("A hammerhead hamster is harrowing"),
+        sourceIdentifier = sourceIdentifier,
+        version = 1,
+        identifiers = Nil,
+        canonicalId = "hz2hrba9",
+        publishers = List(
+          Unidentifiable(Agent("Henry Hare")),
+          Unidentifiable(Agent("Harriet Heron"))
+        )
+      )
+
+      val displayWork = DisplayWorkV1(work)
+      displayWork.publishers shouldBe List(
+        DisplayAgent(
+          id = None,
+          identifiers = None,
+          label = "Henry Hare",
+          ontologyType = "Agent"),
+        DisplayAgent(
+          id = None,
+          identifiers = None,
+          label = "Harriet Heron",
+          ontologyType = "Agent")
+      )
+    }
+
+    it("parses a work with agents and organisations as publishers") {
+      val work = IdentifiedWork(
+        title = Some("Jumping over jackals in Japan"),
+        sourceIdentifier = sourceIdentifier,
+        version = 1,
+        identifiers = Nil,
+        canonicalId = "j7tw9jv3",
+        publishers = List(
+          Unidentifiable(Agent("Janet Jackson")),
+          Unidentifiable(Organisation("Juniper Journals"))
+        )
+      )
+
+      val displayWork = DisplayWorkV1(work)
+      displayWork.publishers shouldBe List(
+        DisplayAgent(id = None, identifiers = None, label = "Janet Jackson"),
+        DisplayOrganisation(
+          id = None,
+          identifiers = None,
+          label = "Juniper Journals")
+      )
+    }
+  }
+
+  it("parses a work with unidentifiable persons and organisations as creators") {
+    val work = IdentifiedWork(
+      title = Some("Jumping over jackals in Japan"),
+      sourceIdentifier = sourceIdentifier,
+      version = 1,
+      identifiers = Nil,
+      canonicalId = "j7tw9jv3",
+      creators = List(
+        Unidentifiable(Person("Esmerelda Weatherwax", prefix = Some("Witch"))),
+        Unidentifiable(Organisation("Juniper Journals"))
+      )
+    )
+
+    val displayWork = DisplayWorkV1(work)
+    displayWork.creators shouldBe List(
+      DisplayPerson(
+        id = None,
+        identifiers = None,
+        label = "Esmerelda Weatherwax",
+        prefix = Some("Witch")),
+      DisplayOrganisation(
+        id = None,
+        identifiers = None,
+        label = "Juniper Journals")
+    )
+  }
+
+  it(
+    "parses a work with a mixture of identifed or unidentifable persons and organisations as creators") {
+    val canonicalId = "abcdefgh"
+    val sourceIdentifier = SourceIdentifier(
+      IdentifierSchemes.libraryOfCongressNames,
+      "Organisation",
+      "EW")
+    val work = IdentifiedWork(
+      title = Some("Jumping over jackals in Japan"),
+      sourceIdentifier = sourceIdentifier,
+      version = 1,
+      identifiers = Nil,
+      canonicalId = "j7tw9jv3",
+      creators = List(
+        Unidentifiable(Person("Esmerelda Weatherwax", prefix = Some("Witch"))),
+        Identified(
+          Organisation("Juniper Journals"),
+          canonicalId = canonicalId,
+          identifiers = List(sourceIdentifier))
+      )
+    )
+
+    val displayWork = DisplayWorkV1(work)
+    displayWork.creators shouldBe List(
+      DisplayPerson(
+        id = None,
+        identifiers = None,
+        label = "Esmerelda Weatherwax",
+        prefix = Some("Witch")),
+      DisplayOrganisation(
+        id = Some(canonicalId),
+        identifiers = Some(
+          List(
+            DisplayIdentifier(
+              IdentifierSchemes.libraryOfCongressNames.toString,
+              sourceIdentifier.value))),
+        label = "Juniper Journals"
+      )
+    )
+  }
+
+  it("gets the publicationDate from a Work") {
+    val work = IdentifiedWork(
+      title = Some("Calling a cacophany of cats to consume carrots"),
+      canonicalId = "c4kauupf",
+      sourceIdentifier = sourceIdentifier,
+      publicationDate = Some(Period("c1900")),
+      version = 1
+    )
+
+    val displayWork = DisplayWorkV1(work)
+    displayWork.publicationDate shouldBe Some(DisplayPeriod("c1900"))
+  }
+
+  it("gets the physicalDescription from a Work") {
+    val physicalDescription = "A magnificent mural of magpies"
+
+    val work = IdentifiedWork(
+      title = Some("Moving a mighty mouse to Madagascar"),
+      canonicalId = "mtc2wvrg",
+      sourceIdentifier = sourceIdentifier,
+      physicalDescription = Some(physicalDescription),
+      version = 1
+    )
+
+    val displayWork = DisplayWorkV1(work)
+    displayWork.physicalDescription shouldBe Some(physicalDescription)
+  }
+
+  it("gets the workType from a Work") {
+    val workType = WorkType(
+      id = "id",
+      label = "Proud pooch pavement plops"
+    )
+
+    val expectedDisplayWorkV1 = DisplayWorkType(
+      id = workType.id,
+      label = workType.label
+    )
+
+    val work = IdentifiedWork(
+      title = Some("Moving a mighty mouse to Madagascar"),
+      canonicalId = "mtc2wvrg",
+      sourceIdentifier = sourceIdentifier,
+      workType = Some(workType),
+      version = 1
+    )
+
+    val displayWork = DisplayWorkV1(work)
+    displayWork.workType shouldBe Some(expectedDisplayWorkV1)
+  }
+
+  it("gets the extent from a Work") {
+    val extent = "Bound in boxes of bark"
+
+    val work = IdentifiedWork(
+      title = Some("Brilliant beeches in Bucharest"),
+      canonicalId = "bmnppscn",
+      sourceIdentifier = sourceIdentifier,
+      extent = Some(extent),
+      version = 1
+    )
+
+    val displayWork = DisplayWorkV1(work)
+    displayWork.extent shouldBe Some(extent)
+  }
+
+  it("gets the language from a Work") {
+    val language = Language(
+      id = "bsl",
+      label = "British Sign Language"
+    )
+
+    val work = IdentifiedWork(
+      title = Some("A largesse of leaping Libyan lions"),
+      canonicalId = "lfk6nkje",
+      sourceIdentifier = sourceIdentifier,
+      language = Some(language),
+      version = 1
+    )
+
+    val displayWork = DisplayWorkV1(work)
+    val displayLanguage = displayWork.language.get
+    displayLanguage.id shouldBe language.id
+    displayLanguage.label shouldBe language.label
+  }
+
+  it("gives a helpful error if you try to convert a work with visible=False") {
+    val work = IdentifiedWork(
+      canonicalId = "xpudrscx",
+      title = Some("Invisible igloos improve iguanas"),
+      sourceIdentifier = sourceIdentifier,
+      visible = false,
+      version = 1
+    )
+
+    val caught = intercept[RuntimeException] {
+      DisplayWorkV1(work)
+    }
+
+    caught.getMessage shouldBe s"IdentifiedWork ${work.canonicalId} has visible=false, cannot be converted to DisplayWork"
+  }
+}


### PR DESCRIPTION
Initial approach at freezing the V1 DisplayWork with its own namespace and tests.

~Probably not for actual use, just testing the waters.~