### PR TITLE
Add a script for toggling the data science ASG, and connecting to instances

### DIFF
--- a/data_science/scripts/asg_utils.py
+++ b/data_science/scripts/asg_utils.py
@@ -1,14 +1,16 @@
 # -*- encoding: utf-8
 
+import sys
+
 
 DATA_SCIENCE_ASG_TAGS = {
     'data_science': 'true',
 }
 
 
-def discover_asg_name(asg_client):
+def discover_data_science_asg(asg_client):
     """
-    Returns the name of the first autoscaling group whose tags exactly match
+    Return data about the first autoscaling group whose tags exactly match
     the supplied input.
     """
     # This API is paginated, but for now we assume we have less than 100 ASGs
@@ -31,9 +33,16 @@ def discover_asg_name(asg_client):
         actual_tags = {t['Key']: t['Value'] for t in asg_data['Tags']}
 
         if actual_tags == DATA_SCIENCE_ASG_TAGS:
-            return asg_data['AutoScalingGroupName']
+            return asg_data
 
     else:
-        raise RuntimeError(
-            "Can't find an ASG with tags %r!" % DATA_SCIENCE_ASG_TAGS
-        )
+        sys.exit("Can't find an ASG with tags %r!" % DATA_SCIENCE_ASG_TAGS)
+
+
+def discover_asg_name(asg_client):
+    """
+    Returns the name of the first autoscaling group whose tags exactly match
+    the supplied input.
+    """
+    asg_data = discover_data_science_asg(asg_client=asg_client)
+    return asg_data['AutoScalingGroupName']

