### PR TITLE
Less messages on the pipeline DLQs

### DIFF
--- a/catalogue_pipeline/terraform/queues.tf
+++ b/catalogue_pipeline/terraform/queues.tf
@@ -5,6 +5,9 @@ module "miro_transformer_queue" {
   account_id  = "${data.aws_caller_identity.current.account_id}"
   topic_names = ["${module.miro_transformer_topic.name}"]
 
+  visibility_timeout_seconds = 60
+  max_receive_count          = 8
+
   alarm_topic_arn = "${local.dlq_alarm_arn}"
 }
 
@@ -14,6 +17,9 @@ module "transformer_queue" {
   aws_region  = "${var.aws_region}"
   account_id  = "${data.aws_caller_identity.current.account_id}"
   topic_names = ["${module.transformer_topic.name}"]
+
+  visibility_timeout_seconds = 60
+  max_receive_count          = 8
 
   alarm_topic_arn = "${local.dlq_alarm_arn}"
 }
@@ -25,6 +31,9 @@ module "es_ingest_queue" {
   account_id  = "${data.aws_caller_identity.current.account_id}"
   topic_names = ["${module.es_ingest_topic.name}"]
 
+  visibility_timeout_seconds = 60
+  max_receive_count          = 8
+
   alarm_topic_arn = "${local.dlq_alarm_arn}"
 }
 
@@ -34,6 +43,9 @@ module "id_minter_queue" {
   aws_region  = "${var.aws_region}"
   account_id  = "${data.aws_caller_identity.current.account_id}"
   topic_names = ["${module.id_minter_topic.name}"]
+
+  visibility_timeout_seconds = 60
+  max_receive_count          = 8
 
   alarm_topic_arn = "${local.dlq_alarm_arn}"
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

When running large reindexes we are seeing a small percentage of messages end up on catalogue pipeline DLQs. These are then processed successfully after being re-driven.

DLQs are required to prevent deterministic errors caused by work in messages from being retried endlessly and choking the services. We can be reasonably sure that the messages ending up on the DLQ are caused by non-deterministic errors (e.g. intermittent service availability) as they generally succeed when retried.

We can reduce the opportunity for messages ending up on the DLQ to be caused by non-deterministic errors by increasing the number of retries required for moving a message to the DLQ and increasing the amount of time messages remain hidden while they're being worked on.

### Who is this change for?

🕙 🏎 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.