### PR TITLE
Modify the snapshot convertor to write either V1 or V2 snapshots

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/versions/ApiVersions.scala
+++ b/common/src/main/scala/uk/ac/wellcome/versions/ApiVersions.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.versions
 
+import io.circe.{Decoder, Encoder}
+
 object ApiVersions extends Enumeration {
   // We need to explicitly state the string representation of
   // each value as we've seen inconsistent behaviour where v2 would be
@@ -7,4 +9,7 @@ object ApiVersions extends Enumeration {
   val v1 = Value("v1")
   val v2 = Value("v2")
   val default = v2
+
+  implicit val decoder = Decoder.enumDecoder(ApiVersions)
+  implicit val encoder = Encoder.enumEncoder(ApiVersions)
 }

--- a/data_api/elasticdump/run_elasticdump.py
+++ b/data_api/elasticdump/run_elasticdump.py
@@ -19,6 +19,7 @@ from service_utils import service
 @attr.s
 class SnapshotRequest(object):
     time = attr.ib()
+    model_version = attr.ib()
     private_bucket_name = attr.ib()
     public_bucket_name = attr.ib()
     public_object_key = attr.ib()
@@ -146,6 +147,7 @@ def run():
             'privateObjectKey': private_object_key,
             'publicBucketName': snapshot_request.public_bucket_name,
             'publicObjectKey': snapshot_request.public_object_key,
+            'modelVersion': snapshot_request.model_version,
         })
     )
     print(f'resp = {resp!r}')

--- a/data_api/elasticdump/run_elasticdump.py
+++ b/data_api/elasticdump/run_elasticdump.py
@@ -19,7 +19,7 @@ from service_utils import service
 @attr.s
 class SnapshotRequest(object):
     time = attr.ib()
-    model_version = attr.ib()
+    api_version = attr.ib()
     private_bucket_name = attr.ib()
     public_bucket_name = attr.ib()
     public_object_key = attr.ib()
@@ -147,7 +147,7 @@ def run():
             'privateObjectKey': private_object_key,
             'publicBucketName': snapshot_request.public_bucket_name,
             'publicObjectKey': snapshot_request.public_object_key,
-            'modelVersion': snapshot_request.model_version,
+            'apiVersion': snapshot_request.api_version,
         })
     )
     print(f'resp = {resp!r}')

--- a/data_api/elasticdump/test_run_elasticdump.py
+++ b/data_api/elasticdump/test_run_elasticdump.py
@@ -68,7 +68,8 @@ def test_getting_only_one_message_from_sqs(
                 private_bucket_name=bucket,
                 public_bucket_name='bukkit',
                 public_object_key='works.json.gz',
-                es_index=elasticsearch_index
+                es_index=elasticsearch_index,
+                api_version='v1'
             )
         ) for time in ('now', 'then')
     ]
@@ -112,7 +113,8 @@ def test_end_to_end(
                     private_bucket_name=bucket,
                     public_bucket_name=public_bucket_name,
                     public_object_key=public_object_key,
-                    es_index=elasticsearch_index
+                    es_index=elasticsearch_index,
+                    api_version='v1'
                 )
             )
         )
