### PR TITLE
Increase the number of retries in the Sierra bibs pipeline

### DIFF
--- a/sierra_adapter/terraform/merger/queues.tf
+++ b/sierra_adapter/terraform/merger/queues.tf
@@ -5,5 +5,14 @@ module "updates_queue" {
   account_id  = "${var.account_id}"
   topic_names = ["${var.updates_topic_name}"]
 
+  # Ensure that messages are spread around -- if the merger has an error
+  # (for example, hitting DynamoDB write limits), we don't retry too quickly.
+  visibility_timeout_seconds = 180
+
+  # The bib merger queue has had consistent problems where the DLQ fills up,
+  # and then redriving it fixes everything.  Increase the number of times a
+  # message can be received before it gets marked as failed.
+  max_receive_count = 8
+
   alarm_topic_arn = "${var.dlq_alarm_arn}"
 }

--- a/sierra_adapter/terraform/sierra_reader/queues.tf
+++ b/sierra_adapter/terraform/sierra_reader/queues.tf
@@ -12,7 +12,7 @@ module "windows_queue" {
   # In certain periods of high activity, we've seen the Sierra API timeout
   # multiple times.  Since the reader can restart a partially-completed
   # window, it's okay to retry the window several times.
-  max_receive_count = 8
+  max_receive_count = 12
 
   alarm_topic_arn = "${var.dlq_alarm_arn}"
 }


### PR DESCRIPTION
Both the bib windows and bib merger queues are getting DLQ entries fairly consistently. Redriving usually fixes the problem – it doesn’t seem to be a systemic error with those messages – so increase the number of times a message is automatically redriven.