### PR TITLE
Add new modules for VHS and VHS configuration

### DIFF
--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VHSConfig.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VHSConfig.scala
@@ -1,0 +1,9 @@
+package uk.ac.wellcome.storage.vhs
+
+import uk.ac.wellcome.storage.dynamo.DynamoConfig
+import uk.ac.wellcome.storage.s3.S3Config
+
+case class VHSConfig(
+  dynamoConfig: DynamoConfig,
+  s3Config: S3Config
+)

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VHSConfigModule.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VHSConfigModule.scala
@@ -1,0 +1,26 @@
+package uk.ac.wellcome.storage.vhs
+
+import com.google.inject.Provides
+import com.twitter.inject.TwitterModule
+import javax.inject.Singleton
+
+import uk.ac.wellcome.storage.dynamo.DynamoConfig
+import uk.ac.wellcome.storage.s3.S3Config
+
+object VHSConfigModule extends TwitterModule {
+  private val tableName = flag[String](
+    "aws.vhs.dynamo.tableName", "",
+    "Name of the DynamoDB table holding the VHS index")
+
+  private val bucketName = flag[String](
+    "aws.vhs.s3.bucketName", "",
+    "Name of the S3 bucket holding VHS objects")
+
+  @Singleton
+  @Provides
+  def providesVHSConfig(): VHSConfig = {
+    val dynamoConfig = DynamoConfig(table = tableName())
+    val s3Config = S3Config(bucketName = bucketName())
+    VHSConfig(dynamoConfig = dynamoConfig, s3Config = s3Config)
+  }
+}

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VHSConfigModule.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VHSConfigModule.scala
@@ -9,11 +9,13 @@ import uk.ac.wellcome.storage.s3.S3Config
 
 object VHSConfigModule extends TwitterModule {
   private val tableName = flag[String](
-    "aws.vhs.dynamo.tableName", "",
+    "aws.vhs.dynamo.tableName",
+    "",
     "Name of the DynamoDB table holding the VHS index")
 
   private val bucketName = flag[String](
-    "aws.vhs.s3.bucketName", "",
+    "aws.vhs.s3.bucketName",
+    "",
     "Name of the S3 bucket holding VHS objects")
 
   @Singleton

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
@@ -40,7 +40,7 @@ trait LocalDynamoDb[T <: Versioned with Id]
   def dynamoClientLocalFlags = Map(
     "aws.dynamoDb.endpoint" -> dynamoDBEndPoint,
     "aws.dynamoDb.accessKey" -> accessKey,
-    "aws.dynamoDb.secretKey" -> secretKey
+    "aws.dynamoDb.secretKey" -> secretKey,
     "aws.region" -> "localhost"
   )
 

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
@@ -33,14 +33,17 @@ trait LocalDynamoDb[T <: Versioned with Id]
   private val accessKey = "access"
   private val secretKey = "secret"
 
-  def dynamoDbLocalEndpointFlags(table: Table) =
+  def dynamoDbLocalEndpointFlags(table: Table, namespace: String = "") = {
+    val prefix = if (namespace != "") { s"aws.${namespace}.dynamo" } else { "aws.dynamo" }
+
     Map(
       "aws.region" -> "localhost",
-      "aws.dynamo.tableName" -> table.name,
+      s"${prefix}.tableName" -> table.name,
       "aws.dynamoDb.endpoint" -> dynamoDBEndPoint,
       "aws.dynamoDb.accessKey" -> accessKey,
       "aws.dynamoDb.secretKey" -> secretKey
     )
+  }
 
   private val credentials = new AWSStaticCredentialsProvider(
     new BasicAWSCredentials(accessKey, secretKey))

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
@@ -33,18 +33,16 @@ trait LocalDynamoDb[T <: Versioned with Id]
   private val accessKey = "access"
   private val secretKey = "secret"
 
-  def dynamoDbLocalEndpointFlags(table: Table, namespace: String = "") = {
-    val prefix =
-      if (namespace != "") { s"aws.${namespace}.dynamo" } else { "aws.dynamo" }
+  def dynamoDbLocalEndpointFlags(table: Table) = dynamoClientLocalFlags ++ Map(
+    "aws.dynamo.tableName" -> table.name
+  )
 
-    Map(
-      "aws.region" -> "localhost",
-      s"${prefix}.tableName" -> table.name,
-      "aws.dynamoDb.endpoint" -> dynamoDBEndPoint,
-      "aws.dynamoDb.accessKey" -> accessKey,
-      "aws.dynamoDb.secretKey" -> secretKey
-    )
-  }
+  def dynamoClientLocalFlags = Map(
+    "aws.dynamoDb.endpoint" -> dynamoDBEndPoint,
+    "aws.dynamoDb.accessKey" -> accessKey,
+    "aws.dynamoDb.secretKey" -> secretKey
+    "aws.region" -> "localhost"
+  )
 
   private val credentials = new AWSStaticCredentialsProvider(
     new BasicAWSCredentials(accessKey, secretKey))

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
@@ -34,7 +34,8 @@ trait LocalDynamoDb[T <: Versioned with Id]
   private val secretKey = "secret"
 
   def dynamoDbLocalEndpointFlags(table: Table, namespace: String = "") = {
-    val prefix = if (namespace != "") { s"aws.${namespace}.dynamo" } else { "aws.dynamo" }
+    val prefix =
+      if (namespace != "") { s"aws.${namespace}.dynamo" } else { "aws.dynamo" }
 
     Map(
       "aws.region" -> "localhost",

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
@@ -25,6 +25,12 @@ trait LocalVersionedHybridStore
   override lazy val evidence: DynamoFormat[HybridRecord] =
     DynamoFormat[HybridRecord]
 
+  def vhsLocalFlags(bucket: Bucket, table: Table) =
+    Map(
+      "aws.vhs.s3.bucketName" -> bucket.name,
+      "aws.vhs.dynamo.tableName" -> table.name
+    ) ++ s3ClientLocalFlags ++ dynamoClientLocalFlags
+
   def withVersionedHybridStore[T <: Id, R](bucket: Bucket, table: Table)(
     testWith: TestWith[VersionedHybridStore[T], R]): R = {
     val s3Config = S3Config(bucketName = bucket.name)

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/Server.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/Server.scala
@@ -14,8 +14,9 @@ import uk.ac.wellcome.messaging.metrics.MetricsSenderModule
 import uk.ac.wellcome.messaging.sqs.{SQSClientModule, SQSConfigModule}
 import uk.ac.wellcome.platform.sierra_bib_merger.modules.SierraBibMergerModule
 import uk.ac.wellcome.sierra_adapter.modules.SierraKeyPrefixGeneratorModule
-import uk.ac.wellcome.storage.dynamo.{DynamoClientModule, DynamoConfigModule}
-import uk.ac.wellcome.storage.s3.{S3ClientModule, S3ConfigModule}
+import uk.ac.wellcome.storage.dynamo.DynamoClientModule
+import uk.ac.wellcome.storage.s3.S3ClientModule
+import uk.ac.wellcome.storage.vhs.VHSConfigModule
 
 object ServerMain extends Server
 
@@ -23,7 +24,7 @@ class Server extends HttpServer {
   override val name =
     "uk.ac.wellcome.platform.sierra_bib_merger SierraBibMerger"
   override val modules = Seq(
-    DynamoConfigModule,
+    VHSConfigModule,
     DynamoClientModule,
     SierraBibMergerModule,
     SierraKeyPrefixGeneratorModule,
@@ -31,7 +32,6 @@ class Server extends HttpServer {
     SQSConfigModule,
     SQSClientModule,
     S3ClientModule,
-    S3ConfigModule,
     AkkaModule
   )
 

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
@@ -21,11 +21,7 @@ class ServerTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
-            bucket,
-            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table,
-            namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(bucket, table)
           withServer(flags) { server =>
             server.httpGet(
               path = "/management/healthcheck",

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
@@ -21,8 +21,8 @@ class ServerTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            table)
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table, namespace = "vhs")
           withServer(flags) { server =>
             server.httpGet(
               path = "/management/healthcheck",

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
@@ -4,14 +4,13 @@ import com.gu.scanamo.DynamoFormat
 import com.twitter.finagle.http.Status._
 import org.scalatest.FunSpec
 import uk.ac.wellcome.messaging.test.fixtures.SQS
-import uk.ac.wellcome.storage.test.fixtures.{LocalDynamoDb, S3}
+import uk.ac.wellcome.storage.test.fixtures.LocalVersionedHybridStore
 import uk.ac.wellcome.storage.vhs.HybridRecord
 
 class ServerTest
     extends FunSpec
-    with LocalDynamoDb[HybridRecord]
+    with LocalVersionedHybridStore
     with fixtures.Server
-    with S3
     with SQS {
 
   override lazy val evidence: DynamoFormat[HybridRecord] =

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
@@ -21,8 +21,11 @@ class ServerTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table, namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
+            bucket,
+            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table,
+            namespace = "vhs")
           withServer(flags) { server =>
             server.httpGet(
               path = "/management/healthcheck",

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -68,8 +68,8 @@ class SierraBibMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            table)
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table, namespace = "vhs")
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>
@@ -106,8 +106,8 @@ class SierraBibMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            table)
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table, namespace = "vhs")
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>
@@ -164,8 +164,8 @@ class SierraBibMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            table)
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table, namespace = "vhs")
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>
@@ -221,8 +221,8 @@ class SierraBibMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            table)
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table, namespace = "vhs")
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>
@@ -279,8 +279,8 @@ class SierraBibMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            table)
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table, namespace = "vhs")
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -68,11 +68,7 @@ class SierraBibMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
-            bucket,
-            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table,
-            namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(bucket, table)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>
@@ -109,11 +105,7 @@ class SierraBibMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
-            bucket,
-            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table,
-            namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(bucket, table)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>
@@ -170,11 +162,7 @@ class SierraBibMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
-            bucket,
-            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table,
-            namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(bucket, table)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>
@@ -230,11 +218,7 @@ class SierraBibMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
-            bucket,
-            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table,
-            namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(bucket, table)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>
@@ -291,11 +275,7 @@ class SierraBibMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
-            bucket,
-            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table,
-            namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(bucket, table)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -68,8 +68,11 @@ class SierraBibMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table, namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
+            bucket,
+            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table,
+            namespace = "vhs")
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>
@@ -106,8 +109,11 @@ class SierraBibMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table, namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
+            bucket,
+            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table,
+            namespace = "vhs")
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>
@@ -164,8 +170,11 @@ class SierraBibMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table, namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
+            bucket,
+            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table,
+            namespace = "vhs")
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>
@@ -221,8 +230,11 @@ class SierraBibMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table, namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
+            bucket,
+            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table,
+            namespace = "vhs")
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>
@@ -279,8 +291,11 @@ class SierraBibMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table, namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
+            bucket,
+            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table,
+            namespace = "vhs")
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>

