### PR TITLE
Typesafe loan fixtures

### DIFF
--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -64,9 +64,9 @@ class IdMinterFeatureTest
   it(
     "mints the same ID for SourcedWorks that have matching source identifiers") {
     withLocalSqsQueue { queueUrl =>
-      withLocalSnsTopic { topicArn =>
+      withLocalSnsTopic { topic =>
         withIdentifiersDatabase { dbConfig =>
-          val flags = sqsLocalFlags(queueUrl) ++ snsLocalFlags(topicArn) ++ dbConfig.flags
+          val flags = sqsLocalFlags(queueUrl) ++ snsLocalFlags(topic) ++ dbConfig.flags
 
           withServer(flags) { _ =>
             eventuallyTableExists(dbConfig)
@@ -104,7 +104,7 @@ class IdMinterFeatureTest
             }
 
             eventually {
-              val messages = listMessagesReceivedFromSNS(topicArn)
+              val messages = listMessagesReceivedFromSNS(topic)
               messages.length shouldBe >=(messageCount)
 
               getWorksFromMessages(messages).foreach { work =>
@@ -120,9 +120,9 @@ class IdMinterFeatureTest
 
   it("continues if something fails processing a message") {
     withLocalSqsQueue { queueUrl =>
-      withLocalSnsTopic { topicArn =>
+      withLocalSnsTopic { topic =>
         withIdentifiersDatabase { dbConfig =>
-          val flags = sqsLocalFlags(queueUrl) ++ snsLocalFlags(topicArn) ++ dbConfig.flags
+          val flags = sqsLocalFlags(queueUrl) ++ snsLocalFlags(topic) ++ dbConfig.flags
 
           withServer(flags) { _ =>
             sqsClient.sendMessage(queueUrl, "not a json string")
@@ -133,7 +133,7 @@ class IdMinterFeatureTest
             sqsClient.sendMessage(queueUrl, toJson(sqsMessage).get)
 
             eventually {
-              val messages = listMessagesReceivedFromSNS(topicArn)
+              val messages = listMessagesReceivedFromSNS(topic)
               messages should have size (1)
             }
 

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/ServerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/ServerTest.scala
@@ -13,10 +13,10 @@ class ServerTest
     with fixtures.IdentifiersDatabase {
 
   it("shows the healthcheck message") {
-    withLocalSqsQueue { queueUrl =>
+    withLocalSqsQueue { queue =>
       withLocalSnsTopic { topic =>
         withIdentifiersDatabase { dbConfig =>
-          val flags = sqsLocalFlags(queueUrl) ++ snsLocalFlags(topic) ++ dbConfig.flags
+          val flags = sqsLocalFlags(queue) ++ snsLocalFlags(topic) ++ dbConfig.flags
 
           withServer(flags) { server =>
             server.httpGet(

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/ServerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/ServerTest.scala
@@ -14,9 +14,9 @@ class ServerTest
 
   it("shows the healthcheck message") {
     withLocalSqsQueue { queueUrl =>
-      withLocalSnsTopic { topicArn =>
+      withLocalSnsTopic { topic =>
         withIdentifiersDatabase { dbConfig =>
-          val flags = sqsLocalFlags(queueUrl) ++ snsLocalFlags(topicArn) ++ dbConfig.flags
+          val flags = sqsLocalFlags(queueUrl) ++ snsLocalFlags(topic) ++ dbConfig.flags
 
           withServer(flags) { server =>
             server.httpGet(

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
@@ -27,10 +27,10 @@ class IdMinterWorkerTest
     with MockitoSugar {
 
   it("should create the Identifiers table in MySQL upon startup") {
-    withLocalSqsQueue { queueUrl =>
+    withLocalSqsQueue { queue =>
       withLocalSnsTopic { topic =>
         withIdentifiersDatabase { dbConfig =>
-          val flags = sqsLocalFlags(queueUrl) ++ snsLocalFlags(topic) ++ dbConfig.flags
+          val flags = sqsLocalFlags(queue) ++ snsLocalFlags(topic) ++ dbConfig.flags
 
           val identifiersDao = mock[IdentifiersDao]
 

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
@@ -28,9 +28,9 @@ class IdMinterWorkerTest
 
   it("should create the Identifiers table in MySQL upon startup") {
     withLocalSqsQueue { queueUrl =>
-      withLocalSnsTopic { topicArn =>
+      withLocalSnsTopic { topic =>
         withIdentifiersDatabase { dbConfig =>
-          val flags = sqsLocalFlags(queueUrl) ++ snsLocalFlags(topicArn) ++ dbConfig.flags
+          val flags = sqsLocalFlags(queueUrl) ++ snsLocalFlags(topic) ++ dbConfig.flags
 
           val identifiersDao = mock[IdentifiersDao]
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
@@ -28,8 +28,8 @@ class IngestorIndexTest
       }
     }
 
-    withLocalSqsQueue { queueUrl =>
-      val flags = sqsLocalFlags(queueUrl) ++ esLocalFlags(indexName, itemType)
+    withLocalSqsQueue { queue =>
+      val flags = sqsLocalFlags(queue) ++ esLocalFlags(indexName, itemType)
 
       withServer(flags) { _ =>
         eventually {

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -82,11 +82,11 @@ class IngestorWorkerServiceTest
     val workIndexer =
       new WorkIndexer(indexName, itemType, elasticClient, metricsSender)
 
-    withLocalSqsQueue { queueUrl =>
+    withLocalSqsQueue { queue =>
       withLocalElasticsearchIndex(indexName, itemType) { _ =>
         val service = new IngestorWorkerService(
           identifiedWorkIndexer = workIndexer,
-          reader = new SQSReader(sqsClient, SQSConfig(queueUrl, 1.second, 1)),
+          reader = new SQSReader(sqsClient, SQSConfig(queue.url, 1.second, 1)),
           system = actorSystem,
           metrics = metricsSender
         )
@@ -107,7 +107,7 @@ class IngestorWorkerServiceTest
     val sqsMessage = messageFromString("<xml><item> ??? Not JSON!!")
     val indexName = "works"
 
-    withLocalSqsQueue { queueUrl =>
+    withLocalSqsQueue { queue =>
       val workIndexer = new WorkIndexer(
         esIndex = indexName,
         esType = itemType,
@@ -117,7 +117,7 @@ class IngestorWorkerServiceTest
 
       val service = new IngestorWorkerService(
         identifiedWorkIndexer = workIndexer,
-        reader = new SQSReader(sqsClient, SQSConfig(queueUrl, 1.second, 1)),
+        reader = new SQSReader(sqsClient, SQSConfig(queue.url, 1.second, 1)),
         system = actorSystem,
         metrics = metricsSender
       )
@@ -155,10 +155,10 @@ class IngestorWorkerServiceTest
 
     val sqsMessage = messageFromString(toJson(work).get)
 
-    withLocalSqsQueue { queueUrl =>
+    withLocalSqsQueue { queue =>
       val service = new IngestorWorkerService(
         identifiedWorkIndexer = brokenWorkIndexer,
-        reader = new SQSReader(sqsClient, SQSConfig(queueUrl, 1.second, 1)),
+        reader = new SQSReader(sqsClient, SQSConfig(queue.url, 1.second, 1)),
         system = actorSystem,
         metrics = metricsSender
       )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
@@ -36,18 +36,18 @@ class CalmTransformerFeatureTest
 
     withLocalSnsTopic { topicArn =>
       withLocalSqsQueue { queueUrl =>
-        withLocalS3Bucket { bucketName =>
+        withLocalS3Bucket { bucket =>
           val calmHybridRecordMessage = hybridRecordSqsMessage(
             message = JsonUtil.toJson(calmTransformable).get,
             sourceName = "calm",
             version = 1,
             s3Client = s3Client,
-            bucketName = bucketName
+            bucket = bucket
           )
 
           val flags: Map[String, String] = Map(
             "aws.metrics.namespace" -> "sierra-transformer"
-          ) ++ s3LocalFlags(bucketName) ++ snsLocalFlags(topicArn) ++ sqsLocalFlags(
+          ) ++ s3LocalFlags(bucket) ++ snsLocalFlags(topicArn) ++ sqsLocalFlags(
             queueUrl)
 
           withServer(flags) { _ =>

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
@@ -35,7 +35,7 @@ class CalmTransformerFeatureTest
         data = """{"AccessStatus": ["public"]}""")
 
     withLocalSnsTopic { topicArn =>
-      withLocalSqsQueue { queueUrl =>
+      withLocalSqsQueue { queue =>
         withLocalS3Bucket { bucket =>
           val calmHybridRecordMessage = hybridRecordSqsMessage(
             message = JsonUtil.toJson(calmTransformable).get,
@@ -48,11 +48,11 @@ class CalmTransformerFeatureTest
           val flags: Map[String, String] = Map(
             "aws.metrics.namespace" -> "sierra-transformer"
           ) ++ s3LocalFlags(bucket) ++ snsLocalFlags(topicArn) ++ sqsLocalFlags(
-            queueUrl)
+            queue)
 
           withServer(flags) { _ =>
             sqsClient.sendMessage(
-              queueUrl,
+              queue.url,
               JsonUtil.toJson(calmHybridRecordMessage).get
             )
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
@@ -32,7 +32,7 @@ class SierraTransformerFeatureTest
     val lastModifiedDate = Instant.now()
 
     withLocalSnsTopic { topicArn =>
-      withLocalSqsQueue { queueUrl =>
+      withLocalSqsQueue { queue =>
         withLocalS3Bucket { bucket =>
           val sierraHybridRecordMessage =
             hybridRecordSqsMessage(
@@ -48,14 +48,14 @@ class SierraTransformerFeatureTest
             )
 
           sqsClient.sendMessage(
-            queueUrl,
+            queue.url,
             JsonUtil.toJson(sierraHybridRecordMessage).get
           )
 
           val flags: Map[String, String] = Map(
             "aws.metrics.namespace" -> "sierra-transformer"
           ) ++ s3LocalFlags(bucket) ++ snsLocalFlags(topicArn) ++ sqsLocalFlags(
-            queueUrl)
+            queue)
 
           withServer(flags) { _ =>
             eventually {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
@@ -33,7 +33,7 @@ class SierraTransformerFeatureTest
 
     withLocalSnsTopic { topicArn =>
       withLocalSqsQueue { queueUrl =>
-        withLocalS3Bucket { bucketName =>
+        withLocalS3Bucket { bucket =>
           val sierraHybridRecordMessage =
             hybridRecordSqsMessage(
               message = createValidSierraTransformableJson(
@@ -44,7 +44,7 @@ class SierraTransformerFeatureTest
               sourceName = "sierra",
               version = 1,
               s3Client = s3Client,
-              bucketName = bucketName
+              bucket = bucket
             )
 
           sqsClient.sendMessage(
@@ -54,7 +54,7 @@ class SierraTransformerFeatureTest
 
           val flags: Map[String, String] = Map(
             "aws.metrics.namespace" -> "sierra-transformer"
-          ) ++ s3LocalFlags(bucketName) ++ snsLocalFlags(topicArn) ++ sqsLocalFlags(
+          ) ++ s3LocalFlags(bucket) ++ snsLocalFlags(topicArn) ++ sqsLocalFlags(
             queueUrl)
 
           withServer(flags) { _ =>

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -75,7 +75,7 @@ class SQSMessageReceiverTest
     val recordReceiver = new SQSMessageReceiver(
       snsWriter = snsWriter,
       s3Client = s3Client,
-      s3Config = S3Config(bucket.underlying),
+      s3Config = S3Config(bucket.name),
       metricsSender = metricsSender
     )
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -86,7 +86,7 @@ class SQSMessageReceiverTest
   it("receives a message and send it to SNS client") {
 
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { queueUrl =>
+      withLocalSqsQueue { _ =>
         withLocalS3Bucket { bucket =>
           val calmSqsMessage: SQSMessage = hybridRecordSqsMessage(
             message = createValidCalmTramsformableJson(
@@ -123,7 +123,7 @@ class SQSMessageReceiverTest
     val version = 5
 
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { queueUrl =>
+      withLocalSqsQueue { _ =>
         withLocalS3Bucket { bucket =>
           val sierraMessage: SQSMessage = hybridRecordSqsMessage(
             message =
@@ -170,7 +170,7 @@ class SQSMessageReceiverTest
 
   it("returns a failed future if it's unable to parse the SQS message") {
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { queueUrl =>
+      withLocalSqsQueue { _ =>
         withLocalS3Bucket { bucket =>
           val invalidCalmSqsMessage: SQSMessage =
             hybridRecordSqsMessage(
@@ -195,7 +195,7 @@ class SQSMessageReceiverTest
 
   it("sends no message where Transformable work is None") {
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { queueUrl =>
+      withLocalSqsQueue { _ =>
         withLocalS3Bucket { bucket =>
           val snsWriter = mockSNSWriter
 
@@ -222,7 +222,7 @@ class SQSMessageReceiverTest
   it(
     "returns a failed future if it's unable to transform the transformable object") {
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { queueUrl =>
+      withLocalSqsQueue { _ =>
         withLocalS3Bucket { bucket =>
           val failingTransformCalmSqsMessage: SQSMessage =
             hybridRecordSqsMessage(
@@ -267,7 +267,7 @@ class SQSMessageReceiverTest
           .get)
 
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { queueUrl =>
+      withLocalSqsQueue { _ =>
         withLocalS3Bucket { bucket =>
           val message = hybridRecordSqsMessage(
             message = JsonUtil.toJson(sierraTransformable).get,

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -98,10 +98,10 @@ class SQSMessageReceiverTest
             sourceName = "calm",
             version = 1,
             s3Client = s3Client,
-            bucketName = bucket.underlying
+            bucket = bucket
           )
 
-          withSQSMessageReceiver(topicArn, bucketName) { recordReceiver =>
+          withSQSMessageReceiver(topicArn, bucket) { recordReceiver =>
             val future = recordReceiver.receiveMessage(calmSqsMessage)
 
             whenReady(future) { _ =>
@@ -133,7 +133,7 @@ class SQSMessageReceiverTest
             bucket = bucket
           )
 
-          withSQSMessageReceiver(topicArn, bucketName) { recordReceiver =>
+          withSQSMessageReceiver(topicArn, bucket) { recordReceiver =>
             val future = recordReceiver.receiveMessage(sierraMessage)
 
             val sourceIdentifier = SourceIdentifier(
@@ -180,7 +180,7 @@ class SQSMessageReceiverTest
               bucket = bucket
             )
 
-          withSQSMessageReceiver(topicArn, bucketName) { recordReceiver =>
+          withSQSMessageReceiver(topicArn, bucket) { recordReceiver =>
             val future = recordReceiver.receiveMessage(invalidCalmSqsMessage)
 
             whenReady(future.failed) { x =>
@@ -198,7 +198,7 @@ class SQSMessageReceiverTest
         withLocalS3Bucket { bucket =>
           val snsWriter = mockSNSWriter
 
-          withSQSMessageReceiver(topicArn, bucketName, Some(snsWriter)) {
+          withSQSMessageReceiver(topicArn, bucket, Some(snsWriter)) {
             recordReceiver =>
               val future = recordReceiver.receiveMessage(
                 createValidEmptySierraBibSQSMessage(
@@ -222,7 +222,7 @@ class SQSMessageReceiverTest
     "returns a failed future if it's unable to transform the transformable object") {
     withLocalSnsTopic { topicArn =>
       withLocalSqsQueue { queueUrl =>
-        withLocalS3Bucket { bucketName =>
+        withLocalS3Bucket { bucket =>
           val failingTransformCalmSqsMessage: SQSMessage =
             hybridRecordSqsMessage(
               message = createValidCalmTramsformableJson(
@@ -235,10 +235,10 @@ class SQSMessageReceiverTest
               sourceName = "calm",
               version = 1,
               s3Client = s3Client,
-              bucketName = bucketName
+              bucket = bucket
             )
 
-          withSQSMessageReceiver(topicArn, bucketName) { recordReceiver =>
+          withSQSMessageReceiver(topicArn, bucket) { recordReceiver =>
             val future =
               recordReceiver.receiveMessage(failingTransformCalmSqsMessage)
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformableMessageUtils.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformableMessageUtils.scala
@@ -95,7 +95,7 @@ trait TransformableMessageUtils {
                              bucket: Bucket) = {
 
     val key = "testSource/1/testId/dshg548.json"
-    s3Client.putObject(bucket.underlying, key, message)
+    s3Client.putObject(bucket.name, key, message)
 
     val hybridRecord = HybridRecord(
       id = "testId",

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformableMessageUtils.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformableMessageUtils.scala
@@ -19,6 +19,7 @@ import uk.ac.wellcome.models.transformable.sierra.{
 }
 import uk.ac.wellcome.storage.HybridRecord
 import uk.ac.wellcome.utils.JsonUtil
+import uk.ac.wellcome.test.fixtures.S3.Bucket
 
 trait TransformableMessageUtils {
   def createValidCalmTramsformableJson(RecordID: String,
@@ -35,7 +36,7 @@ trait TransformableMessageUtils {
   def createValidEmptySierraBibSQSMessage(
     id: String,
     s3Client: AmazonS3,
-    bucketName: String
+    bucket: Bucket
   ): SQSMessage = {
 
     val sierraTransformable = SierraTransformable(
@@ -49,7 +50,7 @@ trait TransformableMessageUtils {
       sourceName = "sierra",
       version = 1,
       s3Client = s3Client,
-      bucketName = bucketName
+      bucket = bucket
     )
   }
 
@@ -91,10 +92,10 @@ trait TransformableMessageUtils {
                              sourceName: String,
                              version: Int = 1,
                              s3Client: AmazonS3,
-                             bucketName: String) = {
+                             bucket: Bucket) = {
 
     val key = "testSource/1/testId/dshg548.json"
-    s3Client.putObject(bucketName, key, message)
+    s3Client.putObject(bucket.underlying, key, message)
 
     val hybridRecord = HybridRecord(
       id = "testId",

--- a/common/src/test/scala/uk/ac/wellcome/s3/S3ObjectStoreTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/s3/S3ObjectStoreTest.scala
@@ -29,7 +29,7 @@ class S3ObjectStoreTest
 
       val objectStore = new S3ObjectStore(
         s3Client,
-        S3Config(bucketName = bucket.underlying),
+        S3Config(bucketName = bucket.name),
         new KeyPrefixGenerator[TestObject] {
           override def generate(obj: TestObject): String = prefix
         }
@@ -63,7 +63,7 @@ class S3ObjectStoreTest
 
       val objectStore = new S3ObjectStore(
         s3Client,
-        S3Config(bucketName = bucket.underlying),
+        S3Config(bucketName = bucket.name),
         new KeyPrefixGenerator[TestObject] {
           override def generate(obj: TestObject): String = prefix
         }
@@ -88,7 +88,7 @@ class S3ObjectStoreTest
 
       val objectStore = new S3ObjectStore(
         s3Client,
-        S3Config(bucketName = bucket.underlying),
+        S3Config(bucketName = bucket.name),
         new KeyPrefixGenerator[TestObject] {
           override def generate(obj: TestObject): String = prefix
         }
@@ -113,7 +113,7 @@ class S3ObjectStoreTest
 
       val objectStore = new S3ObjectStore(
         s3Client,
-        S3Config(bucketName = bucket.underlying),
+        S3Config(bucketName = bucket.name),
         new KeyPrefixGenerator[TestObject] {
           override def generate(obj: TestObject): String = prefix
         }
@@ -133,7 +133,7 @@ class S3ObjectStoreTest
     withLocalS3Bucket { bucket =>
       val objectStore = new S3ObjectStore(
         s3Client,
-        S3Config(bucketName = bucket.underlying),
+        S3Config(bucketName = bucket.name),
         new KeyPrefixGenerator[TestObject] {
           override def generate(obj: TestObject): String = "doesnt_matter"
         }

--- a/common/src/test/scala/uk/ac/wellcome/s3/S3ObjectStoreTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/s3/S3ObjectStoreTest.scala
@@ -47,7 +47,7 @@ class S3ObjectStoreTest
         actualKey shouldBe expectedKey
 
         val jsonFromS3 = getJsonFromS3(
-          bucket.underlying,
+          bucket,
           expectedKey
         ).noSpaces
 

--- a/common/src/test/scala/uk/ac/wellcome/s3/S3ObjectStoreTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/s3/S3ObjectStoreTest.scala
@@ -23,13 +23,13 @@ class S3ObjectStoreTest
     with ExtendedPatience {
 
   it("stores a versioned object with path id/version/hash") {
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       val content = "Some content!"
       val prefix = "foo"
 
       val objectStore = new S3ObjectStore(
         s3Client,
-        S3Config(bucketName = bucketName),
+        S3Config(bucketName = bucket.underlying),
         new KeyPrefixGenerator[TestObject] {
           override def generate(obj: TestObject): String = prefix
         }
@@ -47,7 +47,7 @@ class S3ObjectStoreTest
         actualKey shouldBe expectedKey
 
         val jsonFromS3 = getJsonFromS3(
-          bucketName,
+          bucket.underlying,
           expectedKey
         ).noSpaces
 
@@ -57,13 +57,13 @@ class S3ObjectStoreTest
   }
 
   it("removes leading slashes from prefixes") {
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       val content = "Some content!"
       val prefix = "/foo"
 
       val objectStore = new S3ObjectStore(
         s3Client,
-        S3Config(bucketName = bucketName),
+        S3Config(bucketName = bucket.underlying),
         new KeyPrefixGenerator[TestObject] {
           override def generate(obj: TestObject): String = prefix
         }
@@ -82,13 +82,13 @@ class S3ObjectStoreTest
   }
 
   it("removes trailing slashes from prefixes") {
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       val content = "Some content!"
       val prefix = "foo/"
 
       val objectStore = new S3ObjectStore(
         s3Client,
-        S3Config(bucketName = bucketName),
+        S3Config(bucketName = bucket.underlying),
         new KeyPrefixGenerator[TestObject] {
           override def generate(obj: TestObject): String = prefix
         }
@@ -107,13 +107,13 @@ class S3ObjectStoreTest
   }
 
   it("retrieves a versioned object from s3") {
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       val content = "Some content!"
       val prefix = "foo"
 
       val objectStore = new S3ObjectStore(
         s3Client,
-        S3Config(bucketName = bucketName),
+        S3Config(bucketName = bucket.underlying),
         new KeyPrefixGenerator[TestObject] {
           override def generate(obj: TestObject): String = prefix
         }
@@ -130,10 +130,10 @@ class S3ObjectStoreTest
   }
 
   it("throws an exception when retrieving a missing object") {
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       val objectStore = new S3ObjectStore(
         s3Client,
-        S3Config(bucketName = bucketName),
+        S3Config(bucketName = bucket.underlying),
         new KeyPrefixGenerator[TestObject] {
           override def generate(obj: TestObject): String = "doesnt_matter"
         }

--- a/common/src/test/scala/uk/ac/wellcome/sns/SNSWriterTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sns/SNSWriterTest.scala
@@ -17,8 +17,8 @@ class SNSWriterTest
 
   it(
     "should send a message with subject to the SNS client and return a publish attempt with the id of the request") {
-    withLocalSnsTopic { arn =>
-      val snsConfig = SNSConfig(arn)
+    withLocalSnsTopic { topic =>
+      val snsConfig = SNSConfig(topic.arn)
       val snsWriter = new SNSWriter(snsClient, snsConfig)
       val message = "sns-writer-test-message"
       val subject = "sns-writer-test-subject"
@@ -28,7 +28,7 @@ class SNSWriterTest
       )
 
       whenReady(futurePublishAttempt) { publishAttempt =>
-        val messages = listMessagesReceivedFromSNS(arn)
+        val messages = listMessagesReceivedFromSNS(topic)
         messages should have size (1)
         messages.head.message shouldBe message
         messages.head.subject shouldBe subject

--- a/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
@@ -70,8 +70,7 @@ class VersionedHybridStoreTest
             .flatMap(_ => hybridStore.updateRecord(record.id)(record)(t)())
 
         whenReady(future) { _ =>
-          getJsonFor(bucket, table, record) shouldBe toJson(
-            expectedRecord).get
+          getJsonFor(bucket, table, record) shouldBe toJson(expectedRecord).get
         }
     }
   }
@@ -199,7 +198,8 @@ class VersionedHybridStoreTest
 
         whenReady(future) { _ =>
           val maybeResult =
-            Scanamo.get[ExtraData](dynamoDbClient)(table.name)('id -> record.id)
+            Scanamo.get[ExtraData](dynamoDbClient)(table.name)(
+              'id -> record.id)
 
           maybeResult shouldBe defined
           maybeResult.get.isRight shouldBe true

--- a/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
@@ -37,7 +37,7 @@ class VersionedHybridStoreTest
 
   it("stores a versioned record if it has never been seen before") {
     withFixtures {
-      case (bucketName, tableName, hybridStore) =>
+      case (bucket, tableName, hybridStore) =>
         val record = ExampleRecord(
           id = "1111",
           content = "One ocelot in orange"
@@ -47,14 +47,14 @@ class VersionedHybridStoreTest
           hybridStore.updateRecord(record.id)(record)(identity)()
 
         whenReady(future) { _ =>
-          getJsonFor(bucketName, tableName, record) shouldBe toJson(record).get
+          getJsonFor(bucket.underlying, tableName, record) shouldBe toJson(record).get
         }
     }
   }
 
   it("applies the given transformation to an existing record") {
     withFixtures {
-      case (bucketName, tableName, hybridStore) =>
+      case (bucket, tableName, hybridStore) =>
         val record = ExampleRecord(
           id = "1111",
           content = "One ocelot in orange"
@@ -70,7 +70,7 @@ class VersionedHybridStoreTest
             .flatMap(_ => hybridStore.updateRecord(record.id)(record)(t)())
 
         whenReady(future) { _ =>
-          getJsonFor(bucketName, tableName, record) shouldBe toJson(
+          getJsonFor(bucket.underlying, tableName, record) shouldBe toJson(
             expectedRecord).get
         }
     }
@@ -78,7 +78,7 @@ class VersionedHybridStoreTest
 
   it("updates DynamoDB and S3 if it sees a new version of a record") {
     withFixtures {
-      case (bucketName, tableName, hybridStore) =>
+      case (bucket, tableName, hybridStore) =>
         val record = ExampleRecord(
           id = "2222",
           content = "Two teal turtles in Tenerife"
@@ -97,7 +97,7 @@ class VersionedHybridStoreTest
         }
 
         whenReady(updatedFuture) { _ =>
-          getJsonFor(bucketName, tableName, updatedRecord) shouldBe toJson(
+          getJsonFor(bucket.underlying, tableName, updatedRecord) shouldBe toJson(
             updatedRecord).get
         }
     }
@@ -105,7 +105,7 @@ class VersionedHybridStoreTest
 
   it("returns a future of None for a non-existent record") {
     withFixtures {
-      case (bucketName, tableName, hybridStore) =>
+      case (_, _, hybridStore) =>
         val future = hybridStore.getRecord(id = "does/notexist")
 
         whenReady(future) { result =>
@@ -116,7 +116,7 @@ class VersionedHybridStoreTest
 
   it("returns a future of Some[ExampleRecord] if the record exists") {
     withFixtures {
-      case (bucketName, tableName, hybridStore) =>
+      case (_, _, hybridStore) =>
         val record = ExampleRecord(
           id = "5555",
           content = "Five fishing flinging flint"
@@ -137,7 +137,7 @@ class VersionedHybridStoreTest
 
   it("does not allow creation of records with a different id than indicated") {
     withFixtures {
-      case (bucketName, tableName, hybridStore) =>
+      case (_, _, hybridStore) =>
         val record = ExampleRecord(
           id = "8934",
           content = "Five fishing flinging flint"
@@ -193,7 +193,7 @@ class VersionedHybridStoreTest
     )
 
     withFixtures {
-      case (bucketName, tableName, hybridStore) =>
+      case (_, tableName, hybridStore) =>
         val future =
           hybridStore.updateRecord(record.id)(record)(identity)(data)
 

--- a/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/storage/VersionedHybridStoreTest.scala
@@ -47,7 +47,7 @@ class VersionedHybridStoreTest
           hybridStore.updateRecord(record.id)(record)(identity)()
 
         whenReady(future) { _ =>
-          getJsonFor(bucket.underlying, tableName, record) shouldBe toJson(record).get
+          getJsonFor(bucket, tableName, record) shouldBe toJson(record).get
         }
     }
   }
@@ -70,7 +70,7 @@ class VersionedHybridStoreTest
             .flatMap(_ => hybridStore.updateRecord(record.id)(record)(t)())
 
         whenReady(future) { _ =>
-          getJsonFor(bucket.underlying, tableName, record) shouldBe toJson(
+          getJsonFor(bucket, tableName, record) shouldBe toJson(
             expectedRecord).get
         }
     }
@@ -97,7 +97,7 @@ class VersionedHybridStoreTest
         }
 
         whenReady(updatedFuture) { _ =>
-          getJsonFor(bucket.underlying, tableName, updatedRecord) shouldBe toJson(
+          getJsonFor(bucket, tableName, updatedRecord) shouldBe toJson(
             updatedRecord).get
         }
     }

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalDynamoDb.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalDynamoDb.scala
@@ -51,7 +51,7 @@ trait LocalDynamoDb[T <: Versioned with Id] extends ImplicitLogging {
 
   implicit val evidence: DynamoFormat[T]
 
-  def withLocalDynamoDbTable[R] = fixture[Table, R] (
+  def withLocalDynamoDbTable[R] = fixture[Table, R](
     create = {
       val tableName = Random.alphanumeric.take(10).mkString
       val indexName = Random.alphanumeric.take(10).mkString

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalVersionedHybridStore.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalVersionedHybridStore.scala
@@ -51,17 +51,17 @@ trait LocalVersionedHybridStore
   def assertStored[T <: Id](bucket: Bucket, tableName: String, record: T)(
     implicit encoder: Encoder[T]) =
     assertJsonStringsAreEqual(
-      getJsonFor[T](bucket.underlying, tableName, record),
+      getJsonFor[T](bucket, tableName, record),
       toJson(record).get
     )
 
-  def getJsonFor[T <: Id](bucketName: String, tableName: String, record: T) = {
+  def getJsonFor[T <: Id](bucket: Bucket, tableName: String, record: T) = {
     val hybridRecord = Scanamo
       .get[HybridRecord](dynamoDbClient)(tableName)('id -> record.id)
       .get
       .right
       .get
 
-    getJsonFromS3(bucketName, hybridRecord.s3key).noSpaces
+    getJsonFromS3(bucket, hybridRecord.s3key).noSpaces
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalVersionedHybridStore.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalVersionedHybridStore.scala
@@ -31,9 +31,8 @@ trait LocalVersionedHybridStore
     )
   )
 
-  def withVersionedHybridStore[T <: Id, R](
-    bucket: Bucket,
-    table: Table)(testWith: TestWith[VersionedHybridStore[T], R]): R = {
+  def withVersionedHybridStore[T <: Id, R](bucket: Bucket, table: Table)(
+    testWith: TestWith[VersionedHybridStore[T], R]): R = {
     withVersionedDao(table) { dao =>
       val store = new VersionedHybridStore[T](
         sourcedObjectStore = new S3ObjectStore(

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalVersionedHybridStore.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/LocalVersionedHybridStore.scala
@@ -37,7 +37,7 @@ trait LocalVersionedHybridStore
       val store = new VersionedHybridStore[T](
         sourcedObjectStore = new S3ObjectStore(
           s3Client = s3Client,
-          s3Config = S3Config(bucketName = bucket.underlying),
+          s3Config = S3Config(bucketName = bucket.name),
           keyPrefixGenerator = new KeyPrefixGenerator[T] {
             override def generate(obj: T): String = "/"
           }

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/S3.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/S3.scala
@@ -14,8 +14,8 @@ import scala.util.Random
 
 object S3 {
 
-  class Bucket(val underlying: String) extends AnyVal {
-    override def toString = s"Bucket($underlying)"
+  class Bucket(val name: String) extends AnyVal {
+    override def toString = s"S3.Bucket($name)"
   }
 
   object Bucket {
@@ -39,7 +39,7 @@ trait S3 extends Logging with Eventually with ImplicitLogging {
     "aws.s3.accessKey" -> accessKey,
     "aws.s3.secretKey" -> secretKey,
     "aws.region" -> "localhost",
-    "aws.s3.bucketName" -> bucket.underlying
+    "aws.s3.bucketName" -> bucket.name
   )
 
   private val credentials = new AWSStaticCredentialsProvider(
@@ -66,17 +66,17 @@ trait S3 extends Logging with Eventually with ImplicitLogging {
       },
       destroy = { bucket: Bucket =>
         safeCleanup(s3Client) {
-          _.listObjects(bucket.underlying).getObjectSummaries.foreach { obj =>
-            safeCleanup(obj.getKey) { s3Client.deleteObject(bucket.underlying, _) }
+          _.listObjects(bucket.name).getObjectSummaries.foreach { obj =>
+            safeCleanup(obj.getKey) { s3Client.deleteObject(bucket.name, _) }
           }
         }
 
-        s3Client.deleteBucket(bucket.underlying)
+        s3Client.deleteBucket(bucket.name)
       }
     )
 
   def getContentFromS3(bucket: Bucket, key: String): String = {
-    IOUtils.toString(s3Client.getObject(bucket.underlying, key).getObjectContent)
+    IOUtils.toString(s3Client.getObject(bucket.name, key).getObjectContent)
   }
 
   def getJsonFromS3(bucket: Bucket, key: String): Json = {

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/S3.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/S3.scala
@@ -12,7 +12,21 @@ import org.scalatest.concurrent.Eventually
 import scala.collection.JavaConversions._
 import scala.util.Random
 
+object S3 {
+
+  class Bucket(val underlying: String) extends AnyVal {
+    override def toString = s"Bucket($underlying)"
+  }
+
+  object Bucket {
+    def apply(name: String): Bucket = new Bucket(name)
+  }
+
+}
+
 trait S3 extends Logging with Eventually with ImplicitLogging {
+
+  import S3._
 
   protected val localS3EndpointUrl = "http://localhost:33333"
   protected val regionName = "localhost"
@@ -20,12 +34,12 @@ trait S3 extends Logging with Eventually with ImplicitLogging {
   protected val accessKey = "accessKey1"
   protected val secretKey = "verySecretKey1"
 
-  def s3LocalFlags(bucketName: String) = Map(
+  def s3LocalFlags(bucket: Bucket) = Map(
     "aws.s3.endpoint" -> localS3EndpointUrl,
     "aws.s3.accessKey" -> accessKey,
     "aws.s3.secretKey" -> secretKey,
     "aws.region" -> "localhost",
-    "aws.s3.bucketName" -> bucketName
+    "aws.s3.bucketName" -> bucket.underlying
   )
 
   private val credentials = new AWSStaticCredentialsProvider(
@@ -40,33 +54,33 @@ trait S3 extends Logging with Eventually with ImplicitLogging {
     .build()
 
   def withLocalS3Bucket[R] =
-    fixture[String, R](
+    fixture[Bucket, R](
       create = {
         val bucketName: String =
           (Random.alphanumeric take 10 mkString).toLowerCase
 
-        val bucket = s3Client.createBucket(bucketName)
+        s3Client.createBucket(bucketName)
         eventually { s3Client.doesBucketExistV2(bucketName) }
 
-        bucketName
+        Bucket(bucketName)
       },
-      destroy = { bucketName: String =>
+      destroy = { bucket: Bucket =>
         safeCleanup(s3Client) {
-          _.listObjects(bucketName).getObjectSummaries.foreach { obj =>
-            safeCleanup(obj.getKey) { s3Client.deleteObject(bucketName, _) }
+          _.listObjects(bucket.underlying).getObjectSummaries.foreach { obj =>
+            safeCleanup(obj.getKey) { s3Client.deleteObject(bucket.underlying, _) }
           }
         }
 
-        s3Client.deleteBucket(bucketName)
+        s3Client.deleteBucket(bucket.underlying)
       }
     )
 
-  def getContentFromS3(bucketName: String, key: String): String = {
-    IOUtils.toString(s3Client.getObject(bucketName, key).getObjectContent)
+  def getContentFromS3(bucket: Bucket, key: String): String = {
+    IOUtils.toString(s3Client.getObject(bucket.underlying, key).getObjectContent)
   }
 
-  def getJsonFromS3(bucketName: String, key: String): Json = {
-    parse(getContentFromS3(bucketName, key)).right.get
+  def getJsonFromS3(bucket: Bucket, key: String): Json = {
+    parse(getContentFromS3(bucket, key)).right.get
   }
 
 }

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/SNS.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/SNS.scala
@@ -58,7 +58,9 @@ trait SNS extends ImplicitLogging {
       val arn = snsClient.createTopic(topicName).getTopicArn
       Topic(arn)
     },
-    destroy = { topic => snsClient.deleteTopic(topic.arn) }
+    destroy = { topic =>
+      snsClient.deleteTopic(topic.arn)
+    }
   )
 
   private val mapper =

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/SNS.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/SNS.scala
@@ -13,19 +13,33 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 import scala.util.Random
 
+object SNS {
+
+  class Topic(val arn: String) extends AnyVal {
+    override def toString = s"SNS.Topic($arn)"
+  }
+
+  object Topic {
+    def apply(arn: String): Topic = new Topic(arn)
+  }
+
+}
+
 trait SNS extends ImplicitLogging {
+
+  import SNS._
 
   private val localSNSEndpointUrl = "http://localhost:9292"
 
   private val accessKey = "access"
   private val secretKey = "secret"
 
-  def snsLocalFlags(topicArn: String) = Map(
+  def snsLocalFlags(topic: Topic) = Map(
     "aws.sns.endpoint" -> localSNSEndpointUrl,
     "aws.sns.accessKey" -> accessKey,
     "aws.sns.secretKey" -> secretKey,
     "aws.region" -> "localhost",
-    "aws.sns.topic.arn" -> topicArn
+    "aws.sns.topic.arn" -> topic.arn
   )
 
   private val credentials = new AWSStaticCredentialsProvider(
@@ -38,13 +52,13 @@ trait SNS extends ImplicitLogging {
       new EndpointConfiguration(localSNSEndpointUrl, "local"))
     .build()
 
-  def withLocalSnsTopic[R] = fixture[String, R](
+  def withLocalSnsTopic[R] = fixture[Topic, R](
     create = {
       val topicName = Random.alphanumeric take 10 mkString
       val arn = snsClient.createTopic(topicName).getTopicArn
-      arn
+      Topic(arn)
     },
-    destroy = snsClient.deleteTopic(_)
+    destroy = { topic => snsClient.deleteTopic(topic.arn) }
   )
 
   private val mapper =
@@ -52,7 +66,7 @@ trait SNS extends ImplicitLogging {
       .registerModule(DefaultScalaModule)
       .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
-  def listMessagesReceivedFromSNS(topicArn: String): List[MessageInfo] = {
+  def listMessagesReceivedFromSNS(topic: Topic): List[MessageInfo] = {
     /*
     This is a sample returned by the fake-sns implementation:
     ---
@@ -74,7 +88,7 @@ trait SNS extends ImplicitLogging {
 
     val string = scala.io.Source.fromURL(localSNSEndpointUrl).mkString
     val messages = mapper.readValue(string, classOf[Messages])
-    messages.messages.filter(_.topic_arn == topicArn)
+    messages.messages.filter(_.topic_arn == topic.arn)
   }
 }
 

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/ServerTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/ServerTest.scala
@@ -15,9 +15,9 @@ class ServerTest
 
   it("shows the healthcheck message") {
     withLocalSqsQueue { queueUrl =>
-      withLocalSnsTopic { topicArn =>
+      withLocalSnsTopic { topic =>
         withLocalS3Bucket { bucket =>
-          val flags = snsLocalFlags(topicArn) ++ sqsLocalFlags(queueUrl) ++ s3LocalFlags(
+          val flags = snsLocalFlags(topic) ++ sqsLocalFlags(queueUrl) ++ s3LocalFlags(
             bucket)
           withServer(flags) { server =>
             server.httpGet(

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/ServerTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/ServerTest.scala
@@ -14,10 +14,10 @@ class ServerTest
     with fixtures.Server {
 
   it("shows the healthcheck message") {
-    withLocalSqsQueue { queueUrl =>
+    withLocalSqsQueue { queue =>
       withLocalSnsTopic { topic =>
         withLocalS3Bucket { bucket =>
-          val flags = snsLocalFlags(topic) ++ sqsLocalFlags(queueUrl) ++ s3LocalFlags(
+          val flags = snsLocalFlags(topic) ++ sqsLocalFlags(queue) ++ s3LocalFlags(
             bucket)
           withServer(flags) { server =>
             server.httpGet(

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/ServerTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/ServerTest.scala
@@ -16,9 +16,9 @@ class ServerTest
   it("shows the healthcheck message") {
     withLocalSqsQueue { queueUrl =>
       withLocalSnsTopic { topicArn =>
-        withLocalS3Bucket { bucketName =>
+        withLocalS3Bucket { bucket =>
           val flags = snsLocalFlags(topicArn) ++ sqsLocalFlags(queueUrl) ++ s3LocalFlags(
-            bucketName)
+            bucket)
           withServer(flags) { server =>
             server.httpGet(
               path = "/management/healthcheck",

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
@@ -73,9 +73,9 @@ class SnapshotConvertorFeatureTest
 
           withGzipCompressedS3Key(sourceBucket, content) { objectKey =>
             val conversionJob = ConversionJob(
-              sourceBucketName = sourceBucket.underlying,
+              sourceBucketName = sourceBucket.name,
               sourceObjectKey = objectKey,
-              targetBucketName = targetBucket.underlying,
+              targetBucketName = targetBucket.name,
               targetObjectKey = targetObjectKey
             )
 
@@ -95,7 +95,7 @@ class SnapshotConvertorFeatureTest
                 File.createTempFile("convertorServiceTest", ".txt.gz")
 
               s3Client.getObject(
-                new GetObjectRequest(targetBucket.underlying, targetObjectKey),
+                new GetObjectRequest(targetBucket.name, targetObjectKey),
                 downloadFile)
 
               val actualJsonLines: List[String] =
@@ -127,7 +127,7 @@ class SnapshotConvertorFeatureTest
               val expectedJob = CompletedConversionJob(
                 conversionJob = conversionJob,
                 targetLocation =
-                  s"http://localhost:33333/${targetBucket.underlying}/$targetObjectKey"
+                  s"http://localhost:33333/${targetBucket.name}/$targetObjectKey"
               )
               val actualJob = fromJson[CompletedConversionJob](
                 receivedMessages.head.message).get

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
@@ -43,8 +43,8 @@ class SnapshotConvertorFeatureTest
 
   it("completes a conversion successfully") {
     withFixtures {
-      case (((queueUrl, topic), sourceBucket), targetBucket) =>
-        val flags = snsLocalFlags(topic) ++ sqsLocalFlags(queueUrl) ++ s3LocalFlags(
+      case (((queue, topic), sourceBucket), targetBucket) =>
+        val flags = snsLocalFlags(topic) ++ sqsLocalFlags(queue) ++ s3LocalFlags(
           sourceBucket)
 
         withServer(flags) { _ =>
@@ -87,7 +87,7 @@ class SnapshotConvertorFeatureTest
               timestamp = "now"
             )
 
-            sqsClient.sendMessage(queueUrl, toJson(message).get)
+            sqsClient.sendMessage(queue.url, toJson(message).get)
 
             eventually {
 

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
@@ -43,8 +43,8 @@ class SnapshotConvertorFeatureTest
 
   it("completes a conversion successfully") {
     withFixtures {
-      case (((queueUrl, topicArn), sourceBucket), targetBucket) =>
-        val flags = snsLocalFlags(topicArn) ++ sqsLocalFlags(queueUrl) ++ s3LocalFlags(
+      case (((queueUrl, topic), sourceBucket), targetBucket) =>
+        val flags = snsLocalFlags(topic) ++ sqsLocalFlags(queueUrl) ++ s3LocalFlags(
           sourceBucket)
 
         withServer(flags) { _ =>
@@ -83,7 +83,7 @@ class SnapshotConvertorFeatureTest
               subject = Some("Sent from SnapshotConvertorFeatureTest"),
               body = toJson(conversionJob).get,
               messageType = "json",
-              topic = topicArn,
+              topic = topic.arn,
               timestamp = "now"
             )
 
@@ -121,7 +121,7 @@ class SnapshotConvertorFeatureTest
                   assertJsonStringsAreEqual(actualLine, expectedLine)
               }
 
-              val receivedMessages = listMessagesReceivedFromSNS(topicArn)
+              val receivedMessages = listMessagesReceivedFromSNS(topic)
               receivedMessages.size should be >= 1
 
               val expectedJob = CompletedConversionJob(

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -68,8 +68,7 @@ class ConvertorServiceTest
   it("completes a conversion successfully") {
     withFixtures {
       case (
-          ((_, _, _, convertorService: ConvertorService), sourceBucketName),
-          targetBucketName) =>
+          ((_, _, _, convertorService: ConvertorService), sourceBucket), targetBucket) =>
         // Create a collection of works.  These three differ by version,
         // if not anything more interesting!
         val visibleWorks = (1 to 3).map { version =>
@@ -105,13 +104,13 @@ class ConvertorServiceTest
         }
         val content = elasticsearchJsons.mkString("\n")
 
-        withGzipCompressedS3Key(sourceBucketName, content) { objectKey =>
+        withGzipCompressedS3Key(sourceBucket.underlying, content) { objectKey =>
           val targetObjectKey = "target.txt.gz"
 
           val conversionJob = ConversionJob(
-            sourceBucketName = sourceBucketName,
+            sourceBucketName = sourceBucket.underlying,
             sourceObjectKey = objectKey,
-            targetBucketName = targetBucketName,
+            targetBucketName = targetBucket.underlying,
             targetObjectKey = targetObjectKey
           )
 
@@ -121,7 +120,7 @@ class ConvertorServiceTest
             val downloadFile =
               File.createTempFile("convertorServiceTest", ".txt.gz")
             s3Client.getObject(
-              new GetObjectRequest(targetBucketName, targetObjectKey),
+              new GetObjectRequest(targetBucket.underlying, targetObjectKey),
               downloadFile)
 
             val contents = readGzipFile(downloadFile.getPath)
@@ -139,7 +138,7 @@ class ConvertorServiceTest
             result shouldBe CompletedConversionJob(
               conversionJob = conversionJob,
               targetLocation =
-                s"http://localhost:33333/$targetBucketName/$targetObjectKey"
+                s"http://localhost:33333/${targetBucket.underlying}/$targetObjectKey"
             )
           }
         }
@@ -162,8 +161,8 @@ class ConvertorServiceTest
   it("completes a very large conversion successfully") {
     withFixtures {
       case (
-          ((_, _, _, convertorService: ConvertorService), sourceBucketName),
-          targetBucketName) =>
+          ((_, _, _, convertorService: ConvertorService), sourceBucket),
+          targetBucket) =>
         // Create a collection of works.  The use of Random is meant
         // to increase the entropy of works, and thus the degree to
         // which they can be gzip-compressed -- so we can cross the
@@ -193,12 +192,12 @@ class ConvertorServiceTest
         val gzipFileSize = createGzipFile(content).length.toInt
         gzipFileSize shouldBe >=(8 * 1024 * 1024)
 
-        withGzipCompressedS3Key(sourceBucketName, content) { objectKey =>
+        withGzipCompressedS3Key(sourceBucket.underlying, content) { objectKey =>
           val targetObjectKey = "target.txt.gz"
           val conversionJob = ConversionJob(
-            sourceBucketName = sourceBucketName,
+            sourceBucketName = sourceBucket.underlying,
             sourceObjectKey = objectKey,
-            targetBucketName = targetBucketName,
+            targetBucketName = targetBucket.underlying,
             targetObjectKey = targetObjectKey
           )
 
@@ -208,7 +207,7 @@ class ConvertorServiceTest
             val downloadFile =
               File.createTempFile("convertorServiceTest", ".txt.gz")
             s3Client.getObject(
-              new GetObjectRequest(targetBucketName, targetObjectKey),
+              new GetObjectRequest(targetBucket.underlying, targetObjectKey),
               downloadFile)
 
             val contents = readGzipFile(downloadFile.getPath)
@@ -226,7 +225,7 @@ class ConvertorServiceTest
             result shouldBe CompletedConversionJob(
               conversionJob = conversionJob,
               targetLocation =
-                s"http://localhost:33333/$targetBucketName/$targetObjectKey"
+                s"http://localhost:33333/${targetBucket.underlying}/$targetObjectKey"
             )
           }
         }
@@ -236,12 +235,12 @@ class ConvertorServiceTest
   it("returns a failed future if asked to convert a non-existent snapshot") {
     withFixtures {
       case (
-          ((_, _, _, convertorService: ConvertorService), sourceBucketName),
-          targetBucketName) =>
+          ((_, _, _, convertorService: ConvertorService), sourceBucket),
+          targetBucket) =>
         val conversionJob = ConversionJob(
-          sourceBucketName = sourceBucketName,
+          sourceBucketName = sourceBucket.underlying,
           sourceObjectKey = "doesnotexist.txt.gz",
-          targetBucketName = targetBucketName,
+          targetBucketName = targetBucket.underlying,
           targetObjectKey = "target.txt.gz"
         )
 
@@ -256,15 +255,15 @@ class ConvertorServiceTest
   it("returns a failed future if asked to convert a malformed snapshot") {
     withFixtures {
       case (
-          ((_, _, _, convertorService: ConvertorService), sourceBucketName),
-          targetBucketName) =>
+          ((_, _, _, convertorService: ConvertorService), sourceBucket),
+          targetBucket) =>
         withGzipCompressedS3Key(
-          sourceBucketName,
+          sourceBucket,
           content = "This is not what snapshots look like") { objectKey =>
           val conversionJob = ConversionJob(
-            sourceBucketName = sourceBucketName,
+            sourceBucketName = sourceBucket.underlying,
             sourceObjectKey = objectKey,
-            targetBucketName = targetBucketName,
+            targetBucketName = targetBucket.underlying,
             targetObjectKey = "target.txt.gz"
           )
 
@@ -280,8 +279,8 @@ class ConvertorServiceTest
   it("returns a failed future if the S3 upload fails") {
     withFixtures {
       case (
-          ((_, _, _, convertorService: ConvertorService), sourceBucketName),
-          targetBucketName) =>
+          ((_, _, _, convertorService: ConvertorService), sourceBucket),
+          targetBucket) =>
         // Create a collection of works.  These three differ by version,
         // if not anything more interesting!
         val works = (1 to 3).map { version =>

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -108,9 +108,9 @@ class ConvertorServiceTest
           val targetObjectKey = "target.txt.gz"
 
           val conversionJob = ConversionJob(
-            sourceBucketName = sourceBucket.underlying,
+            sourceBucketName = sourceBucket.name,
             sourceObjectKey = objectKey,
-            targetBucketName = targetBucket.underlying,
+            targetBucketName = targetBucket.name,
             targetObjectKey = targetObjectKey
           )
 
@@ -120,7 +120,7 @@ class ConvertorServiceTest
             val downloadFile =
               File.createTempFile("convertorServiceTest", ".txt.gz")
             s3Client.getObject(
-              new GetObjectRequest(targetBucket.underlying, targetObjectKey),
+              new GetObjectRequest(targetBucket.name, targetObjectKey),
               downloadFile)
 
             val contents = readGzipFile(downloadFile.getPath)
@@ -138,7 +138,7 @@ class ConvertorServiceTest
             result shouldBe CompletedConversionJob(
               conversionJob = conversionJob,
               targetLocation =
-                s"http://localhost:33333/${targetBucket.underlying}/$targetObjectKey"
+                s"http://localhost:33333/${targetBucket.name}/$targetObjectKey"
             )
           }
         }
@@ -195,9 +195,9 @@ class ConvertorServiceTest
         withGzipCompressedS3Key(sourceBucket, content) { objectKey =>
           val targetObjectKey = "target.txt.gz"
           val conversionJob = ConversionJob(
-            sourceBucketName = sourceBucket.underlying,
+            sourceBucketName = sourceBucket.name,
             sourceObjectKey = objectKey,
-            targetBucketName = targetBucket.underlying,
+            targetBucketName = targetBucket.name,
             targetObjectKey = targetObjectKey
           )
 
@@ -207,7 +207,7 @@ class ConvertorServiceTest
             val downloadFile =
               File.createTempFile("convertorServiceTest", ".txt.gz")
             s3Client.getObject(
-              new GetObjectRequest(targetBucket.underlying, targetObjectKey),
+              new GetObjectRequest(targetBucket.name, targetObjectKey),
               downloadFile)
 
             val contents = readGzipFile(downloadFile.getPath)
@@ -225,7 +225,7 @@ class ConvertorServiceTest
             result shouldBe CompletedConversionJob(
               conversionJob = conversionJob,
               targetLocation =
-                s"http://localhost:33333/${targetBucket.underlying}/$targetObjectKey"
+                s"http://localhost:33333/${targetBucket.name}/$targetObjectKey"
             )
           }
         }
@@ -238,9 +238,9 @@ class ConvertorServiceTest
           ((_, _, _, convertorService: ConvertorService), sourceBucket),
           targetBucket) =>
         val conversionJob = ConversionJob(
-          sourceBucketName = sourceBucket.underlying,
+          sourceBucketName = sourceBucket.name,
           sourceObjectKey = "doesnotexist.txt.gz",
-          targetBucketName = targetBucket.underlying,
+          targetBucketName = targetBucket.name,
           targetObjectKey = "target.txt.gz"
         )
 
@@ -261,9 +261,9 @@ class ConvertorServiceTest
           sourceBucket,
           content = "This is not what snapshots look like") { objectKey =>
           val conversionJob = ConversionJob(
-            sourceBucketName = sourceBucket.underlying,
+            sourceBucketName = sourceBucket.name,
             sourceObjectKey = objectKey,
-            targetBucketName = targetBucket.underlying,
+            targetBucketName = targetBucket.name,
             targetObjectKey = "target.txt.gz"
           )
 

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -68,7 +68,8 @@ class ConvertorServiceTest
   it("completes a conversion successfully") {
     withFixtures {
       case (
-          ((_, _, _, convertorService: ConvertorService), sourceBucket), targetBucket) =>
+          ((_, _, _, convertorService: ConvertorService), sourceBucket),
+          targetBucket) =>
         // Create a collection of works.  These three differ by version,
         // if not anything more interesting!
         val visibleWorks = (1 to 3).map { version =>

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -104,7 +104,7 @@ class ConvertorServiceTest
         }
         val content = elasticsearchJsons.mkString("\n")
 
-        withGzipCompressedS3Key(sourceBucket.underlying, content) { objectKey =>
+        withGzipCompressedS3Key(sourceBucket, content) { objectKey =>
           val targetObjectKey = "target.txt.gz"
 
           val conversionJob = ConversionJob(
@@ -192,7 +192,7 @@ class ConvertorServiceTest
         val gzipFileSize = createGzipFile(content).length.toInt
         gzipFileSize shouldBe >=(8 * 1024 * 1024)
 
-        withGzipCompressedS3Key(sourceBucket.underlying, content) { objectKey =>
+        withGzipCompressedS3Key(sourceBucket, content) { objectKey =>
           val targetObjectKey = "target.txt.gz"
           val conversionJob = ConversionJob(
             sourceBucketName = sourceBucket.underlying,

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
@@ -28,7 +28,7 @@ class S3SourceTest
       implicit val system = actorSystem
       implicit val materializer = ActorMaterializer()
 
-      withLocalS3Bucket { bucketName =>
+      withLocalS3Bucket { bucker =>
         withS3AkkaClient(actorSystem, materializer) { akkaS3client =>
           val expectedLines = List(
             "AARGH! An armada of alpaccas",
@@ -37,9 +37,9 @@ class S3SourceTest
           )
           val content = expectedLines.mkString("\n")
 
-          withGzipCompressedS3Key(bucketName, content) { key =>
+          withGzipCompressedS3Key(bucket, content) { key =>
             val s3inputStream = s3Client
-              .getObject(bucketName, key)
+              .getObject(bucket.underlying, key)
               .getObjectContent()
 
             val source = S3Source(s3inputStream = s3inputStream)
@@ -59,13 +59,13 @@ class S3SourceTest
       implicit val system = actorSystem
       implicit val materializer = ActorMaterializer()
 
-      withLocalS3Bucket { bucketName =>
+      withLocalS3Bucket { bucket =>
         withS3AkkaClient(actorSystem, materializer) { akkaS3client =>
           val key = "example.txt.gz"
-          s3Client.putObject(bucketName, key, "NotAGzipCompressedFile")
+          s3Client.putObject(bucket.underlying, key, "NotAGzipCompressedFile")
 
           val s3inputStream = s3Client
-            .getObject(bucketName, key)
+            .getObject(bucket.underlying, key)
             .getObjectContent()
 
           val source = S3Source(s3inputStream = s3inputStream)

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
@@ -39,7 +39,7 @@ class S3SourceTest
 
           withGzipCompressedS3Key(bucket, content) { key =>
             val s3inputStream = s3Client
-              .getObject(bucket.underlying, key)
+              .getObject(bucket.name, key)
               .getObjectContent()
 
             val source = S3Source(s3inputStream = s3inputStream)
@@ -62,10 +62,10 @@ class S3SourceTest
       withLocalS3Bucket { bucket =>
         withS3AkkaClient(actorSystem, materializer) { akkaS3client =>
           val key = "example.txt.gz"
-          s3Client.putObject(bucket.underlying, key, "NotAGzipCompressedFile")
+          s3Client.putObject(bucket.name, key, "NotAGzipCompressedFile")
 
           val s3inputStream = s3Client
-            .getObject(bucket.underlying, key)
+            .getObject(bucket.name, key)
             .getObjectContent()
 
           val source = S3Source(s3inputStream = s3inputStream)

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/source/S3SourceTest.scala
@@ -28,7 +28,7 @@ class S3SourceTest
       implicit val system = actorSystem
       implicit val materializer = ActorMaterializer()
 
-      withLocalS3Bucket { bucker =>
+      withLocalS3Bucket { bucket =>
         withS3AkkaClient(actorSystem, materializer) { akkaS3client =>
           val expectedLines = List(
             "AARGH! An armada of alpaccas",

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/test/utils/GzipUtils.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/test/utils/GzipUtils.scala
@@ -15,7 +15,7 @@ trait GzipUtils extends S3 {
     val gzipFile = createGzipFile(content)
     val key = (Random.alphanumeric take 10 mkString).toLowerCase
 
-    s3Client.putObject(bucket.underlying, key, gzipFile)
+    s3Client.putObject(bucket.name, key, gzipFile)
 
     testWith(key)
   }

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/test/utils/GzipUtils.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/test/utils/GzipUtils.scala
@@ -10,12 +10,12 @@ import org.scalatest.Assertion
 import uk.ac.wellcome.test.fixtures.{S3, TestWith}
 
 trait GzipUtils extends S3 {
-  def withGzipCompressedS3Key(bucketName: String, content: String)(
+  def withGzipCompressedS3Key(bucket: S3.Bucket, content: String)(
     testWith: TestWith[String, Assertion]) = {
     val gzipFile = createGzipFile(content)
     val key = (Random.alphanumeric take 10 mkString).toLowerCase
 
-    s3Client.putObject(bucketName, key, gzipFile)
+    s3Client.putObject(bucket.underlying, key, gzipFile)
 
     testWith(key)
   }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
@@ -91,13 +91,13 @@ class ReindexerFeatureTest
 
   it("increases the reindexVersion on every record that needs a reindex") {
     withLocalSqsQueue { queueUrl =>
-      withLocalSnsTopic { topicArn =>
+      withLocalSnsTopic { topic =>
         withLocalDynamoDbTableAndIndex { fixtures =>
           val tableName = fixtures.tableName
           val indexName = fixtures.indexName
 
           val flags
-            : Map[String, String] = snsLocalFlags(topicArn) ++ dynamoDbLocalEndpointFlags(
+            : Map[String, String] = snsLocalFlags(topic) ++ dynamoDbLocalEndpointFlags(
             tableName) ++ sqsLocalFlags(queueUrl) ++ Map(
             "aws.dynamo.indexName" -> indexName)
 
@@ -121,13 +121,13 @@ class ReindexerFeatureTest
 
   it("sends an SNS notice for a completed reindex") {
     withLocalSqsQueue { queueUrl =>
-      withLocalSnsTopic { topicArn =>
+      withLocalSnsTopic { topic =>
         withLocalDynamoDbTableAndIndex { fixtures =>
           val tableName = fixtures.tableName
           val indexName = fixtures.indexName
 
           val flags
-            : Map[String, String] = snsLocalFlags(topicArn) ++ dynamoDbLocalEndpointFlags(
+            : Map[String, String] = snsLocalFlags(topic) ++ dynamoDbLocalEndpointFlags(
             tableName) ++ sqsLocalFlags(queueUrl) ++ Map(
             "aws.dynamo.indexName" -> indexName)
 
@@ -141,7 +141,7 @@ class ReindexerFeatureTest
             )
 
             eventually {
-              val messages = listMessagesReceivedFromSNS(topicArn)
+              val messages = listMessagesReceivedFromSNS(topic)
 
               messages should have size 1
 
@@ -159,13 +159,13 @@ class ReindexerFeatureTest
 
   it("does not send a message if it cannot complete a reindex") {
     withLocalSqsQueue { queueUrl =>
-      withLocalSnsTopic { topicArn =>
+      withLocalSnsTopic { topic =>
         withLocalDynamoDbTableAndIndex { fixtures =>
           val tableName = fixtures.tableName
           val indexName = fixtures.indexName
 
           val flags
-            : Map[String, String] = snsLocalFlags(topicArn) ++ dynamoDbLocalEndpointFlags(
+            : Map[String, String] = snsLocalFlags(topic) ++ dynamoDbLocalEndpointFlags(
             "non_existent_table") ++ sqsLocalFlags(queueUrl) ++ Map(
             "aws.dynamo.indexName" -> indexName)
 
@@ -176,7 +176,7 @@ class ReindexerFeatureTest
             // We wait some time to ensure that the message is not processed
             Thread.sleep(5000)
 
-            val messages = listMessagesReceivedFromSNS(topicArn)
+            val messages = listMessagesReceivedFromSNS(topic)
             messages should have size 0
           }
         }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
@@ -95,7 +95,6 @@ class ReindexerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalSnsTopic { topic =>
         withLocalDynamoDbTable { table =>
-
           val flags
             : Map[String, String] = snsLocalFlags(topic) ++ dynamoDbLocalEndpointFlags(
             table) ++ sqsLocalFlags(queue) ++ Map(
@@ -123,7 +122,6 @@ class ReindexerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalSnsTopic { topic =>
         withLocalDynamoDbTable { table =>
-
           val flags
             : Map[String, String] = snsLocalFlags(topic) ++ dynamoDbLocalEndpointFlags(
             table) ++ sqsLocalFlags(queue) ++ Map(
@@ -160,8 +158,8 @@ class ReindexerFeatureTest
       withLocalSnsTopic { topic =>
         withLocalDynamoDbTable { table =>
           val flags
-            : Map[String, String] = snsLocalFlags(topic) ++ dynamoDbLocalEndpointFlags(
-            table.copy(name ="non_existent_table")) ++ sqsLocalFlags(queue) ++ Map(
+            : Map[String, String] = snsLocalFlags(topic) ++ dynamoDbLocalEndpointFlags(table
+            .copy(name = "non_existent_table")) ++ sqsLocalFlags(queue) ++ Map(
             "aws.dynamo.indexName" -> table.index)
 
           withServer(flags) { _ =>

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -53,7 +53,7 @@ class ReindexWorkerServiceTest
       )
 
       withLocalSqsQueue { queueUrl =>
-        withLocalSnsTopic { topicArn =>
+        withLocalSnsTopic { topic =>
           val workerService = new ReindexWorkerService(
             targetService = new ReindexService(
               dynamoDBClient = dynamoDbClient,
@@ -75,7 +75,7 @@ class ReindexWorkerServiceTest
             ),
             snsWriter = new SNSWriter(
               snsClient = snsClient,
-              snsConfig = SNSConfig(topicArn = topicArn)
+              snsConfig = SNSConfig(topicArn = topic.arn)
             ),
             system = actorSystem,
             metrics = metricsSender

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -52,7 +52,7 @@ class ReindexWorkerServiceTest
         actorSystem = actorSystem
       )
 
-      withLocalSqsQueue { queueUrl =>
+      withLocalSqsQueue { queue =>
         withLocalSnsTopic { topic =>
           val workerService = new ReindexWorkerService(
             targetService = new ReindexService(
@@ -68,7 +68,7 @@ class ReindexWorkerServiceTest
             reader = new SQSReader(
               sqsClient = sqsClient,
               sqsConfig = SQSConfig(
-                queueUrl = queueUrl,
+                queueUrl = queue.url,
                 waitTime = 1 second,
                 maxMessages = 1
               )

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
@@ -19,9 +19,9 @@ class ServerTest
   it("shows the healthcheck message") {
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        withLocalDynamoDbTable { tableName =>
+        withLocalDynamoDbTable { table =>
           val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            tableName)
+            table)
           withServer(flags) { server =>
             server.httpGet(
               path = "/management/healthcheck",

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
@@ -17,10 +17,10 @@ class ServerTest
     DynamoFormat[HybridRecord]
 
   it("shows the healthcheck message") {
-    withLocalSqsQueue { queueUrl =>
+    withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { tableName =>
-          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             tableName)
           withServer(flags) { server =>
             server.httpGet(

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
@@ -18,9 +18,9 @@ class ServerTest
 
   it("shows the healthcheck message") {
     withLocalSqsQueue { queueUrl =>
-      withLocalS3Bucket { bucketName =>
+      withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { tableName =>
-          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucketName) ++ dynamoDbLocalEndpointFlags(
+          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             tableName)
           withServer(flags) { server =>
             server.httpGet(

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -63,13 +63,13 @@ class SierraBibMergerFeatureTest
 
   it("should store a bib in the hybrid store") {
     withLocalSqsQueue { queueUrl =>
-      withLocalS3Bucket { bucketName =>
+      withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { tableName =>
-          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucketName) ++ dynamoDbLocalEndpointFlags(
+          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             tableName)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](
-              bucketName,
+              bucket,
               tableName) { hybridStore =>
               val id = "1000001"
               val record = SierraBibRecord(
@@ -89,7 +89,7 @@ class SierraBibMergerFeatureTest
 
               eventually {
                 assertStored[SierraTransformable](
-                  bucketName,
+                  bucket.underlying,
                   tableName,
                   expectedSierraTransformable)
               }
@@ -102,13 +102,13 @@ class SierraBibMergerFeatureTest
 
   it("stores multiple bibs from SQS") {
     withLocalSqsQueue { queueUrl =>
-      withLocalS3Bucket { bucketName =>
+      withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { tableName =>
-          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucketName) ++ dynamoDbLocalEndpointFlags(
+          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             tableName)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](
-              bucketName,
+              bucket,
               tableName) { hybridStore =>
               val id1 = "1000001"
               val record1 = SierraBibRecord(
@@ -144,11 +144,11 @@ class SierraBibMergerFeatureTest
 
               eventually {
                 assertStored[SierraTransformable](
-                  bucketName,
+                  bucket,
                   tableName,
                   expectedSierraTransformable1)
                 assertStored[SierraTransformable](
-                  bucketName,
+                  bucket,
                   tableName,
                   expectedSierraTransformable2)
               }
@@ -161,13 +161,13 @@ class SierraBibMergerFeatureTest
 
   it("updates a bib if a newer version is sent to SQS") {
     withLocalSqsQueue { queueUrl =>
-      withLocalS3Bucket { bucketName =>
+      withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { tableName =>
-          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucketName) ++ dynamoDbLocalEndpointFlags(
+          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             tableName)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](
-              bucketName,
+              bucket,
               tableName) { hybridStore =>
               val id = "3000003"
               val oldBibRecord = SierraBibRecord(
@@ -206,7 +206,7 @@ class SierraBibMergerFeatureTest
 
               eventually {
                 assertStored[SierraTransformable](
-                  bucketName,
+                  bucket,
                   tableName,
                   expectedSierraTransformable)
               }
@@ -219,13 +219,13 @@ class SierraBibMergerFeatureTest
 
   it("does not update a bib if an older version is sent to SQS") {
     withLocalSqsQueue { queueUrl =>
-      withLocalS3Bucket { bucketName =>
+      withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { tableName =>
-          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucketName) ++ dynamoDbLocalEndpointFlags(
+          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             tableName)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](
-              bucketName,
+              bucket,
               tableName) { hybridStore =>
               val id = "6000006"
               val newBibRecord = SierraBibRecord(
@@ -266,7 +266,7 @@ class SierraBibMergerFeatureTest
               Thread.sleep(5000)
 
               assertStored[SierraTransformable](
-                bucketName,
+                bucket,
                 tableName,
                 expectedSierraTransformable)
             }
@@ -278,13 +278,13 @@ class SierraBibMergerFeatureTest
 
   it("stores a bib from SQS if the ID already exists but no bibData") {
     withLocalSqsQueue { queueUrl =>
-      withLocalS3Bucket { bucketName =>
+      withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { tableName =>
-          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucketName) ++ dynamoDbLocalEndpointFlags(
+          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             tableName)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](
-              bucketName,
+              bucket,
               tableName) { hybridStore =>
               val id = "7000007"
               val newRecord = SierraTransformable(sourceId = id)
@@ -314,7 +314,7 @@ class SierraBibMergerFeatureTest
 
               eventually {
                 assertStored[SierraTransformable](
-                  bucketName,
+                  bucket,
                   tableName,
                   expectedSierraTransformable)
               }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -69,31 +69,30 @@ class SierraBibMergerFeatureTest
           val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             table)
           withServer(flags) { _ =>
-            withVersionedHybridStore[SierraTransformable, Unit](
-              bucket,
-              table) { hybridStore =>
-              val id = "1000001"
-              val record = SierraBibRecord(
-                id = id,
-                data = bibRecordString(
+            withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
+              hybridStore =>
+                val id = "1000001"
+                val record = SierraBibRecord(
                   id = id,
-                  updatedDate = "2001-01-01T01:01:01Z",
-                  title = "One ocelot on our oval"
-                ),
-                modifiedDate = "2001-01-01T01:01:01Z"
-              )
+                  data = bibRecordString(
+                    id = id,
+                    updatedDate = "2001-01-01T01:01:01Z",
+                    title = "One ocelot on our oval"
+                  ),
+                  modifiedDate = "2001-01-01T01:01:01Z"
+                )
 
-              sendMessageToSQS(toJson(record).get, queue)
+                sendMessageToSQS(toJson(record).get, queue)
 
-              val expectedSierraTransformable =
-                SierraTransformable(bibRecord = record)
+                val expectedSierraTransformable =
+                  SierraTransformable(bibRecord = record)
 
-              eventually {
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  expectedSierraTransformable)
-              }
+                eventually {
+                  assertStored[SierraTransformable](
+                    bucket,
+                    table,
+                    expectedSierraTransformable)
+                }
             }
           }
         }
@@ -108,51 +107,50 @@ class SierraBibMergerFeatureTest
           val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             table)
           withServer(flags) { _ =>
-            withVersionedHybridStore[SierraTransformable, Unit](
-              bucket,
-              table) { hybridStore =>
-              val id1 = "1000001"
-              val record1 = SierraBibRecord(
-                id = id1,
-                data = bibRecordString(
+            withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
+              hybridStore =>
+                val id1 = "1000001"
+                val record1 = SierraBibRecord(
                   id = id1,
-                  updatedDate = "2001-01-01T01:01:01Z",
-                  title = "The first ferret of four"
-                ),
-                modifiedDate = "2001-01-01T01:01:01Z"
-              )
+                  data = bibRecordString(
+                    id = id1,
+                    updatedDate = "2001-01-01T01:01:01Z",
+                    title = "The first ferret of four"
+                  ),
+                  modifiedDate = "2001-01-01T01:01:01Z"
+                )
 
-              sendMessageToSQS(toJson(record1).get, queue)
+                sendMessageToSQS(toJson(record1).get, queue)
 
-              val expectedSierraTransformable1 =
-                SierraTransformable(bibRecord = record1)
+                val expectedSierraTransformable1 =
+                  SierraTransformable(bibRecord = record1)
 
-              val id2 = "2000002"
-              val record2 = SierraBibRecord(
-                id = id2,
-                data = bibRecordString(
+                val id2 = "2000002"
+                val record2 = SierraBibRecord(
                   id = id2,
-                  updatedDate = "2002-02-02T02:02:02Z",
-                  title = "The second swan of a set"
-                ),
-                modifiedDate = "2002-02-02T02:02:02Z"
-              )
+                  data = bibRecordString(
+                    id = id2,
+                    updatedDate = "2002-02-02T02:02:02Z",
+                    title = "The second swan of a set"
+                  ),
+                  modifiedDate = "2002-02-02T02:02:02Z"
+                )
 
-              sendMessageToSQS(toJson(record2).get, queue)
+                sendMessageToSQS(toJson(record2).get, queue)
 
-              val expectedSierraTransformable2 =
-                SierraTransformable(bibRecord = record2)
+                val expectedSierraTransformable2 =
+                  SierraTransformable(bibRecord = record2)
 
-              eventually {
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  expectedSierraTransformable1)
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  expectedSierraTransformable2)
-              }
+                eventually {
+                  assertStored[SierraTransformable](
+                    bucket,
+                    table,
+                    expectedSierraTransformable1)
+                  assertStored[SierraTransformable](
+                    bucket,
+                    table,
+                    expectedSierraTransformable2)
+                }
             }
           }
         }
@@ -167,50 +165,49 @@ class SierraBibMergerFeatureTest
           val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             table)
           withServer(flags) { _ =>
-            withVersionedHybridStore[SierraTransformable, Unit](
-              bucket,
-              table) { hybridStore =>
-              val id = "3000003"
-              val oldBibRecord = SierraBibRecord(
-                id = id,
-                data = bibRecordString(
+            withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
+              hybridStore =>
+                val id = "3000003"
+                val oldBibRecord = SierraBibRecord(
                   id = id,
-                  updatedDate = "2003-03-03T03:03:03Z",
-                  title = "Old orangutans outside an office"
-                ),
-                modifiedDate = "2003-03-03T03:03:03Z"
-              )
+                  data = bibRecordString(
+                    id = id,
+                    updatedDate = "2003-03-03T03:03:03Z",
+                    title = "Old orangutans outside an office"
+                  ),
+                  modifiedDate = "2003-03-03T03:03:03Z"
+                )
 
-              val oldRecord = SierraTransformable(bibRecord = oldBibRecord)
+                val oldRecord = SierraTransformable(bibRecord = oldBibRecord)
 
-              val newTitle = "A number of new narwhals near Newmarket"
-              val newUpdatedDate = "2004-04-04T04:04:04Z"
-              val record = SierraBibRecord(
-                id = id,
-                data = bibRecordString(
+                val newTitle = "A number of new narwhals near Newmarket"
+                val newUpdatedDate = "2004-04-04T04:04:04Z"
+                val record = SierraBibRecord(
                   id = id,
-                  updatedDate = newUpdatedDate,
-                  title = newTitle
-                ),
-                modifiedDate = newUpdatedDate
-              )
+                  data = bibRecordString(
+                    id = id,
+                    updatedDate = newUpdatedDate,
+                    title = newTitle
+                  ),
+                  modifiedDate = newUpdatedDate
+                )
 
-              hybridStore
-                .updateRecord(oldRecord.id)(oldRecord)(identity)(
-                  SourceMetadata(oldRecord.sourceName))
-                .map { _ =>
-                  sendMessageToSQS(toJson(record).get, queue)
+                hybridStore
+                  .updateRecord(oldRecord.id)(oldRecord)(identity)(
+                    SourceMetadata(oldRecord.sourceName))
+                  .map { _ =>
+                    sendMessageToSQS(toJson(record).get, queue)
+                  }
+
+                val expectedSierraTransformable =
+                  SierraTransformable(bibRecord = record)
+
+                eventually {
+                  assertStored[SierraTransformable](
+                    bucket,
+                    table,
+                    expectedSierraTransformable)
                 }
-
-              val expectedSierraTransformable =
-                SierraTransformable(bibRecord = record)
-
-              eventually {
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  expectedSierraTransformable)
-              }
             }
           }
         }
@@ -225,51 +222,50 @@ class SierraBibMergerFeatureTest
           val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             table)
           withServer(flags) { _ =>
-            withVersionedHybridStore[SierraTransformable, Unit](
-              bucket,
-              table) { hybridStore =>
-              val id = "6000006"
-              val newBibRecord = SierraBibRecord(
-                id = id,
-                data = bibRecordString(
+            withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
+              hybridStore =>
+                val id = "6000006"
+                val newBibRecord = SierraBibRecord(
                   id = id,
-                  updatedDate = "2006-06-06T06:06:06Z",
-                  title = "A presence of pristine porpoises"
-                ),
-                modifiedDate = "2006-06-06T06:06:06Z"
-              )
+                  data = bibRecordString(
+                    id = id,
+                    updatedDate = "2006-06-06T06:06:06Z",
+                    title = "A presence of pristine porpoises"
+                  ),
+                  modifiedDate = "2006-06-06T06:06:06Z"
+                )
 
-              val expectedSierraTransformable =
-                SierraTransformable(bibRecord = newBibRecord)
+                val expectedSierraTransformable =
+                  SierraTransformable(bibRecord = newBibRecord)
 
-              val oldTitle = "A small selection of sad shellfish"
-              val oldUpdatedDate = "2001-01-01T01:01:01Z"
-              val record = SierraBibRecord(
-                id = id,
-                data = bibRecordString(
+                val oldTitle = "A small selection of sad shellfish"
+                val oldUpdatedDate = "2001-01-01T01:01:01Z"
+                val record = SierraBibRecord(
                   id = id,
-                  updatedDate = oldUpdatedDate,
-                  title = oldTitle
-                ),
-                modifiedDate = oldUpdatedDate
-              )
+                  data = bibRecordString(
+                    id = id,
+                    updatedDate = oldUpdatedDate,
+                    title = oldTitle
+                  ),
+                  modifiedDate = oldUpdatedDate
+                )
 
-              hybridStore
-                .updateRecord(expectedSierraTransformable.id)(
-                  expectedSierraTransformable)(identity)(
-                  SourceMetadata(expectedSierraTransformable.sourceName))
-                .map { _ =>
-                  sendMessageToSQS(toJson(record).get, queue)
-                }
+                hybridStore
+                  .updateRecord(expectedSierraTransformable.id)(
+                    expectedSierraTransformable)(identity)(
+                    SourceMetadata(expectedSierraTransformable.sourceName))
+                  .map { _ =>
+                    sendMessageToSQS(toJson(record).get, queue)
+                  }
 
-              // Blocking in Scala is generally a bad idea; we do it here so there's
-              // enough time for this update to have gone through (if it was going to).
-              Thread.sleep(5000)
+                // Blocking in Scala is generally a bad idea; we do it here so there's
+                // enough time for this update to have gone through (if it was going to).
+                Thread.sleep(5000)
 
-              assertStored[SierraTransformable](
-                bucket,
-                table,
-                expectedSierraTransformable)
+                assertStored[SierraTransformable](
+                  bucket,
+                  table,
+                  expectedSierraTransformable)
             }
           }
         }
@@ -284,41 +280,40 @@ class SierraBibMergerFeatureTest
           val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             table)
           withServer(flags) { _ =>
-            withVersionedHybridStore[SierraTransformable, Unit](
-              bucket,
-              table) { hybridStore =>
-              val id = "7000007"
-              val newRecord = SierraTransformable(sourceId = id)
+            withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
+              hybridStore =>
+                val id = "7000007"
+                val newRecord = SierraTransformable(sourceId = id)
 
-              val title = "Inside an inquisitive igloo of ice imps"
-              val updatedDate = "2007-07-07T07:07:07Z"
-              val record = SierraBibRecord(
-                id = id,
-                data = bibRecordString(
+                val title = "Inside an inquisitive igloo of ice imps"
+                val updatedDate = "2007-07-07T07:07:07Z"
+                val record = SierraBibRecord(
                   id = id,
-                  title = title,
-                  updatedDate = updatedDate
-                ),
-                modifiedDate = updatedDate
-              )
+                  data = bibRecordString(
+                    id = id,
+                    title = title,
+                    updatedDate = updatedDate
+                  ),
+                  modifiedDate = updatedDate
+                )
 
-              val future =
-                hybridStore.updateRecord(newRecord.id)(newRecord)(identity)(
-                  SourceMetadata(newRecord.sourceName))
+                val future =
+                  hybridStore.updateRecord(newRecord.id)(newRecord)(identity)(
+                    SourceMetadata(newRecord.sourceName))
 
-              future.map { _ =>
-                sendMessageToSQS(toJson(record).get, queue)
-              }
+                future.map { _ =>
+                  sendMessageToSQS(toJson(record).get, queue)
+                }
 
-              val expectedSierraTransformable =
-                SierraTransformable(bibRecord = record)
+                val expectedSierraTransformable =
+                  SierraTransformable(bibRecord = record)
 
-              eventually {
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  expectedSierraTransformable)
-              }
+                eventually {
+                  assertStored[SierraTransformable](
+                    bucket,
+                    table,
+                    expectedSierraTransformable)
+                }
             }
           }
         }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -89,7 +89,7 @@ class SierraBibMergerFeatureTest
 
               eventually {
                 assertStored[SierraTransformable](
-                  bucket.underlying,
+                  bucket,
                   tableName,
                   expectedSierraTransformable)
               }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -65,13 +65,13 @@ class SierraBibMergerFeatureTest
   it("should store a bib in the hybrid store") {
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        withLocalDynamoDbTable { tableName =>
+        withLocalDynamoDbTable { table =>
           val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            tableName)
+            table)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](
               bucket,
-              tableName) { hybridStore =>
+              table) { hybridStore =>
               val id = "1000001"
               val record = SierraBibRecord(
                 id = id,
@@ -91,7 +91,7 @@ class SierraBibMergerFeatureTest
               eventually {
                 assertStored[SierraTransformable](
                   bucket,
-                  tableName,
+                  table,
                   expectedSierraTransformable)
               }
             }
@@ -104,13 +104,13 @@ class SierraBibMergerFeatureTest
   it("stores multiple bibs from SQS") {
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        withLocalDynamoDbTable { tableName =>
+        withLocalDynamoDbTable { table =>
           val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            tableName)
+            table)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](
               bucket,
-              tableName) { hybridStore =>
+              table) { hybridStore =>
               val id1 = "1000001"
               val record1 = SierraBibRecord(
                 id = id1,
@@ -146,11 +146,11 @@ class SierraBibMergerFeatureTest
               eventually {
                 assertStored[SierraTransformable](
                   bucket,
-                  tableName,
+                  table,
                   expectedSierraTransformable1)
                 assertStored[SierraTransformable](
                   bucket,
-                  tableName,
+                  table,
                   expectedSierraTransformable2)
               }
             }
@@ -163,13 +163,13 @@ class SierraBibMergerFeatureTest
   it("updates a bib if a newer version is sent to SQS") {
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        withLocalDynamoDbTable { tableName =>
+        withLocalDynamoDbTable { table =>
           val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            tableName)
+            table)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](
               bucket,
-              tableName) { hybridStore =>
+              table) { hybridStore =>
               val id = "3000003"
               val oldBibRecord = SierraBibRecord(
                 id = id,
@@ -208,7 +208,7 @@ class SierraBibMergerFeatureTest
               eventually {
                 assertStored[SierraTransformable](
                   bucket,
-                  tableName,
+                  table,
                   expectedSierraTransformable)
               }
             }
@@ -221,13 +221,13 @@ class SierraBibMergerFeatureTest
   it("does not update a bib if an older version is sent to SQS") {
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        withLocalDynamoDbTable { tableName =>
+        withLocalDynamoDbTable { table =>
           val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            tableName)
+            table)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](
               bucket,
-              tableName) { hybridStore =>
+              table) { hybridStore =>
               val id = "6000006"
               val newBibRecord = SierraBibRecord(
                 id = id,
@@ -268,7 +268,7 @@ class SierraBibMergerFeatureTest
 
               assertStored[SierraTransformable](
                 bucket,
-                tableName,
+                table,
                 expectedSierraTransformable)
             }
           }
@@ -280,13 +280,13 @@ class SierraBibMergerFeatureTest
   it("stores a bib from SQS if the ID already exists but no bibData") {
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        withLocalDynamoDbTable { tableName =>
+        withLocalDynamoDbTable { table =>
           val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            tableName)
+            table)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](
               bucket,
-              tableName) { hybridStore =>
+              table) { hybridStore =>
               val id = "7000007"
               val newRecord = SierraTransformable(sourceId = id)
 
@@ -316,7 +316,7 @@ class SierraBibMergerFeatureTest
               eventually {
                 assertStored[SierraTransformable](
                   bucket,
-                  tableName,
+                  table,
                   expectedSierraTransformable)
               }
             }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
@@ -19,9 +19,9 @@ class ServerTest
   it("shows the healthcheck message") {
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        withLocalDynamoDbTable { tableName =>
+        withLocalDynamoDbTable { table =>
           val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            tableName)
+            table)
           withServer(flags) { server =>
             server.httpGet(
               path = "/management/healthcheck",

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
@@ -17,10 +17,10 @@ class ServerTest
     DynamoFormat[HybridRecord]
 
   it("shows the healthcheck message") {
-    withLocalSqsQueue { queueUrl =>
+    withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { tableName =>
-          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             tableName)
           withServer(flags) { server =>
             server.httpGet(

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
@@ -18,9 +18,9 @@ class ServerTest
 
   it("shows the healthcheck message") {
     withLocalSqsQueue { queueUrl =>
-      withLocalS3Bucket { bucketName =>
+      withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { tableName =>
-          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucketName) ++ dynamoDbLocalEndpointFlags(
+          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             tableName)
           withServer(flags) { server =>
             server.httpGet(

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
@@ -29,31 +29,30 @@ class SierraItemMergerFeatureTest
           val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             table)
           withServer(flags) { _ =>
-            withVersionedHybridStore[SierraTransformable, Unit](
-              bucket,
-              table) { hybridStore =>
-              val id = "i1000001"
-              val bibId = "b1000001"
+            withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
+              hybridStore =>
+                val id = "i1000001"
+                val bibId = "b1000001"
 
-              val record = sierraItemRecord(
-                id = id,
-                updatedDate = "2001-01-01T01:01:01Z",
-                bibIds = List(bibId)
-              )
+                val record = sierraItemRecord(
+                  id = id,
+                  updatedDate = "2001-01-01T01:01:01Z",
+                  bibIds = List(bibId)
+                )
 
-              sendItemRecordToSQS(record, queue)
+                sendItemRecordToSQS(record, queue)
 
-              val expectedSierraTransformable = SierraTransformable(
-                sourceId = bibId,
-                itemData = Map(id -> record)
-              )
+                val expectedSierraTransformable = SierraTransformable(
+                  sourceId = bibId,
+                  itemData = Map(id -> record)
+                )
 
-              eventually {
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  expectedSierraTransformable)
-              }
+                eventually {
+                  assertStored[SierraTransformable](
+                    bucket,
+                    table,
+                    expectedSierraTransformable)
+                }
             }
           }
         }
@@ -68,52 +67,51 @@ class SierraItemMergerFeatureTest
           val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             table)
           withServer(flags) { _ =>
-            withVersionedHybridStore[SierraTransformable, Unit](
-              bucket,
-              table) { hybridStore =>
-              val bibId1 = "b1000001"
+            withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
+              hybridStore =>
+                val bibId1 = "b1000001"
 
-              val id1 = "1000001"
+                val id1 = "1000001"
 
-              val record1 = sierraItemRecord(
-                id = id1,
-                updatedDate = "2001-01-01T01:01:01Z",
-                bibIds = List(bibId1)
-              )
-
-              sendItemRecordToSQS(record1, queue)
-
-              val bibId2 = "b2000002"
-              val id2 = "2000002"
-
-              val record2 = sierraItemRecord(
-                id = id2,
-                updatedDate = "2002-02-02T02:02:02Z",
-                bibIds = List(bibId2)
-              )
-
-              sendItemRecordToSQS(record2, queue)
-
-              eventually {
-                val expectedSierraTransformable1 = SierraTransformable(
-                  sourceId = bibId1,
-                  itemData = Map(id1 -> record1)
+                val record1 = sierraItemRecord(
+                  id = id1,
+                  updatedDate = "2001-01-01T01:01:01Z",
+                  bibIds = List(bibId1)
                 )
 
-                val expectedSierraTransformable2 = SierraTransformable(
-                  sourceId = bibId2,
-                  itemData = Map(id2 -> record2)
+                sendItemRecordToSQS(record1, queue)
+
+                val bibId2 = "b2000002"
+                val id2 = "2000002"
+
+                val record2 = sierraItemRecord(
+                  id = id2,
+                  updatedDate = "2002-02-02T02:02:02Z",
+                  bibIds = List(bibId2)
                 )
 
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  expectedSierraTransformable1)
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  expectedSierraTransformable2)
-              }
+                sendItemRecordToSQS(record2, queue)
+
+                eventually {
+                  val expectedSierraTransformable1 = SierraTransformable(
+                    sourceId = bibId1,
+                    itemData = Map(id1 -> record1)
+                  )
+
+                  val expectedSierraTransformable2 = SierraTransformable(
+                    sourceId = bibId2,
+                    itemData = Map(id2 -> record2)
+                  )
+
+                  assertStored[SierraTransformable](
+                    bucket,
+                    table,
+                    expectedSierraTransformable1)
+                  assertStored[SierraTransformable](
+                    bucket,
+                    table,
+                    expectedSierraTransformable2)
+                }
             }
           }
         }
@@ -121,8 +119,7 @@ class SierraItemMergerFeatureTest
     }
   }
 
-  private def sendItemRecordToSQS(itemRecord: SierraItemRecord,
-                                  queue: Queue) = {
+  private def sendItemRecordToSQS(itemRecord: SierraItemRecord, queue: Queue) = {
     val message = SQSMessage(
       subject = Some("Test message sent by SierraItemMergerWorkerServiceTest"),
       body = toJson(itemRecord).get,

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
@@ -23,13 +23,13 @@ class SierraItemMergerFeatureTest
 
   it("stores an item from SQS") {
     withLocalSqsQueue { queueUrl =>
-      withLocalS3Bucket { bucketName =>
+      withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { tableName =>
-          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucketName) ++ dynamoDbLocalEndpointFlags(
+          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             tableName)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](
-              bucketName,
+              bucket,
               tableName) { hybridStore =>
               val id = "i1000001"
               val bibId = "b1000001"
@@ -49,7 +49,7 @@ class SierraItemMergerFeatureTest
 
               eventually {
                 assertStored[SierraTransformable](
-                  bucketName,
+                  bucket,
                   tableName,
                   expectedSierraTransformable)
               }
@@ -62,13 +62,13 @@ class SierraItemMergerFeatureTest
 
   it("stores multiple items from SQS") {
     withLocalSqsQueue { queueUrl =>
-      withLocalS3Bucket { bucketName =>
+      withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { tableName =>
-          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucketName) ++ dynamoDbLocalEndpointFlags(
+          val flags = sqsLocalFlags(queueUrl) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
             tableName)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](
-              bucketName,
+              bucket,
               tableName) { hybridStore =>
               val bibId1 = "b1000001"
 
@@ -105,11 +105,11 @@ class SierraItemMergerFeatureTest
                 )
 
                 assertStored[SierraTransformable](
-                  bucketName,
+                  bucket,
                   tableName,
                   expectedSierraTransformable1)
                 assertStored[SierraTransformable](
-                  bucketName,
+                  bucket,
                   tableName,
                   expectedSierraTransformable2)
               }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
@@ -25,13 +25,13 @@ class SierraItemMergerFeatureTest
   it("stores an item from SQS") {
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        withLocalDynamoDbTable { tableName =>
+        withLocalDynamoDbTable { table =>
           val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            tableName)
+            table)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](
               bucket,
-              tableName) { hybridStore =>
+              table) { hybridStore =>
               val id = "i1000001"
               val bibId = "b1000001"
 
@@ -51,7 +51,7 @@ class SierraItemMergerFeatureTest
               eventually {
                 assertStored[SierraTransformable](
                   bucket,
-                  tableName,
+                  table,
                   expectedSierraTransformable)
               }
             }
@@ -64,13 +64,13 @@ class SierraItemMergerFeatureTest
   it("stores multiple items from SQS") {
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        withLocalDynamoDbTable { tableName =>
+        withLocalDynamoDbTable { table =>
           val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            tableName)
+            table)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](
               bucket,
-              tableName) { hybridStore =>
+              table) { hybridStore =>
               val bibId1 = "b1000001"
 
               val id1 = "1000001"
@@ -107,11 +107,11 @@ class SierraItemMergerFeatureTest
 
                 assertStored[SierraTransformable](
                   bucket,
-                  tableName,
+                  table,
                   expectedSierraTransformable1)
                 assertStored[SierraTransformable](
                   bucket,
-                  tableName,
+                  table,
                   expectedSierraTransformable2)
               }
             }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -51,10 +51,10 @@ class SierraItemMergerUpdaterServiceTest
 
   it("creates a record if it receives an item with a bibId that doesn't exist") {
     withLocalS3Bucket { bucket =>
-      withLocalDynamoDbTable { tableName =>
+      withLocalDynamoDbTable { table =>
         withVersionedHybridStore[SierraTransformable, Unit](
           bucket,
-          tableName) { hybridStore =>
+          table) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val bibId = "b666"
             val newItemRecord = sierraItemRecord(
@@ -74,7 +74,7 @@ class SierraItemMergerUpdaterServiceTest
 
               assertStored[SierraTransformable](
                 bucket,
-                tableName,
+                table,
                 expectedSierraTransformable)
             }
           }
@@ -85,10 +85,10 @@ class SierraItemMergerUpdaterServiceTest
 
   it("updates multiple merged records if the item contains multiple bibIds") {
     withLocalS3Bucket { bucket =>
-      withLocalDynamoDbTable { tableName =>
+      withLocalDynamoDbTable { table =>
         withVersionedHybridStore[SierraTransformable, Unit](
           bucket,
-          tableName) { hybridStore =>
+          table) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val bibIdNotExisting = "b666"
             val bibIdWithOldData = "b555"
@@ -164,7 +164,7 @@ class SierraItemMergerUpdaterServiceTest
 
                   assertStored[SierraTransformable](
                     bucket,
-                    tableName,
+                    table,
                     expectedNewSierraTransformable)
 
                   val expectedUpdatedSierraTransformable = oldRecord.copy(
@@ -176,11 +176,11 @@ class SierraItemMergerUpdaterServiceTest
 
                   assertStored[SierraTransformable](
                     bucket,
-                    tableName,
+                    table,
                     expectedUpdatedSierraTransformable)
                   assertStored[SierraTransformable](
                     bucket,
-                    tableName,
+                    table,
                     newRecord)
                 }
               }
@@ -193,10 +193,10 @@ class SierraItemMergerUpdaterServiceTest
 
   it("updates an item if it receives an update with a newer date") {
     withLocalS3Bucket { bucket =>
-      withLocalDynamoDbTable { tableName =>
+      withLocalDynamoDbTable { table =>
         withVersionedHybridStore[SierraTransformable, Unit](
           bucket,
-          tableName) { hybridStore =>
+          table) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val id = "i3000003"
             val bibId = "b3000003"
@@ -229,7 +229,7 @@ class SierraItemMergerUpdaterServiceTest
 
                 assertStored[SierraTransformable](
                   bucket,
-                  tableName,
+                  table,
                   expectedSierraRecord)
               }
             }
@@ -241,10 +241,10 @@ class SierraItemMergerUpdaterServiceTest
 
   it("unlinks an item if it is updated with an unlinked item") {
     withLocalS3Bucket { bucket =>
-      withLocalDynamoDbTable { tableName =>
+      withLocalDynamoDbTable { table =>
         withVersionedHybridStore[SierraTransformable, Unit](
           bucket,
-          tableName) { hybridStore =>
+          table) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val itemId = "i3000003"
 
@@ -309,11 +309,11 @@ class SierraItemMergerUpdaterServiceTest
 
               assertStored[SierraTransformable](
                 bucket,
-                tableName,
+                table,
                 expectedSierraRecord1)
               assertStored[SierraTransformable](
                 bucket,
-                tableName,
+                table,
                 expectedSierraRecord2)
             }
           }
@@ -324,10 +324,10 @@ class SierraItemMergerUpdaterServiceTest
 
   it("unlinks and updates a bib from a single call") {
     withLocalS3Bucket { bucket =>
-      withLocalDynamoDbTable { tableName =>
+      withLocalDynamoDbTable { table =>
         withVersionedHybridStore[SierraTransformable, Unit](
           bucket,
-          tableName) { hybridStore =>
+          table) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val itemId = "i3000003"
 
@@ -387,11 +387,11 @@ class SierraItemMergerUpdaterServiceTest
 
                 assertStored[SierraTransformable](
                   bucket,
-                  tableName,
+                  table,
                   expectedSierraRecord1)
                 assertStored[SierraTransformable](
                   bucket,
-                  tableName,
+                  table,
                   expectedSierraRecord2)
               }
             }
@@ -403,10 +403,10 @@ class SierraItemMergerUpdaterServiceTest
 
   it("does not unlink an item if it receives an out of date unlink update") {
     withLocalS3Bucket { bucket =>
-      withLocalDynamoDbTable { tableName =>
+      withLocalDynamoDbTable { table =>
         withVersionedHybridStore[SierraTransformable, Unit](
           bucket,
-          tableName) { hybridStore =>
+          table) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val itemId = "i3000003"
 
@@ -467,11 +467,11 @@ class SierraItemMergerUpdaterServiceTest
 
                 assertStored[SierraTransformable](
                   bucket,
-                  tableName,
+                  table,
                   expectedSierraRecord1)
                 assertStored[SierraTransformable](
                   bucket,
-                  tableName,
+                  table,
                   expectedSierraRecord2)
               }
             }
@@ -483,10 +483,10 @@ class SierraItemMergerUpdaterServiceTest
 
   it("does not update an item if it receives an update with an older date") {
     withLocalS3Bucket { bucket =>
-      withLocalDynamoDbTable { tableName =>
+      withLocalDynamoDbTable { table =>
         withVersionedHybridStore[SierraTransformable, Unit](
           bucket,
-          tableName) { hybridStore =>
+          table) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val id = "i6000006"
             val bibId = "b6000006"
@@ -515,7 +515,7 @@ class SierraItemMergerUpdaterServiceTest
               whenReady(sierraUpdaterService.update(oldItemRecord)) { _ =>
                 assertStored[SierraTransformable](
                   bucket,
-                  tableName,
+                  table,
                   sierraRecord)
               }
             }
@@ -527,10 +527,10 @@ class SierraItemMergerUpdaterServiceTest
 
   it("adds an item to the record if the bibId exists but has no itemData") {
     withLocalS3Bucket { bucket =>
-      withLocalDynamoDbTable { tableName =>
+      withLocalDynamoDbTable { table =>
         withVersionedHybridStore[SierraTransformable, Unit](
           bucket,
-          tableName) { hybridStore =>
+          table) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val bibId = "b7000007"
 
@@ -559,7 +559,7 @@ class SierraItemMergerUpdaterServiceTest
 
                 assertStored[SierraTransformable](
                   bucket,
-                  tableName,
+                  table,
                   expectedSierraRecord)
               }
             }
@@ -571,10 +571,10 @@ class SierraItemMergerUpdaterServiceTest
 
   it("returns a failed future if putting an item fails") {
     withLocalS3Bucket { bucket =>
-      withLocalDynamoDbTable { tableName =>
+      withLocalDynamoDbTable { table =>
         withVersionedHybridStore[SierraTransformable, Unit](
           bucket,
-          tableName) { hybridStore =>
+          table) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val failingVersionedDao = mock[VersionedDao]
             val expectedException = new RuntimeException("BOOOM!")

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -591,7 +591,7 @@ class SierraItemMergerUpdaterServiceTest
               new VersionedHybridStore[SierraTransformable](
                 sourcedObjectStore = new S3ObjectStore(
                   s3Client = s3Client,
-                  s3Config = S3Config(bucketName = bucket.underlying),
+                  s3Config = S3Config(bucketName = bucket.name),
                   new SourcedKeyPrefixGenerator),
                 versionedDao = failingVersionedDao
               )

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -50,10 +50,10 @@ class SierraItemMergerUpdaterServiceTest
   }
 
   it("creates a record if it receives an item with a bibId that doesn't exist") {
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { tableName =>
         withVersionedHybridStore[SierraTransformable, Unit](
-          bucketName,
+          bucket,
           tableName) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val bibId = "b666"
@@ -73,7 +73,7 @@ class SierraItemMergerUpdaterServiceTest
                   ))
 
               assertStored[SierraTransformable](
-                bucketName,
+                bucket,
                 tableName,
                 expectedSierraTransformable)
             }
@@ -84,10 +84,10 @@ class SierraItemMergerUpdaterServiceTest
   }
 
   it("updates multiple merged records if the item contains multiple bibIds") {
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { tableName =>
         withVersionedHybridStore[SierraTransformable, Unit](
-          bucketName,
+          bucket,
           tableName) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val bibIdNotExisting = "b666"
@@ -163,7 +163,7 @@ class SierraItemMergerUpdaterServiceTest
                     )
 
                   assertStored[SierraTransformable](
-                    bucketName,
+                    bucket,
                     tableName,
                     expectedNewSierraTransformable)
 
@@ -175,11 +175,11 @@ class SierraItemMergerUpdaterServiceTest
                   )
 
                   assertStored[SierraTransformable](
-                    bucketName,
+                    bucket,
                     tableName,
                     expectedUpdatedSierraTransformable)
                   assertStored[SierraTransformable](
-                    bucketName,
+                    bucket,
                     tableName,
                     newRecord)
                 }
@@ -192,10 +192,10 @@ class SierraItemMergerUpdaterServiceTest
   }
 
   it("updates an item if it receives an update with a newer date") {
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { tableName =>
         withVersionedHybridStore[SierraTransformable, Unit](
-          bucketName,
+          bucket,
           tableName) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val id = "i3000003"
@@ -228,7 +228,7 @@ class SierraItemMergerUpdaterServiceTest
                 )
 
                 assertStored[SierraTransformable](
-                  bucketName,
+                  bucket,
                   tableName,
                   expectedSierraRecord)
               }
@@ -240,10 +240,10 @@ class SierraItemMergerUpdaterServiceTest
   }
 
   it("unlinks an item if it is updated with an unlinked item") {
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { tableName =>
         withVersionedHybridStore[SierraTransformable, Unit](
-          bucketName,
+          bucket,
           tableName) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val itemId = "i3000003"
@@ -308,11 +308,11 @@ class SierraItemMergerUpdaterServiceTest
               )
 
               assertStored[SierraTransformable](
-                bucketName,
+                bucket,
                 tableName,
                 expectedSierraRecord1)
               assertStored[SierraTransformable](
-                bucketName,
+                bucket,
                 tableName,
                 expectedSierraRecord2)
             }
@@ -323,10 +323,10 @@ class SierraItemMergerUpdaterServiceTest
   }
 
   it("unlinks and updates a bib from a single call") {
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { tableName =>
         withVersionedHybridStore[SierraTransformable, Unit](
-          bucketName,
+          bucket,
           tableName) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val itemId = "i3000003"
@@ -386,11 +386,11 @@ class SierraItemMergerUpdaterServiceTest
                 )
 
                 assertStored[SierraTransformable](
-                  bucketName,
+                  bucket,
                   tableName,
                   expectedSierraRecord1)
                 assertStored[SierraTransformable](
-                  bucketName,
+                  bucket,
                   tableName,
                   expectedSierraRecord2)
               }
@@ -402,10 +402,10 @@ class SierraItemMergerUpdaterServiceTest
   }
 
   it("does not unlink an item if it receives an out of date unlink update") {
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { tableName =>
         withVersionedHybridStore[SierraTransformable, Unit](
-          bucketName,
+          bucket,
           tableName) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val itemId = "i3000003"
@@ -466,11 +466,11 @@ class SierraItemMergerUpdaterServiceTest
                 )
 
                 assertStored[SierraTransformable](
-                  bucketName,
+                  bucket,
                   tableName,
                   expectedSierraRecord1)
                 assertStored[SierraTransformable](
-                  bucketName,
+                  bucket,
                   tableName,
                   expectedSierraRecord2)
               }
@@ -482,10 +482,10 @@ class SierraItemMergerUpdaterServiceTest
   }
 
   it("does not update an item if it receives an update with an older date") {
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { tableName =>
         withVersionedHybridStore[SierraTransformable, Unit](
-          bucketName,
+          bucket,
           tableName) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val id = "i6000006"
@@ -514,7 +514,7 @@ class SierraItemMergerUpdaterServiceTest
             whenReady(f1) { _ =>
               whenReady(sierraUpdaterService.update(oldItemRecord)) { _ =>
                 assertStored[SierraTransformable](
-                  bucketName,
+                  bucket,
                   tableName,
                   sierraRecord)
               }
@@ -526,10 +526,10 @@ class SierraItemMergerUpdaterServiceTest
   }
 
   it("adds an item to the record if the bibId exists but has no itemData") {
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { tableName =>
         withVersionedHybridStore[SierraTransformable, Unit](
-          bucketName,
+          bucket,
           tableName) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val bibId = "b7000007"
@@ -558,7 +558,7 @@ class SierraItemMergerUpdaterServiceTest
                 )
 
                 assertStored[SierraTransformable](
-                  bucketName,
+                  bucket,
                   tableName,
                   expectedSierraRecord)
               }
@@ -570,10 +570,10 @@ class SierraItemMergerUpdaterServiceTest
   }
 
   it("returns a failed future if putting an item fails") {
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { tableName =>
         withVersionedHybridStore[SierraTransformable, Unit](
-          bucketName,
+          bucket,
           tableName) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val failingVersionedDao = mock[VersionedDao]
@@ -591,7 +591,7 @@ class SierraItemMergerUpdaterServiceTest
               new VersionedHybridStore[SierraTransformable](
                 sourcedObjectStore = new S3ObjectStore(
                   s3Client = s3Client,
-                  s3Config = S3Config(bucketName = bucketName),
+                  s3Config = S3Config(bucketName = bucket.underlying),
                   new SourcedKeyPrefixGenerator),
                 versionedDao = failingVersionedDao
               )

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -52,32 +52,31 @@ class SierraItemMergerUpdaterServiceTest
   it("creates a record if it receives an item with a bibId that doesn't exist") {
     withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { table =>
-        withVersionedHybridStore[SierraTransformable, Unit](
-          bucket,
-          table) { hybridStore =>
-          withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
-            val bibId = "b666"
-            val newItemRecord = sierraItemRecord(
-              id = "i666",
-              updatedDate = "2014-04-04T04:04:04Z",
-              bibIds = List(bibId)
-            )
+        withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
+          hybridStore =>
+            withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
+              val bibId = "b666"
+              val newItemRecord = sierraItemRecord(
+                id = "i666",
+                updatedDate = "2014-04-04T04:04:04Z",
+                bibIds = List(bibId)
+              )
 
-            whenReady(sierraUpdaterService.update(newItemRecord)) { _ =>
-              val expectedSierraTransformable =
-                SierraTransformable(
-                  sourceId = bibId,
-                  maybeBibData = None,
-                  itemData = Map(
-                    newItemRecord.id -> newItemRecord
-                  ))
+              whenReady(sierraUpdaterService.update(newItemRecord)) { _ =>
+                val expectedSierraTransformable =
+                  SierraTransformable(
+                    sourceId = bibId,
+                    maybeBibData = None,
+                    itemData = Map(
+                      newItemRecord.id -> newItemRecord
+                    ))
 
-              assertStored[SierraTransformable](
-                bucket,
-                table,
-                expectedSierraTransformable)
+                assertStored[SierraTransformable](
+                  bucket,
+                  table,
+                  expectedSierraTransformable)
+              }
             }
-          }
         }
       }
     }
@@ -86,106 +85,102 @@ class SierraItemMergerUpdaterServiceTest
   it("updates multiple merged records if the item contains multiple bibIds") {
     withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { table =>
-        withVersionedHybridStore[SierraTransformable, Unit](
-          bucket,
-          table) { hybridStore =>
-          withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
-            val bibIdNotExisting = "b666"
-            val bibIdWithOldData = "b555"
-            val bibIdWithNewerData = "b777"
+        withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
+          hybridStore =>
+            withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
+              val bibIdNotExisting = "b666"
+              val bibIdWithOldData = "b555"
+              val bibIdWithNewerData = "b777"
 
-            val itemId = "i666"
+              val itemId = "i666"
 
-            val bibIds = List(
-              bibIdNotExisting,
-              bibIdWithOldData,
-              bibIdWithNewerData
-            )
-
-            val itemRecord = sierraItemRecord(
-              id = itemId,
-              updatedDate = "2014-04-04T04:04:04Z",
-              bibIds = bibIds
-            )
-
-            val otherItem = sierraItemRecord(
-              id = "i888",
-              updatedDate = "2003-03-03T03:03:03Z",
-              bibIds = bibIds
-            )
-
-            val oldRecord = SierraTransformable(
-              sourceId = bibIdWithOldData,
-              itemData = Map(
-                itemId -> sierraItemRecord(
-                  id = itemId,
-                  updatedDate = "2003-03-03T03:03:03Z",
-                  bibIds = bibIds
-                ),
-                "i888" -> otherItem
+              val bibIds = List(
+                bibIdNotExisting,
+                bibIdWithOldData,
+                bibIdWithNewerData
               )
-            )
 
-            val f1 = hybridStore.updateRecord(oldRecord.id)(
-              oldRecord
-            )(identity)(SourceMetadata(oldRecord.sourceName))
-
-            val anotherItem = sierraItemRecord(
-              id = "i999",
-              updatedDate = "2003-03-03T03:03:03Z",
-              bibIds = bibIds
-            )
-
-            val newRecord = SierraTransformable(
-              sourceId = bibIdWithNewerData,
-              itemData = Map(
-                itemId -> sierraItemRecord(
-                  id = itemId,
-                  updatedDate = "3003-03-03T03:03:03Z",
-                  bibIds = bibIds
-                ),
-                "i999" -> anotherItem
+              val itemRecord = sierraItemRecord(
+                id = itemId,
+                updatedDate = "2014-04-04T04:04:04Z",
+                bibIds = bibIds
               )
-            )
 
-            whenReady(f1) { _ =>
-              val f2 = hybridStore.updateRecord(newRecord.id)(
-                newRecord
-              )(identity)(SourceMetadata(newRecord.sourceName))
+              val otherItem = sierraItemRecord(
+                id = "i888",
+                updatedDate = "2003-03-03T03:03:03Z",
+                bibIds = bibIds
+              )
 
-              whenReady(f2) { _ =>
-                whenReady(sierraUpdaterService.update(itemRecord)) { _ =>
-                  val expectedNewSierraTransformable =
-                    SierraTransformable(
-                      sourceId = bibIdNotExisting,
-                      maybeBibData = None,
-                      itemData = Map(itemRecord.id -> itemRecord)
+              val oldRecord = SierraTransformable(
+                sourceId = bibIdWithOldData,
+                itemData = Map(
+                  itemId -> sierraItemRecord(
+                    id = itemId,
+                    updatedDate = "2003-03-03T03:03:03Z",
+                    bibIds = bibIds
+                  ),
+                  "i888" -> otherItem
+                )
+              )
+
+              val f1 = hybridStore.updateRecord(oldRecord.id)(
+                oldRecord
+              )(identity)(SourceMetadata(oldRecord.sourceName))
+
+              val anotherItem = sierraItemRecord(
+                id = "i999",
+                updatedDate = "2003-03-03T03:03:03Z",
+                bibIds = bibIds
+              )
+
+              val newRecord = SierraTransformable(
+                sourceId = bibIdWithNewerData,
+                itemData = Map(
+                  itemId -> sierraItemRecord(
+                    id = itemId,
+                    updatedDate = "3003-03-03T03:03:03Z",
+                    bibIds = bibIds
+                  ),
+                  "i999" -> anotherItem
+                )
+              )
+
+              whenReady(f1) { _ =>
+                val f2 = hybridStore.updateRecord(newRecord.id)(
+                  newRecord
+                )(identity)(SourceMetadata(newRecord.sourceName))
+
+                whenReady(f2) { _ =>
+                  whenReady(sierraUpdaterService.update(itemRecord)) { _ =>
+                    val expectedNewSierraTransformable =
+                      SierraTransformable(
+                        sourceId = bibIdNotExisting,
+                        maybeBibData = None,
+                        itemData = Map(itemRecord.id -> itemRecord)
+                      )
+
+                    assertStored[SierraTransformable](
+                      bucket,
+                      table,
+                      expectedNewSierraTransformable)
+
+                    val expectedUpdatedSierraTransformable = oldRecord.copy(
+                      itemData = Map(
+                        itemId -> itemRecord,
+                        "i888" -> otherItem
+                      )
                     )
 
-                  assertStored[SierraTransformable](
-                    bucket,
-                    table,
-                    expectedNewSierraTransformable)
-
-                  val expectedUpdatedSierraTransformable = oldRecord.copy(
-                    itemData = Map(
-                      itemId -> itemRecord,
-                      "i888" -> otherItem
-                    )
-                  )
-
-                  assertStored[SierraTransformable](
-                    bucket,
-                    table,
-                    expectedUpdatedSierraTransformable)
-                  assertStored[SierraTransformable](
-                    bucket,
-                    table,
-                    newRecord)
+                    assertStored[SierraTransformable](
+                      bucket,
+                      table,
+                      expectedUpdatedSierraTransformable)
+                    assertStored[SierraTransformable](bucket, table, newRecord)
+                  }
                 }
               }
             }
-          }
         }
       }
     }
@@ -194,46 +189,45 @@ class SierraItemMergerUpdaterServiceTest
   it("updates an item if it receives an update with a newer date") {
     withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { table =>
-        withVersionedHybridStore[SierraTransformable, Unit](
-          bucket,
-          table) { hybridStore =>
-          withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
-            val id = "i3000003"
-            val bibId = "b3000003"
+        withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
+          hybridStore =>
+            withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
+              val id = "i3000003"
+              val bibId = "b3000003"
 
-            val oldRecord = SierraTransformable(
-              sourceId = bibId,
-              itemData = Map(
-                id -> sierraItemRecord(
-                  id = id,
-                  updatedDate = "2003-03-03T03:03:03Z",
-                  bibIds = List(bibId)
-                ))
-            )
-
-            val f1 = hybridStore.updateRecord(oldRecord.id)(
-              oldRecord
-            )(identity)(SourceMetadata(oldRecord.sourceName))
-
-            whenReady(f1) { _ =>
-              val newItemRecord = sierraItemRecord(
-                id = id,
-                updatedDate = "2014-04-04T04:04:04Z",
-                bibIds = List(bibId)
+              val oldRecord = SierraTransformable(
+                sourceId = bibId,
+                itemData = Map(
+                  id -> sierraItemRecord(
+                    id = id,
+                    updatedDate = "2003-03-03T03:03:03Z",
+                    bibIds = List(bibId)
+                  ))
               )
 
-              whenReady(sierraUpdaterService.update(newItemRecord)) { _ =>
-                val expectedSierraRecord = oldRecord.copy(
-                  itemData = Map(id -> newItemRecord)
+              val f1 = hybridStore.updateRecord(oldRecord.id)(
+                oldRecord
+              )(identity)(SourceMetadata(oldRecord.sourceName))
+
+              whenReady(f1) { _ =>
+                val newItemRecord = sierraItemRecord(
+                  id = id,
+                  updatedDate = "2014-04-04T04:04:04Z",
+                  bibIds = List(bibId)
                 )
 
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  expectedSierraRecord)
+                whenReady(sierraUpdaterService.update(newItemRecord)) { _ =>
+                  val expectedSierraRecord = oldRecord.copy(
+                    itemData = Map(id -> newItemRecord)
+                  )
+
+                  assertStored[SierraTransformable](
+                    bucket,
+                    table,
+                    expectedSierraRecord)
+                }
               }
             }
-          }
         }
       }
     }
@@ -242,81 +236,80 @@ class SierraItemMergerUpdaterServiceTest
   it("unlinks an item if it is updated with an unlinked item") {
     withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { table =>
-        withVersionedHybridStore[SierraTransformable, Unit](
-          bucket,
-          table) { hybridStore =>
-          withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
-            val itemId = "i3000003"
+        withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
+          hybridStore =>
+            withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
+              val itemId = "i3000003"
 
-            val bibId1 = "b9000001"
-            val bibId2 = "b9000002"
+              val bibId1 = "b9000001"
+              val bibId2 = "b9000002"
 
-            val itemRecord = sierraItemRecord(
-              id = itemId,
-              updatedDate = "2003-03-03T03:03:03Z",
-              bibIds = List(bibId1)
-            )
+              val itemRecord = sierraItemRecord(
+                id = itemId,
+                updatedDate = "2003-03-03T03:03:03Z",
+                bibIds = List(bibId1)
+              )
 
-            val itemData = Map(
-              itemRecord.id -> itemRecord
-            )
+              val itemData = Map(
+                itemRecord.id -> itemRecord
+              )
 
-            val sierraTransformable1 = SierraTransformable(
-              sourceId = bibId1,
-              itemData = itemData
-            )
+              val sierraTransformable1 = SierraTransformable(
+                sourceId = bibId1,
+                itemData = itemData
+              )
 
-            val sierraTransformable2 = SierraTransformable(
-              sourceId = bibId2
-            )
+              val sierraTransformable2 = SierraTransformable(
+                sourceId = bibId2
+              )
 
-            val f1 = hybridStore.updateRecord(sierraTransformable1.id)(
-              sierraTransformable1
-            )(_ => sierraTransformable1)(
-              SourceMetadata(sierraTransformable1.sourceName))
+              val f1 = hybridStore.updateRecord(sierraTransformable1.id)(
+                sierraTransformable1
+              )(_ => sierraTransformable1)(
+                SourceMetadata(sierraTransformable1.sourceName))
 
-            val f2 = hybridStore.updateRecord(sierraTransformable2.id)(
-              sierraTransformable2
-            )(identity)(SourceMetadata(sierraTransformable2.sourceName))
+              val f2 = hybridStore.updateRecord(sierraTransformable2.id)(
+                sierraTransformable2
+              )(identity)(SourceMetadata(sierraTransformable2.sourceName))
 
-            val unlinkItemRecord = itemRecord.copy(
-              bibIds = List(bibId2),
-              unlinkedBibIds = List(bibId1),
-              modifiedDate = itemRecord.modifiedDate.plusSeconds(1)
-            )
-
-            val expectedItemData = Map(
-              itemRecord.id -> itemRecord.copy(
+              val unlinkItemRecord = itemRecord.copy(
                 bibIds = List(bibId2),
                 unlinkedBibIds = List(bibId1),
-                modifiedDate = unlinkItemRecord.modifiedDate
-              )
-            )
-
-            val unlinkItemRecordFuture = for {
-              _ <- Future.sequence(List(f1, f2))
-              _ <- sierraUpdaterService.update(unlinkItemRecord)
-            } yield {}
-
-            whenReady(unlinkItemRecordFuture) { _ =>
-              val expectedSierraRecord1 = sierraTransformable1.copy(
-                itemData = Map.empty
+                modifiedDate = itemRecord.modifiedDate.plusSeconds(1)
               )
 
-              val expectedSierraRecord2 = sierraTransformable2.copy(
-                itemData = expectedItemData
+              val expectedItemData = Map(
+                itemRecord.id -> itemRecord.copy(
+                  bibIds = List(bibId2),
+                  unlinkedBibIds = List(bibId1),
+                  modifiedDate = unlinkItemRecord.modifiedDate
+                )
               )
 
-              assertStored[SierraTransformable](
-                bucket,
-                table,
-                expectedSierraRecord1)
-              assertStored[SierraTransformable](
-                bucket,
-                table,
-                expectedSierraRecord2)
+              val unlinkItemRecordFuture = for {
+                _ <- Future.sequence(List(f1, f2))
+                _ <- sierraUpdaterService.update(unlinkItemRecord)
+              } yield {}
+
+              whenReady(unlinkItemRecordFuture) { _ =>
+                val expectedSierraRecord1 = sierraTransformable1.copy(
+                  itemData = Map.empty
+                )
+
+                val expectedSierraRecord2 = sierraTransformable2.copy(
+                  itemData = expectedItemData
+                )
+
+                assertStored[SierraTransformable](
+                  bucket,
+                  table,
+                  expectedSierraRecord1)
+                assertStored[SierraTransformable](
+                  bucket,
+                  table,
+                  expectedSierraRecord2)
+              }
             }
-          }
         }
       }
     }
@@ -325,77 +318,76 @@ class SierraItemMergerUpdaterServiceTest
   it("unlinks and updates a bib from a single call") {
     withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { table =>
-        withVersionedHybridStore[SierraTransformable, Unit](
-          bucket,
-          table) { hybridStore =>
-          withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
-            val itemId = "i3000003"
+        withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
+          hybridStore =>
+            withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
+              val itemId = "i3000003"
 
-            val bibId1 = "b9000001"
-            val bibId2 = "b9000002"
+              val bibId1 = "b9000001"
+              val bibId2 = "b9000002"
 
-            val itemRecord = sierraItemRecord(
-              id = itemId,
-              updatedDate = "2003-03-03T03:03:03Z",
-              bibIds = List(bibId1)
-            )
+              val itemRecord = sierraItemRecord(
+                id = itemId,
+                updatedDate = "2003-03-03T03:03:03Z",
+                bibIds = List(bibId1)
+              )
 
-            val itemData = Map(
-              itemRecord.id -> itemRecord
-            )
+              val itemData = Map(
+                itemRecord.id -> itemRecord
+              )
 
-            val sierraTransformable1 = SierraTransformable(
-              sourceId = bibId1,
-              itemData = itemData
-            )
+              val sierraTransformable1 = SierraTransformable(
+                sourceId = bibId1,
+                itemData = itemData
+              )
 
-            val sierraTransformable2 = SierraTransformable(
-              sourceId = bibId2,
-              itemData = itemData
-            )
+              val sierraTransformable2 = SierraTransformable(
+                sourceId = bibId2,
+                itemData = itemData
+              )
 
-            val f1 = hybridStore.updateRecord(sierraTransformable1.id)(
-              sierraTransformable1
-            )(_ => sierraTransformable1)(
-              SourceMetadata(sierraTransformable1.sourceName))
+              val f1 = hybridStore.updateRecord(sierraTransformable1.id)(
+                sierraTransformable1
+              )(_ => sierraTransformable1)(
+                SourceMetadata(sierraTransformable1.sourceName))
 
-            val f2 = hybridStore.updateRecord(sierraTransformable2.id)(
-              sierraTransformable2
-            )(identity)(SourceMetadata(sierraTransformable2.sourceName))
+              val f2 = hybridStore.updateRecord(sierraTransformable2.id)(
+                sierraTransformable2
+              )(identity)(SourceMetadata(sierraTransformable2.sourceName))
 
-            val unlinkItemRecord = itemRecord.copy(
-              bibIds = List(bibId2),
-              unlinkedBibIds = List(bibId1),
-              modifiedDate = itemRecord.modifiedDate.plusSeconds(1)
-            )
+              val unlinkItemRecord = itemRecord.copy(
+                bibIds = List(bibId2),
+                unlinkedBibIds = List(bibId1),
+                modifiedDate = itemRecord.modifiedDate.plusSeconds(1)
+              )
 
-            val expectedItemData = Map(
-              itemRecord.id -> unlinkItemRecord
-            )
+              val expectedItemData = Map(
+                itemRecord.id -> unlinkItemRecord
+              )
 
-            whenReady(Future.sequence(List(f1, f2))) { _ =>
-              whenReady(sierraUpdaterService.update(unlinkItemRecord)) { _ =>
-                val expectedSierraRecord1 = sierraTransformable1.copy(
-                  itemData = Map.empty
-                )
+              whenReady(Future.sequence(List(f1, f2))) { _ =>
+                whenReady(sierraUpdaterService.update(unlinkItemRecord)) { _ =>
+                  val expectedSierraRecord1 = sierraTransformable1.copy(
+                    itemData = Map.empty
+                  )
 
-                // In this situation the item was already linked to sierraTransformable2
-                // but the modified date is updated in line with the item update
-                val expectedSierraRecord2 = sierraTransformable2.copy(
-                  itemData = expectedItemData
-                )
+                  // In this situation the item was already linked to sierraTransformable2
+                  // but the modified date is updated in line with the item update
+                  val expectedSierraRecord2 = sierraTransformable2.copy(
+                    itemData = expectedItemData
+                  )
 
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  expectedSierraRecord1)
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  expectedSierraRecord2)
+                  assertStored[SierraTransformable](
+                    bucket,
+                    table,
+                    expectedSierraRecord1)
+                  assertStored[SierraTransformable](
+                    bucket,
+                    table,
+                    expectedSierraRecord2)
+                }
               }
             }
-          }
         }
       }
     }
@@ -404,78 +396,77 @@ class SierraItemMergerUpdaterServiceTest
   it("does not unlink an item if it receives an out of date unlink update") {
     withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { table =>
-        withVersionedHybridStore[SierraTransformable, Unit](
-          bucket,
-          table) { hybridStore =>
-          withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
-            val itemId = "i3000003"
+        withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
+          hybridStore =>
+            withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
+              val itemId = "i3000003"
 
-            val bibId1 = "b9000001"
-            val bibId2 = "b9000002"
+              val bibId1 = "b9000001"
+              val bibId2 = "b9000002"
 
-            val itemRecord = sierraItemRecord(
-              id = itemId,
-              updatedDate = "2003-03-03T03:03:03Z",
-              bibIds = List(bibId1)
-            )
+              val itemRecord = sierraItemRecord(
+                id = itemId,
+                updatedDate = "2003-03-03T03:03:03Z",
+                bibIds = List(bibId1)
+              )
 
-            val itemData = Map(
-              itemRecord.id -> itemRecord
-            )
+              val itemData = Map(
+                itemRecord.id -> itemRecord
+              )
 
-            val sierraTransformable1 = SierraTransformable(
-              sourceId = bibId1,
-              itemData = itemData
-            )
+              val sierraTransformable1 = SierraTransformable(
+                sourceId = bibId1,
+                itemData = itemData
+              )
 
-            val sierraTransformable2 = SierraTransformable(
-              sourceId = bibId2
-            )
+              val sierraTransformable2 = SierraTransformable(
+                sourceId = bibId2
+              )
 
-            val f1 = hybridStore.updateRecord(sierraTransformable1.id)(
-              sierraTransformable1
-            )(_ => sierraTransformable1)(
-              SourceMetadata(sierraTransformable1.sourceName))
+              val f1 = hybridStore.updateRecord(sierraTransformable1.id)(
+                sierraTransformable1
+              )(_ => sierraTransformable1)(
+                SourceMetadata(sierraTransformable1.sourceName))
 
-            val f2 = hybridStore.updateRecord(sierraTransformable2.id)(
-              sierraTransformable2
-            )(identity)(SourceMetadata(sierraTransformable2.sourceName))
+              val f2 = hybridStore.updateRecord(sierraTransformable2.id)(
+                sierraTransformable2
+              )(identity)(SourceMetadata(sierraTransformable2.sourceName))
 
-            val unlinkItemRecord = itemRecord.copy(
-              bibIds = List(bibId2),
-              unlinkedBibIds = List(bibId1),
-              modifiedDate = itemRecord.modifiedDate.minusSeconds(1)
-            )
-
-            val expectedItemData = Map(
-              itemRecord.id -> itemRecord.copy(
+              val unlinkItemRecord = itemRecord.copy(
                 bibIds = List(bibId2),
                 unlinkedBibIds = List(bibId1),
-                modifiedDate = unlinkItemRecord.modifiedDate
+                modifiedDate = itemRecord.modifiedDate.minusSeconds(1)
               )
-            )
 
-            whenReady(Future.sequence(List(f1, f2))) { _ =>
-              whenReady(sierraUpdaterService.update(unlinkItemRecord)) { _ =>
-                // In this situation the item will _not_ be unlinked from the original
-                // record but will be linked to the new record (as this is the first
-                // time we've seen the link so it is valid for that bib.
-                val expectedSierraRecord1 = sierraTransformable1
-                val expectedSierraRecord2 = sierraTransformable2.copy(
-                  itemData = expectedItemData
+              val expectedItemData = Map(
+                itemRecord.id -> itemRecord.copy(
+                  bibIds = List(bibId2),
+                  unlinkedBibIds = List(bibId1),
+                  modifiedDate = unlinkItemRecord.modifiedDate
                 )
+              )
 
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  expectedSierraRecord1)
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  expectedSierraRecord2)
+              whenReady(Future.sequence(List(f1, f2))) { _ =>
+                whenReady(sierraUpdaterService.update(unlinkItemRecord)) { _ =>
+                  // In this situation the item will _not_ be unlinked from the original
+                  // record but will be linked to the new record (as this is the first
+                  // time we've seen the link so it is valid for that bib.
+                  val expectedSierraRecord1 = sierraTransformable1
+                  val expectedSierraRecord2 = sierraTransformable2.copy(
+                    itemData = expectedItemData
+                  )
+
+                  assertStored[SierraTransformable](
+                    bucket,
+                    table,
+                    expectedSierraRecord1)
+                  assertStored[SierraTransformable](
+                    bucket,
+                    table,
+                    expectedSierraRecord2)
+                }
               }
             }
-          }
         }
       }
     }
@@ -484,42 +475,41 @@ class SierraItemMergerUpdaterServiceTest
   it("does not update an item if it receives an update with an older date") {
     withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { table =>
-        withVersionedHybridStore[SierraTransformable, Unit](
-          bucket,
-          table) { hybridStore =>
-          withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
-            val id = "i6000006"
-            val bibId = "b6000006"
+        withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
+          hybridStore =>
+            withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
+              val id = "i6000006"
+              val bibId = "b6000006"
 
-            val sierraRecord = SierraTransformable(
-              sourceId = bibId,
-              itemData = Map(
-                id -> sierraItemRecord(
-                  id = id,
-                  updatedDate = "2006-06-06T06:06:06Z",
-                  bibIds = List(bibId)
-                ))
-            )
+              val sierraRecord = SierraTransformable(
+                sourceId = bibId,
+                itemData = Map(
+                  id -> sierraItemRecord(
+                    id = id,
+                    updatedDate = "2006-06-06T06:06:06Z",
+                    bibIds = List(bibId)
+                  ))
+              )
 
-            val f1 = hybridStore.updateRecord(sierraRecord.id)(
-              sierraRecord
-            )(identity)(SourceMetadata(sierraRecord.sourceName))
+              val f1 = hybridStore.updateRecord(sierraRecord.id)(
+                sierraRecord
+              )(identity)(SourceMetadata(sierraRecord.sourceName))
 
-            val oldItemRecord = sierraItemRecord(
-              id = id,
-              updatedDate = "2001-01-01T01:01:01Z",
-              bibIds = List(bibId)
-            )
+              val oldItemRecord = sierraItemRecord(
+                id = id,
+                updatedDate = "2001-01-01T01:01:01Z",
+                bibIds = List(bibId)
+              )
 
-            whenReady(f1) { _ =>
-              whenReady(sierraUpdaterService.update(oldItemRecord)) { _ =>
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  sierraRecord)
+              whenReady(f1) { _ =>
+                whenReady(sierraUpdaterService.update(oldItemRecord)) { _ =>
+                  assertStored[SierraTransformable](
+                    bucket,
+                    table,
+                    sierraRecord)
+                }
               }
             }
-          }
         }
       }
     }
@@ -528,42 +518,41 @@ class SierraItemMergerUpdaterServiceTest
   it("adds an item to the record if the bibId exists but has no itemData") {
     withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { table =>
-        withVersionedHybridStore[SierraTransformable, Unit](
-          bucket,
-          table) { hybridStore =>
-          withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
-            val bibId = "b7000007"
+        withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
+          hybridStore =>
+            withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
+              val bibId = "b7000007"
 
-            val sierraRecord = SierraTransformable(
-              sourceId = bibId
-            )
+              val sierraRecord = SierraTransformable(
+                sourceId = bibId
+              )
 
-            val f1 = hybridStore.updateRecord(sierraRecord.id)(
-              sierraRecord
-            )(identity)(SourceMetadata(sierraRecord.sourceName))
+              val f1 = hybridStore.updateRecord(sierraRecord.id)(
+                sierraRecord
+              )(identity)(SourceMetadata(sierraRecord.sourceName))
 
-            val itemRecord = sierraItemRecord(
-              id = "i7000007",
-              updatedDate = "2007-07-07T07:07:07Z",
-              bibIds = List(bibId)
-            )
+              val itemRecord = sierraItemRecord(
+                id = "i7000007",
+                updatedDate = "2007-07-07T07:07:07Z",
+                bibIds = List(bibId)
+              )
 
-            whenReady(f1) { _ =>
-              whenReady(sierraUpdaterService.update(itemRecord)) { _ =>
-                val expectedSierraRecord = SierraTransformable(
-                  sourceId = bibId,
-                  itemData = Map(
-                    itemRecord.id -> itemRecord
+              whenReady(f1) { _ =>
+                whenReady(sierraUpdaterService.update(itemRecord)) { _ =>
+                  val expectedSierraRecord = SierraTransformable(
+                    sourceId = bibId,
+                    itemData = Map(
+                      itemRecord.id -> itemRecord
+                    )
                   )
-                )
 
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  expectedSierraRecord)
+                  assertStored[SierraTransformable](
+                    bucket,
+                    table,
+                    expectedSierraRecord)
+                }
               }
             }
-          }
         }
       }
     }
@@ -572,47 +561,47 @@ class SierraItemMergerUpdaterServiceTest
   it("returns a failed future if putting an item fails") {
     withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { table =>
-        withVersionedHybridStore[SierraTransformable, Unit](
-          bucket,
-          table) { hybridStore =>
-          withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
-            val failingVersionedDao = mock[VersionedDao]
-            val expectedException = new RuntimeException("BOOOM!")
+        withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
+          hybridStore =>
+            withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
+              val failingVersionedDao = mock[VersionedDao]
+              val expectedException = new RuntimeException("BOOOM!")
 
-            when(
-              failingVersionedDao.getRecord[HybridRecord](
-                any[String]
-              )(
-                any[DynamoFormat[HybridRecord]]
-              ))
-              .thenReturn(Future.failed(expectedException))
+              when(
+                failingVersionedDao.getRecord[HybridRecord](
+                  any[String]
+                )(
+                  any[DynamoFormat[HybridRecord]]
+                ))
+                .thenReturn(Future.failed(expectedException))
 
-            val failingVersionedHybridStore =
-              new VersionedHybridStore[SierraTransformable](
-                sourcedObjectStore = new S3ObjectStore(
-                  s3Client = s3Client,
-                  s3Config = S3Config(bucketName = bucket.name),
-                  new SourcedKeyPrefixGenerator),
-                versionedDao = failingVersionedDao
+              val failingVersionedHybridStore =
+                new VersionedHybridStore[SierraTransformable](
+                  sourcedObjectStore = new S3ObjectStore(
+                    s3Client = s3Client,
+                    s3Config = S3Config(bucketName = bucket.name),
+                    new SourcedKeyPrefixGenerator),
+                  versionedDao = failingVersionedDao
+                )
+
+              val failingUpdaterService = new SierraItemMergerUpdaterService(
+                failingVersionedHybridStore,
+                mock[MetricsSender]
               )
 
-            val failingUpdaterService = new SierraItemMergerUpdaterService(
-              failingVersionedHybridStore,
-              mock[MetricsSender]
-            )
+              val bibId = "b242"
 
-            val bibId = "b242"
+              val itemRecord = sierraItemRecord(
+                "i000",
+                "2007-07-07T07:07:07Z",
+                List(bibId)
+              )
 
-            val itemRecord = sierraItemRecord(
-              "i000",
-              "2007-07-07T07:07:07Z",
-              List(bibId)
-            )
-
-            whenReady(failingUpdaterService.update(itemRecord).failed) { ex =>
-              ex shouldBe expectedException
+              whenReady(failingUpdaterService.update(itemRecord).failed) {
+                ex =>
+                  ex shouldBe expectedException
+              }
             }
-          }
         }
       }
     }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
@@ -17,10 +17,10 @@ class ServerTest
   override lazy val evidence = DynamoFormat[SierraItemRecord]
 
   it("shows the healthcheck message") {
-    withLocalDynamoDbTable { tableName =>
+    withLocalDynamoDbTable { table =>
       withLocalSqsQueue { queue =>
         val flags = sqsLocalFlags(queue) ++ dynamoDbLocalEndpointFlags(
-          tableName)
+          table)
 
         withServer(flags) { server =>
           server.httpGet(

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
@@ -18,8 +18,8 @@ class ServerTest
 
   it("shows the healthcheck message") {
     withLocalDynamoDbTable { tableName =>
-      withLocalSqsQueue { queueUrl =>
-        val flags = sqsLocalFlags(queueUrl) ++ dynamoDbLocalEndpointFlags(
+      withLocalSqsQueue { queue =>
+        val flags = sqsLocalFlags(queue) ++ dynamoDbLocalEndpointFlags(
           tableName)
 
         withServer(flags) { server =>

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
@@ -19,8 +19,7 @@ class ServerTest
   it("shows the healthcheck message") {
     withLocalDynamoDbTable { table =>
       withLocalSqsQueue { queue =>
-        val flags = sqsLocalFlags(queue) ++ dynamoDbLocalEndpointFlags(
-          table)
+        val flags = sqsLocalFlags(queue) ++ dynamoDbLocalEndpointFlags(table)
 
         withServer(flags) { server =>
           server.httpGet(

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
@@ -32,10 +32,10 @@ class SierraItemsToDynamoFeatureTest
     DynamoFormat[SierraItemRecord]
 
   it("reads items from Sierra and adds them to DynamoDB") {
-    withLocalDynamoDbTable { tableName =>
+    withLocalDynamoDbTable { table =>
       withLocalSqsQueue { queue =>
         val flags = sqsLocalFlags(queue) ++ dynamoDbLocalEndpointFlags(
-          tableName)
+          table)
 
         withServer(flags) { server =>
           val id = "i12345"
@@ -54,10 +54,10 @@ class SierraItemsToDynamoFeatureTest
           sqsClient.sendMessage(queue.url, toJson(sqsMessage).get)
 
           eventually {
-            Scanamo.scan[SierraItemRecord](dynamoDbClient)(tableName) should have size 1
+            Scanamo.scan[SierraItemRecord](dynamoDbClient)(table.name) should have size 1
 
             val scanamoResult =
-              Scanamo.get[SierraItemRecord](dynamoDbClient)(tableName)(
+              Scanamo.get[SierraItemRecord](dynamoDbClient)(table.name)(
                 'id -> id)
 
             scanamoResult shouldBe defined

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
@@ -34,8 +34,7 @@ class SierraItemsToDynamoFeatureTest
   it("reads items from Sierra and adds them to DynamoDB") {
     withLocalDynamoDbTable { table =>
       withLocalSqsQueue { queue =>
-        val flags = sqsLocalFlags(queue) ++ dynamoDbLocalEndpointFlags(
-          table)
+        val flags = sqsLocalFlags(queue) ++ dynamoDbLocalEndpointFlags(table)
 
         withServer(flags) { server =>
           val id = "i12345"

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
@@ -33,8 +33,8 @@ class SierraItemsToDynamoFeatureTest
 
   it("reads items from Sierra and adds them to DynamoDB") {
     withLocalDynamoDbTable { tableName =>
-      withLocalSqsQueue { queueUrl =>
-        val flags = sqsLocalFlags(queueUrl) ++ dynamoDbLocalEndpointFlags(
+      withLocalSqsQueue { queue =>
+        val flags = sqsLocalFlags(queue) ++ dynamoDbLocalEndpointFlags(
           tableName)
 
         withServer(flags) { server =>
@@ -51,7 +51,7 @@ class SierraItemsToDynamoFeatureTest
               "topic",
               "messageType",
               "timestamp")
-          sqsClient.sendMessage(queueUrl, toJson(sqsMessage).get)
+          sqsClient.sendMessage(queue.url, toJson(sqsMessage).get)
 
           eventually {
             Scanamo.scan[SierraItemRecord](dynamoDbClient)(tableName) should have size 1

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/DynamoInserterFixture.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/DynamoInserterFixture.scala
@@ -6,6 +6,7 @@ import uk.ac.wellcome.models.aws.DynamoConfig
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.services.DynamoInserter
 import uk.ac.wellcome.test.fixtures.{LocalDynamoDb, TestWith}
+import uk.ac.wellcome.test.fixtures.LocalDynamoDb.Table
 
 import uk.ac.wellcome.dynamo._
 
@@ -14,16 +15,16 @@ trait DynamoInserterFixture extends LocalDynamoDb[SierraItemRecord] {
     DynamoFormat[SierraItemRecord]
 
   def withDynamoInserter[R](
-    testWith: TestWith[(String, DynamoInserter), R]): Unit = {
-    withLocalDynamoDbTable { tableName =>
+    testWith: TestWith[(Table, DynamoInserter), R]): Unit = {
+    withLocalDynamoDbTable { table =>
       val dynamoInserter = new DynamoInserter(
         new VersionedDao(
           dynamoDbClient,
-          dynamoConfig = DynamoConfig(tableName)
+          dynamoConfig = DynamoConfig(table.name)
         )
       )
 
-      testWith((tableName, dynamoInserter))
+      testWith((table, dynamoInserter))
     }
   }
 }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/ServerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/ServerTest.scala
@@ -8,9 +8,9 @@ import uk.ac.wellcome.test.fixtures.{S3, SQS}
 class ServerTest extends FunSpec with fixtures.Server with S3 with SQS {
 
   it("it shows the healthcheck message") {
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       withLocalSqsQueue { queueUrl =>
-        val flags = s3LocalFlags(bucketName) ++ sqsLocalFlags(queueUrl) ++ Map(
+        val flags = s3LocalFlags(bucket) ++ sqsLocalFlags(queueUrl) ++ Map(
           "reader.resourceType" -> "bibs",
           "sierra.apiUrl" -> "http://localhost:8080",
           "sierra.oauthKey" -> "key",

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/ServerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/ServerTest.scala
@@ -9,8 +9,8 @@ class ServerTest extends FunSpec with fixtures.Server with S3 with SQS {
 
   it("it shows the healthcheck message") {
     withLocalS3Bucket { bucket =>
-      withLocalSqsQueue { queueUrl =>
-        val flags = s3LocalFlags(bucket) ++ sqsLocalFlags(queueUrl) ++ Map(
+      withLocalSqsQueue { queue =>
+        val flags = s3LocalFlags(bucket) ++ sqsLocalFlags(queue) ++ Map(
           "reader.resourceType" -> "bibs",
           "sierra.apiUrl" -> "http://localhost:8080",
           "sierra.oauthKey" -> "key",

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/SierraReaderFeatureTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/SierraReaderFeatureTest.scala
@@ -17,9 +17,9 @@ class SierraReaderFeatureTest
     with ExtendedPatience {
 
   it("reads bibs from Sierra and writes files to S3") {
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       withLocalSqsQueue { queueUrl =>
-        val flags = s3LocalFlags(bucketName) ++ sqsLocalFlags(queueUrl) ++ Map(
+        val flags = s3LocalFlags(bucket) ++ sqsLocalFlags(queueUrl) ++ Map(
           "reader.resourceType" -> "bibs",
           "sierra.apiUrl" -> "http://localhost:8080",
           "sierra.oauthKey" -> "key",
@@ -47,7 +47,7 @@ class SierraReaderFeatureTest
           eventually {
             // This comes from the wiremock recordings for Sierra API response
             s3Client
-              .listObjects(bucketName)
+              .listObjects(bucket.underlying)
               .getObjectSummaries should have size 2
           }
         }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/SierraReaderFeatureTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/SierraReaderFeatureTest.scala
@@ -18,8 +18,8 @@ class SierraReaderFeatureTest
 
   it("reads bibs from Sierra and writes files to S3") {
     withLocalS3Bucket { bucket =>
-      withLocalSqsQueue { queueUrl =>
-        val flags = s3LocalFlags(bucket) ++ sqsLocalFlags(queueUrl) ++ Map(
+      withLocalSqsQueue { queue =>
+        val flags = s3LocalFlags(bucket) ++ sqsLocalFlags(queue) ++ Map(
           "reader.resourceType" -> "bibs",
           "sierra.apiUrl" -> "http://localhost:8080",
           "sierra.oauthKey" -> "key",
@@ -42,7 +42,7 @@ class SierraReaderFeatureTest
             "topic",
             "messageType",
             "timestamp")
-          sqsClient.sendMessage(queueUrl, toJson(sqsMessage).get)
+          sqsClient.sendMessage(queue.url, toJson(sqsMessage).get)
 
           eventually {
             // This comes from the wiremock recordings for Sierra API response

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/SierraReaderFeatureTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/SierraReaderFeatureTest.scala
@@ -47,7 +47,7 @@ class SierraReaderFeatureTest
           eventually {
             // This comes from the wiremock recordings for Sierra API response
             s3Client
-              .listObjects(bucket.underlying)
+              .listObjects(bucket.name)
               .getObjectSummaries should have size 2
           }
         }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -25,7 +25,7 @@ class WindowManagerTest
     testWith: TestWith[WindowManager, Assertion]) = {
     val windowManager = new WindowManager(
       s3client = s3Client,
-      s3Config = S3Config(bucket),
+      s3Config = S3Config(bucket.underlying),
       fields = "title",
       resourceType = SierraResourceTypes.bibs
     )

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -25,7 +25,7 @@ class WindowManagerTest
     testWith: TestWith[WindowManager, Assertion]) = {
     val windowManager = new WindowManager(
       s3client = s3Client,
-      s3Config = S3Config(bucket.underlying),
+      s3Config = S3Config(bucket.name),
       fields = "title",
       resourceType = SierraResourceTypes.bibs
     )
@@ -51,7 +51,7 @@ class WindowManagerTest
         val prefix = windowManager.buildWindowShard("[2013,2014]")
 
         // We pre-populate S3 with files as if they'd come from a prior run of the reader.
-        s3Client.putObject(bucket.underlying, s"$prefix/0000.json", "[]")
+        s3Client.putObject(bucket.name, s"$prefix/0000.json", "[]")
 
         val record =
           SierraRecord(
@@ -60,7 +60,7 @@ class WindowManagerTest
             modifiedDate = Instant.now())
 
         s3Client.putObject(
-          bucket.underlying,
+          bucket.name,
           s"$prefix/0001.json",
           toJson(List(record)).get
         )
@@ -78,7 +78,7 @@ class WindowManagerTest
     withLocalS3Bucket { bucket =>
       withWindowManager(bucket) { windowManager =>
         val prefix = windowManager.buildWindowShard("[2013,2014]")
-        s3Client.putObject(bucket.underlying, s"$prefix/0000.json", "not valid")
+        s3Client.putObject(bucket.name, s"$prefix/0000.json", "not valid")
 
         val result = windowManager.getCurrentStatus("[2013,2014]")
 
@@ -94,7 +94,7 @@ class WindowManagerTest
       withWindowManager(bucket) { windowManager =>
         val prefix = windowManager.buildWindowShard("[2013,2014]")
 
-        s3Client.putObject(bucket.underlying, s"$prefix/0000.json", "[]")
+        s3Client.putObject(bucket.name, s"$prefix/0000.json", "[]")
 
         val result = windowManager.getCurrentStatus("[2013,2014]")
 
@@ -110,7 +110,7 @@ class WindowManagerTest
       withWindowManager(bucket) { windowManager =>
         val prefix = windowManager.buildWindowShard("[2013,2014]")
 
-        s3Client.putObject(bucket.underlying, s"$prefix/000x.json", "[]")
+        s3Client.putObject(bucket.name, s"$prefix/000x.json", "[]")
 
         val result = windowManager.getCurrentStatus("[2013,2014]")
 

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -65,10 +65,10 @@ class SierraReaderWorkerServiceTest
           val worker = new SierraReaderWorkerService(
             reader = new SQSReader(sqsClient, SQSConfig(queueUrl, 1.second, 1)),
             s3client = s3Client,
-            s3Config = S3Config(bucket.underlying),
+            s3Config = S3Config(bucket.name),
             windowManager = new WindowManager(
               s3Client,
-              S3Config(bucket.underlying),
+              S3Config(bucket.name),
               fields,
               resourceType),
             batchSize = batchSize,
@@ -124,7 +124,7 @@ class SierraReaderWorkerServiceTest
 
       eventually {
         val objects =
-          s3Client.listObjects(fixtures.bucket.underlying).getObjectSummaries
+          s3Client.listObjects(fixtures.bucket.name).getObjectSummaries
 
         // there are 29 bib updates in the sierra wiremock so we expect 3 files
         objects.map { _.getKey() } shouldBe pageNames
@@ -168,7 +168,7 @@ class SierraReaderWorkerServiceTest
 
       eventually {
         val objects =
-          s3Client.listObjects(fixtures.bucket.underlying).getObjectSummaries
+          s3Client.listObjects(fixtures.bucket.name).getObjectSummaries
 
         // There are 157 item records in the Sierra wiremock so we expect 4 files
         objects.map { _.getKey() } shouldBe pageNames
@@ -190,9 +190,9 @@ class SierraReaderWorkerServiceTest
       val prefix = "records_items/2013-12-10T17-16-35Z__2013-12-13T21-34-35Z"
 
       // First we pre-populate S3 with files as if they'd come from a prior run of the reader.
-      s3Client.putObject(fixtures.bucket.underlying, s"$prefix/0000.json", "[]")
+      s3Client.putObject(fixtures.bucket.name, s"$prefix/0000.json", "[]")
       s3Client.putObject(
-        fixtures.bucket.underlying,
+        fixtures.bucket.name,
         s"$prefix/0001.json",
         """
           |[
@@ -231,7 +231,7 @@ class SierraReaderWorkerServiceTest
 
       eventually {
         val objects =
-          s3Client.listObjects(fixtures.bucket.underlying).getObjectSummaries
+          s3Client.listObjects(fixtures.bucket.name).getObjectSummaries
 
         // There are 157 item records in the Sierra wiremock so we expect 4 files
         objects.map { _.getKey() } shouldBe pageNames

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -64,7 +64,8 @@ class SierraReaderWorkerServiceTest
       withLocalSqsQueue { queue =>
         withLocalS3Bucket { bucket =>
           val worker = new SierraReaderWorkerService(
-            reader = new SQSReader(sqsClient, SQSConfig(queue.url, 1.second, 1)),
+            reader =
+              new SQSReader(sqsClient, SQSConfig(queue.url, 1.second, 1)),
             s3client = s3Client,
             s3Config = S3Config(bucket.name),
             windowManager = new WindowManager(

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -129,9 +129,9 @@ class SierraReaderWorkerServiceTest
         // there are 29 bib updates in the sierra wiremock so we expect 3 files
         objects.map { _.getKey() } shouldBe pageNames
 
-        getRecordsFromS3(fixtures.bucket.underlying, pageNames(0)) should have size 10
-        getRecordsFromS3(fixtures.bucket.underlying, pageNames(1)) should have size 10
-        getRecordsFromS3(fixtures.bucket.underlying, pageNames(2)) should have size 9
+        getRecordsFromS3(fixtures.bucket, pageNames(0)) should have size 10
+        getRecordsFromS3(fixtures.bucket, pageNames(1)) should have size 10
+        getRecordsFromS3(fixtures.bucket, pageNames(2)) should have size 9
       }
     }
   }
@@ -173,10 +173,10 @@ class SierraReaderWorkerServiceTest
         // There are 157 item records in the Sierra wiremock so we expect 4 files
         objects.map { _.getKey() } shouldBe pageNames
 
-        getRecordsFromS3(fixtures.bucket.underlying, pageNames(0)) should have size 50
-        getRecordsFromS3(fixtures.bucket.underlying, pageNames(1)) should have size 50
-        getRecordsFromS3(fixtures.bucket.underlying, pageNames(2)) should have size 50
-        getRecordsFromS3(fixtures.bucket.underlying, pageNames(3)) should have size 7
+        getRecordsFromS3(fixtures.bucket, pageNames(0)) should have size 50
+        getRecordsFromS3(fixtures.bucket, pageNames(1)) should have size 50
+        getRecordsFromS3(fixtures.bucket, pageNames(2)) should have size 50
+        getRecordsFromS3(fixtures.bucket, pageNames(3)) should have size 7
       }
     }
   }
@@ -249,7 +249,7 @@ class SierraReaderWorkerServiceTest
 
   private def getRecordsFromS3(bucket: Bucket,
                                key: String): List[SierraRecord] =
-    fromJson[List[SierraRecord]](getContentFromS3(bucket.underlying, key)).get
+    fromJson[List[SierraRecord]](getContentFromS3(bucket, key)).get
 
   it(
     "returns a GracefulFailureException if it receives a message that doesn't contain start or end values") {

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -18,6 +18,7 @@ import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.transformable.sierra.SierraRecord
 import uk.ac.wellcome.platform.sierra_reader.modules.WindowManager
+import uk.ac.wellcome.test.fixtures.S3.Bucket
 
 import scala.concurrent.duration._
 import org.scalatest.compatible.Assertion
@@ -50,7 +51,7 @@ class SierraReaderWorkerServiceTest
 
   case class FixtureParams(worker: SierraReaderWorkerService,
                            queueUrl: String,
-                           bucketName: String)
+                           bucket: Bucket)
 
   def withSierraReaderWorkerService(
     fields: String,
@@ -60,14 +61,14 @@ class SierraReaderWorkerServiceTest
   )(testWith: TestWith[FixtureParams, Assertion]) = {
     withActorSystem { actorSystem =>
       withLocalSqsQueue { queueUrl =>
-        withLocalS3Bucket { bucketName =>
+        withLocalS3Bucket { bucket =>
           val worker = new SierraReaderWorkerService(
             reader = new SQSReader(sqsClient, SQSConfig(queueUrl, 1.second, 1)),
             s3client = s3Client,
-            s3Config = S3Config(bucketName),
+            s3Config = S3Config(bucket.underlying),
             windowManager = new WindowManager(
               s3Client,
-              S3Config(bucketName),
+              S3Config(bucket.underlying),
               fields,
               resourceType),
             batchSize = batchSize,
@@ -81,7 +82,7 @@ class SierraReaderWorkerServiceTest
           )
 
           try {
-            testWith(FixtureParams(worker, queueUrl, bucketName))
+            testWith(FixtureParams(worker, queueUrl, bucket))
           } finally {
             worker.stop()
           }
@@ -123,14 +124,14 @@ class SierraReaderWorkerServiceTest
 
       eventually {
         val objects =
-          s3Client.listObjects(fixtures.bucketName).getObjectSummaries
+          s3Client.listObjects(fixtures.bucket.underlying).getObjectSummaries
 
         // there are 29 bib updates in the sierra wiremock so we expect 3 files
         objects.map { _.getKey() } shouldBe pageNames
 
-        getRecordsFromS3(fixtures.bucketName, pageNames(0)) should have size 10
-        getRecordsFromS3(fixtures.bucketName, pageNames(1)) should have size 10
-        getRecordsFromS3(fixtures.bucketName, pageNames(2)) should have size 9
+        getRecordsFromS3(fixtures.bucket.underlying, pageNames(0)) should have size 10
+        getRecordsFromS3(fixtures.bucket.underlying, pageNames(1)) should have size 10
+        getRecordsFromS3(fixtures.bucket.underlying, pageNames(2)) should have size 9
       }
     }
   }
@@ -167,15 +168,15 @@ class SierraReaderWorkerServiceTest
 
       eventually {
         val objects =
-          s3Client.listObjects(fixtures.bucketName).getObjectSummaries
+          s3Client.listObjects(fixtures.bucket.underlying).getObjectSummaries
 
         // There are 157 item records in the Sierra wiremock so we expect 4 files
         objects.map { _.getKey() } shouldBe pageNames
 
-        getRecordsFromS3(fixtures.bucketName, pageNames(0)) should have size 50
-        getRecordsFromS3(fixtures.bucketName, pageNames(1)) should have size 50
-        getRecordsFromS3(fixtures.bucketName, pageNames(2)) should have size 50
-        getRecordsFromS3(fixtures.bucketName, pageNames(3)) should have size 7
+        getRecordsFromS3(fixtures.bucket.underlying, pageNames(0)) should have size 50
+        getRecordsFromS3(fixtures.bucket.underlying, pageNames(1)) should have size 50
+        getRecordsFromS3(fixtures.bucket.underlying, pageNames(2)) should have size 50
+        getRecordsFromS3(fixtures.bucket.underlying, pageNames(3)) should have size 7
       }
     }
   }
@@ -189,9 +190,9 @@ class SierraReaderWorkerServiceTest
       val prefix = "records_items/2013-12-10T17-16-35Z__2013-12-13T21-34-35Z"
 
       // First we pre-populate S3 with files as if they'd come from a prior run of the reader.
-      s3Client.putObject(fixtures.bucketName, s"$prefix/0000.json", "[]")
+      s3Client.putObject(fixtures.bucket.underlying, s"$prefix/0000.json", "[]")
       s3Client.putObject(
-        fixtures.bucketName,
+        fixtures.bucket.underlying,
         s"$prefix/0001.json",
         """
           |[
@@ -230,25 +231,25 @@ class SierraReaderWorkerServiceTest
 
       eventually {
         val objects =
-          s3Client.listObjects(fixtures.bucketName).getObjectSummaries
+          s3Client.listObjects(fixtures.bucket.underlying).getObjectSummaries
 
         // There are 157 item records in the Sierra wiremock so we expect 4 files
         objects.map { _.getKey() } shouldBe pageNames
 
         // These two files were pre-populated -- we check the reader hasn't overwritten these
-        getRecordsFromS3(fixtures.bucketName, pageNames(0)) should have size 0
-        getRecordsFromS3(fixtures.bucketName, pageNames(1)) should have size 1
+        getRecordsFromS3(fixtures.bucket, pageNames(0)) should have size 0
+        getRecordsFromS3(fixtures.bucket, pageNames(1)) should have size 1
 
         // We check the reader has filled these in correctly
-        getRecordsFromS3(fixtures.bucketName, pageNames(2)) should have size 50
-        getRecordsFromS3(fixtures.bucketName, pageNames(3)) should have size 7
+        getRecordsFromS3(fixtures.bucket, pageNames(2)) should have size 50
+        getRecordsFromS3(fixtures.bucket, pageNames(3)) should have size 7
       }
     }
   }
 
-  private def getRecordsFromS3(bucketName: String,
+  private def getRecordsFromS3(bucket: Bucket,
                                key: String): List[SierraRecord] =
-    fromJson[List[SierraRecord]](getContentFromS3(bucketName, key)).get
+    fromJson[List[SierraRecord]](getContentFromS3(bucket.underlying, key)).get
 
   it(
     "returns a GracefulFailureException if it receives a message that doesn't contain start or end values") {

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/sink/SequentialS3SinkTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/sink/SequentialS3SinkTest.scala
@@ -33,7 +33,7 @@ class SequentialS3SinkTest
     implicit val executionContext = actorSystem.dispatcher
     val sink = SequentialS3Sink(
       s3Client,
-      bucketName = bucket.underlying,
+      bucketName = bucket.name,
       keyPrefix = keyPrefix,
       offset = offset
     )
@@ -58,7 +58,7 @@ class SequentialS3SinkTest
 
             whenReady(futureDone) { _ =>
               val s3objects =
-                s3Client.listObjects(bucket.underlying).getObjectSummaries
+                s3Client.listObjects(bucket.name).getObjectSummaries
               s3objects should have size 1
               s3objects.head.getKey() shouldBe "testA_0000.json"
 
@@ -87,7 +87,7 @@ class SequentialS3SinkTest
 
             whenReady(futureDone) { _ =>
               val s3objects =
-                s3Client.listObjects(bucket.underlying).getObjectSummaries
+                s3Client.listObjects(bucket.name).getObjectSummaries
               s3objects should have size 3
               s3objects.map {
                 _.getKey()
@@ -124,7 +124,7 @@ class SequentialS3SinkTest
 
             whenReady(futureDone) { _ =>
               val s3objects =
-                s3Client.listObjects(bucket.underlying).getObjectSummaries
+                s3Client.listObjects(bucket.name).getObjectSummaries
               s3objects.map {
                 _.getKey()
               } shouldBe List(

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/sink/SequentialS3SinkTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/sink/SequentialS3SinkTest.scala
@@ -11,6 +11,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import uk.ac.wellcome.test.fixtures.{Akka, S3, TestWith}
 import uk.ac.wellcome.test.utils.ExtendedPatience
+import uk.ac.wellcome.test.fixtures.S3.Bucket
 
 import scala.collection.JavaConversions._
 import scala.concurrent.Future
@@ -25,14 +26,14 @@ class SequentialS3SinkTest
     with ExtendedPatience {
 
   private def withSink(actorSystem: ActorSystem,
-                       bucketName: String,
+                       bucket: Bucket,
                        keyPrefix: String,
                        offset: Int = 0)(
     testWith: TestWith[Sink[(Json, Long), Future[Done]], Assertion]) = {
     implicit val executionContext = actorSystem.dispatcher
     val sink = SequentialS3Sink(
       s3Client,
-      bucketName = bucketName,
+      bucketName = bucket.underlying,
       keyPrefix = keyPrefix,
       offset = offset
     )
@@ -43,11 +44,11 @@ class SequentialS3SinkTest
   it("puts a single JSON in S3") {
     val json = parse(s"""{"hello": "world"}""").right.get
 
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       withActorSystem { actorSystem =>
         withSink(
           actorSystem = actorSystem,
-          bucketName = bucketName,
+          bucket = bucket,
           keyPrefix = "testA_") { sink =>
           withMaterializer(actorSystem) { materializer =>
             val futureDone = Source
@@ -57,11 +58,11 @@ class SequentialS3SinkTest
 
             whenReady(futureDone) { _ =>
               val s3objects =
-                s3Client.listObjects(bucketName).getObjectSummaries
+                s3Client.listObjects(bucket.underlying).getObjectSummaries
               s3objects should have size 1
               s3objects.head.getKey() shouldBe "testA_0000.json"
 
-              getJsonFromS3(bucketName, "testA_0000.json") shouldBe json
+              getJsonFromS3(bucket, "testA_0000.json") shouldBe json
             }
           }
         }
@@ -74,11 +75,11 @@ class SequentialS3SinkTest
     val json1 = parse(s"""{"orange": "yellow"}""").right.get
     val json2 = parse(s"""{"yellow": "green"}""").right.get
 
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       withActorSystem { actorSystem =>
         withSink(
           actorSystem = actorSystem,
-          bucketName = bucketName,
+          bucket = bucket,
           keyPrefix = "testB_") { sink =>
           withMaterializer(actorSystem) { materializer =>
             val futureDone = Source(List(json0, json1, json2)).zipWithIndex
@@ -86,7 +87,7 @@ class SequentialS3SinkTest
 
             whenReady(futureDone) { _ =>
               val s3objects =
-                s3Client.listObjects(bucketName).getObjectSummaries
+                s3Client.listObjects(bucket.underlying).getObjectSummaries
               s3objects should have size 3
               s3objects.map {
                 _.getKey()
@@ -95,9 +96,9 @@ class SequentialS3SinkTest
                 "testB_0001.json",
                 "testB_0002.json")
 
-              getJsonFromS3(bucketName, "testB_0000.json") shouldBe json0
-              getJsonFromS3(bucketName, "testB_0001.json") shouldBe json1
-              getJsonFromS3(bucketName, "testB_0002.json") shouldBe json2
+              getJsonFromS3(bucket, "testB_0000.json") shouldBe json0
+              getJsonFromS3(bucket, "testB_0001.json") shouldBe json1
+              getJsonFromS3(bucket, "testB_0002.json") shouldBe json2
             }
           }
         }
@@ -110,11 +111,11 @@ class SequentialS3SinkTest
     val json1 = parse(s"""{"orange": "yellow"}""").right.get
     val json2 = parse(s"""{"yellow": "green"}""").right.get
 
-    withLocalS3Bucket { bucketName =>
+    withLocalS3Bucket { bucket =>
       withActorSystem { actorSystem =>
         withSink(
           actorSystem = actorSystem,
-          bucketName = bucketName,
+          bucket = bucket,
           keyPrefix = "testC_",
           offset = 3) { sink =>
           withMaterializer(actorSystem) { materializer =>
@@ -123,7 +124,7 @@ class SequentialS3SinkTest
 
             whenReady(futureDone) { _ =>
               val s3objects =
-                s3Client.listObjects(bucketName).getObjectSummaries
+                s3Client.listObjects(bucket.underlying).getObjectSummaries
               s3objects.map {
                 _.getKey()
               } shouldBe List(
@@ -131,9 +132,9 @@ class SequentialS3SinkTest
                 "testC_0004.json",
                 "testC_0005.json")
 
-              getJsonFromS3(bucketName, "testC_0003.json") shouldBe json0
-              getJsonFromS3(bucketName, "testC_0004.json") shouldBe json1
-              getJsonFromS3(bucketName, "testC_0005.json") shouldBe json2
+              getJsonFromS3(bucket, "testC_0003.json") shouldBe json0
+              getJsonFromS3(bucket, "testC_0004.json") shouldBe json1
+              getJsonFromS3(bucket, "testC_0005.json") shouldBe json2
             }
           }
         }


### PR DESCRIPTION
### What is this PR trying to achieve?

Make fixture methods type safe using [value classes](https://docs.scala-lang.org/overviews/core/value-classes.html) to help prevent bugs.