### PR TITLE
Tidy up our AWS Client modules

### DIFF
--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageConfigModule.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageConfigModule.scala
@@ -18,25 +18,12 @@ object MessageConfigModule extends TwitterModule {
       "aws.message.s3.bucketName",
       "",
       "Name of the S3 bucket holding messaging pointers")
-  private val endpoint = flag[String](
-    "aws.message.s3.endpoint",
-    "",
-    "Endpoint of S3. The region will be used if the endpoint is not provided")
-  private val accessKey =
-    flag[String]("aws.message.s3.accessKey", "", "AccessKey to access S3")
-  private val secretKey =
-    flag[String]("aws.message.s3.secretKey", "", "SecretKey to access S3")
 
   @Singleton
   @Provides
   def providesMessageConfig(): MessageConfig = {
     val snsConfig = SNSConfig(topicArn = topicArn())
-    val s3Config = S3Config(
-      bucketName = bucketName(),
-      endpoint = endpoint(),
-      accessKey = accessKey(),
-      secretKey = secretKey()
-    )
+    val s3Config = S3Config(bucketName = bucketName())
     MessageConfig(snsConfig = snsConfig, s3Config = s3Config)
   }
 }

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoClientModule.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoClientModule.scala
@@ -25,25 +25,17 @@ object DynamoClientModule extends TwitterModule {
   @Singleton
   @Provides
   def providesDynamoClient(awsConfig: AWSConfig): AmazonDynamoDB = {
-    val standardDynamoDBClientBuilder = AmazonDynamoDBClientBuilder.standard
-    createAwsClient(awsConfig, standardDynamoDBClientBuilder)
-  }
-
-  private def createAwsClient[T <: AwsClientBuilder[_, _], J](
-    awsConfig: AWSConfig,
-    awsClientBuilder: AwsClientBuilder[T, J]): J = {
-    if (dynamoDbEndpoint().isEmpty) {
-      awsClientBuilder
-        .setRegion(awsConfig.region)
-      awsClientBuilder.build()
-    } else {
-      awsClientBuilder
-        .setEndpointConfiguration(
-          new EndpointConfiguration(dynamoDbEndpoint(), awsConfig.region))
-      awsClientBuilder.withCredentials(
-        new AWSStaticCredentialsProvider(
+    val standardClient = AmazonDynamoDBClientBuilder.standard
+    if (dynamoDbEndpoint().isEmpty)
+      standardClient
+        .withRegion(awsConfig.region)
+        .build()
+    else
+      standardClient
+        .withCredentials(new AWSStaticCredentialsProvider(
           new BasicAWSCredentials(accessKey(), secretKey())))
-      awsClientBuilder.build()
-    }
+        .withEndpointConfiguration(
+          new EndpointConfiguration(dynamoDbEndpoint(), awsConfig.region))
+        .build()
   }
 }

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoClientModule.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoClientModule.scala
@@ -32,8 +32,9 @@ object DynamoClientModule extends TwitterModule {
         .build()
     else
       standardClient
-        .withCredentials(new AWSStaticCredentialsProvider(
-          new BasicAWSCredentials(accessKey(), secretKey())))
+        .withCredentials(
+          new AWSStaticCredentialsProvider(
+            new BasicAWSCredentials(accessKey(), secretKey())))
         .withEndpointConfiguration(
           new EndpointConfiguration(dynamoDbEndpoint(), awsConfig.region))
         .build()

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3ClientModule.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3ClientModule.scala
@@ -11,21 +11,30 @@ import uk.ac.wellcome.models.aws.AWSConfig
 
 object S3ClientModule extends TwitterModule {
 
+  private val endpoint = flag[String](
+    "aws.s3.endpoint",
+    "",
+    "Endpoint of AWS S3. The region will be used if the endpoint is not provided")
+  private val accessKey =
+    flag[String]("aws.s3.accessKey", "", "AccessKey to access S3")
+  private val secretKey =
+    flag[String]("aws.s3.secretKey", "", "SecretKey to access S3")
+
   @Singleton
   @Provides
-  def providesS3Client(awsConfig: AWSConfig, s3Config: S3Config): AmazonS3 = {
+  def providesS3Client(awsConfig: AWSConfig): AmazonS3 = {
     val standardClient = AmazonS3ClientBuilder.standard
-    if (s3Config.endpoint.isEmpty)
+    if (endpoint().isEmpty)
       standardClient
         .withRegion(awsConfig.region)
         .build()
     else
       standardClient
         .withCredentials(new AWSStaticCredentialsProvider(
-          new BasicAWSCredentials(s3Config.accessKey, s3Config.secretKey)))
+          new BasicAWSCredentials(accessKey(), secretKey())))
         .withPathStyleAccessEnabled(true)
         .withEndpointConfiguration(
-          new EndpointConfiguration(s3Config.endpoint, awsConfig.region))
+          new EndpointConfiguration(endpoint(), awsConfig.region))
         .build()
   }
 

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3Config.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3Config.scala
@@ -1,8 +1,3 @@
 package uk.ac.wellcome.storage.s3
 
-case class S3Config(
-  bucketName: String,
-  endpoint: String = "",
-  accessKey: String = "",
-  secretKey: String = ""
-)
+case class S3Config(bucketName: String)

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3ConfigModule.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3ConfigModule.scala
@@ -9,21 +9,8 @@ object S3ConfigModule extends TwitterModule {
 
   private val bucketName =
     flag[String]("aws.s3.bucketName", "", "Name of the S3 bucket")
-  private val endpoint = flag[String](
-    "aws.s3.endpoint",
-    "",
-    "Endpoint of AWS S3. The region will be used if the endpoint is not provided")
-  private val accessKey =
-    flag[String]("aws.s3.accessKey", "", "AccessKey to access S3")
-  private val secretKey =
-    flag[String]("aws.s3.secretKey", "", "SecretKey to access S3")
 
   @Singleton
   @Provides
-  def providesS3Config(): S3Config = S3Config(
-    bucketName = bucketName(),
-    endpoint = endpoint(),
-    accessKey = accessKey(),
-    secretKey = secretKey()
-  )
+  def providesS3Config(): S3Config = S3Config(bucketName = bucketName())
 }


### PR DESCRIPTION
Spun out as a separate patch from #1967.

In particular, getting the endpoint configuration out of S3Config allows us to have multiple instances of S3Config (for multiple buckets), but we can still use the existing S3Client module for injecting clients.