### PR TITLE
[WIP] Implement new config models for messaging

### DIFF
--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageConfig.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageConfig.scala
@@ -1,0 +1,9 @@
+package uk.ac.wellcome.messaging.message
+
+import uk.ac.wellcome.messaging.sns.SNSConfig
+import uk.ac.wellcome.models.aws.S3Config
+
+case class MessageConfig(
+  snsConfig: SNSConfig,
+  s3Config: S3Config
+)

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageConfigModule.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageConfigModule.scala
@@ -1,0 +1,38 @@
+package uk.ac.wellcome.messaging.message
+
+import com.google.inject.Provides
+import com.twitter.inject.TwitterModule
+import javax.inject.Singleton
+
+import uk.ac.wellcome.messaging.sns.SNSConfig
+import uk.ac.wellcome.models.aws.S3Config
+
+object MessageConfigModule extends TwitterModule {
+  private val topicArn = flag[String](
+    "aws.message.sns.topic.arn", "", "ARN of the SNS topic used for messaging")
+
+  private val bucketName =
+    flag[String](
+      "aws.message.s3.bucketName", "",
+      "Name of the S3 bucket holding messaging pointers")
+  private val endpoint = flag[String](
+    "aws.message.s3.endpoint", "",
+    "Endpoint of S3. The region will be used if the endpoint is not provided")
+  private val accessKey =
+    flag[String]("aws.message.s3.accessKey", "", "AccessKey to access S3")
+  private val secretKey =
+    flag[String]("aws.smessage.3.secretKey", "", "SecretKey to access S3")
+
+  @Singleton
+  @Provides
+  def providesMessageConfig(): MessageConfig = {
+    val snsConfig = SNSConfig(topicArn = topicArn())
+    val s3Config = S3Config(
+      bucketName = bucketName(),
+      endpoint = endpoint(),
+      accessKey = accessKey(),
+      secretKey = secretKey()
+    )
+    MessageConfig(snsConfig = snsConfig, s3Config = s3Config)
+  }
+}

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageReader.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageReader.scala
@@ -1,17 +1,28 @@
 package uk.ac.wellcome.messaging.message
 
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs
 import io.circe.Decoder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.utils.JsonUtil._
 import com.google.inject.Inject
-import uk.ac.wellcome.s3.S3ObjectStore
+import uk.ac.wellcome.s3.{KeyPrefixGenerator, S3ObjectStore}
 
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.Future
 