--- a/data_science/scripts/asg_utils.py
+++ b/data_science/scripts/asg_utils.py
@@ -46,3 +46,17 @@ def discover_asg_name(asg_client):
     """
     asg_data = discover_data_science_asg(asg_client=asg_client)
     return asg_data['AutoScalingGroupName']
+
+
+def set_asg_size(asg_client, asg_name, desired_size):
+    """
+    Set the size of an ASG to ``desired_size``.
+    """
+    print('Setting size of ASG group %r to %r' % (asg_name, desired_size))
+
+    asg_client.update_auto_scaling_group(
+        AutoScalingGroupName=asg_name,
+        MinSize=desired_size,
+        MaxSize=desired_size,
+        DesiredCapacity=desired_size,
+    )

--- a/data_science/scripts/asg_utils.py
+++ b/data_science/scripts/asg_utils.py
@@ -1,0 +1,39 @@
+# -*- encoding: utf-8
+
+
+DATA_SCIENCE_ASG_TAGS = {
+    'data_science': 'true',
+}
+
+
+def discover_asg_name(asg_client):
+    """
+    Returns the name of the first autoscaling group whose tags exactly match
+    the supplied input.
+    """
+    # This API is paginated, but for now we assume we have less than 100 ASGs
+    # to check!
+    resp = asg_client.describe_auto_scaling_groups(MaxRecords=100)
+
+    for asg_data in resp['AutoScalingGroups']:
+
+        # The structure of the response is a little awkward.  It's a list of
+        # entries of the form:
+        #
+        #   {'Key': '<KEY>',
+        #    'PropagateAtLaunch': (True|False),
+        #    'ResourceId': '<RESOURCE_ID>',
+        #    'ResourceType': 'auto-scaling-group',
+        #    'Value': '<VALUE>'}]
+        #
+        # We only care about the tag values, so we extract them into a
+        # Python dict.
+        actual_tags = {t['Key']: t['Value'] for t in asg_data['Tags']}
+
+        if actual_tags == DATA_SCIENCE_ASG_TAGS:
+            return asg_data['AutoScalingGroupName']
+
+    else:
+        raise RuntimeError(
+            "Can't find an ASG with tags %r!" % DATA_SCIENCE_ASG_TAGS
+        )

--- a/data_science/scripts/asg_utils.py
+++ b/data_science/scripts/asg_utils.py
@@ -4,7 +4,7 @@ import sys
 
 
 DATA_SCIENCE_ASG_TAGS = {
-    'data_science': 'true',
+    'name': 'jupyter',
 }
 
 

--- a/data_science/scripts/create_tunnel_to_asg.py
+++ b/data_science/scripts/create_tunnel_to_asg.py
@@ -67,4 +67,7 @@ if __name__ == '__main__':
 
     print('Connecting to instance %r' % public_dns)
 
-    subprocess.check_call(['ssh', '-i', key_path, 'ubuntu@%s' % public_dns])
+    try:
+        subprocess.check_call(['ssh', '-i', key_path, 'core@%s' % public_dns])
+    except subprocess.CalledProcessError as err:
+        sys.exit(err.returncode)

--- a/data_science/scripts/create_tunnel_to_asg.py
+++ b/data_science/scripts/create_tunnel_to_asg.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8
+"""
+Connect to the first instance in an autoscaling group.
+
+Usage: create_tunnel_to_asg.py --key=<KEY>
+
+Actions:
+  --key=<KEY>   Path to an SSH key with access to the instances in the ASG.
+
+"""
+
+import os
+import subprocess
+import sys
+
+import boto3
+import docopt
+
+from asg_utils import discover_data_science_asg
+
+
+if __name__ == '__main__':
+    args = docopt.docopt(__doc__)
+
+    key_path = os.path.abspath(args['--key'])
+    assert os.path.exists(key_path)
+
+    asg_client = boto3.client('autoscaling')
+    asg_data = discover_data_science_asg(asg_client=asg_client)
+
+    if len(asg_data['Instances']) == 0:
+        sys.exit(
+            'No instances running in ASG group %r; is it started?' %
+            asg_data['AutoScalingGroupName']
+        )
+
+    in_service_instances = [
+        inst
+        for inst in asg_data['Instances']
+        if inst['LifecycleState'] == 'InService'
+    ]
+
+    if len(in_service_instances) == 0:
+        sys.exit(
+            'No instances in ASG group %r are "InService"; wait a few seconds and try again.' %
+            asg_data['AutoScalingGroupName']
+        )
+
+    instance_data = in_service_instances[0]
+    instance_id = instance_data['InstanceId']
+
+    print('Looking up EC2 instance ID %r' % instance_id)
+
+    ec2_client = boto3.client('ec2')
+    resp = ec2_client.describe_instances(InstanceIds=[instance_id])
+
+    try:
+        instances = resp['Reservations'][0]['Instances']
+        ec2_data = instances[0]
+        assert ec2_data['InstanceId'] == instance_id
+
+        public_dns = ec2_data['PublicDnsName']
+    except (IndexError, KeyError) as err:
+        print('Unexpected error parsing the EC2 response: %r' % err)
+        sys.exit('resp=%r' % resp)
+
+    print('Connecting to instance %r' % public_dns)
+
+    subprocess.check_call(['ssh', '-i', key_path, 'ubuntu@%s' % public_dns])

--- a/data_science/scripts/create_tunnel_to_asg.py
+++ b/data_science/scripts/create_tunnel_to_asg.py
@@ -68,6 +68,6 @@ if __name__ == '__main__':
     print('Connecting to instance %r' % public_dns)
 
     try:
-        subprocess.check_call(['ssh', '-i', key_path, 'core@%s' % public_dns])
+        subprocess.check_call(['ssh', '-i', key_path, 'ubuntu@%s' % public_dns])
     except subprocess.CalledProcessError as err:
         sys.exit(err.returncode)

--- a/data_science/scripts/toggle_asg.py
+++ b/data_science/scripts/toggle_asg.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8
+"""
+Start/stop all the instances in an autoscaling group.
+
+Usage: toggle_asg.py --name=<NAME> (--start | --stop)
+
+Options:
+  --name=<NAME>     Name of the autoscaling group.
+
+Actions:
+  --start           Start the autoscaling group (set the desired count to 1).
+  --stop            Stop the autoscaling group (set the desired count to 0).
+
+"""
+
+import docopt
+
+
+if __name__ == '__main__':
+    args = docopt.docopt(__doc__)

--- a/data_science/scripts/toggle_asg.py
+++ b/data_science/scripts/toggle_asg.py
@@ -3,10 +3,7 @@
 """
 Start/stop all the instances in an autoscaling group.
 
-Usage: toggle_asg.py --name=<NAME> (--start | --stop)
-
-Options:
-  --name=<NAME>     Name of the autoscaling group.
+Usage: toggle_asg.py (--start | --stop)
 
 Actions:
   --start           Start the autoscaling group (set the desired count to 1).
@@ -20,10 +17,45 @@ import boto3
 import docopt
 
 
+DATA_SCIENCE_ASG_TAGS = {
+    'data_science': 'true',
+}
+
+
+def discover_asg_name(asg_client, desired_tags):
+    """
+    Returns the name of the first autoscaling group whose tags match the
+    supplied input.
+
+    e.g. if you pass desired_tags={'data_science': 'true'}, it might find
+    an ASG whose tags are
+
+        {
+            'data_science': 'true',
+            'autoscaling': 'false',
+            'color': 'green'
+        }
+
+    """
+    # This API is paginated, but for now we assume we have less than 100 ASGs
+    # to check!
+    resp = asg_client.describe_auto_scaling_groups(MaxRecords=100)
+
+    for asg_data in resp['AutoScalingGroups']:
+        actual_tags = {t['Key']: t['Value'] for t in asg_data['Tags']}
+
+        for k, v in desired_tags.items():
+            if (k not in actual_tags) or (actual_tags[k] != v):
+                continue
+
+        return asg_data['AutoScalingGroupName']
+
+    else:
+        raise RuntimeError("Can't find an ASG with tags %r!" % desired_tags)
+
+
 if __name__ == '__main__':
     args = docopt.docopt(__doc__)
