### PR TITLE
Changes to travistooling only affect the travistooling tests

### DIFF
--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -90,6 +90,15 @@ def does_file_affect_build_task(path, task):
                 else:
                     raise ScalaChangeAndNotScalaApp()
 
+    # Changes made in the travistooling directory only ever affect the
+    # travistooling tests (but they're not defined in a Makefile).
+    # Check and skip here if possible.
+    if path.startswith('travistooling/'):
+        if task == 'travistooling-test':
+            raise ExclusivelyAffectsThisTask()
+        else:
+            raise ExclusivelyAffectsAnotherTask('travistooling-test')
+
     # If we can't decide if a file affects a build job, we assume it's
     # significant and run the job just-in-case.
     raise UnrecognisedFile()

--- a/travistooling/tests/test_decisionmaker.py
+++ b/travistooling/tests/test_decisionmaker.py
@@ -66,6 +66,10 @@ from travistooling.decisions import (
     # a -publish task.
     ('sbt_common/src/test/scala/uk/ac/wellcome/MyTest.scala', 'sierra_adapter-publish', ChangesToTestsDontGetPublished, False),
     ('sbt_common/src/test/scala/uk/ac/wellcome/MyTest.scala', 'sierra_adapter-test', UnrecognisedFile, True),
+
+    # Changes to travistooling only trigger the travistooling tests
+    ('travistooling/decisionmaker.py', 'travistooling-test', ExclusivelyAffectsThisTask, True),
+    ('travistooling/decisionmaker.py', 'loris-test', ExclusivelyAffectsAnotherTask, False),
 ])
 def test_does_file_affect_build_task(path, task, exc_class, is_significant):
     with pytest.raises(exc_class) as err:


### PR DESCRIPTION
### What is this PR trying to achieve?

Reduce Travis build churn – since none of the source code in travistooling is used anywhere else, changes to it (for example, to reduce build churn!) shouldn't trigger a full rebuild of everything else.

### Who is this change for?

Devs who want speedy and quiet Travis.