### PR TITLE
Fix post to slack bug when no timestamp

### DIFF
--- a/monitoring/post_to_slack/src/post_to_slack.py
+++ b/monitoring/post_to_slack/src/post_to_slack.py
@@ -184,7 +184,7 @@ def prepare_slack_payload(alarm, bitly_access_token, sess=None):
     return slack_data
 
 
-def main(event, context):
+def main(event, _ctxt=None):
     print(f'event = {event!r}')
 
     bitly_access_token = os.environ['BITLY_ACCESS_TOKEN']

--- a/monitoring/post_to_slack/src/post_to_slack.py
+++ b/monitoring/post_to_slack/src/post_to_slack.py
@@ -32,9 +32,13 @@ class Interval:
     end = attr.ib()
 
 
+class MessageHasNoDateError(Exception):
+    pass
+
+
+@attr.s
 class Alarm:
-    def __init__(self, json_message):
-        self.message = json.loads(json_message)
+    message = attr.ib(converter=json.loads)
 
     @property
     def name(self):
@@ -48,17 +52,20 @@ class Alarm:
     # about useful CloudWatch logs to check, so we include that in the alarm.
     # The methods and properties below pull out the relevant info.
 
-    @property
     def cloudwatch_timeframe(self):
         """
         Try to work out a likely timeframe for CloudWatch errors.
         """
         threshold = ThresholdMessage.from_message(self.state_reason)
 
-        return Interval(
-            start=threshold.date - dt.timedelta(seconds=300),
-            end=threshold.date + dt.timedelta(seconds=300)
-        )
+        try:
+            return Interval(
+                start=threshold.date - dt.timedelta(seconds=300),
+                end=threshold.date + dt.timedelta(seconds=300)
+            )
+        except TypeError:
+            # Raised when threshold.date is None.
+            raise MessageHasNoDateError()
 
     def cloudwatch_urls(self):
         """
@@ -66,7 +73,7 @@ class Alarm:
         """
         try:
             log_group_name = guess_cloudwatch_log_group(alarm_name=self.name)
-            timeframe = self.cloudwatch_timeframe
+            timeframe = self.cloudwatch_timeframe()
             return [
                 build_cloudwatch_url(
                     search_term=search_term,
@@ -77,6 +84,10 @@ class Alarm:
                 for search_term in guess_cloudwatch_search_terms(
                     alarm_name=self.name)
             ]
+
+        except MessageHasNoDateError:
+            pass
+
         except ValueError as err:
             print(f'Error in cloudwatch_urls: {err}')
             return []
@@ -94,7 +105,7 @@ class Alarm:
 
             # CloudWatch wants these parameters specified as seconds since
             # 1 Jan 1970 00:00:00, so convert to that first.
-            timeframe = self.cloudwatch_timeframe
+            timeframe = self.cloudwatch_timeframe()
             startTime = datetime_to_cloudwatch_ts(timeframe.start)
             endTime = datetime_to_cloudwatch_ts(timeframe.end)
 
@@ -109,6 +120,9 @@ class Alarm:
                     filterPattern=term
                 )
                 messages.extend([e['message'] for e in resp['events']])
+
+        except MessageHasNoDateError:
+            pass
 
         except Exception as err:
             print(f'Error in cloudwatch_messages: {err!r}')
@@ -159,6 +173,8 @@ def prepare_slack_payload(alarm, bitly_access_token, sess=None):
             }]
         }
     ]
+
+    print(alarm)
 
     messages = alarm.cloudwatch_messages()
     if messages:

--- a/monitoring/post_to_slack/src/test_post_to_slack.py
+++ b/monitoring/post_to_slack/src/test_post_to_slack.py
@@ -108,7 +108,7 @@ def event(critical_hook, alarm_name, alarm_reason):
 def test_post_to_slack(mock_post, event, critical_hook, alarm_name):
     mock_post.return_value.ok = True
 
-    post_to_slack.main(event, context=None)
+    post_to_slack.main(event)
 
     calls = mock_post.call_args_list
 
