### PR TITLE
Restore the transformation for Miro contributors

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformer.scala
@@ -36,8 +36,7 @@ class MiroTransformableTransformer
           createdDate =
             getCreatedDate(miroData, miroTransformable.MiroCollection),
           subjects = getSubjects(miroData),
-          // TODO: Replace this with a proper contributors transformation
-//          creators = getCreators(miroData),
+          contributors = getContributors(miroData),
           genres = getGenres(miroData),
           thumbnail = Some(getThumbnail(miroData, miroTransformable.sourceId)),
           items = getItems(miroData, miroTransformable.sourceId)

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroContributors.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroContributors.scala
@@ -1,0 +1,65 @@
+package uk.ac.wellcome.transformer.transformers.miro
+
+import java.io.InputStream
+
+import uk.ac.wellcome.models.{Agent, Contributor, Unidentifiable}
+import uk.ac.wellcome.transformer.source.MiroTransformableData
+import uk.ac.wellcome.utils.JsonUtil.toMap
+
+import scala.io.Source
+
+trait MiroContributors {
+
+  // This JSON resource gives us credit lines for contributor codes.
+  //
+  // It is constructed as a map with fields drawn from the `contributors.xml`
+  // export from Miro, with:
+  //
+  //     - `contributor_id` as the key
+  //     - `contributor_credit_line` as the value
+  //
+  // Note that the checked-in file has had some manual edits for consistency,
+  // and with a lot of the Wellcome-related strings replaced with
+  // "Wellcome Collection".  There are also a handful of manual edits
+  // where the fields in Miro weren't filled in correctly.
+  val stream: InputStream = getClass
+    .getResourceAsStream("/miro_contributor_map.json")
+  val contributorMap =
+    toMap[String](Source.fromInputStream(stream).mkString).get
+
+  /* Populate wwork:contributors.  We use the <image_creator> tag from the Miro XML. */
+  def getContributors(miroData: MiroTransformableData): List[Contributor[Unidentifiable[Agent]]] = {
+    val primaryCreators = miroData.creator match {
+      case Some(maybeCreators) =>
+        maybeCreators.collect {
+          case Some(c) => Unidentifiable(Agent(c))
+        }
+      case None => List()
+    }
+
+    // <image_secondary_creator>: what MIRO calls Secondary Creator, which
+    // will also just have to map to our object property "hasCreator"
+    val secondaryCreators = miroData.secondaryCreator match {
+      case Some(creator) =>
+        creator.map { c =>
+          Unidentifiable(Agent(c))
+        }
+      case None => List()
+    }
+
+    // We also add the contributor code for the non-historical images, but
+    // only if the contributor *isn't* Wellcome Collection.v
+    val contributorCreators = miroData.sourceCode match {
+      case Some(code) =>
+        contributorMap(code.toUpperCase) match {
+          case "Wellcome Collection" => List()
+          case contributor => List(Unidentifiable(Agent(contributor)))
+        }
+      case None => List()
+    }
+
+    val creators = primaryCreators ++ secondaryCreators ++ contributorCreators
+
+    creators.map { agent: Unidentifiable[Agent] => Contributor(agent = agent) }
+  }
+}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformerContributorsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformerContributorsTest.scala
@@ -1,38 +1,38 @@
 package uk.ac.wellcome.transformer.transformers
 
 import org.scalatest.{FunSpec, FunSuite}
-import uk.ac.wellcome.models.{Agent, Unidentifiable}
+import uk.ac.wellcome.models.{Agent, Contributor, Unidentifiable}
 