@@ -184,4 +186,5 @@ def test_end_to_end(
         'privateObjectKey': 'blah/dump.txt.gz',
         'publicBucketName': public_bucket_name,
         'publicObjectKey': public_object_key,
+        'apiVersion': 'v1',
     }

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/DisplayWorkToJsonStringFlow.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/DisplayWorkToJsonStringFlow.scala
@@ -4,7 +4,7 @@ import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.twitter.inject.Logging
-import uk.ac.wellcome.display.models.v1.DisplayWorkV1
+import uk.ac.wellcome.display.models.DisplayWork
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
@@ -12,7 +12,7 @@ import scala.util.{Failure, Success, Try}
 object DisplayWorkToJsonStringFlow extends Logging {
 
   def apply(mapper: ObjectMapper)(implicit executionContext: ExecutionContext)
-    : Flow[DisplayWorkV1, String, NotUsed] =
+    : Flow[DisplayWork, String, NotUsed] =
     Flow.fromFunction({ work =>
       Try(mapper.writeValueAsString(work)) match {
         case Success(s: String) => s

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/IdentifiedWorkToVisibleDisplayWork.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/IdentifiedWorkToVisibleDisplayWork.scala
@@ -2,16 +2,16 @@ package uk.ac.wellcome.platform.snapshot_convertor.flow
 
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
-import uk.ac.wellcome.display.models.AllWorksIncludes
-import uk.ac.wellcome.display.models.v1.DisplayWorkV1
+import uk.ac.wellcome.display.models.{AllWorksIncludes, DisplayWork, WorksIncludes}
 import uk.ac.wellcome.models.IdentifiedWork
 
 import scala.concurrent.ExecutionContext
 
 object IdentifiedWorkToVisibleDisplayWork {
-  def apply()(implicit executionContext: ExecutionContext)
-    : Flow[IdentifiedWork, DisplayWorkV1, NotUsed] =
+  def apply[T <: DisplayWork](
+    toDisplayWork: (IdentifiedWork, WorksIncludes) => T)(implicit executionContext: ExecutionContext)
+    : Flow[IdentifiedWork, T, NotUsed] =
     Flow[IdentifiedWork]
       .filter(_.visible)
-      .map { DisplayWorkV1(_, includes = AllWorksIncludes()) }
+      .map { toDisplayWork(_, AllWorksIncludes()) }
 }

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/IdentifiedWorkToVisibleDisplayWork.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/IdentifiedWorkToVisibleDisplayWork.scala
@@ -2,14 +2,19 @@ package uk.ac.wellcome.platform.snapshot_convertor.flow
 
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
-import uk.ac.wellcome.display.models.{AllWorksIncludes, DisplayWork, WorksIncludes}
+import uk.ac.wellcome.display.models.{
+  AllWorksIncludes,
+  DisplayWork,
+  WorksIncludes
+}
 import uk.ac.wellcome.models.IdentifiedWork
 
 import scala.concurrent.ExecutionContext
 
 object IdentifiedWorkToVisibleDisplayWork {
   def apply[T <: DisplayWork](
-    toDisplayWork: (IdentifiedWork, WorksIncludes) => T)(implicit executionContext: ExecutionContext)
+    toDisplayWork: (IdentifiedWork, WorksIncludes) => T)(
+    implicit executionContext: ExecutionContext)
     : Flow[IdentifiedWork, T, NotUsed] =
     Flow[IdentifiedWork]
       .filter(_.visible)

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/models/ConversionJob.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/models/ConversionJob.scala
@@ -1,9 +1,9 @@
 package uk.ac.wellcome.platform.snapshot_convertor.models
 
-import uk.ac.wellcome.platform.snapshot_convertor.versions.ModelVersions
+import uk.ac.wellcome.versions.ApiVersions
 
 case class ConversionJob(privateBucketName: String,
                          privateObjectKey: String,
                          publicBucketName: String,
                          publicObjectKey: String,
-                         modelVersion: ModelVersions.Value)
+                         modelVersion: ApiVersions.Value)

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/models/ConversionJob.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/models/ConversionJob.scala
@@ -1,6 +1,9 @@
 package uk.ac.wellcome.platform.snapshot_convertor.models
 
+import uk.ac.wellcome.platform.snapshot_convertor.versions.ModelVersions
+
 case class ConversionJob(privateBucketName: String,
                          privateObjectKey: String,
                          publicBucketName: String,
-                         publicObjectKey: String)
+                         publicObjectKey: String,
+                         modelVersion: ModelVersions.Value)

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/models/ConversionJob.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/models/ConversionJob.scala
@@ -6,4 +6,4 @@ case class ConversionJob(privateBucketName: String,
                          privateObjectKey: String,
                          publicBucketName: String,
                          publicObjectKey: String,
-                         modelVersion: ApiVersions.Value)
+                         apiVersion: ApiVersions.Value)

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
@@ -12,7 +12,11 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.twitter.inject.Logging
 import com.twitter.inject.annotations.Flag
 import javax.inject.Inject
+
+import uk.ac.wellcome.display.models.{DisplayWork, WorksIncludes}
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
+import uk.ac.wellcome.display.models.v2.DisplayWorkV2
+import uk.ac.wellcome.models.IdentifiedWork
 import uk.ac.wellcome.platform.snapshot_convertor.flow.{
   DisplayWorkToJsonStringFlow,
   ElasticsearchHitToIdentifiedWorkFlow,
@@ -25,6 +29,7 @@ import uk.ac.wellcome.platform.snapshot_convertor.models.{
 }
 import uk.ac.wellcome.platform.snapshot_convertor.source.S3Source
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
+import uk.ac.wellcome.versions.ApiVersions
 
 import scala.concurrent.Future
 
@@ -57,6 +62,7 @@ class ConvertorService @Inject()(actorSystem: ActorSystem,
       gzipStream <- runStream(
         publicBucketName = publicBucketName,
         publicObjectKey = publicObjectKey,
+        modelVersion = conversionJob.modelVersion,
         s3inputStream = s3inputStream
       )
     } yield gzipStream
@@ -75,13 +81,19 @@ class ConvertorService @Inject()(actorSystem: ActorSystem,
   private def runStream(
     publicBucketName: String,
     publicObjectKey: String,
+    modelVersion: ApiVersions.Value,
     s3inputStream: S3ObjectInputStream): Future[MultipartUploadResult] = {
     val s3source = S3Source(s3inputStream = s3inputStream)
 
+    val toDisplayWork: ((IdentifiedWork, WorksIncludes) => DisplayWork) = modelVersion match {
+      case ApiVersions.v1 => DisplayWorkV1.apply
+      case ApiVersions.v2 => DisplayWorkV2.apply
+    }
+
     // This source generates instances of DisplayWork from the source snapshot.
-    val displayWorks: Source[DisplayWorkV1, Any] = s3source
+    val displayWorks: Source[DisplayWork, Any] = s3source
       .via(ElasticsearchHitToIdentifiedWorkFlow())
-      .via(IdentifiedWorkToVisibleDisplayWork(DisplayWorkV1.apply))
+      .via(IdentifiedWorkToVisibleDisplayWork(toDisplayWork))
 
     // This source generates JSON strings of DisplayWork instances, which
     // should be written to the destination snapshot.

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
@@ -62,7 +62,7 @@ class ConvertorService @Inject()(actorSystem: ActorSystem,
       gzipStream <- runStream(
         publicBucketName = publicBucketName,
         publicObjectKey = publicObjectKey,
-        modelVersion = conversionJob.modelVersion,
+        apiVersion = conversionJob.apiVersion,
         s3inputStream = s3inputStream
       )
     } yield gzipStream
@@ -81,11 +81,11 @@ class ConvertorService @Inject()(actorSystem: ActorSystem,
   private def runStream(
     publicBucketName: String,
     publicObjectKey: String,
-    modelVersion: ApiVersions.Value,
+    apiVersion: ApiVersions.Value,
     s3inputStream: S3ObjectInputStream): Future[MultipartUploadResult] = {
     val s3source = S3Source(s3inputStream = s3inputStream)
 
-    val toDisplayWork: ((IdentifiedWork, WorksIncludes) => DisplayWork) = modelVersion match {
+    val toDisplayWork: ((IdentifiedWork, WorksIncludes) => DisplayWork) = apiVersion match {
       case ApiVersions.v1 => DisplayWorkV1.apply
       case ApiVersions.v2 => DisplayWorkV2.apply
     }

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
@@ -85,10 +85,11 @@ class ConvertorService @Inject()(actorSystem: ActorSystem,
     s3inputStream: S3ObjectInputStream): Future[MultipartUploadResult] = {
     val s3source = S3Source(s3inputStream = s3inputStream)
 
-    val toDisplayWork: ((IdentifiedWork, WorksIncludes) => DisplayWork) = apiVersion match {
-      case ApiVersions.v1 => DisplayWorkV1.apply
-      case ApiVersions.v2 => DisplayWorkV2.apply
-    }
+    val toDisplayWork: ((IdentifiedWork, WorksIncludes) => DisplayWork) =
+      apiVersion match {
+        case ApiVersions.v1 => DisplayWorkV1.apply
+        case ApiVersions.v2 => DisplayWorkV2.apply
+      }
 
     // This source generates instances of DisplayWork from the source snapshot.
     val displayWorks: Source[DisplayWork, Any] = s3source

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorService.scala
@@ -81,7 +81,7 @@ class ConvertorService @Inject()(actorSystem: ActorSystem,
     // This source generates instances of DisplayWork from the source snapshot.
     val displayWorks: Source[DisplayWorkV1, Any] = s3source
       .via(ElasticsearchHitToIdentifiedWorkFlow())
-      .via(IdentifiedWorkToVisibleDisplayWork())
+      .via(IdentifiedWorkToVisibleDisplayWork(DisplayWorkV1.apply))
 
     // This source generates JSON strings of DisplayWork instances, which
     // should be written to the destination snapshot.

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/versions/ModelVersions.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/versions/ModelVersions.scala
@@ -1,6 +1,0 @@
-package uk.ac.wellcome.platform.snapshot_convertor.versions
-
-object ModelVersions extends Enumeration {
-  val v1, v2 = Value
-  val default = v2
-}

--- a/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/versions/ModelVersions.scala
+++ b/data_api/snapshot_convertor/src/main/scala/uk/ac/wellcome/platform/snapshot_convertor/versions/ModelVersions.scala
@@ -1,0 +1,6 @@
+package uk.ac.wellcome.platform.snapshot_convertor.versions
+
+object ModelVersions extends Enumeration {
+  val v1, v2 = Value
+  val default = v2
+}

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
@@ -78,7 +78,7 @@ class SnapshotConvertorFeatureTest
               privateObjectKey = objectKey,
               publicBucketName = publicBucket.name,
               publicObjectKey = publicObjectKey,
-              modelVersion = ApiVersions.v1
+              apiVersion = ApiVersions.v1
             )
 
             val message = SQSMessage(

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
@@ -17,6 +17,7 @@ import uk.ac.wellcome.platform.snapshot_convertor.models.{
   ConversionJob
 }
 import uk.ac.wellcome.platform.snapshot_convertor.test.utils.GzipUtils
+import uk.ac.wellcome.platform.snapshot_convertor.versions.ModelVersions
 import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.test.utils.{ExtendedPatience, JsonTestUtil}
 import uk.ac.wellcome.utils.JsonUtil._
@@ -76,7 +77,8 @@ class SnapshotConvertorFeatureTest
               privateBucketName = privateBucket.name,
               privateObjectKey = objectKey,
               publicBucketName = publicBucket.name,
-              publicObjectKey = publicObjectKey
+              publicObjectKey = publicObjectKey,
+              modelVersion = ModelVersions.v1
             )
 
             val message = SQSMessage(

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/SnapshotConvertorFeatureTest.scala
@@ -17,10 +17,10 @@ import uk.ac.wellcome.platform.snapshot_convertor.models.{
   ConversionJob
 }
 import uk.ac.wellcome.platform.snapshot_convertor.test.utils.GzipUtils
-import uk.ac.wellcome.platform.snapshot_convertor.versions.ModelVersions
 import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.test.utils.{ExtendedPatience, JsonTestUtil}
 import uk.ac.wellcome.utils.JsonUtil._
+import uk.ac.wellcome.versions.ApiVersions
 
 class SnapshotConvertorFeatureTest
     extends FunSpec
@@ -78,7 +78,7 @@ class SnapshotConvertorFeatureTest
               privateObjectKey = objectKey,
               publicBucketName = publicBucket.name,
               publicObjectKey = publicObjectKey,
-              modelVersion = ModelVersions.v1
+              modelVersion = ApiVersions.v1
             )
 
             val message = SQSMessage(

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
@@ -24,7 +24,8 @@ class IdentifiedWorkToVisibleDisplayWorkFlowTest
       implicit val executionContext: ExecutionContextExecutor =
         actorSystem.dispatcher
       withMaterializer(actorSystem) { materializer =>
-        val flow = IdentifiedWorkToVisibleDisplayWork(toDisplayWork = DisplayWorkV1.apply)
+        val flow = IdentifiedWorkToVisibleDisplayWork(
+          toDisplayWork = DisplayWorkV1.apply)
 
         val works = createWorks(count = 3).toList
 
@@ -47,7 +48,8 @@ class IdentifiedWorkToVisibleDisplayWorkFlowTest
       implicit val executionContext: ExecutionContextExecutor =
         actorSystem.dispatcher
       withMaterializer(actorSystem) { materializer =>
-        val flow = IdentifiedWorkToVisibleDisplayWork(toDisplayWork = DisplayWorkV2.apply)
+        val flow = IdentifiedWorkToVisibleDisplayWork(
+          toDisplayWork = DisplayWorkV2.apply)
 
         val works = createWorks(count = 3).toList
 
@@ -70,7 +72,8 @@ class IdentifiedWorkToVisibleDisplayWorkFlowTest
       implicit val executionContext: ExecutionContextExecutor =
         actorSystem.dispatcher
       withMaterializer(actorSystem) { materializer =>
-        val flow = IdentifiedWorkToVisibleDisplayWork(toDisplayWork = DisplayWorkV1.apply)
+        val flow = IdentifiedWorkToVisibleDisplayWork(
+          toDisplayWork = DisplayWorkV1.apply)
 
         val visibleWorks = createWorks(count = 3).toList
         val notVisibleWorks = createWorks(count = 2, visible = false).toList

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -93,7 +93,7 @@ class ConvertorServiceTest
             privateObjectKey = objectKey,
             publicBucketName = publicBucket.name,
             publicObjectKey = publicObjectKey,
-            modelVersion = ApiVersions.v1
+            apiVersion = ApiVersions.v1
           )
 
           val future = convertorService.runConversion(conversionJob)
@@ -151,7 +151,7 @@ class ConvertorServiceTest
             privateObjectKey = objectKey,
             publicBucketName = publicBucket.name,
             publicObjectKey = publicObjectKey,
-            modelVersion = ApiVersions.v2
+            apiVersion = ApiVersions.v2
           )
 
           val future = convertorService.runConversion(conversionJob)
@@ -239,7 +239,7 @@ class ConvertorServiceTest
             privateObjectKey = objectKey,
             publicBucketName = publicBucket.name,
             publicObjectKey = publicObjectKey,
-            modelVersion = ApiVersions.v1
+            apiVersion = ApiVersions.v1
           )
 
           val future = convertorService.runConversion(conversionJob)
@@ -283,7 +283,7 @@ class ConvertorServiceTest
           privateObjectKey = "doesnotexist.txt.gz",
           publicBucketName = publicBucket.name,
           publicObjectKey = "target.txt.gz",
-          modelVersion = ApiVersions.v1
+          apiVersion = ApiVersions.v1
         )
 
         val future = convertorService.runConversion(conversionJob)
@@ -307,7 +307,7 @@ class ConvertorServiceTest
             privateObjectKey = objectKey,
             publicBucketName = publicBucket.name,
             publicObjectKey = "target.txt.gz",
-            modelVersion = ApiVersions.v1
+            apiVersion = ApiVersions.v1
           )
 
           val future = convertorService.runConversion(conversionJob)
@@ -338,7 +338,7 @@ class ConvertorServiceTest
           privateObjectKey = "wrongKey",
           publicBucketName = bucketName,
           publicObjectKey = "target.json.gz",
-          modelVersion = ApiVersions.v1
+          apiVersion = ApiVersions.v1
         )
 
         val future = convertorService.runConversion(conversionJob)

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -25,6 +25,7 @@ import uk.ac.wellcome.platform.snapshot_convertor.models.{
   ConversionJob
 }
 import uk.ac.wellcome.platform.snapshot_convertor.test.utils.GzipUtils
+import uk.ac.wellcome.platform.snapshot_convertor.versions.ModelVersions
 import uk.ac.wellcome.test.fixtures.{Akka, S3, TestWith, _}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.utils.JsonUtil._
@@ -90,7 +91,8 @@ class ConvertorServiceTest
             privateBucketName = privateBucket.name,
             privateObjectKey = objectKey,
             publicBucketName = publicBucket.name,
-            publicObjectKey = publicObjectKey
+            publicObjectKey = publicObjectKey,
+            modelVersion = ModelVersions.v1
           )
 
           val future = convertorService.runConversion(conversionJob)
@@ -177,7 +179,8 @@ class ConvertorServiceTest
             privateBucketName = privateBucket.name,
             privateObjectKey = objectKey,
             publicBucketName = publicBucket.name,
-            publicObjectKey = publicObjectKey
+            publicObjectKey = publicObjectKey,
+            modelVersion = ModelVersions.v1
           )
 
           val future = convertorService.runConversion(conversionJob)
@@ -220,7 +223,8 @@ class ConvertorServiceTest
           privateBucketName = privateBucket.name,
           privateObjectKey = "doesnotexist.txt.gz",
           publicBucketName = publicBucket.name,
-          publicObjectKey = "target.txt.gz"
+          publicObjectKey = "target.txt.gz",
+          modelVersion = ModelVersions.v1
         )
 
         val future = convertorService.runConversion(conversionJob)
@@ -243,7 +247,8 @@ class ConvertorServiceTest
             privateBucketName = privateBucket.name,
             privateObjectKey = objectKey,
             publicBucketName = publicBucket.name,
-            publicObjectKey = "target.txt.gz"
+            publicObjectKey = "target.txt.gz",
+            modelVersion = ModelVersions.v1
           )
 
           val future = convertorService.runConversion(conversionJob)
@@ -273,7 +278,8 @@ class ConvertorServiceTest
           privateBucketName = bucketName,
           privateObjectKey = "wrongKey",
           publicBucketName = bucketName,
-          publicObjectKey = "target.json.gz"
+          publicObjectKey = "target.json.gz",
+          modelVersion = ModelVersions.v1
         )
 
         val future = convertorService.runConversion(conversionJob)

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -26,10 +26,10 @@ import uk.ac.wellcome.platform.snapshot_convertor.models.{
   ConversionJob
 }
 import uk.ac.wellcome.platform.snapshot_convertor.test.utils.GzipUtils
-import uk.ac.wellcome.platform.snapshot_convertor.versions.ModelVersions
 import uk.ac.wellcome.test.fixtures.{Akka, S3, TestWith, _}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.utils.JsonUtil._
+import uk.ac.wellcome.versions.ApiVersions
 
 import scala.util.Random
 
@@ -93,7 +93,7 @@ class ConvertorServiceTest
             privateObjectKey = objectKey,
             publicBucketName = publicBucket.name,
             publicObjectKey = publicObjectKey,
-            modelVersion = ModelVersions.v1
+            modelVersion = ApiVersions.v1
           )
 
           val future = convertorService.runConversion(conversionJob)
