### PR TITLE
Remove compiler arguments unsupported by Eclipse

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -12,11 +12,8 @@ object Common {
       "-encoding",
       "UTF-8",
       "-Xlint",
-      "-Yclosure-elim",
-      "-Yinline",
       "-Xverify",
       "-Xfatal-warnings",
-      "-Yinline-warnings:false",
       "-feature",
       "-language:postfixOps"
     ),


### PR DESCRIPTION
### What is this PR trying to achieve?

Removed `scalac` arguments not supported by the Scala IDE Eclipse plugin.
