### PR TITLE
Ignore changes to the data_science scripts directory in Travis

### DIFF
--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -51,7 +51,7 @@ def does_file_affect_build_task(path, task):
         'LICENSE',
         '.travis.yml',
         'run_travis_task.py',
-    ] or path.startswith(('misc/', 'ontologies/')):
+    ] or path.startswith(('misc/', 'ontologies/', 'data_science/scripts/')):
         raise IgnoredPath()
 
     # Some directories only affect one task.

--- a/travistooling/tests/test_decisionmaker.py
+++ b/travistooling/tests/test_decisionmaker.py
@@ -81,6 +81,10 @@ from travistooling.decisions import (
     # Changes to travistooling only trigger the travistooling tests
     ('travistooling/decisionmaker.py', 'travistooling-test', ExclusivelyAffectsThisTask, True),
     ('travistooling/decisionmaker.py', 'loris-test', ExclusivelyAffectsAnotherTask, False),
+
+    # Changes to the data_science/scripts folder only trigger the format tests
+    ('data_science/scripts/foo.py', 'loris-test', IgnoredPath, False),
+    ('data_science/scripts/bar.py', 'travis-format', CheckedByTravisFormat, True),
 ])
 def test_does_file_affect_build_task(path, task, exc_class, is_significant):
     with pytest.raises(exc_class) as err:


### PR DESCRIPTION
Resolves #1951.

This should improve our Travis times as we continue to add stuff here – the tests for #1946 took nearly two hours of vCPU time, even though they didn’t affect any of the Scala apps.

Simply ignoring the entire directory is a cheap heuristic, but it’ll do for now. If/when we add proper tests in this directory, we can revisit these rules.