### PR TITLE
Only run travis tests for library changes if an app depends on that library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,6 @@ lazy val common_display = doSharedLibrarySetup(project, "sbt_common/display")
   .settings(libraryDependencies ++= Dependencies.commonDisplayDependencies)
 
 lazy val common_elasticsearch = doSharedLibrarySetup(project, "sbt_common/elasticsearch")
-
   .dependsOn(internal_model % "compile->compile;test->test")
   .settings(libraryDependencies ++= Dependencies.commonElasticsearchDependencies)
 

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -95,7 +95,14 @@ def does_file_affect_build_task(path, task):
             break
 
     else:  # pragma: no cover
-        raise RuntimeError("Unrecognised task: %s" % task)
+        if task == 'travis-format':
+            project = Project(
+                name='travis-format',
+                type='python_lib',
+                exclusive_path=None
+            )
+        else:
+            raise RuntimeError("Unrecognised task: %s" % task)
 
     # Changes to the sbt_common libraries should only be tested if the
     # application in question uses this library.

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -13,6 +13,8 @@ import collections
 import os
 
 from travistooling.decisions import (
+    AppDoesNotUseThisScalaCommonLib,
+    AppUsesThisScalaCommonLib,
     ChangesToTestsDontGetPublished,
     CheckedByTravisFormat,
     ExclusivelyAffectsAnotherTask,
@@ -27,6 +29,7 @@ from travistooling.decisions import (
 )
 from travistooling.git_utils import ROOT
 from travistooling.parse_makefiles import get_projects
+from travistooling.sbt_dependency_checker import does_path_depend_on_library
 
 
 # Cache the Makefile information in a global variable, so we only have to
@@ -60,7 +63,9 @@ def does_file_affect_build_task(path, task):
     # for the api Scala app, so changes in this directory cannot affect
     # any other task.
     exclusive_directories = {
-        os.path.relpath(t.exclusive_path, start=ROOT): t.name for t in PROJECTS
+        os.path.relpath(p.exclusive_path, start=ROOT): p.name
+        for p in PROJECTS
+        if p.exclusive_path is not None
     }
 
     for dir_name, task_prefix in exclusive_directories.items():
@@ -82,6 +87,38 @@ def does_file_affect_build_task(path, task):
     ):
         raise ChangesToTestsDontGetPublished()
 
+    # Now we need to start looking at projects on an individual basis.
+    project = None
+    for p in PROJECTS:
+        if task.startswith(p.name):
+            project = p
+            break
+
+    else:  # pragma: no cover
+        raise RuntimeError("Unrecognised task: %s" % task)
+
+    # Changes to the sbt_common libraries should only be tested if the
+    # application in question uses this library.
+    if path.startswith('sbt_common/') and project.type == 'sbt_app':
+
+        # This directory has libraries of the form
+        #
+        #   sbt_common/display/...
+        #   sbt_common/elasticsearch/...
+        #
+        library_name = path.split('/')[1]
+
+        # This tells us where the exclusive code for this app exists.
+        project_dir = os.path.relpath(project.exclusive_path, start=ROOT)
+
+        if does_path_depend_on_library(
+            path=project_dir,
+            library_name=library_name
+        ):
+            raise AppUsesThisScalaCommonLib(library_name)
+        else:
+            raise AppDoesNotUseThisScalaCommonLib(library_name)
+
     # We have a couple of sbt common libs and files scattered around the
     # repository; changes to any of these don't affect non-sbt applications.
     if path.startswith((
@@ -89,14 +126,12 @@ def does_file_affect_build_task(path, task):
         'common/',
         'project/',
         'build.sbt',
-        'sbt_common/'
+        'sbt_common/',
     )):
-        for project in PROJECTS:
-            if task.startswith(project.name):
-                if project.type == 'sbt_app':
-                    raise ScalaChangeAndIsScalaApp()
-                else:
-                    raise ScalaChangeAndNotScalaApp()
+        if project.type == 'sbt_app':
+            raise ScalaChangeAndIsScalaApp()
+        else:
+            raise ScalaChangeAndNotScalaApp()
 
     # Changes made in the travistooling directory only ever affect the
     # travistooling tests (but they're not defined in a Makefile).

