### PR TITLE
Adds data science stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ include assets/Makefile
 include loris/Makefile
 include shared_infra/Makefile
 include data_api/Makefile
+include data_science/Makefile
 include catalogue_api/Makefile
 include catalogue_pipeline/Makefile
 include monitoring/Makefile

--- a/data_science/Makefile
+++ b/data_science/Makefile
@@ -1,0 +1,16 @@
+ROOT = $(shell git rev-parse --show-toplevel)
+include $(ROOT)/functions.Makefile
+
+STACK_ROOT  = data_science
+
+SBT_APPS    =
+ECS_TASKS   =
+LAMBDAS     =
+
+TF_NAME     = data_science
+TF_PATH     = $(STACK_ROOT)/terraform
+TF_IS_PUBLIC_FACING = false
+
+
+
+$(val $(call stack_setup))

--- a/data_science/README.md
+++ b/data_science/README.md
@@ -1,0 +1,3 @@
+# data_science
+
+Top level data science project folder.

--- a/data_science/terraform/provider.tf
+++ b/data_science/terraform/provider.tf
@@ -1,0 +1,6 @@
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "1.10.0"
+}
+
+data "aws_caller_identity" "current" {}

--- a/data_science/terraform/terraform.tf
+++ b/data_science/terraform/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.9"
+
+  backend "s3" {
+    bucket         = "wellcomecollection-platform-infra"
+    key            = "terraform/data_science.tfstate"
+    dynamodb_table = "terraform-locktable"
+    region         = "eu-west-1"
+  }
+}

--- a/data_science/terraform/variables.tf
+++ b/data_science/terraform/variables.tf
@@ -1,0 +1,2 @@
+variable "aws_region" {}
+variable "key_name" {}

--- a/data_science/terraform/variables.tf
+++ b/data_science/terraform/variables.tf
@@ -1,4 +1,5 @@
 variable "aws_region" {
   default = "eu-west-1"
 }
+
 variable "key_name" {}

--- a/data_science/terraform/variables.tf
+++ b/data_science/terraform/variables.tf
@@ -1,2 +1,4 @@
-variable "aws_region" {}
+variable "aws_region" {
+  default = "eu-west-1"
+}
 variable "key_name" {}

--- a/data_science/terraform/vpc.tf
+++ b/data_science/terraform/vpc.tf
@@ -1,0 +1,6 @@
+module "vpc" {
+  source     = "git::https://github.com/wellcometrust/terraform.git//network?ref=v1.0.0"
+  cidr_block = "10.90.0.0/16"
+  az_count   = "2"
+  name       = "data_science"
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

Allow Data Science infrastructure to be cheaply and easily deployed and used.

This uses an instance of the [new asg module](https://github.com/wellcometrust/terraform-modules/tree/master/ec2/asg). 

In it's current state this will deploy an ASG with 0 p2.xlarge by default  running the default Amazon Deep Learning AMI on Ubuntu - when scaled up manually it will request spot instances max priced at 0.35$ and hour. The ASG will be automatically scaled down to 0 at 8pm UTC every evening.


### Who is this change for?

@harrisonpim 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.