--- a/sierra_adapter/sierra_bib_merger/src/universal/conf/application.ini.template
+++ b/sierra_adapter/sierra_bib_merger/src/universal/conf/application.ini.template
@@ -1,4 +1,4 @@
 -aws.sqs.queue.url=${windows_queue_url}
 -aws.metrics.namespace=${metrics_namespace}
--aws.s3.bucketName=${bucket_name}
--aws.dynamo.tableName=${dynamo_table_name}
+-aws.vhs.s3.bucketName=${bucket_name}
+-aws.vhs.dynamo.tableName=${dynamo_table_name}

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/Server.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/Server.scala
@@ -27,7 +27,6 @@ class Server extends HttpServer {
     DynamoClientModule,
     VHSConfigModule,
     MetricsSenderModule,
-    VHSConfigModule,
     AWSConfigModule,
     SQSConfigModule,
     SQSClientModule,

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/Server.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/Server.scala
@@ -14,8 +14,9 @@ import uk.ac.wellcome.messaging.metrics.MetricsSenderModule
 import uk.ac.wellcome.messaging.sqs.{SQSClientModule, SQSConfigModule}
 import uk.ac.wellcome.platform.sierra_item_merger.modules.SierraItemMergerModule
 import uk.ac.wellcome.sierra_adapter.modules.SierraKeyPrefixGeneratorModule
-import uk.ac.wellcome.storage.dynamo.{DynamoClientModule, DynamoConfigModule}
-import uk.ac.wellcome.storage.s3.{S3ClientModule, S3ConfigModule}
+import uk.ac.wellcome.storage.dynamo.DynamoClientModule
+import uk.ac.wellcome.storage.s3.S3ClientModule
+import uk.ac.wellcome.storage.vhs.VHSConfigModule
 
 object ServerMain extends Server
 
@@ -24,12 +25,14 @@ class Server extends HttpServer {
     "uk.ac.wellcome.platform.sierra_item_merger SierraItemMerger"
   override val modules = Seq(
     DynamoClientModule,
-    DynamoConfigModule,
+    VHSConfigModule,
     MetricsSenderModule,
+    VHSConfigModule,
+    AmazonCloudWatchModule,
+    AWSConfigModule,
     SQSConfigModule,
     SQSClientModule,
     S3ClientModule,
-    S3ConfigModule,
     AkkaModule,
     SierraItemMergerModule,
     SierraKeyPrefixGeneratorModule

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/Server.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/Server.scala
@@ -28,7 +28,6 @@ class Server extends HttpServer {
     VHSConfigModule,
     MetricsSenderModule,
     VHSConfigModule,
-    AmazonCloudWatchModule,
     AWSConfigModule,
     SQSConfigModule,
     SQSClientModule,

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
@@ -21,11 +21,7 @@ class ServerTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
-            bucket,
-            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table,
-            namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(bucket, table)
           withServer(flags) { server =>
             server.httpGet(
               path = "/management/healthcheck",

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
@@ -21,8 +21,8 @@ class ServerTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            table)
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table, namespace = "vhs")
           withServer(flags) { server =>
             server.httpGet(
               path = "/management/healthcheck",

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
@@ -4,14 +4,13 @@ import com.gu.scanamo.DynamoFormat
 import com.twitter.finagle.http.Status._
 import org.scalatest.FunSpec
 import uk.ac.wellcome.messaging.test.fixtures.SQS
-import uk.ac.wellcome.storage.test.fixtures.{LocalDynamoDb, S3}
+import uk.ac.wellcome.storage.test.fixtures.LocalVersionedHybridStore
 import uk.ac.wellcome.storage.vhs.HybridRecord
 
 class ServerTest
     extends FunSpec
-    with LocalDynamoDb[HybridRecord]
+    with LocalVersionedHybridStore
     with fixtures.Server
-    with S3
     with SQS {
 
   override lazy val evidence: DynamoFormat[HybridRecord] =

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
@@ -21,8 +21,11 @@ class ServerTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table, namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
+            bucket,
+            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table,
+            namespace = "vhs")
           withServer(flags) { server =>
             server.httpGet(
               path = "/management/healthcheck",

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
@@ -27,11 +27,7 @@ class SierraItemMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
-            bucket,
-            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table,
-            namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(bucket, table)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>
@@ -68,11 +64,7 @@ class SierraItemMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
-            bucket,
-            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table,
-            namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(bucket, table)
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
@@ -27,8 +27,8 @@ class SierraItemMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            table)
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table, namespace = "vhs")
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>
@@ -65,8 +65,8 @@ class SierraItemMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket) ++ dynamoDbLocalEndpointFlags(
-            table)
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table, namespace = "vhs")
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
@@ -27,8 +27,11 @@ class SierraItemMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table, namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
+            bucket,
+            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table,
+            namespace = "vhs")
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>
@@ -65,8 +68,11 @@ class SierraItemMergerFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
-          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(bucket, namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
-            table, namespace = "vhs")
+          val flags = sqsLocalFlags(queue) ++ s3LocalFlags(
+            bucket,
+            namespace = "vhs") ++ dynamoDbLocalEndpointFlags(
+            table,
+            namespace = "vhs")
           withServer(flags) { _ =>
             withVersionedHybridStore[SierraTransformable, Unit](bucket, table) {
               hybridStore =>

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -575,9 +575,8 @@ class SierraItemMergerUpdaterServiceTest
               List(bibId)
             )
 
-            whenReady(brokenService.update(itemRecord).failed) {
-              ex =>
-                ex shouldBe a[RuntimeException]
+            whenReady(brokenService.update(itemRecord).failed) { ex =>
+              ex shouldBe a[RuntimeException]
             }
           }
       }

--- a/sierra_adapter/sierra_item_merger/src/universal/conf/application.ini.template
+++ b/sierra_adapter/sierra_item_merger/src/universal/conf/application.ini.template
@@ -1,4 +1,4 @@
 -aws.sqs.queue.url=${windows_queue_url}
 -aws.metrics.namespace=${metrics_namespace}
--aws.s3.bucketName=${bucket_name}
--aws.dynamo.tableName=${dynamo_table_name}
+-aws.vhs.s3.bucketName=${bucket_name}
+-aws.vhs.dynamo.tableName=${dynamo_table_name}


### PR DESCRIPTION
The spiritual successor to #1961 and #1963. Now you inject an instance of the VHS directly, rather than the individual pieces. I had to apply it to the sierra bib/item mergers, which are the only applications currently using VHS.

~This patch got more involved than I was intending, and I might break it apart further for easier review.~ (I did.)