### PR TITLE
Adds MetricsSender fixture

### DIFF
--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSWorkerTest.scala
@@ -21,7 +21,7 @@ import akka.actor.ActorSystem
 import uk.ac.wellcome.test.fixtures.SQS.Queue
 
 class SQSWorkerTest
-  extends FunSpec
+    extends FunSpec
     with MockitoSugar
     with Eventually
     with fixtures.Akka
@@ -29,9 +29,9 @@ class SQSWorkerTest
     with fixtures.MetricsSender {
 
   def withSqsWorker[R](
-                        actors: ActorSystem,
-                        queue: Queue,
-                        metrics: MetricsSender)(testWith: TestWith[SQSWorker, R]) = {
+    actors: ActorSystem,
+    queue: Queue,
+    metrics: MetricsSender)(testWith: TestWith[SQSWorker, R]) = {
     val sqsReader = new SQSReader(sqsClient, SQSConfig(queue.url, 1.second, 1))
 
     val testWorker =

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/CloudWatch.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/CloudWatch.scala
@@ -4,19 +4,18 @@ package uk.ac.wellcome.test.fixtures
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.twitter.inject.Logging
 import org.scalatest.concurrent.Eventually
 
 import scala.concurrent.duration._
 
-trait CloudWatch extends Logging with Eventually with ImplicitLogging {
+trait CloudWatch extends Logging with ImplicitLogging {
   protected val awsNamespace: String = "test"
 
   private val localCloudWatchEndpointUrl: String = "http://localhost:4582"
   private val regionName: String = "localhost"
 
-  private val flushInterval: FiniteDuration = 1 second
+  protected val flushInterval: FiniteDuration = 1 second
 
   private val accessKey: String = "accessKey1"
   private val secretKey: String = "verySecretKey1"

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/CloudWatch.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/CloudWatch.scala
@@ -1,9 +1,11 @@
 package uk.ac.wellcome.test.fixtures
 
-
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
+import com.amazonaws.services.cloudwatch.{
+  AmazonCloudWatch,
+  AmazonCloudWatchClientBuilder
+}
 import com.twitter.inject.Logging
 import org.scalatest.concurrent.Eventually
 

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/MetricsSender.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/MetricsSender.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.metrics
 import scala.concurrent.Future
 
 trait MetricsSender
-  extends Logging
+    extends Logging
     with ImplicitLogging
     with MockitoSugar
     with CloudWatch
@@ -20,7 +20,11 @@ trait MetricsSender
     withActorSystem { actorSystem =>
       withCloudWatchClient { cloudWatchClient =>
         fixture[metrics.MetricsSender, R](
-          create = new metrics.MetricsSender(awsNamespace, flushInterval, cloudWatchClient, actorSystem)
+          create = new metrics.MetricsSender(
+            awsNamespace,
+            flushInterval,
+            cloudWatchClient,
+            actorSystem)
         )
       }
     }

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/MetricsSender.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/MetricsSender.scala
@@ -1,0 +1,43 @@
+package uk.ac.wellcome.test.fixtures
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import com.twitter.inject.Logging
+import org.mockito.Matchers.{any, anyString}
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
+import uk.ac.wellcome.metrics
+
+import scala.concurrent.Future
+
+trait MetricsSender
+  extends Logging
+    with ImplicitLogging
+    with MockitoSugar
+    with CloudWatch
+    with Akka {
+
+  def withMetricsSender[R](cloudWatchClient: AmazonCloudWatch) =
+    withActorSystem { actorSystem =>
+      withCloudWatchClient { cloudWatchClient =>
+        fixture[metrics.MetricsSender, R](
+          create = new metrics.MetricsSender(awsNamespace, flushInterval, cloudWatchClient, actorSystem)
+        )
+      }
+    }
+
+  def withMockMetricSender[R] = fixture[metrics.MetricsSender, R](
+    create = {
+      val metricsSender = mock[metrics.MetricsSender]
+
+      when(
+        metricsSender
+          .timeAndCount[Unit](anyString, any[() => Future[Unit]].apply)
+      ).thenReturn(
+        Future.successful(())
+      )
+
+      metricsSender
+    }
+  )
+
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

Adds fixture for MetricsSender incorporating `withMetricsSender` and `withMockMetricsSender` methods.

### Who is this change for?

💻 

Depends: https://github.com/wellcometrust/platform/pull/1936