@@ -213,3 +213,40 @@ class TestPrepareSlackPayload:
         )
 
         # TODO: Make an assertion on the payload about the log events we see.
+
+
+@mock.patch('post_to_slack.requests.post')
+def test_regression_issue_1900(mock_post):
+    event = {
+        'Records': [{
+            'EventSource': 'aws:sns',
+            'EventSubscriptionArn': 'arn:aws:sns:eu-west-1:760097843905:shared_alb_server_error_alarm:7701d498-64a4-425e-b966-f9069ecf91a2',
+            'EventVersion': '1.0',
+            'Sns': {
+                'Message': '{"AlarmName":"loris-alb-not-enough-healthy-hosts","AlarmDescription":"This '
+                           'metric monitors '
+                           'loris-alb-not-enough-healthy-hosts","AWSAccountId":"760097843905","NewStateValue":"ALARM","NewStateReason":"Threshold '
+                           'Crossed: no datapoints were received for 1 '
+                           'period and 1 missing datapoint was treated '
+                           'as '
+                           '[Breaching].","StateChangeTime":"2018-04-16T15:34:56.438+0000","Region":"EU '
+                           '(Ireland)","OldStateValue":"INSUFFICIENT_DATA","Trigger":{"MetricName":"HealthyHostCount","Namespace":"AWS/ApplicationELB","StatisticType":"Statistic","Statistic":"SUM","Unit":null,"Dimensions":[{"name":"TargetGroup","value":"targetgroup/loris/087013874ebbe481"},{"name":"LoadBalancer","value":"app/loris/c0af06f31b54a8c9"}],"Period":60,"EvaluationPeriods":1,"ComparisonOperator":"LessThanThreshold","Threshold":2.0,"TreatMissingData":"- '
+                           'TreatMissingData: '
+                           'Breaching","EvaluateLowSampleCountPercentile":""}}',
+                'MessageAttributes': {},
+                'MessageId': '6bd3a539-6665-5449-9496-f677a285954e',
+                'Signature': 'QI0mjffHTGE0y/HcQQoECquP0c3Xtzc6CiFzFBEfM3KRKWFmT2gcebnRU7vGBqh5uHKU+H98k7XJkUqkTVwtz0NkNk5gnRdP/Aqz3ZOtheRqv2qydbzXiIh94mHm9u62Fsiplqlq2vXdKMRKtRFovw58baieYSYAuPhxf+s74TTIY1gU79Lx4IdXfJHf1xfT2UZLHvt83swy5C+19elIlqM9+48+dnShRdQJAk/SOQnGNyTWeVdu+6w2JeNNa6avFaTqLryIBXUO8kgQy6E5VdXtka0Ufiu6qmDKhWRWZajGQBhYHpS6QbgVD7tsBr+FEgeQSb8JfOeuAHtly+hIOw==',
+                'SignatureVersion': '1',
+                'SigningCertUrl': 'https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-433026a4050d206028891664da859041.pem',
+                'Subject': 'ALARM: "loris-alb-not-enough-healthy-hosts" '
+                           'in EU (Ireland)',
+                'Timestamp': '2018-04-16T15:34:56.473Z',
+                'TopicArn': 'arn:aws:sns:eu-west-1:760097843905:shared_alb_server_error_alarm',
+                'Type': 'Notification',
+                'UnsubscribeUrl': 'https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:760097843905:shared_alb_server_error_alarm:7701d498-64a4-425e-b966-f9069ecf91a2'
+            }
+        }]
+    }
+
+    mock_post.return_value.ok = True
+    post_to_slack.main(event)


### PR DESCRIPTION
Quick bugfix in #1900. When there isn’t a timestamp in the message, we were trying to find relevant CloudWatch logs and throwing a TypeError. This is a quick patch which means it won’t be thrown again.

In practice this only occurs just after we’ve created new alarms, so it’s quite rare – otherwise I’d write a more sophisticated test.