-class MessageReader[T] @Inject()(s3ObjectStore: S3ObjectStore[T]) {
+class MessageReader[T] @Inject()(
+  messageConfig: MessageConfig,
+  s3Client: AmazonS3,
+  keyPrefixGenerator: KeyPrefixGenerator[T]
+) {
+
+  val s3ObjectStore = new S3ObjectStore[T](
+    s3Client = s3Client,
+    s3Config = messageConfig.s3Config,
+    keyPrefixGenerator = keyPrefixGenerator
+  )
 
   def read(message: sqs.model.Message)(
     implicit decoderN: Decoder[NotificationMessage],

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -2,6 +2,8 @@ package uk.ac.wellcome.messaging.message
 
 import java.net.URI
 
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.sns.AmazonSNS
 import com.google.inject.Inject
 import com.twitter.inject.Logging
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -9,21 +11,33 @@ import uk.ac.wellcome.models.aws.S3Config
 
 import io.circe.Encoder
 import uk.ac.wellcome.messaging.sns.SNSWriter
-import uk.ac.wellcome.s3.S3ObjectStore
+import uk.ac.wellcome.s3.{KeyPrefixGenerator, S3ObjectStore}
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.{blocking, Future}
 
 class MessageWriter[T] @Inject()(
-  private val sns: SNSWriter,
-  private val s3Config: S3Config,
-  private val s3: S3ObjectStore[T]
+  messageConfig: MessageConfig,
+  snsClient: AmazonSNS,
+  s3Client: AmazonS3,
+  keyPrefixGenerator: KeyPrefixGenerator[T]
 ) extends Logging {
+
+  private val sns = new SNSWriter(
+    snsClient = snsClient,
+    snsConfig = messageConfig.snsConfig
+  )
+
+  private val s3 = new S3ObjectStore[T](
+    s3Client = s3Client,
+    s3Config = messageConfig.s3Config,
+    keyPrefixGenerator = keyPrefixGenerator
+  )
 
   def write(message: T, subject: String)(
     implicit encoder: Encoder[T]): Future[Unit] = {
 
-    val bucket = s3Config.bucketName
+    val bucket = messageConfig.s3Config.bucketName
 
     for {
       location <- s3.put(message)

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageWriterTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageWriterTest.scala
@@ -2,10 +2,10 @@ package uk.ac.wellcome.messaging.message
 
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest._
-import uk.ac.wellcome.messaging.sns.{SNSConfig, SNSWriter}
+import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.test.fixtures.Messaging
 import uk.ac.wellcome.models.aws.S3Config
-import uk.ac.wellcome.s3.{KeyPrefixGenerator, S3ObjectLocation, S3ObjectStore}
+import uk.ac.wellcome.s3.{KeyPrefixGenerator, S3ObjectLocation}
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.util.Success
@@ -18,24 +18,30 @@ class MessageWriterTest
     with IntegrationPatience
     with Inside {
 
+  val keyPrefixGenerator: KeyPrefixGenerator[ExampleObject] =
+    new KeyPrefixGenerator[ExampleObject] {
+      override def generate(obj: ExampleObject): String = "/"
+    }
+
+  val message = ExampleObject("A message sent in the MessageWriterTest")
+  val subject = "message-writer-test-subject"
+
   it("sends messages") {
     withLocalSnsTopic { topic =>
       withLocalS3Bucket { bucket =>
         val s3Config = S3Config(bucketName = bucket.name)
-
         val snsConfig = SNSConfig(topic.arn)
-        val snsWriter = new SNSWriter(snsClient, snsConfig)
+        val messageConfig = MessageConfig(
+          s3Config = s3Config,
+          snsConfig = snsConfig
+        )
 
-        val s3ObjectStore = new S3ObjectStore[ExampleObject](
-          s3Client,
-          s3Config,
-          keyPrefixGenerator)
-
-        val messageWriter =
-          new MessageWriter[ExampleObject](snsWriter, s3Config, s3ObjectStore)
-
-        val message = ExampleObject("Some value")
-        val subject = "sns-writer-test-subject"
+        val messageWriter = new MessageWriter[ExampleObject](
+          messageConfig = messageConfig,
+          snsClient = snsClient,
+          s3Client = s3Client,
+          keyPrefixGenerator = keyPrefixGenerator
+        )
 
         val eventualAttempt = messageWriter.write(message, subject)
 
@@ -61,27 +67,23 @@ class MessageWriterTest
     }
   }
 
-  it("returns a failed future if it fails to publish to sns") {
+  it("returns a failed future if it fails to publish to SNS") {
     withLocalS3Bucket { bucket =>
       val s3Config = S3Config(bucketName = bucket.name)
       val snsConfig = SNSConfig(topicArn = "invalid-topic")
-      val snsWriter = new SNSWriter(snsClient, snsConfig)
+      val messageConfig = MessageConfig(
+        s3Config = s3Config,
+        snsConfig = snsConfig
+      )
 
-      val keyPrefixGenerator: KeyPrefixGenerator[ExampleObject] =
-        new KeyPrefixGenerator[ExampleObject] {
-          override def generate(obj: ExampleObject): String = "/"
-        }
+      val messageWriter = new MessageWriter[ExampleObject](
+        messageConfig = messageConfig,
+        snsClient = snsClient,
+        s3Client = s3Client,
+        keyPrefixGenerator = keyPrefixGenerator
+      )
 
-      val s3ObjectStore = new S3ObjectStore[ExampleObject](
-        s3Client,
-        s3Config,
-        keyPrefixGenerator)
-      val messages =
-        new MessageWriter[ExampleObject](snsWriter, s3Config, s3ObjectStore)
-
-      val message = ExampleObject("Some value")
-
-      val eventualAttempt = messages.write(message, "subject")
+      val eventualAttempt = messageWriter.write(message, subject)
 
       whenReady(eventualAttempt.failed) { ex =>
         ex shouldBe a[Throwable]
@@ -93,23 +95,19 @@ class MessageWriterTest
     withLocalSnsTopic { topic =>
       val s3Config = S3Config(bucketName = "invalid-bucket")
       val snsConfig = SNSConfig(topic.arn)
-      val snsWriter = new SNSWriter(snsClient, snsConfig)
+      val messageConfig = MessageConfig(
+        s3Config = s3Config,
+        snsConfig = snsConfig
+      )
 
-      val keyPrefixGenerator: KeyPrefixGenerator[ExampleObject] =
-        new KeyPrefixGenerator[ExampleObject] {
-          override def generate(obj: ExampleObject): String = "/"
-        }
+      val messageWriter = new MessageWriter[ExampleObject](
+        messageConfig = messageConfig,
+        snsClient = snsClient,
+        s3Client = s3Client,
+        keyPrefixGenerator = keyPrefixGenerator
+      )
 
-      val s3ObjectStore = new S3ObjectStore[ExampleObject](
-        s3Client,
-        s3Config,
-        keyPrefixGenerator)
-      val messages =
-        new MessageWriter[ExampleObject](snsWriter, s3Config, s3ObjectStore)
-
-      val message = ExampleObject("Some value")
-
-      val eventualAttempt = messages.write(message, "subject")
+      val eventualAttempt = messageWriter.write(message, subject)
 
       whenReady(eventualAttempt.failed) { ex =>
         ex shouldBe a[Throwable]
@@ -121,23 +119,19 @@ class MessageWriterTest
     withLocalSnsTopic { topic =>
       val s3Config = S3Config(bucketName = "invalid-bucket")
       val snsConfig = SNSConfig(topic.arn)
-      val snsWriter = new SNSWriter(snsClient, snsConfig)
+      val messageConfig = MessageConfig(
+        s3Config = s3Config,
+        snsConfig = snsConfig
+      )
 
-      val keyPrefixGenerator: KeyPrefixGenerator[ExampleObject] =
-        new KeyPrefixGenerator[ExampleObject] {
-          override def generate(obj: ExampleObject): String = "/"
-        }
+      val messageWriter = new MessageWriter[ExampleObject](
+        messageConfig = messageConfig,
+        snsClient = snsClient,
+        s3Client = s3Client,
+        keyPrefixGenerator = keyPrefixGenerator
+      )
 
-      val s3ObjectStore = new S3ObjectStore[ExampleObject](
-        s3Client,
-        s3Config,
-        keyPrefixGenerator)
-      val messages =
-        new MessageWriter[ExampleObject](snsWriter, s3Config, s3ObjectStore)
-
-      val message = ExampleObject("Some value")
-
-      val eventualAttempt = messages.write(message, "subject")
+      val eventualAttempt = messageWriter.write(message, subject)
 
       whenReady(eventualAttempt.failed) { _ =>
         listMessagesReceivedFromSNS(topic) should be('empty)


### PR DESCRIPTION
With the new messaging stack, some of our applications need to read from multiple buckets.

This PR adds a new config class – `MessageConfig` – which is to be used in place of SNSConfig and S3Config for the messaging stack.

A separate PR will add VHSConfig.