-
-    asg_name = args['--name']
 
     if args.get('--start'):
         desired_size = 1
@@ -34,6 +66,14 @@ if __name__ == '__main__':
         sys.exit(1)
 
     asg_client = boto3.client('autoscaling')
+
+    asg_name = discover_asg_name(
+        asg_client=asg_client,
+        desired_tags=DATA_SCIENCE_ASG_TAGS
+    )
+
+    print('Setting size of ASG group %r to %r' % (asg_name, desired_size))
+
     asg_client.update_auto_scaling_group(
         AutoScalingGroupName=asg_name,
         MinSize=desired_size,

--- a/data_science/scripts/toggle_asg.py
+++ b/data_science/scripts/toggle_asg.py
@@ -16,7 +16,7 @@ import sys
 import boto3
 import docopt
 
-from asg_utils import discover_asg_name
+from asg_utils import discover_asg_name, set_asg_size
 
 
 if __name__ == '__main__':
@@ -34,11 +34,8 @@ if __name__ == '__main__':
 
     asg_name = discover_asg_name(asg_client=asg_client)
 
-    print('Setting size of ASG group %r to %r' % (asg_name, desired_size))
-
-    asg_client.update_auto_scaling_group(
-        AutoScalingGroupName=asg_name,
-        MinSize=desired_size,
-        MaxSize=desired_size,
-        DesiredCapacity=desired_size,
+    set_asg_size(
+        asg_client=asg_client,
+        asg_name=asg_name,
+        desired_size=desired_size
     )

--- a/data_science/scripts/toggle_asg.py
+++ b/data_science/scripts/toggle_asg.py
@@ -14,8 +14,29 @@ Actions:
 
 """
 
+import sys
+
+import boto3
 import docopt
 
 
 if __name__ == '__main__':
     args = docopt.docopt(__doc__)
+
+    asg_name = args['--name']
+
+    if args.get('--start'):
+        desired_size = 1
+    elif args.get('--stop'):
+        desired_size = 0
+    else:
+        print('Neither --start nor --stop flags supplied?  args=%r' % args)
+        sys.exit(1)
+
+    asg_client = boto3.client('autoscaling')
+    asg_client.update_auto_scaling_group(
+        AutoScalingGroupName=asg_name,
+        MinSize=desired_size,
+        MaxSize=desired_size,
+        DesiredCapacity=desired_size,
+    )

--- a/data_science/scripts/toggle_asg.py
+++ b/data_science/scripts/toggle_asg.py
@@ -16,41 +16,7 @@ import sys
 import boto3
 import docopt
 
-
-DATA_SCIENCE_ASG_TAGS = {
-    'data_science': 'true',
-}
-
-
-def discover_asg_name(asg_client, desired_tags):
-    """
-    Returns the name of the first autoscaling group whose tags exactly match
-    the supplied input.
-    """
-    # This API is paginated, but for now we assume we have less than 100 ASGs
-    # to check!
-    resp = asg_client.describe_auto_scaling_groups(MaxRecords=100)
-
-    for asg_data in resp['AutoScalingGroups']:
-
-        # The structure of the response is a little awkward.  It's a list of
-        # entries of the form:
-        #
-        #   {'Key': '<KEY>',
-        #    'PropagateAtLaunch': (True|False),
-        #    'ResourceId': '<RESOURCE_ID>',
-        #    'ResourceType': 'auto-scaling-group',
-        #    'Value': '<VALUE>'}]
-        #
-        # We only care about the tag values, so we extract them into a
-        # Python dict.
-        actual_tags = {t['Key']: t['Value'] for t in asg_data['Tags']}
-
-        if desired_tags == actual_tags:
-            return asg_data['AutoScalingGroupName']
-
-    else:
-        raise RuntimeError("Can't find an ASG with tags %r!" % desired_tags)
+from asg_utils import discover_asg_name
 
 
 if __name__ == '__main__':
@@ -66,10 +32,7 @@ if __name__ == '__main__':
 
     asg_client = boto3.client('autoscaling')
 
-    asg_name = discover_asg_name(
-        asg_client=asg_client,
-        desired_tags=DATA_SCIENCE_ASG_TAGS
-    )
+    asg_name = discover_asg_name(asg_client=asg_client)
 
     print('Setting size of ASG group %r to %r' % (asg_name, desired_size))
 


### PR DESCRIPTION
### What is this PR trying to achieve?

A standalone piece related to #1639.

This adds a script which either “starts” or “stops” an autoscaling group. The ASG name is “discovered” by use of tags – currently it looks for a test group with `{'data_science': 'true'}`, but we can define other tags in Terraform and have this script search for them.

I’d like review from:

* @wellcometrust/platform-devs for code quality
* @harrisonpim for usability – is this what you want?

I’ve set up a test ASG `alex-test` for testing

### Who is this change for?

@harrisonpim.