### PR TITLE
data_api: Identify buckets/keys in the pipeline as "private/public", not "source/target"

### DIFF
--- a/data_api/elasticdump/run_elasticdump.py
+++ b/data_api/elasticdump/run_elasticdump.py
@@ -120,7 +120,7 @@ def run():
     # which are human-readable, unambiguous, and easy to browse in the
     # S3 Console.
     try:
-        key = os.environ['target_key']
+        key = os.environ['private_object_key']
     except KeyError:
         key = dt.datetime.now().strftime('%Y/%m/%Y-%m-%d') + f'_{es_index}.txt.gz'
     print(f'*** Uploading gzip file to S3 with key {key}')

--- a/data_api/elasticdump/run_elasticdump.py
+++ b/data_api/elasticdump/run_elasticdump.py
@@ -19,7 +19,7 @@ from service_utils import service
 @attr.s
 class SnapshotRequest(object):
     time = attr.ib()
-    target_bucket_name = attr.ib()
+    private_bucket_name = attr.ib()
     es_index = attr.ib()
 
 
@@ -126,7 +126,7 @@ def run():
     print(f'*** Uploading gzip file to S3 with key {key}')
 
     s3_client.upload_file(
-        Bucket=snapshot_request.target_bucket_name,
+        Bucket=snapshot_request.private_bucket_name,
         Key=prefix + key,
         Filename='index.txt.gz'
     )