@@ -151,7 +151,7 @@ class ConvertorServiceTest
             privateObjectKey = objectKey,
             publicBucketName = publicBucket.name,
             publicObjectKey = publicObjectKey,
-            modelVersion = ModelVersions.v2
+            modelVersion = ApiVersions.v2
           )
 
           val future = convertorService.runConversion(conversionJob)
@@ -239,7 +239,7 @@ class ConvertorServiceTest
             privateObjectKey = objectKey,
             publicBucketName = publicBucket.name,
             publicObjectKey = publicObjectKey,
-            modelVersion = ModelVersions.v1
+            modelVersion = ApiVersions.v1
           )
 
           val future = convertorService.runConversion(conversionJob)
@@ -283,7 +283,7 @@ class ConvertorServiceTest
           privateObjectKey = "doesnotexist.txt.gz",
           publicBucketName = publicBucket.name,
           publicObjectKey = "target.txt.gz",
-          modelVersion = ModelVersions.v1
+          modelVersion = ApiVersions.v1
         )
 
         val future = convertorService.runConversion(conversionJob)
@@ -307,7 +307,7 @@ class ConvertorServiceTest
             privateObjectKey = objectKey,
             publicBucketName = publicBucket.name,
             publicObjectKey = "target.txt.gz",
-            modelVersion = ModelVersions.v1
+            modelVersion = ApiVersions.v1
           )
 
           val future = convertorService.runConversion(conversionJob)
