### PR TITLE
Try to fix the flaky Elasticsearch test

### DIFF
--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/ElasticSearchIndexTest.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/ElasticSearchIndexTest.scala
@@ -68,7 +68,8 @@ class ElasticSearchIndexTest
   }
 
   it("creates an index into which doc of the expected type can be put") {
-    withLocalElasticsearchIndex(TestIndex, indexName = "test-index") {
+    val indexName = "working-index"
+    withLocalElasticsearchIndex(TestIndex, indexName = indexName) {
       indexName =>
         val testObject = TestObject("id", "description", true)
         val testObjectJson = JsonUtil.toJson(testObject).get
@@ -90,7 +91,8 @@ class ElasticSearchIndexTest
   }
 
   it("create an index where inserting a doc of an unexpected type fails") {
-    withLocalElasticsearchIndex(TestIndex, indexName = "test-index") {
+    val indexName = "unexpected-type-index"
+    withLocalElasticsearchIndex(TestIndex, indexName = indexName) {
       indexName =>
         val badTestObject = BadTestObject("id", 5)
         val badTestObjectJson = JsonUtil.toJson(badTestObject).get
@@ -108,10 +110,11 @@ class ElasticSearchIndexTest
   }
 
   it("updates an already existing index with a compatible mapping") {
-    withLocalElasticsearchIndex(TestIndex, indexName = "test-index") { _ =>
+    val indexName = "existing-index"
+    withLocalElasticsearchIndex(TestIndex, indexName = indexName) { _ =>
       withLocalElasticsearchIndex(
         CompatibleTestIndex,
-        indexName = "test-index") { testIndexName =>
+        indexName = indexName) { testIndexName =>
         val compatibleTestObject =
           CompatibleTestObject("id", "description", 5, visible = true)
         val compatibleTestObjectJson =

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/ElasticSearchIndexTest.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/ElasticSearchIndexTest.scala
@@ -112,32 +112,31 @@ class ElasticSearchIndexTest
   it("updates an already existing index with a compatible mapping") {
     val indexName = "existing-index"
     withLocalElasticsearchIndex(TestIndex, indexName = indexName) { _ =>
-      withLocalElasticsearchIndex(
-        CompatibleTestIndex,
-        indexName = indexName) { testIndexName =>
-        val compatibleTestObject =
-          CompatibleTestObject("id", "description", 5, visible = true)
-        val compatibleTestObjectJson =
-          JsonUtil.toJson(compatibleTestObject).get
+      withLocalElasticsearchIndex(CompatibleTestIndex, indexName = indexName) {
+        testIndexName =>
+          val compatibleTestObject =
+            CompatibleTestObject("id", "description", 5, visible = true)
+          val compatibleTestObjectJson =
+            JsonUtil.toJson(compatibleTestObject).get
 
-        val futureInsert = elasticClient.execute(
-          indexInto(testIndexName / testType) doc compatibleTestObjectJson)
+          val futureInsert = elasticClient.execute(
+            indexInto(testIndexName / testType) doc compatibleTestObjectJson)
 
-        whenReady(futureInsert) { _ =>
-          eventually {
-            val hits = elasticClient
-              .execute(search(s"$testIndexName/$testType").matchAllQuery())
-              .map { _.hits.hits }
-              .await
+          whenReady(futureInsert) { _ =>
+            eventually {
+              val hits = elasticClient
+                .execute(search(s"$testIndexName/$testType").matchAllQuery())
+                .map { _.hits.hits }
+                .await
 
-            hits should have size 1
+              hits should have size 1
 
-            assertJsonStringsAreEqual(
-              hits.head.sourceAsString,
-              compatibleTestObjectJson
-            )
+              assertJsonStringsAreEqual(
+                hits.head.sourceAsString,
+                compatibleTestObjectJson
+              )
+            }
           }
-        }
       }
     }
   }


### PR DESCRIPTION
The issue was in the test that "updates an already existing index". We get the occasional 404 "index doesn't exist" error.

The index it uses has the same name as the other tests.  I think we were hitting a race condition where the index was being created in this test, then deleted by *another* test before we could use it a second time.

An attempt to resolve #1962.