### PR TITLE
Try to fix the flaky snapshot_generator test

### DIFF
--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -192,7 +192,7 @@ class SnapshotServiceTest
   it("completes a snapshot generation of an index with more than 10000 items") {
     withFixtures {
       case (snapshotService: SnapshotService, indexNameV1, _, publicBucket) =>
-        val works = (1 to 20000).map { id =>
+        val works = (1 to 11000).map { id =>
           workWith(
             canonicalId = id.toString,
             title = Random.alphanumeric.take(1500).mkString)


### PR DESCRIPTION
We occasionally saw this test fail with the error

    java.lang.OutOfMemoryError: Java heap space

Since we only need "just a bit more than 10000", we can reduce the amount of memory we use without affecting the test, and hopefully it will fail less often.

Log attached from a previous flaky run.
[log.txt](https://github.com/wellcometrust/platform/files/1966967/log.txt)