@@ -338,7 +338,7 @@ class ConvertorServiceTest
           privateObjectKey = "wrongKey",
           publicBucketName = bucketName,
           publicObjectKey = "target.json.gz",
-          modelVersion = ModelVersions.v1
+          modelVersion = ApiVersions.v1
         )
 
         val future = convertorService.runConversion(conversionJob)

--- a/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
+++ b/data_api/snapshot_convertor/src/test/scala/uk/ac/wellcome/platform/snapshot_convertor/services/ConvertorServiceTest.scala
@@ -130,8 +130,8 @@ class ConvertorServiceTest
   it("completes a V2 conversion successfully") {
     withFixtures {
       case (
-        ((_, _, _, convertorService: ConvertorService), privateBucket),
-        publicBucket) =>
+          ((_, _, _, convertorService: ConvertorService), privateBucket),
+          publicBucket) =>
         val visibleWorks = createWorks(count = 4).toList
         val notVisibleWorks = createWorks(count = 2, visible = false).toList
 

--- a/data_api/snapshot_scheduler/src/snapshot_scheduler.py
+++ b/data_api/snapshot_scheduler/src/snapshot_scheduler.py
@@ -17,7 +17,7 @@ from wellcome_aws_utils.sns_utils import publish_sns_message
 @attr.s
 class SnapshotRequest(object):
     time = attr.ib()
-    model_version = attr.ib()
+    api_version = attr.ib()
     private_bucket_name = attr.ib()
     public_bucket_name = attr.ib()
     public_object_key = attr.ib()
@@ -40,13 +40,13 @@ def main(event=None, _ctxt=None, sns_client=None):
     public_object_key_v1 = os.environ['PUBLIC_OBJECT_KEY_V1']
     public_object_key_v2 = os.environ['PUBLIC_OBJECT_KEY_V2']
 
-    for (model_version, es_index, public_object_key) in [
+    for (api_version, es_index, public_object_key) in [
         ('v1', es_index_v1, public_object_key_v1),
         ('v2', es_index_v2, public_object_key_v2),
     ]:
         snapshot_request_message = SnapshotRequest(
             time=dt.datetime.utcnow().isoformat(),
-            model_version=model_version,
+            api_version=api_version,
             private_bucket_name=private_bucket_name,
             public_bucket_name=public_bucket_name,
             public_object_key=public_object_key,

--- a/data_api/snapshot_scheduler/src/snapshot_scheduler.py
+++ b/data_api/snapshot_scheduler/src/snapshot_scheduler.py
@@ -17,6 +17,7 @@ from wellcome_aws_utils.sns_utils import publish_sns_message
 @attr.s
 class SnapshotRequest(object):
     time = attr.ib()
+    model_version = attr.ib()
     private_bucket_name = attr.ib()
     public_bucket_name = attr.ib()
     public_object_key = attr.ib()
@@ -39,12 +40,13 @@ def main(event=None, _ctxt=None, sns_client=None):
     public_object_key_v1 = os.environ['PUBLIC_OBJECT_KEY_V1']
     public_object_key_v2 = os.environ['PUBLIC_OBJECT_KEY_V2']
 
-    for (es_index, public_object_key) in [
-        (es_index_v1, public_object_key_v1),
-        (es_index_v2, public_object_key_v2),
+    for (model_version, es_index, public_object_key) in [
+        ('v1', es_index_v1, public_object_key_v1),
+        ('v2', es_index_v2, public_object_key_v2),
     ]:
         snapshot_request_message = SnapshotRequest(
             time=dt.datetime.utcnow().isoformat(),
+            model_version=model_version,
             private_bucket_name=private_bucket_name,
             public_bucket_name=public_bucket_name,
             public_object_key=public_object_key,

--- a/data_api/snapshot_scheduler/src/test_snapshot_scheduler.py
+++ b/data_api/snapshot_scheduler/src/test_snapshot_scheduler.py
@@ -46,12 +46,14 @@ def test_writes_message_to_sqs(sns_client, topic_arn):
             'public_bucket_name': public_bucket_name,
             'public_object_key': public_object_key_v1,
             'es_index': es_index_v1,
+            'api_version': 'v1',
         },
         {
             'time': '2011-06-21T00:00:00',
             'private_bucket_name': private_bucket_name,
             'public_bucket_name': public_bucket_name,
             'public_object_key': public_object_key_v2,
-            'es_index': es_index_v2
+            'es_index': es_index_v2,
+            'api_version': 'v2',
         },
     ]


### PR DESCRIPTION
### What is this PR trying to achieve?

Messages to the snapshot convertor include a new field "apiVersion", which is either V1 or V2. This is used to decide which of the DisplayWork models should be used to serialise the snapshot. Part of #1840, #1842.

### Who is this change for?

🐮 🍮 

### Have the following been considered/are they needed?

- [ ] Deployed new versions