### PR TITLE
Start Jupyter on startup

### DIFF
--- a/data_science/terraform/main.tf
+++ b/data_science/terraform/main.tf
@@ -1,27 +1,24 @@
 module "notebook_compute" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//ec2/asg?ref=v9.2.0"
-  name   = "jupyter"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//ec2/asg?ref=fix-tags"
+  name = "jupyter"
 
   # Ubuntu DLAMI
   image_id = "ami-0bc19972"
   key_name = "${var.key_name}"
 
   subnet_list = "${module.vpc.subnets}"
-  vpc_id      = "${module.vpc.vpc_id}"
+  vpc_id = "${module.vpc.vpc_id}"
 
-  use_spot   = 1
+  use_spot = 1
   spot_price = "0.4"
 
-  asg_min     = "0"
+  asg_min = "0"
   asg_desired = "0"
-  asg_max     = "1"
+  asg_max = "1"
 
   instance_type = "p2.xlarge"
 
-  user_data = <<EOF
-#!/bin/bash
-/home/ubuntu/anaconda2/bin/jupyter notebook
-EOF
+  user_data = "${data.template_file.userdata.rendered}"
 }
 
 # Scale down to 0 every night at 8pm
@@ -32,4 +29,14 @@ resource "aws_autoscaling_schedule" "ensure_down" {
   desired_capacity       = 0
   recurrence             = "0 20 * * *"
   autoscaling_group_name = "${module.notebook_compute.asg_name}"
+}
+
+data "template_file" "userdata" {
+  template = "${file("userdata.sh.tpl")}"
+
+  vars {
+    notebook_user = "jupyter"
+    notebook_port = "8888"
+    hashed_password = "${var.hashed_password}"
+  }
 }