--- a/travistooling/decisions.py
+++ b/travistooling/decisions.py
@@ -38,13 +38,19 @@ class ExclusivelyAffectsThisTask(SignificantFile):
     message = 'Path is an exclusive dependency of this build task'
 
 
+class AppUsesThisScalaCommonLib(SignificantFile):
+    def __init__(self, library_name):
+        self.message = 'This app depends on the %s library' % library_name
+        super().__init__()
+
+
 class ExclusivelyAffectsAnotherTask(InsignificantFile):
     def __init__(self, other_task):
         self.message = (
             'Path is an exclusive dependency of a different build task (%s)' %
             (other_task,)
         )
-        super(ExclusivelyAffectsAnotherTask, self).__init__()
+        super().__init__()
 
 
 class CheckedByTravisFormat(SignificantFile):
@@ -61,3 +67,10 @@ class ScalaChangeAndNotScalaApp(InsignificantFile):
 
 class ChangesToTestsDontGetPublished(InsignificantFile):
     message = "Changes to test files don't need to be published"
+
+
+class AppDoesNotUseThisScalaCommonLib(InsignificantFile):
+    def __init__(self, library_name):
+        self.message = 'This app does not use the %s library' % library_name
+        super().__init__()
+

--- a/travistooling/parse_makefiles.py
+++ b/travistooling/parse_makefiles.py
@@ -19,6 +19,12 @@ def get_projects(repo):
                 for proj in _get_projects_from_makefile(root=root, path=path):
                     yield proj
 
+    yield Project(
+        name='travistooling',
+        type='python_lib',
+        exclusive_path=None
+    )
+
 
 def _get_projects_from_makefile(root, path):
     contents = open(path).read()

--- a/travistooling/sbt_dependency_checker.py
+++ b/travistooling/sbt_dependency_checker.py
@@ -1,0 +1,33 @@
+# -*- encoding: utf-8
+
+import functools
+import os
+import subprocess
+
+
+@functools.lru_cache()
+def does_path_depend_on_library(path, library_name):
+    """Given a path to an sbt app and the name of one of our common libraries,
+    does this app depend on that library?
+
+    It uses a somewhat crude heuristic (grep) rather than looking at the build
+    configuration.  Parsing build.sbt is icky, and trying to get sbt to give
+    up a dependency tree in a sensible format is slow and also icky.
+
+    >>> does_path_depend_on_library('catalogue_api/api', 'messaging')
+    False
+
+    >>> does_path_depend_on_library('catalogue_api/api', 'elasticsearch')
+    True
+
+    """
+    try:
+        subprocess.check_call([
+            'grep', '--recursive',
+            'import uk.ac.wellcome.%s' % library_name,
+            os.path.join(path, 'src', 'main', 'scala')
+        ], stdout=subprocess.DEVNULL)
+    except subprocess.CalledProcessError:
+        return False
+    else:
+        return True

--- a/travistooling/sbt_dependency_checker.py
+++ b/travistooling/sbt_dependency_checker.py
@@ -14,6 +14,12 @@ def does_path_depend_on_library(path, library_name):
     configuration.  Parsing build.sbt is icky, and trying to get sbt to give
     up a dependency tree in a sensible format is slow and also icky.
 
+    It's not perfect -- in particular, it can't spot transitive dependencies.
+    For example, if app A depends on lib B, and lib B depends on lib C, then
+    changes to lib C won't be detected as significant here.
+
+    TODO: Make this better!
+
     >>> does_path_depend_on_library('catalogue_api/api', 'messaging')
     False
 
