### PR TITLE
Simplify ImplicitLogging

### DIFF
--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/Akka.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/Akka.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import org.scalatest.concurrent.Eventually
 
-trait Akka extends Eventually with ImplicitLogging {
+trait Akka extends Eventually {
 
   def withActorSystem[R] = fixture[ActorSystem, R](
     create = ActorSystem(),

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/ImplicitLogging.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/ImplicitLogging.scala
@@ -1,9 +1,0 @@
-package uk.ac.wellcome.test.fixtures
-
-import com.twitter.inject.Logging
-
-trait ImplicitLogging extends Logging {
-
-  implicit val implicitLogger = logger
-
-}

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/package.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/package.scala
@@ -5,7 +5,6 @@ import grizzled.slf4j.Logger
 
 import scala.util.Try
 
-
 package object fixtures extends Logging {
 
   type TestWith[T, R] = T => R
@@ -16,9 +15,11 @@ package object fixtures extends Logging {
       logger.debug(s"cleaning up resource=[$resource]")
       f(resource)
     } recover {
-      case e => logger.warn(
-        s"error cleaning up resource=[$resource]", e
-      )
+      case e =>
+        logger.warn(
+          s"error cleaning up resource=[$resource]",
+          e
+        )
     }
   }
 

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/package.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/package.scala
@@ -5,6 +5,7 @@ import grizzled.slf4j.Logger
 
 import scala.util.Try
 
+
 package object fixtures extends Logging {
 
   implicit val implicitLogger = logger
@@ -17,7 +18,9 @@ package object fixtures extends Logging {
       logger.debug(s"cleaning up resource=[$resource]")
       f(resource)
     } recover {
-      case e => logger.warn(s"error cleaning up resource=[$resource]", e)
+      case e => logger.warn(
+        s"error cleaning up resource=[$resource]", e
+      )
     }
   }
 

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/package.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/package.scala
@@ -8,8 +8,6 @@ import scala.util.Try
 
 package object fixtures extends Logging {
 
-  implicit val implicitLogger = logger
-
   type TestWith[T, R] = T => R
   type Fixture[L, R] = TestWith[L, R] => R
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/CloudWatch.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/CloudWatch.scala
@@ -6,11 +6,10 @@ import com.amazonaws.services.cloudwatch.{
   AmazonCloudWatch,
   AmazonCloudWatchClientBuilder
 }
-import uk.ac.wellcome.test.fixtures.ImplicitLogging
 
 import scala.concurrent.duration._
 
-trait CloudWatch extends ImplicitLogging {
+trait CloudWatch {
   protected val awsNamespace: String = "test"
 
   protected val localCloudWatchEndpointUrl: String = "http://localhost:4582"

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -30,12 +30,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Success
 
-trait Messaging
-    extends Akka
-    with MetricsSender
-    with SQS
-    with SNS
-    with S3 {
+trait Messaging extends Akka with MetricsSender with SQS with SNS with S3 {
 
   def withLocalStackSubscription[R](queue: Queue, topic: Topic) =
     fixture[SubscribeResult, R](

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -2,24 +2,17 @@ package uk.ac.wellcome.messaging.test.fixtures
 
 import akka.actor.ActorSystem
 import com.amazonaws.services.sns.AmazonSNS
-import com.amazonaws.services.sns.model.{
-  SubscribeRequest,
-  SubscribeResult,
-  UnsubscribeRequest
-}
+import com.amazonaws.services.sns.model.{SubscribeRequest, SubscribeResult, UnsubscribeRequest}
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
+import org.scalatest.Matchers
 import uk.ac.wellcome.messaging.message._
 import uk.ac.wellcome.messaging.metrics
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSReader}
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
-import uk.ac.wellcome.storage.s3.{
-  KeyPrefixGenerator,
-  S3Config,
-  S3ObjectLocation
-}
+import uk.ac.wellcome.storage.s3.{KeyPrefixGenerator, S3Config, S3ObjectLocation}
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures._
@@ -30,7 +23,13 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Success
 
-trait Messaging extends Akka with MetricsSender with SQS with SNS with S3 {
+trait Messaging
+  extends Akka
+    with MetricsSender
+    with SQS
+    with SNS
+    with S3
+    with Matchers {
 
   def withLocalStackSubscription[R](queue: Queue, topic: Topic) =
     fixture[SubscribeResult, R](

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -35,8 +35,7 @@ trait Messaging
     with MetricsSender
     with SQS
     with SNS
-    with S3
-    with ImplicitLogging {
+    with S3 {
 
   def withLocalStackSubscription[R](queue: Queue, topic: Topic) =
     fixture[SubscribeResult, R](

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -2,7 +2,11 @@ package uk.ac.wellcome.messaging.test.fixtures
 
 import akka.actor.ActorSystem
 import com.amazonaws.services.sns.AmazonSNS
-import com.amazonaws.services.sns.model.{SubscribeRequest, SubscribeResult, UnsubscribeRequest}
+import com.amazonaws.services.sns.model.{
+  SubscribeRequest,
+  SubscribeResult,
+  UnsubscribeRequest
+}
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
 import org.scalatest.Matchers
@@ -12,7 +16,11 @@ import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSReader}
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
-import uk.ac.wellcome.storage.s3.{KeyPrefixGenerator, S3Config, S3ObjectLocation}
+import uk.ac.wellcome.storage.s3.{
+  KeyPrefixGenerator,
+  S3Config,
+  S3ObjectLocation
+}
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures._
@@ -24,7 +32,7 @@ import scala.concurrent.duration._
 import scala.util.Success
 
 trait Messaging
-  extends Akka
+    extends Akka
     with MetricsSender
     with SQS
     with SNS

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/MetricsSender.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/MetricsSender.scala
@@ -13,7 +13,6 @@ import scala.concurrent.Future
 
 trait MetricsSender
     extends Logging
-    with ImplicitLogging
     with MockitoSugar
     with CloudWatch
     with Akka {

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
@@ -26,7 +26,7 @@ object SNS {
 
 }
 
-trait SNS extends ImplicitLogging {
+trait SNS {
 
   import SNS._
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -20,7 +20,7 @@ object SQS {
 
 }
 
-trait SQS extends ImplicitLogging {
+trait SQS {
 
   import SQS._
 

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
@@ -22,8 +22,7 @@ object LocalDynamoDb {
 }
 
 trait LocalDynamoDb[T <: Versioned with Id]
-    extends ImplicitLogging
-    with Eventually {
+    extends Eventually {
 
   import LocalDynamoDb._
 

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
@@ -21,8 +21,7 @@ object LocalDynamoDb {
   case class Table(name: String, index: String)
 }
 
-trait LocalDynamoDb[T <: Versioned with Id]
-    extends Eventually {
+trait LocalDynamoDb[T <: Versioned with Id] extends Eventually {
 
   import LocalDynamoDb._
 

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
@@ -19,8 +19,7 @@ trait LocalVersionedHybridStore
     extends LocalDynamoDb[HybridRecord]
     with S3
     with JsonTestUtil
-    with Matchers
-    with ImplicitLogging {
+    with Matchers {
 
   override lazy val evidence: DynamoFormat[HybridRecord] =
     DynamoFormat[HybridRecord]

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/S3.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/S3.scala
@@ -26,7 +26,7 @@ object S3 {
 
 }
 
-trait S3 extends Logging with Eventually with Matchers with ImplicitLogging {
+trait S3 extends Logging with Eventually {
 
   import S3._
 


### PR DESCRIPTION
### What is this PR trying to achieve?

The `ImplicitLogging` trait appeared in a few places without it being clear what it was for. This change moves all references to the fixtures package object where it is used in the first case.

### Who is this change for?

🎲 💯 
