### PR TITLE
Chuck a few dependencies out of sbt-common

### DIFF
--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableTest.scala
@@ -1,26 +1,21 @@
 package uk.ac.wellcome.platform.idminter.utils
 
 import org.scalatest.{FunSpec, Matchers}
-import org.scalatest.prop.PropertyChecks
 
-class IdentifiableTest extends FunSpec with PropertyChecks with Matchers {
+class IdentifiableTest extends FunSpec with Matchers {
 
-  it(
-    "should generate a string with 8 characters, none of which are ambiguous characters") {
-    forAll(minSuccessful(100)) { (a: Int) =>
-      {
-        val id = Identifiable.generate
-        id should have size (8)
-        id.toCharArray should contain noneOf ('0', 'o', 'i', 'l', '1')
-        id should fullyMatch regex "[0-9|a-z&&[^oil10]]{8}"
-      }
+  it("generates an 8-char string, with no ambiguous characters") {
+    (1 to 100).map { _ =>
+      val id = Identifiable.generate
+      id should have size (8)
+      id.toCharArray should contain noneOf ('0', 'o', 'i', 'l', '1')
+      id should fullyMatch regex "[0-9|a-z&&[^oil10]]{8}"
     }
   }
 
   it("should never generate an identifier that starts with a number") {
-    forAll(minSuccessful(100)) { (_: Int) =>
+    (1 to 100).map { _ =>
       Identifiable.generate should not(startWith regex "[0-9]")
     }
   }
-
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -73,6 +73,11 @@ object Dependencies {
     "org.scalatest" %% "scalatest" % versions.scalatest % "test"
   )
 
+  val scalacheckDependencies = Seq(
+    "org.scalacheck" %% "scalacheck" % versions.scalaCheckVersion % "test",
+    "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % versions.scalaCheckShapelessVersion % "test"
+  )
+
   val commonDependencies: Seq[ModuleID] = Seq(
     "com.twitter" %% "finatra-http" % versions.finatra,
     "com.twitter" %% "finatra-httpclient" % versions.finatra,
@@ -92,16 +97,14 @@ object Dependencies {
     "com.twitter" %% "inject-modules" % versions.finatra % "test" classifier "tests",
     "org.mockito" % "mockito-core" % versions.mockito % "test",
     "com.novocode" % "junit-interface" % versions.junitInterface % "test",
-    "org.scalacheck" %% "scalacheck" % versions.scalaCheckVersion % "test",
-    "javax.xml.bind" % "jaxb-api" % versions.jaxbVersion,
-    "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % versions.scalaCheckShapelessVersion % "test"
+    "javax.xml.bind" % "jaxb-api" % versions.jaxbVersion
   ) ++ akkaDependencies ++ circeDependencies
 
   val pipelineModelDependencies = circeDependencies
 
   val commonDisplayDependencies: Seq[ModuleID] = swaggerDependencies
 
-  val commonElasticsearchDependencies = commonDependencies ++ esDependencies
+  val commonElasticsearchDependencies = commonDependencies ++ esDependencies ++ scalacheckDependencies
 
   // We use Circe for all our JSON serialisation, but our local SNS container
   // returns YAML, and currently we use Jackson to parse that YAML.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -95,7 +95,7 @@ object Dependencies {
     "org.scalacheck" %% "scalacheck" % versions.scalaCheckVersion % "test",
     "javax.xml.bind" % "jaxb-api" % versions.jaxbVersion,
     "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % versions.scalaCheckShapelessVersion % "test"
-  ) ++ akkaDependencies ++ dynamoDependencies ++ circeDependencies
+  ) ++ akkaDependencies ++ circeDependencies
 
   val pipelineModelDependencies = circeDependencies
 
@@ -108,7 +108,7 @@ object Dependencies {
   // TODO: Rewrite the SNS fixture to use https://github.com/circe/circe-yaml
   val commonMessagingDependencies = commonDependencies ++ awsDependencies ++ jacksonDependencies
 
-  val commonStorageDependencies = commonDependencies ++ awsDependencies
+  val commonStorageDependencies = commonDependencies ++ awsDependencies ++ dynamoDependencies
 
   val sierraAdapterCommonDependencies: Seq[ModuleID] = Seq()
 


### PR DESCRIPTION
As we've rearranged the sbt-common lib, we have a couple of packages it no longer depends them. Let's get rid of them and tidy up our classpaths!