### PR TITLE
ingestor: just log timeouts, don't trigger a TerminalFailureException

### DIFF
--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.ingestor.services
 
+import java.util.concurrent.TimeoutException
 import javax.inject.{Inject, Singleton}
 
 import com.sksamuel.elastic4s.Indexable
@@ -11,6 +12,7 @@ import com.twitter.inject.annotations.Flag
 import org.elasticsearch.client.ResponseException
 import org.elasticsearch.index.VersionType
 import uk.ac.wellcome.elasticsearch.ElasticsearchExceptionManager
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.IdentifiedWork
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -56,6 +58,9 @@ class WorkIndexer @Inject()(
               warn(
                 s"Trying to ingest work ${work.canonicalId} with older version: skipping.")
               ()
+            case e: TimeoutException =>
+              warn(s"Timeout indexing work ${work.canonicalId} into Elasticsearch")
+              throw new GracefulFailureException(e)
             case e: Throwable =>
               error(
                 s"Error indexing work ${work.canonicalId} into Elasticsearch",

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -59,7 +59,8 @@ class WorkIndexer @Inject()(
                 s"Trying to ingest work ${work.canonicalId} with older version: skipping.")
               ()
             case e: TimeoutException =>
-              warn(s"Timeout indexing work ${work.canonicalId} into Elasticsearch")
+              warn(
+                s"Timeout indexing work ${work.canonicalId} into Elasticsearch")
               throw new GracefulFailureException(e)
             case e: Throwable =>
               error(


### PR DESCRIPTION
We have a whole bunch of TimeoutExceptions in the logs, which are causing the TerminalFailure alarms in Slack. This is fairly benign – sometimes Elasticsearch flakes out under load – and not cause to raise an alarm.

This should reduce the noise in #platform-alterations, and hopefully make us less likely to miss any legitimate errors thrown in the ingestor.

I haven’t written a test, because I’m not sure how to reliable trigger a timeout from Elasticsearch.