@@ -23,8 +29,7 @@ def does_path_depend_on_library(path, library_name):
     """
     try:
         subprocess.check_call([
-            'grep', '--recursive',
-            'import uk.ac.wellcome.%s' % library_name,
+            'grep', '-r', 'import uk.ac.wellcome.%s' % library_name,
             os.path.join(path, 'src', 'main', 'scala')
         ], stdout=subprocess.DEVNULL)
     except subprocess.CalledProcessError:

--- a/travistooling/tests/test_decisionmaker.py
+++ b/travistooling/tests/test_decisionmaker.py
@@ -7,6 +7,8 @@ from travistooling.decisionmaker import (
     should_run_build_task
 )
 from travistooling.decisions import (
+    AppDoesNotUseThisScalaCommonLib,
+    AppUsesThisScalaCommonLib,
     ChangesToTestsDontGetPublished,
     CheckedByTravisFormat,
     ExclusivelyAffectsAnotherTask,
@@ -63,14 +65,17 @@ from travistooling.decisions import (
     ('sierra_adapter/common/main.scala', 'loris-test', ScalaChangeAndNotScalaApp, False),
     ('sierra_adapter/common/main.scala', 's3_demultiplexer-test', ScalaChangeAndNotScalaApp, False),
     ('sierra_adapter/common/main.scala', 'sierra_window_generator-test', ScalaChangeAndNotScalaApp, False),
-    ('sbt_common/display/model.scala', 'id_minter-test', ScalaChangeAndIsScalaApp, True),
-    ('sbt_common/display/model.scala', 'loris-publish', ScalaChangeAndNotScalaApp, False),
-    ('sbt_common/display/model.scala', 'sierra_adapter-publish', UnrecognisedFile, True),
+
+    # Changes to the sbt_common libraries are based on whether a particular
+    # app uses that file.
+    ('sbt_common/display/model.scala', 'id_minter-test', AppDoesNotUseThisScalaCommonLib, False),
+    ('sbt_common/display/model.scala', 'api-test', AppUsesThisScalaCommonLib, True),
+    ('sbt_common/messaging/message.scala', 'api-test', AppDoesNotUseThisScalaCommonLib, False),
 
     # Changes to Scala test files trigger a -test Scala task, but not
     # a -publish task.
-    ('sbt_common/src/test/scala/uk/ac/wellcome/MyTest.scala', 'sierra_adapter-publish', ChangesToTestsDontGetPublished, False),
-    ('sbt_common/src/test/scala/uk/ac/wellcome/MyTest.scala', 'sierra_adapter-test', UnrecognisedFile, True),
+    ('common/src/test/scala/uk/ac/wellcome/MyTest.scala', 'sierra_reader-publish', ChangesToTestsDontGetPublished, False),
+    ('common/src/test/scala/uk/ac/wellcome/MyTest.scala', 'sierra_reader-test', ScalaChangeAndIsScalaApp, True),
 
     # Changes to Python test files never trigger a -publish task.
     ('lambda_conftest.py', 'loris-publish', ChangesToTestsDontGetPublished, False),

--- a/travistooling/tests/test_sbt_dependency_checker.py
+++ b/travistooling/tests/test_sbt_dependency_checker.py
@@ -1,0 +1,16 @@
+# -*- encoding: utf-8
+
+import pytest
+
+from travistooling.sbt_dependency_checker import does_path_depend_on_library
+
+
+@pytest.mark.parametrize('path, library_name, expected_result', [
+    ('catalogue_api/api', 'messaging', False),
+    ('catalogue_api/api', 'elasticsearch', True),
+])
+def test_does_path_depend_on_library(path, library_name, expected_result):
+    actual_result = does_path_depend_on_library(
+        path=path, library_name=library_name
+    )
+    assert actual_result == expected_result


### PR DESCRIPTION
### What is this PR trying to achieve?

Resolves #1976.

If a build contains changes to library X, then a Scala app will be tested _if and only if_ it has a _direct_ dependency on X. The aim is to speed up builds that edit library code by only re-testing affected applications.

This is an incredibly crude heuristic – grepping for import statements in the application code. I looked at getting a dependency tree from sbt, but doing so is (1) slow and (2) I couldn't find a way to get the dependency-tree in a machine-readable format.

We still have the overnight cron jobs to catch any mistakes that slip through.

### Who is this change for?

🎩 