### PR TITLE
Explicitly state the string representation of values in ApiVersionsEnum

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/versions/ApiVersions.scala
+++ b/common/src/main/scala/uk/ac/wellcome/versions/ApiVersions.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.versions
 
 object ApiVersions extends Enumeration {
-  val v1, v2 = Value
+  val v1 = Value("v1")
+  val v2 = Value("v2")
   val default = v2
 }

--- a/common/src/main/scala/uk/ac/wellcome/versions/ApiVersions.scala
+++ b/common/src/main/scala/uk/ac/wellcome/versions/ApiVersions.scala
@@ -1,6 +1,9 @@
 package uk.ac.wellcome.versions
 
 object ApiVersions extends Enumeration {
+  // We need to explicitly state the string representation of
+  // each value as we've seen inconsistent behaviour where v2 would be
+  // serialised as "v2" or "default" apparently unpredictably
   val v1 = Value("v1")
   val v2 = Value("v2")
   val default = v2


### PR DESCRIPTION
### What is this PR trying to achieve?
Not run into a scala bug (probably) which makes enum serialisation unreliable by explicitly forcing the string representations of each value
### Who is this change for?
📒 🎁 