-class MiroTransformableTransformerCreatorsTest
+class MiroTransformableTransformerContributorsTest
     extends FunSpec
     with MiroTransformableWrapper {
   it("if not image_creator field is present") {
-    transformRecordAndCheckCreators(
+    transformRecordAndCheckContributors(
       data = s""""image_title": "A guide to giraffes"""",
-      expectedCreators = List()
+      expectedContributors = List()
     )
   }
 
   it("passes through a single value in the image_creator field") {
     val creator = "Researcher Rosie"
-    transformRecordAndCheckCreators(
+    transformRecordAndCheckContributors(
       data = s"""
           "image_title": "A radio for a racoon",
           "image_creator": ["$creator"]
         """,
-      expectedCreators = List(creator)
+      expectedContributors = List(creator)
     )
   }
 
   it("ignores null values in the image_creator field") {
     val creator1 = "Beekeeper Brian"
     val creator2 = "Dog-owner Derek"
-    transformRecordAndCheckCreators(
+    transformRecordAndCheckContributors(
       data = s"""
           "image_title": "A radio for a racoon",
           "image_creator": ["$creator1", null, "$creator2"]
         """,
-      expectedCreators = List(creator1, creator2)
+      expectedContributors = List(creator1, creator2)
     )
   }
 
@@ -40,95 +40,92 @@ class MiroTransformableTransformerCreatorsTest
     val creator1 = "Beekeeper Brian"
     val creator2 = "Cat-wrangler Carol"
     val creator3 = "Dog-owner Derek"
-    transformRecordAndCheckCreators(
+    transformRecordAndCheckContributors(
       data = s"""
           "image_title": "A radio for a racoon",
           "image_creator": ["$creator1", "$creator2", "$creator3"]
         """,
-      expectedCreators = List(creator1, creator2, creator3)
+      expectedContributors = List(creator1, creator2, creator3)
     )
   }
 
   it("passes through a single value in the image_creator_secondary field") {
     val secondaryCreator = "Scientist Sarah"
-    transformRecordAndCheckCreators(
+    transformRecordAndCheckContributors(
       data = s"""
           "image_title": "A radio for a racoon",
           "image_secondary_creator": ["$secondaryCreator"]
         """,
-      expectedCreators = List(secondaryCreator)
+      expectedContributors = List(secondaryCreator)
     )
   }
 
   it("passes through multiple values in the image_creator_secondary field") {
     val secondaryCreator1 = "Gamekeeper Gordon"
     val secondaryCreator2 = "Herpetologist Harriet"
-    transformRecordAndCheckCreators(
+    transformRecordAndCheckContributors(
       data = s"""
           "image_title": "Verdant and vivid",
           "image_secondary_creator": [
             "$secondaryCreator1", "$secondaryCreator2"
           ]
         """,
-      expectedCreators = List(secondaryCreator1, secondaryCreator2)
+      expectedContributors = List(secondaryCreator1, secondaryCreator2)
     )
   }
 
   it("combines the image_creator and image_secondary_creator fields") {
     val creator = "Mycologist Morgan"
     val secondaryCreator = "Manufacturer Mel"
-    transformRecordAndCheckCreators(
+    transformRecordAndCheckContributors(
       data = s"""
           "image_title": "Verdant and vivid",
           "image_creator": ["$creator"],
           "image_secondary_creator": ["$secondaryCreator"]
         """,
-      expectedCreators = List(creator, secondaryCreator)
+      expectedContributors = List(creator, secondaryCreator)
     )
   }
 
   it("passes through a value from the image_source_code field") {
-    transformRecordAndCheckCreators(
+    transformRecordAndCheckContributors(
       data = """
           "image_title": "A gander and a goose are game for a goof",
           "image_source_code": "GAV"
         """,
-      expectedCreators = List("Isabella Gavazzi")
+      expectedContributors = List("Isabella Gavazzi")
     )
   }
 
   it("does not use the image_source_code field for Wellcome Collection") {
-    transformRecordAndCheckCreators(
+    transformRecordAndCheckContributors(
       data = """
           "image_title": "Wandering wallabies within water",
           "image_source_code": "WEL"
         """,
-      expectedCreators = List()
+      expectedContributors = List()
     )
   }
 
-  it("does combine the image_creator and image_source_code fields") {
+  it("combines the image_creator and image_source_code fields") {
     val creator = "Sally Snake"
-    transformRecordAndCheckCreators(
+    transformRecordAndCheckContributors(
       data = s"""
           "image_title": "A gander and a goose are game for a goof",
           "image_creator": ["$creator"],
           "image_source_code": "SNL"
         """,
-      expectedCreators = List(creator, "Sue Snell")
+      expectedContributors = List(creator, "Sue Snell")
     )
   }
 
-  private def transformRecordAndCheckCreators(
+  private def transformRecordAndCheckContributors(
     data: String,
-    expectedCreators: List[String]
+    expectedContributors: List[String]
   ) = {
     val transformedWork = transformWork(data = data)
-
-    // TODO: Modify this test to use contributors when the new Miro
-    // transform is done.
-    // transformedWork.creators shouldBe expectedCreators.map { creator =>
-    //   Unidentifiable(Agent(creator))
-    // }
+    transformedWork.contributors shouldBe expectedContributors.map { contributor =>
+      Contributor(agent = Unidentifiable(Agent(creator)))
+    }
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformerTest.scala
@@ -216,9 +216,9 @@ class MiroTransformableTransformerTest
     )
 
     work.title shouldBe Some("A café for cats")
-
-    // TODO: Replace this test with a check on "creators"
-    // work.creators shouldBe List(Unidentifiable(Agent("Gyokushō, a cät Ôwnêr")))
+    work.contributors shouldBe List(
+      Contributor(agent = Unidentifiable(Agent("Gyokushō, a cät Ôwnêr")))
+    )
   }
 
   private def transformRecordAndCheckSierraSystemNumber(


### PR DESCRIPTION
Builds on #1917, required for #1682.

This modifies the Miro transformer to store contributors instead of creators in our internal model. There’s no new logic here, just some existing logic wrapped in a different package.