--- a/data_api/elasticdump/test_run_elasticdump.py
+++ b/data_api/elasticdump/test_run_elasticdump.py
@@ -124,7 +124,7 @@ def test_end_to_end(
     subprocess.check_call([
         'docker', 'run', '--net', 'host',
         '--env', f'sqs_queue_url={queue_url}',
-        '--env', f'target_key=dump.txt.gz',
+        '--env', f'private_object_key=dump.txt.gz',
         '--env', f'key_prefix=blah/',
 
         '--env', 'AWS_DEFAULT_REGION=localhost',

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/models/ConversionJob.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/models/ConversionJob.scala
@@ -3,4 +3,4 @@ package uk.ac.wellcome.platform.snapshot_convertor.models
 case class ConversionJob(privateBucketName: String,
                          privateObjectKey: String,
                          publicBucketName: String,
-                         targetObjectKey: String)
+                         publicObjectKey: String)

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/models/ConversionJob.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/models/ConversionJob.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.snapshot_convertor.models
 
-case class ConversionJob(sourceBucketName: String,
+case class ConversionJob(privateBucketName: String,
                          sourceObjectKey: String,
                          targetBucketName: String,
                          targetObjectKey: String)

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/models/ConversionJob.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/models/ConversionJob.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.snapshot_convertor.models
 
 case class ConversionJob(privateBucketName: String,
-                         sourceObjectKey: String,
+                         privateObjectKey: String,
                          targetBucketName: String,
                          targetObjectKey: String)

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/models/ConversionJob.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/models/ConversionJob.scala
@@ -2,5 +2,5 @@ package uk.ac.wellcome.platform.snapshot_convertor.models
 
 case class ConversionJob(privateBucketName: String,
                          privateObjectKey: String,
-                         targetBucketName: String,
+                         publicBucketName: String,
                          targetObjectKey: String)

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
@@ -50,7 +50,7 @@ class ConvertorService @Inject()(actorSystem: ActorSystem,
         s3Client
           .getObject(
             conversionJob.privateBucketName,
-            conversionJob.sourceObjectKey)
+            conversionJob.privateObjectKey)
           .getObjectContent
       }
 

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
@@ -49,7 +49,7 @@ class ConvertorService @Inject()(actorSystem: ActorSystem,
       s3inputStream <- Future {
         s3Client
           .getObject(
-            conversionJob.sourceBucketName,
+            conversionJob.privateBucketName,
             conversionJob.sourceObjectKey)
           .getObjectContent
       }

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
@@ -43,9 +43,9 @@ class SnapshotConvertorFeatureTest
 
   it("completes a conversion successfully") {
     withFixtures {
-      case (((queue, topic), sourceBucket), targetBucket) =>
+      case (((queue, topic), privateBucket), targetBucket) =>
         val flags = snsLocalFlags(topic) ++ sqsLocalFlags(queue) ++ s3LocalFlags(
-          sourceBucket)
+          privateBucket)
 
         withServer(flags) { _ =>
           // Create a collection of works.  These three differ by version,
@@ -71,9 +71,9 @@ class SnapshotConvertorFeatureTest
 
           val targetObjectKey = "target.txt.gz"
 
-          withGzipCompressedS3Key(sourceBucket, content) { objectKey =>
+          withGzipCompressedS3Key(privateBucket, content) { objectKey =>
             val conversionJob = ConversionJob(
-              sourceBucketName = sourceBucket.name,
+              privateBucketName = privateBucket.name,
               sourceObjectKey = objectKey,
               targetBucketName = targetBucket.name,
               targetObjectKey = targetObjectKey

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
@@ -75,7 +75,7 @@ class SnapshotConvertorFeatureTest
             val conversionJob = ConversionJob(
               privateBucketName = privateBucket.name,
               privateObjectKey = objectKey,
-              targetBucketName = targetBucket.name,
+              publicBucketName = targetBucket.name,
               targetObjectKey = targetObjectKey
             )
 

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
@@ -69,14 +69,14 @@ class SnapshotConvertorFeatureTest
           }
           val content = elasticsearchJsons.mkString("\n")
 
-          val targetObjectKey = "target.txt.gz"
+          val publicObjectKey = "target.txt.gz"
 
           withGzipCompressedS3Key(privateBucket, content) { objectKey =>
             val conversionJob = ConversionJob(
               privateBucketName = privateBucket.name,
               privateObjectKey = objectKey,
               publicBucketName = targetBucket.name,
-              targetObjectKey = targetObjectKey
+              publicObjectKey = publicObjectKey
             )
 
             val message = SQSMessage(
@@ -95,7 +95,7 @@ class SnapshotConvertorFeatureTest
                 File.createTempFile("convertorServiceTest", ".txt.gz")
 
               s3Client.getObject(
-                new GetObjectRequest(targetBucket.name, targetObjectKey),
+                new GetObjectRequest(targetBucket.name, publicObjectKey),
                 downloadFile)
 
               val actualJsonLines: List[String] =
@@ -127,7 +127,7 @@ class SnapshotConvertorFeatureTest
               val expectedJob = CompletedConversionJob(
                 conversionJob = conversionJob,
                 targetLocation =
-                  s"http://localhost:33333/${targetBucket.name}/$targetObjectKey"
+                  s"http://localhost:33333/${targetBucket.name}/$publicObjectKey"
               )
               val actualJob = fromJson[CompletedConversionJob](
                 receivedMessages.head.message).get

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
@@ -74,7 +74,7 @@ class SnapshotConvertorFeatureTest
           withGzipCompressedS3Key(privateBucket, content) { objectKey =>
             val conversionJob = ConversionJob(
               privateBucketName = privateBucket.name,
-              sourceObjectKey = objectKey,
+              privateObjectKey = objectKey,
               targetBucketName = targetBucket.name,
               targetObjectKey = targetObjectKey
             )

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
@@ -43,7 +43,7 @@ class SnapshotConvertorFeatureTest
 
   it("completes a conversion successfully") {
     withFixtures {
-      case (((queue, topic), privateBucket), targetBucket) =>
+      case (((queue, topic), privateBucket), publicBucket) =>
         val flags = snsLocalFlags(topic) ++ sqsLocalFlags(queue) ++ s3LocalFlags(
           privateBucket)
 
@@ -75,7 +75,7 @@ class SnapshotConvertorFeatureTest
             val conversionJob = ConversionJob(
               privateBucketName = privateBucket.name,
               privateObjectKey = objectKey,
-              publicBucketName = targetBucket.name,
+              publicBucketName = publicBucket.name,
               publicObjectKey = publicObjectKey
             )
 
@@ -95,7 +95,7 @@ class SnapshotConvertorFeatureTest
                 File.createTempFile("convertorServiceTest", ".txt.gz")
 
               s3Client.getObject(
-                new GetObjectRequest(targetBucket.name, publicObjectKey),
+                new GetObjectRequest(publicBucket.name, publicObjectKey),
                 downloadFile)
 
               val actualJsonLines: List[String] =
@@ -127,7 +127,7 @@ class SnapshotConvertorFeatureTest
               val expectedJob = CompletedConversionJob(
                 conversionJob = conversionJob,
                 targetLocation =
-                  s"http://localhost:33333/${targetBucket.name}/$publicObjectKey"
+                  s"http://localhost:33333/${publicBucket.name}/$publicObjectKey"
               )
               val actualJob = fromJson[CompletedConversionJob](
                 receivedMessages.head.message).get

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -70,7 +70,7 @@ class ConvertorServiceTest
     withFixtures {
       case (
           ((_, _, _, convertorService: ConvertorService), privateBucket),
-          targetBucket) =>
+          publicBucket) =>
         // Create a collection of works.  These three differ by version,
         // if not anything more interesting!
         val visibleWorks = (1 to 3).map { version =>
@@ -112,7 +112,7 @@ class ConvertorServiceTest
           val conversionJob = ConversionJob(
             privateBucketName = privateBucket.name,
             privateObjectKey = objectKey,
-            publicBucketName = targetBucket.name,
+            publicBucketName = publicBucket.name,
             publicObjectKey = publicObjectKey
           )
 
@@ -122,7 +122,7 @@ class ConvertorServiceTest
             val downloadFile =
               File.createTempFile("convertorServiceTest", ".txt.gz")
             s3Client.getObject(
-              new GetObjectRequest(targetBucket.name, publicObjectKey),
+              new GetObjectRequest(publicBucket.name, publicObjectKey),
               downloadFile)
 
             val contents = readGzipFile(downloadFile.getPath)
@@ -140,7 +140,7 @@ class ConvertorServiceTest
             result shouldBe CompletedConversionJob(
               conversionJob = conversionJob,
               targetLocation =
-                s"http://localhost:33333/${targetBucket.name}/$publicObjectKey"
+                s"http://localhost:33333/${publicBucket.name}/$publicObjectKey"
             )
           }
         }
@@ -164,7 +164,7 @@ class ConvertorServiceTest
     withFixtures {
       case (
           ((_, _, _, convertorService: ConvertorService), privateBucket),
-          targetBucket) =>
+          publicBucket) =>
         // Create a collection of works.  The use of Random is meant
         // to increase the entropy of works, and thus the degree to
         // which they can be gzip-compressed -- so we can cross the
@@ -199,7 +199,7 @@ class ConvertorServiceTest
           val conversionJob = ConversionJob(
             privateBucketName = privateBucket.name,
             privateObjectKey = objectKey,
-            publicBucketName = targetBucket.name,
+            publicBucketName = publicBucket.name,
             publicObjectKey = publicObjectKey
           )
 
@@ -209,7 +209,7 @@ class ConvertorServiceTest
             val downloadFile =
               File.createTempFile("convertorServiceTest", ".txt.gz")
             s3Client.getObject(
-              new GetObjectRequest(targetBucket.name, publicObjectKey),
+              new GetObjectRequest(publicBucket.name, publicObjectKey),
               downloadFile)
 
             val contents = readGzipFile(downloadFile.getPath)
@@ -227,7 +227,7 @@ class ConvertorServiceTest
             result shouldBe CompletedConversionJob(
               conversionJob = conversionJob,
               targetLocation =
-                s"http://localhost:33333/${targetBucket.name}/$publicObjectKey"
+                s"http://localhost:33333/${publicBucket.name}/$publicObjectKey"
             )
           }
         }
@@ -238,11 +238,11 @@ class ConvertorServiceTest
     withFixtures {
       case (
           ((_, _, _, convertorService: ConvertorService), privateBucket),
-          targetBucket) =>
+          publicBucket) =>
         val conversionJob = ConversionJob(
           privateBucketName = privateBucket.name,
           privateObjectKey = "doesnotexist.txt.gz",
-          publicBucketName = targetBucket.name,
+          publicBucketName = publicBucket.name,
           publicObjectKey = "target.txt.gz"
         )
 
@@ -258,14 +258,14 @@ class ConvertorServiceTest
     withFixtures {
       case (
           ((_, _, _, convertorService: ConvertorService), privateBucket),
-          targetBucket) =>
+          publicBucket) =>
         withGzipCompressedS3Key(
           privateBucket,
           content = "This is not what snapshots look like") { objectKey =>
           val conversionJob = ConversionJob(
             privateBucketName = privateBucket.name,
             privateObjectKey = objectKey,
-            publicBucketName = targetBucket.name,
+            publicBucketName = publicBucket.name,
             publicObjectKey = "target.txt.gz"
           )
 
@@ -282,7 +282,7 @@ class ConvertorServiceTest
     withFixtures {
       case (
           ((_, _, _, convertorService: ConvertorService), privateBucket),
-          targetBucket) =>
+          publicBucket) =>
         // Create a collection of works.  These three differ by version,
         // if not anything more interesting!
         val works = (1 to 3).map { version =>

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -111,7 +111,7 @@ class ConvertorServiceTest
 
           val conversionJob = ConversionJob(
             privateBucketName = privateBucket.name,
-            sourceObjectKey = objectKey,
+            privateObjectKey = objectKey,
             targetBucketName = targetBucket.name,
             targetObjectKey = targetObjectKey
           )
@@ -198,7 +198,7 @@ class ConvertorServiceTest
           val targetObjectKey = "target.txt.gz"
           val conversionJob = ConversionJob(
             privateBucketName = privateBucket.name,
-            sourceObjectKey = objectKey,
+            privateObjectKey = objectKey,
             targetBucketName = targetBucket.name,
             targetObjectKey = targetObjectKey
           )
@@ -241,7 +241,7 @@ class ConvertorServiceTest
           targetBucket) =>
         val conversionJob = ConversionJob(
           privateBucketName = privateBucket.name,
-          sourceObjectKey = "doesnotexist.txt.gz",
+          privateObjectKey = "doesnotexist.txt.gz",
           targetBucketName = targetBucket.name,
           targetObjectKey = "target.txt.gz"
         )
@@ -264,7 +264,7 @@ class ConvertorServiceTest
           content = "This is not what snapshots look like") { objectKey =>
           val conversionJob = ConversionJob(
             privateBucketName = privateBucket.name,
-            sourceObjectKey = objectKey,
+            privateObjectKey = objectKey,
             targetBucketName = targetBucket.name,
             targetObjectKey = "target.txt.gz"
           )
@@ -307,7 +307,7 @@ class ConvertorServiceTest
         val bucketName = "wrongBukkit"
         val conversionJob = ConversionJob(
           privateBucketName = bucketName,
-          sourceObjectKey = "wrongKey",
+          privateObjectKey = "wrongKey",
           targetBucketName = bucketName,
           targetObjectKey = "target.json.gz"
         )

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -112,7 +112,7 @@ class ConvertorServiceTest
           val conversionJob = ConversionJob(
             privateBucketName = privateBucket.name,
             privateObjectKey = objectKey,
-            targetBucketName = targetBucket.name,
+            publicBucketName = targetBucket.name,
             targetObjectKey = targetObjectKey
           )
 
@@ -199,7 +199,7 @@ class ConvertorServiceTest
           val conversionJob = ConversionJob(
             privateBucketName = privateBucket.name,
             privateObjectKey = objectKey,
-            targetBucketName = targetBucket.name,
+            publicBucketName = targetBucket.name,
             targetObjectKey = targetObjectKey
           )
 
@@ -242,7 +242,7 @@ class ConvertorServiceTest
         val conversionJob = ConversionJob(
           privateBucketName = privateBucket.name,
           privateObjectKey = "doesnotexist.txt.gz",
-          targetBucketName = targetBucket.name,
+          publicBucketName = targetBucket.name,
           targetObjectKey = "target.txt.gz"
         )
 
@@ -265,7 +265,7 @@ class ConvertorServiceTest
           val conversionJob = ConversionJob(
             privateBucketName = privateBucket.name,
             privateObjectKey = objectKey,
-            targetBucketName = targetBucket.name,
+            publicBucketName = targetBucket.name,
             targetObjectKey = "target.txt.gz"
           )
 
@@ -308,7 +308,7 @@ class ConvertorServiceTest
         val conversionJob = ConversionJob(
           privateBucketName = bucketName,
           privateObjectKey = "wrongKey",
-          targetBucketName = bucketName,
+          publicBucketName = bucketName,
           targetObjectKey = "target.json.gz"
         )
 

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -69,7 +69,7 @@ class ConvertorServiceTest
   it("completes a conversion successfully") {
     withFixtures {
       case (
-          ((_, _, _, convertorService: ConvertorService), sourceBucket),
+          ((_, _, _, convertorService: ConvertorService), privateBucket),
           targetBucket) =>
         // Create a collection of works.  These three differ by version,
         // if not anything more interesting!
@@ -106,11 +106,11 @@ class ConvertorServiceTest
         }
         val content = elasticsearchJsons.mkString("\n")
 
-        withGzipCompressedS3Key(sourceBucket, content) { objectKey =>
+        withGzipCompressedS3Key(privateBucket, content) { objectKey =>
           val targetObjectKey = "target.txt.gz"
 
           val conversionJob = ConversionJob(
-            sourceBucketName = sourceBucket.name,
+            privateBucketName = privateBucket.name,
             sourceObjectKey = objectKey,
             targetBucketName = targetBucket.name,
             targetObjectKey = targetObjectKey
@@ -163,7 +163,7 @@ class ConvertorServiceTest
   it("completes a very large conversion successfully") {
     withFixtures {
       case (
-          ((_, _, _, convertorService: ConvertorService), sourceBucket),
+          ((_, _, _, convertorService: ConvertorService), privateBucket),
           targetBucket) =>
         // Create a collection of works.  The use of Random is meant
         // to increase the entropy of works, and thus the degree to
@@ -194,10 +194,10 @@ class ConvertorServiceTest
         val gzipFileSize = createGzipFile(content).length.toInt
         gzipFileSize shouldBe >=(8 * 1024 * 1024)
 
-        withGzipCompressedS3Key(sourceBucket, content) { objectKey =>
+        withGzipCompressedS3Key(privateBucket, content) { objectKey =>
           val targetObjectKey = "target.txt.gz"
           val conversionJob = ConversionJob(
-            sourceBucketName = sourceBucket.name,
+            privateBucketName = privateBucket.name,
             sourceObjectKey = objectKey,
             targetBucketName = targetBucket.name,
             targetObjectKey = targetObjectKey
@@ -237,10 +237,10 @@ class ConvertorServiceTest
   it("returns a failed future if asked to convert a non-existent snapshot") {
     withFixtures {
       case (
-          ((_, _, _, convertorService: ConvertorService), sourceBucket),
+          ((_, _, _, convertorService: ConvertorService), privateBucket),
           targetBucket) =>
         val conversionJob = ConversionJob(
-          sourceBucketName = sourceBucket.name,
+          privateBucketName = privateBucket.name,
           sourceObjectKey = "doesnotexist.txt.gz",
           targetBucketName = targetBucket.name,
           targetObjectKey = "target.txt.gz"
@@ -257,13 +257,13 @@ class ConvertorServiceTest
   it("returns a failed future if asked to convert a malformed snapshot") {
     withFixtures {
       case (
-          ((_, _, _, convertorService: ConvertorService), sourceBucket),
+          ((_, _, _, convertorService: ConvertorService), privateBucket),
           targetBucket) =>
         withGzipCompressedS3Key(
-          sourceBucket,
+          privateBucket,
           content = "This is not what snapshots look like") { objectKey =>
           val conversionJob = ConversionJob(
-            sourceBucketName = sourceBucket.name,
+            privateBucketName = privateBucket.name,
             sourceObjectKey = objectKey,
             targetBucketName = targetBucket.name,
             targetObjectKey = "target.txt.gz"
@@ -281,7 +281,7 @@ class ConvertorServiceTest
   it("returns a failed future if the S3 upload fails") {
     withFixtures {
       case (
-          ((_, _, _, convertorService: ConvertorService), sourceBucket),
+          ((_, _, _, convertorService: ConvertorService), privateBucket),
           targetBucket) =>
         // Create a collection of works.  These three differ by version,
         // if not anything more interesting!
@@ -306,7 +306,7 @@ class ConvertorServiceTest
 
         val bucketName = "wrongBukkit"
         val conversionJob = ConversionJob(
-          sourceBucketName = bucketName,
+          privateBucketName = bucketName,
           sourceObjectKey = "wrongKey",
           targetBucketName = bucketName,
           targetObjectKey = "target.json.gz"

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -107,13 +107,13 @@ class ConvertorServiceTest
         val content = elasticsearchJsons.mkString("\n")
 
         withGzipCompressedS3Key(privateBucket, content) { objectKey =>
-          val targetObjectKey = "target.txt.gz"
+          val publicObjectKey = "target.txt.gz"
 
           val conversionJob = ConversionJob(
             privateBucketName = privateBucket.name,
             privateObjectKey = objectKey,
             publicBucketName = targetBucket.name,
-            targetObjectKey = targetObjectKey
+            publicObjectKey = publicObjectKey
           )
 
           val future = convertorService.runConversion(conversionJob)
@@ -122,7 +122,7 @@ class ConvertorServiceTest
             val downloadFile =
               File.createTempFile("convertorServiceTest", ".txt.gz")
             s3Client.getObject(
-              new GetObjectRequest(targetBucket.name, targetObjectKey),
+              new GetObjectRequest(targetBucket.name, publicObjectKey),
               downloadFile)
 
             val contents = readGzipFile(downloadFile.getPath)
@@ -140,7 +140,7 @@ class ConvertorServiceTest
             result shouldBe CompletedConversionJob(
               conversionJob = conversionJob,
               targetLocation =
-                s"http://localhost:33333/${targetBucket.name}/$targetObjectKey"
+                s"http://localhost:33333/${targetBucket.name}/$publicObjectKey"
             )
           }
         }
@@ -195,12 +195,12 @@ class ConvertorServiceTest
         gzipFileSize shouldBe >=(8 * 1024 * 1024)
 
         withGzipCompressedS3Key(privateBucket, content) { objectKey =>
-          val targetObjectKey = "target.txt.gz"
+          val publicObjectKey = "target.txt.gz"
           val conversionJob = ConversionJob(
             privateBucketName = privateBucket.name,
             privateObjectKey = objectKey,
             publicBucketName = targetBucket.name,
-            targetObjectKey = targetObjectKey
+            publicObjectKey = publicObjectKey
           )
 
           val future = convertorService.runConversion(conversionJob)
@@ -209,7 +209,7 @@ class ConvertorServiceTest
             val downloadFile =
               File.createTempFile("convertorServiceTest", ".txt.gz")
             s3Client.getObject(
-              new GetObjectRequest(targetBucket.name, targetObjectKey),
+              new GetObjectRequest(targetBucket.name, publicObjectKey),
               downloadFile)
 
             val contents = readGzipFile(downloadFile.getPath)
@@ -227,7 +227,7 @@ class ConvertorServiceTest
             result shouldBe CompletedConversionJob(
               conversionJob = conversionJob,
               targetLocation =
-                s"http://localhost:33333/${targetBucket.name}/$targetObjectKey"
+                s"http://localhost:33333/${targetBucket.name}/$publicObjectKey"
             )
           }
         }
@@ -243,7 +243,7 @@ class ConvertorServiceTest
           privateBucketName = privateBucket.name,
           privateObjectKey = "doesnotexist.txt.gz",
           publicBucketName = targetBucket.name,
-          targetObjectKey = "target.txt.gz"
+          publicObjectKey = "target.txt.gz"
         )
 
         val future = convertorService.runConversion(conversionJob)
@@ -266,7 +266,7 @@ class ConvertorServiceTest
             privateBucketName = privateBucket.name,
             privateObjectKey = objectKey,
             publicBucketName = targetBucket.name,
-            targetObjectKey = "target.txt.gz"
+            publicObjectKey = "target.txt.gz"
           )
 
           val future = convertorService.runConversion(conversionJob)
@@ -309,7 +309,7 @@ class ConvertorServiceTest
           privateBucketName = bucketName,
           privateObjectKey = "wrongKey",
           publicBucketName = bucketName,
-          targetObjectKey = "target.json.gz"
+          publicObjectKey = "target.json.gz"
         )
 
         val future = convertorService.runConversion(conversionJob)

--- a/data_api/snapshot_convertor_job_generator/src/snapshot_convertor_job_generator.py
+++ b/data_api/snapshot_convertor_job_generator/src/snapshot_convertor_job_generator.py
@@ -24,7 +24,7 @@ def _run(event, sns_client, topic_arn):
         # This is the job format accepted by the snapshot_convertor
         message = {
             "privateBucketName": s3_event['bucket_name'],
-            "sourceObjectKey": s3_event['object_key'],
+            "privateObjectKey": s3_event['object_key'],
             "targetBucketName": os.environ['TARGET_BUCKET_NAME'],
             "targetObjectKey": os.environ['TARGET_OBJECT_KEY'],
         }

--- a/data_api/snapshot_convertor_job_generator/src/snapshot_convertor_job_generator.py
+++ b/data_api/snapshot_convertor_job_generator/src/snapshot_convertor_job_generator.py
@@ -26,7 +26,7 @@ def _run(event, sns_client, topic_arn):
             "privateBucketName": s3_event['bucket_name'],
             "privateObjectKey": s3_event['object_key'],
             "publicBucketName": os.environ['TARGET_BUCKET_NAME'],
-            "targetObjectKey": os.environ['TARGET_OBJECT_KEY'],
+            "publicObjectKey": os.environ['TARGET_OBJECT_KEY'],
         }
 
         print(f'Publishing message {message} to SNS')

--- a/data_api/snapshot_convertor_job_generator/src/snapshot_convertor_job_generator.py
+++ b/data_api/snapshot_convertor_job_generator/src/snapshot_convertor_job_generator.py
@@ -25,8 +25,8 @@ def _run(event, sns_client, topic_arn):
         message = {
             "privateBucketName": s3_event['bucket_name'],
             "privateObjectKey": s3_event['object_key'],
-            "publicBucketName": os.environ['TARGET_BUCKET_NAME'],
-            "publicObjectKey": os.environ['TARGET_OBJECT_KEY'],
+            "publicBucketName": os.environ['PUBLIC_BUCKET_NAME'],
+            "publicObjectKey": os.environ['PUBLIC_OBJECT_KEY'],
         }
 
         print(f'Publishing message {message} to SNS')

--- a/data_api/snapshot_convertor_job_generator/src/snapshot_convertor_job_generator.py
+++ b/data_api/snapshot_convertor_job_generator/src/snapshot_convertor_job_generator.py
@@ -25,7 +25,7 @@ def _run(event, sns_client, topic_arn):
         message = {
             "privateBucketName": s3_event['bucket_name'],
             "privateObjectKey": s3_event['object_key'],
-            "targetBucketName": os.environ['TARGET_BUCKET_NAME'],
+            "publicBucketName": os.environ['TARGET_BUCKET_NAME'],
             "targetObjectKey": os.environ['TARGET_OBJECT_KEY'],
         }
 

--- a/data_api/snapshot_convertor_job_generator/src/snapshot_convertor_job_generator.py
+++ b/data_api/snapshot_convertor_job_generator/src/snapshot_convertor_job_generator.py
@@ -23,7 +23,7 @@ def _run(event, sns_client, topic_arn):
 
         # This is the job format accepted by the snapshot_convertor
         message = {
-            "sourceBucketName": s3_event['bucket_name'],
+            "privateBucketName": s3_event['bucket_name'],
             "sourceObjectKey": s3_event['object_key'],
             "targetBucketName": os.environ['TARGET_BUCKET_NAME'],
             "targetObjectKey": os.environ['TARGET_OBJECT_KEY'],

--- a/data_api/snapshot_convertor_job_generator/src/test_snapshot_convertor_job_generator.py
+++ b/data_api/snapshot_convertor_job_generator/src/test_snapshot_convertor_job_generator.py
@@ -48,7 +48,7 @@ def test_snapshot_convertor_job_generator_sends_message_for_object_created_event
     expected_job = {
         "privateBucketName": source_bucket_name,
         "privateObjectKey": source_object_key,
-        "targetBucketName": target_bucket_name,
+        "publicBucketName": target_bucket_name,
         "targetObjectKey": target_object_key
     }
 

--- a/data_api/snapshot_convertor_job_generator/src/test_snapshot_convertor_job_generator.py
+++ b/data_api/snapshot_convertor_job_generator/src/test_snapshot_convertor_job_generator.py
@@ -49,7 +49,7 @@ def test_snapshot_convertor_job_generator_sends_message_for_object_created_event
         "privateBucketName": source_bucket_name,
         "privateObjectKey": source_object_key,
         "publicBucketName": target_bucket_name,
-        "targetObjectKey": target_object_key
+        "publicObjectKey": target_object_key
     }
 
     _run(

--- a/data_api/snapshot_convertor_job_generator/src/test_snapshot_convertor_job_generator.py
+++ b/data_api/snapshot_convertor_job_generator/src/test_snapshot_convertor_job_generator.py
@@ -47,7 +47,7 @@ def test_snapshot_convertor_job_generator_sends_message_for_object_created_event
 
     expected_job = {
         "privateBucketName": source_bucket_name,
-        "sourceObjectKey": source_object_key,
+        "privateObjectKey": source_object_key,
         "targetBucketName": target_bucket_name,
         "targetObjectKey": target_object_key
     }

--- a/data_api/snapshot_convertor_job_generator/src/test_snapshot_convertor_job_generator.py
+++ b/data_api/snapshot_convertor_job_generator/src/test_snapshot_convertor_job_generator.py
@@ -46,7 +46,7 @@ def test_snapshot_convertor_job_generator_sends_message_for_object_created_event
     )
 
     expected_job = {
-        "sourceBucketName": source_bucket_name,
+        "privateBucketName": source_bucket_name,
         "sourceObjectKey": source_object_key,
         "targetBucketName": target_bucket_name,
         "targetObjectKey": target_object_key

--- a/data_api/snapshot_convertor_job_generator/src/test_snapshot_convertor_job_generator.py
+++ b/data_api/snapshot_convertor_job_generator/src/test_snapshot_convertor_job_generator.py
@@ -26,30 +26,30 @@ def createS3Event(bucket_name, object_key, event_name):
 
 
 def test_snapshot_convertor_job_generator_sends_message_for_object_created_event(sns_client, topic_arn):
-    source_bucket_name = "bukkit"
-    source_object_key = "test0001.json"
+    private_bucket_name = "bukkit"
+    private_object_key = "test0001.json"
 
-    target_bucket_name = "target_bukkit"
-    target_object_key = "target.json.gz"
+    public_bucket_name = "target_bukkit"
+    public_object_key = "target.json.gz"
 
     event_name = "ObjectCreated:CompleteMultipartUpload"
 
     os.environ.update({
-        'TARGET_BUCKET_NAME': target_bucket_name,
-        'TARGET_OBJECT_KEY': target_object_key
+        'TARGET_BUCKET_NAME': public_bucket_name,
+        'TARGET_OBJECT_KEY': public_object_key
     })
 
     event = createS3Event(
-        bucket_name=source_bucket_name,
-        object_key=source_object_key,
+        bucket_name=private_bucket_name,
+        object_key=private_object_key,
         event_name=event_name
     )
 
     expected_job = {
-        "privateBucketName": source_bucket_name,
-        "privateObjectKey": source_object_key,
-        "publicBucketName": target_bucket_name,
-        "publicObjectKey": target_object_key
+        "privateBucketName": private_bucket_name,
+        "privateObjectKey": private_object_key,
+        "publicBucketName": public_bucket_name,
+        "publicObjectKey": public_object_key
     }
 
     _run(

--- a/data_api/snapshot_scheduler/src/snapshot_scheduler.py
+++ b/data_api/snapshot_scheduler/src/snapshot_scheduler.py
@@ -17,7 +17,7 @@ from wellcome_aws_utils.sns_utils import publish_sns_message
 @attr.s
 class SnapshotRequest(object):
     time = attr.ib()
-    target_bucket_name = attr.ib()
+    private_bucket_name = attr.ib()
     es_index = attr.ib()
 
 
@@ -36,7 +36,7 @@ def main(event=None, _ctxt=None, sns_client=None):
 
     snapshot_request_message = SnapshotRequest(
         time=dt.datetime.utcnow().isoformat(),
-        target_bucket_name=bucket_name,
+        private_bucket_name=bucket_name,
         es_index=es_index
     )
 

--- a/data_api/snapshot_scheduler/src/test_snapshot_scheduler.py
+++ b/data_api/snapshot_scheduler/src/test_snapshot_scheduler.py
@@ -17,12 +17,12 @@ class patched_datetime(dt.datetime):
 
 @mock.patch('datetime.datetime', patched_datetime)
 def test_writes_message_to_sqs(sns_client, topic_arn):
-    target_bucket_name = "target_bucket_name"
+    private_bucket_name = "private_bucket_name"
     es_index = "es_index"
 
     patched_os_environ = {
         'TOPIC_ARN': topic_arn,
-        'TARGET_BUCKET_NAME': target_bucket_name,
+        'TARGET_BUCKET_NAME': private_bucket_name,
         'ES_INDEX': es_index
     }
 
@@ -37,6 +37,6 @@ def test_writes_message_to_sqs(sns_client, topic_arn):
     assert len(messages) == 1
     assert messages[0][':message'] == {
         'time': '2011-06-21T00:00:00',
-        'target_bucket_name': target_bucket_name,
+        'private_bucket_name': private_bucket_name,
         'es_index': es_index
     }

--- a/data_api/terraform/service_snapshot_convertor.tf
+++ b/data_api/terraform/service_snapshot_convertor.tf
@@ -18,17 +18,14 @@ module "snapshot_convertor" {
   release_id         = "${var.release_ids["snapshot_convertor"]}"
 
   env_vars = {
-    source_bucket_name = "${aws_s3_bucket.private_data.id}"
-    target_bucket_name = "${aws_s3_bucket.public_data.id}"
-
     queue_url = "${module.snapshot_convertor_queue.id}"
     topic_arn = "${module.snapshot_conversion_complete_topic.arn}"
   }
 
+  env_vars_length = 2
+
   memory = 2048
   cpu    = 512
-
-  env_vars_length = 4
 
   cluster_name = "${module.data_api_cluster.cluster_name}"
   vpc_id       = "${module.vpc_data_api.vpc_id}"

--- a/data_api/terraform/service_snapshot_convertor.tf
+++ b/data_api/terraform/service_snapshot_convertor.tf
@@ -3,8 +3,8 @@ module "snapshot_convertor_job_generator" {
 
   lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
   infra_bucket           = "${var.infra_bucket}"
-  target_object_key      = "catalogue/v1/works.json.gz"
-  target_bucket_name     = "${aws_s3_bucket.public_data.id}"
+  public_object_key      = "catalogue/v1/works.json.gz"
+  public_bucket_name     = "${aws_s3_bucket.public_data.id}"
 }
 
 module "snapshot_convertor" {

--- a/data_api/terraform/snapshot_convertor_job_generator/lambdas.tf
+++ b/data_api/terraform/snapshot_convertor_job_generator/lambdas.tf
@@ -12,7 +12,7 @@ module "snapshot_convertor_job_generator_lambda" {
 
   environment_variables = {
     "TOPIC_ARN"          = "${module.snapshot_convertor_topic.arn}"
-    "TARGET_BUCKET_NAME" = "${var.target_bucket_name}"
-    "TARGET_OBJECT_KEY"  = "${var.target_object_key}"
+    "PUBLIC_BUCKET_NAME" = "${var.public_bucket_name}"
+    "PUBLIC_OBJECT_KEY"  = "${var.public_object_key}"
   }
 }

--- a/data_api/terraform/snapshot_convertor_job_generator/variables.tf
+++ b/data_api/terraform/snapshot_convertor_job_generator/variables.tf
@@ -1,4 +1,4 @@
 variable "lambda_error_alarm_arn" {}
 variable "infra_bucket" {}
-variable "target_bucket_name" {}
-variable "target_object_key" {}
+variable "public_bucket_name" {}
+variable "public_object_key" {}


### PR DESCRIPTION
### What is this PR trying to achieve?

Using the words "source"/"target" gets confusing in this stack, because those terms are relative to each application.

Identifying these buckets/keys as "private/public" is closer to the names we use for the associated S3 buckets, and are absolute terms, so it's easier to reason about what "public bucket" means in any given context.

### Who is this change for?

📛 💅 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.