--- a/data_science/terraform/main.tf
+++ b/data_science/terraform/main.tf
@@ -1,6 +1,6 @@
 module "notebook_compute" {
   source = "git::https://github.com/wellcometrust/terraform-modules.git//ec2/asg?ref=v9.2.0"
-  name   = "notebook_compute"
+  name   = "jupyter"
 
   # Ubuntu DLAMI
   image_id = "ami-0bc19972"
@@ -10,12 +10,18 @@ module "notebook_compute" {
   vpc_id      = "${module.vpc.vpc_id}"
 
   use_spot   = 1
-  spot_price = "0.35"
+  spot_price = "0.4"
 
+  asg_min     = "0"
   asg_desired = "0"
   asg_max     = "1"
 
   instance_type = "p2.xlarge"
+
+  user_data = <<EOF
+#!/bin/bash
+/home/ubuntu/anaconda2/bin/jupyter notebook
+EOF
 }
 
 # Scale down to 0 every night at 8pm

--- a/data_science/terraform/main.tf
+++ b/data_science/terraform/main.tf
@@ -1,20 +1,20 @@
 module "notebook_compute" {
   source = "git::https://github.com/wellcometrust/terraform-modules.git//ec2/asg?ref=v9.3.0"
-  name = "jupyter"
+  name   = "jupyter"
 
   # Ubuntu DLAMI
   image_id = "ami-0bc19972"
   key_name = "${var.key_name}"
 
   subnet_list = "${module.vpc.subnets}"
-  vpc_id = "${module.vpc.vpc_id}"
+  vpc_id      = "${module.vpc.vpc_id}"
 
-  use_spot = 1
+  use_spot   = 1
   spot_price = "0.4"
 
-  asg_min = "0"
+  asg_min     = "0"
   asg_desired = "0"
-  asg_max = "1"
+  asg_max     = "1"
 
   instance_type = "p2.xlarge"
 
@@ -35,8 +35,8 @@ data "template_file" "userdata" {
   template = "${file("userdata.sh.tpl")}"
 
   vars {
-    notebook_user = "jupyter"
-    notebook_port = "8888"
+    notebook_user   = "jupyter"
+    notebook_port   = "8888"
     hashed_password = "${var.hashed_password}"
   }
 }

--- a/data_science/terraform/main.tf
+++ b/data_science/terraform/main.tf
@@ -1,5 +1,5 @@
 module "notebook_compute" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//ec2/asg?ref=fix-tags"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//ec2/asg?ref=v9.3.0"
   name = "jupyter"
 
   # Ubuntu DLAMI

--- a/data_science/terraform/userdata.sh.tpl
+++ b/data_science/terraform/userdata.sh.tpl
@@ -9,7 +9,7 @@ cat << EOF > /home/${notebook_user}/.jupyter/jupyter_notebook_config.py
 
 c.NotebookApp.notebook_dir = u"/home/${notebook_user}/"
 c.NotebookApp.ip = "*"
-c.NotebookApp.port = "${notebook_port}"
+c.NotebookApp.port = ${notebook_port}
 c.NotebookApp.open_browser = False
 c.NotebookApp.password = u'${hashed_password}'
 

--- a/data_science/terraform/userdata.sh.tpl
+++ b/data_science/terraform/userdata.sh.tpl
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
 
 # Create jupyter user
 adduser ${notebook_user} --gecos "" --disabled-password
@@ -16,4 +19,4 @@ c.NotebookApp.password = u'${hashed_password}'
 EOF
 
 # Start notebook server
-runuser -l ${notebook_user} -c '/home/ubuntu/anaconda3/bin/jupyter notebook'
+runuser --login ${notebook_user} --command '/home/ubuntu/anaconda3/bin/jupyter notebook'

--- a/data_science/terraform/userdata.sh.tpl
+++ b/data_science/terraform/userdata.sh.tpl
@@ -11,7 +11,7 @@ c.NotebookApp.notebook_dir = u"/home/${notebook_user}/"
 c.NotebookApp.ip = "*"
 c.NotebookApp.port = "${notebook_port}"
 c.NotebookApp.open_browser = False
-c.NotebookApp.password = u'${hashed_password}''
+c.NotebookApp.password = u'${hashed_password}'
 
 EOF
 

--- a/data_science/terraform/userdata.sh.tpl
+++ b/data_science/terraform/userdata.sh.tpl
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Create jupyter user
+adduser ${notebook_user} --gecos "" --disabled-password
+
+# Write config file
+mkdir /home/${notebook_user}/.jupyter
+cat << EOF > /home/${notebook_user}/.jupyter/jupyter_notebook_config.py
+
+c.NotebookApp.notebook_dir = u"/home/${notebook_user}/"
+c.NotebookApp.ip = "*"
+c.NotebookApp.port = "${notebook_port}"
+c.NotebookApp.open_browser = False
+c.NotebookApp.password = u'${hashed_password}''
+
+EOF
+
+# Start notebook server
+runuser -l ${notebook_user} -c '/home/ubuntu/anaconda3/bin/jupyter notebook'

--- a/data_science/terraform/variables.tf
+++ b/data_science/terraform/variables.tf
@@ -1,7 +1,9 @@
 variable "aws_region" {
   default = "eu-west-1"
 }
+
 variable "hashed_password" {
   default = "sha1:5310f21e370d:a4d66e725c179218638c21c03d83933aa066db2d"
 }
+
 variable "key_name" {}

--- a/data_science/terraform/variables.tf
+++ b/data_science/terraform/variables.tf
@@ -1,5 +1,7 @@
 variable "aws_region" {
   default = "eu-west-1"
 }
-
+variable "hashed_password" {
+  default = "sha1:5310f21e370d:a4d66e725c179218638c21c03d83933aa066db2d"
+}
 variable "key_name" {}


### PR DESCRIPTION
### What is this PR trying to achieve?

Start jupyter server on instance start.

This should enable an SSH tunnel to be opened by running:

```sh
ssh -i ~/.ssh/wellcomedigitalplatform -N -f -L localhost:8888:localhost:8888 ubuntu@host
```

### Who is this change for?

@harrisonpim 

### Have the following been considered/are they needed?

- [X] Run `terraform apply`.