### PR TITLE
Remove SQSReader from worker

### DIFF
--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/Server.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/Server.scala
@@ -32,7 +32,6 @@ class Server extends HttpServer {
     IdMinterWorkerModule,
     AWSConfigModule,
     SQSClientModule,
-    SQSConfigModule,
     SQSReaderModule,
     SNSClientModule,
     S3ClientModule,

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/services/IdMinterWorkerService.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/services/IdMinterWorkerService.scala
@@ -18,11 +18,11 @@ import scala.concurrent.duration._
 import scala.util.Try
 
 class IdMinterWorkerService @Inject()(
-                                       idEmbedder: IdEmbedder,
-                                       writer: MessageWriter[Json],
-                                       messageReader: MessageReader[Json],
-                                       system: ActorSystem,
-                                       metrics: MetricsSender
+  idEmbedder: IdEmbedder,
+  writer: MessageWriter[Json],
+  messageReader: MessageReader[Json],
+  system: ActorSystem,
+  metrics: MetricsSender
 ) extends MessageWorker[Json](messageReader, system, metrics) {
 
   override lazy val poll = 100 milliseconds

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/services/IdMinterWorkerService.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/services/IdMinterWorkerService.scala
@@ -18,13 +18,12 @@ import scala.concurrent.duration._
 import scala.util.Try
 
 class IdMinterWorkerService @Inject()(
-  idEmbedder: IdEmbedder,
-  writer: MessageWriter[Json],
-  sqsReader: SQSReader,
-  messageReader: MessageReader[Json],
-  system: ActorSystem,
-  metrics: MetricsSender
-) extends MessageWorker[Json](sqsReader, messageReader, system, metrics) {
+                                       idEmbedder: IdEmbedder,
+                                       writer: MessageWriter[Json],
+                                       messageReader: MessageReader[Json],
+                                       system: ActorSystem,
+                                       metrics: MetricsSender
+) extends MessageWorker[Json](messageReader, system, metrics) {
 
   override lazy val poll = 100 milliseconds
   val snsSubject = "identified-item"

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -42,7 +42,7 @@ class IdMinterFeatureTest
         withLocalS3Bucket { bucket =>
           withIdentifiersDatabase { dbConfig =>
             val flags =
-                dbConfig.flags ++
+              dbConfig.flags ++
                 messagingLocalFlags(bucket, topic, queue)
 
             withServer(flags) { _ =>

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -42,9 +42,8 @@ class IdMinterFeatureTest
         withLocalS3Bucket { bucket =>
           withIdentifiersDatabase { dbConfig =>
             val flags =
-              sqsLocalFlags(queue) ++
                 dbConfig.flags ++
-                messagingLocalFlags(bucket, topic)
+                messagingLocalFlags(bucket, topic, queue)
 
             withServer(flags) { _ =>
               eventuallyTableExists(dbConfig)
@@ -102,9 +101,8 @@ class IdMinterFeatureTest
         withIdentifiersDatabase { dbConfig =>
           withLocalS3Bucket { bucket =>
             val flags =
-              sqsLocalFlags(queue) ++
-                dbConfig.flags ++
-                messagingLocalFlags(bucket, topic)
+              dbConfig.flags ++
+                messagingLocalFlags(bucket, topic, queue)
 
             withServer(flags) { _ =>
               sqsClient.sendMessage(queue.url, "not a json string")

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/ServerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/ServerTest.scala
@@ -18,9 +18,7 @@ class ServerTest
       withLocalSnsTopic { topic =>
         withLocalS3Bucket { bucket =>
           withIdentifiersDatabase { dbConfig =>
-            val flags = sqsLocalFlags(queue) ++ messagingLocalFlags(
-              bucket,
-              topic) ++
+            val flags = messagingLocalFlags(bucket, topic, queue) ++
               dbConfig.flags
 
             withServer(flags) { server =>

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
@@ -33,7 +33,7 @@ class IdMinterWorkerTest
         withIdentifiersDatabase { dbConfig =>
           withLocalS3Bucket { bucket =>
             val flags =
-              sqsLocalFlags(queue) ++ messagingLocalFlags(bucket, topic) ++ dbConfig.flags
+              sqsLocalFlags(queue) ++ messagingLocalFlags(bucket, topic, queue) ++ dbConfig.flags
 
             val identifiersDao = mock[IdentifiersDao]
 

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -24,10 +24,6 @@ class IdEmbedderTests
     with MockitoSugar
     with JsonTestUtil
     with ExtendedPatience {
-  override implicit val patienceConfig: PatienceConfig = PatienceConfig(
-    timeout = scaled(Span(3, Seconds)),
-    interval = scaled(Span(50, Millis))
-  )
 
   private val metricsSender =
     new MetricsSender(

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -10,7 +10,7 @@ import org.scalatest.time._
 import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.test.utils.JsonTestUtil
+import uk.ac.wellcome.test.utils.{ExtendedPatience, JsonTestUtil}
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.duration._
@@ -23,7 +23,7 @@ class IdEmbedderTests
     with BeforeAndAfterEach
     with MockitoSugar
     with JsonTestUtil
-    with PatienceConfiguration {
+    with ExtendedPatience {
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(
     timeout = scaled(Span(3, Seconds)),
     interval = scaled(Span(50, Millis))

--- a/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
@@ -4,8 +4,8 @@
 -aws.rds.password=${db_password}
 -aws.rds.port=${db_port}
 -aws.rds.userName=${db_username}
--aws.sqs.queue.url=${queue_url}
--aws.sqs.maxMessages=${sqs_max_messages}
 -aws.metrics.namespace=id-minter
 -aws.message.s3.bucketName=${message_bucket_name}
 -aws.message.sns.topic.arn=${topic_arn}
+-aws.message.sqs.queue.url=${queue_url}
+-aws.message.sqs.maxMessages=${sqs_max_messages}

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/Server.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/Server.scala
@@ -28,7 +28,6 @@ class Server extends HttpServer {
   override val modules = Seq(
     AWSConfigModule,
     MetricsSenderModule,
-    SQSConfigModule,
     SQSClientModule,
     MessageConfigModule,
     S3ConfigModule,

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -23,10 +23,7 @@ class IngestorWorkerService @Inject()(
   messageReader: MessageReader[IdentifiedWork],
   system: ActorSystem,
   metrics: MetricsSender)
-    extends MessageWorker[IdentifiedWork](
-      messageReader,
-      system,
-      metrics) {
+    extends MessageWorker[IdentifiedWork](messageReader, system, metrics) {
 
   override def processMessage(work: IdentifiedWork): Future[Unit] = {
     val futureIndices: Future[List[String]] =

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -20,12 +20,10 @@ class IngestorWorkerService @Inject()(
   @Flag("es.index.v1") esIndexV1: String,
   @Flag("es.index.v2") esIndexV2: String,
   identifiedWorkIndexer: WorkIndexer,
-  sqsReader: SQSReader,
   messageReader: MessageReader[IdentifiedWork],
   system: ActorSystem,
   metrics: MetricsSender)
     extends MessageWorker[IdentifiedWork](
-      sqsReader,
       messageReader,
       system,
       metrics) {

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -47,10 +47,10 @@ class IngestorFeatureTest
         sendToSqs(work, queue, bucket)
         withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
           withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
-            val flags = sqsLocalFlags(queue) ++ esLocalFlags(
+            val flags = messageReaderLocalFlags(bucket, queue) ++ esLocalFlags(
               indexNameV1,
               indexNameV2,
-              itemType) ++ s3LocalFlags(bucket)
+              itemType)
             withServer(flags) { _ =>
               assertElasticsearchEventuallyHasWork(work, indexNameV1, itemType)
               assertElasticsearchEventuallyHasWork(work, indexNameV2, itemType)
@@ -78,10 +78,10 @@ class IngestorFeatureTest
         sendToSqs(work, queue, bucket)
         withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
           withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
-            val flags = sqsLocalFlags(queue) ++ esLocalFlags(
+            val flags = messageReaderLocalFlags(bucket, queue) ++ esLocalFlags(
               indexNameV1,
               indexNameV2,
-              itemType) ++ s3LocalFlags(bucket)
+              itemType)
             withServer(flags) { _ =>
               assertElasticsearchEventuallyHasWork(work, indexNameV2, itemType)
               assertElasticsearchNeverHasWork(work, indexNameV1, itemType)
@@ -97,7 +97,7 @@ class IngestorFeatureTest
       withLocalS3Bucket { bucket =>
         withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
           withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
-            val flags = sqsLocalFlags(queue) ++ esLocalFlags(
+            val flags = messageReaderLocalFlags(bucket, queue) ++ esLocalFlags(
               indexNameV1,
               indexNameV2,
               itemType) ++ s3LocalFlags(bucket)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
@@ -5,7 +5,7 @@ import com.sksamuel.elastic4s.http.ElasticDsl._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.messaging.test.fixtures.SQS
+import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
 import uk.ac.wellcome.storage.test.fixtures.S3
 
 class IngestorIndexTest
@@ -15,6 +15,7 @@ class IngestorIndexTest
     with S3
     with Matchers
     with ScalaFutures
+    with Messaging
     with ElasticsearchFixtures {
 
   val indexNameV1 = "works-v1"
@@ -27,10 +28,10 @@ class IngestorIndexTest
 
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        val flags = sqsLocalFlags(queue) ++ esLocalFlags(
+        val flags = messageReaderLocalFlags(bucket, queue) ++ esLocalFlags(
           indexNameV1,
           indexNameV2,
-          itemType) ++ s3LocalFlags(bucket)
+          itemType)
 
         withServer(flags) { _ =>
           eventuallyIndexExists(indexNameV1)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -55,11 +55,6 @@ class IngestorWorkerServiceTest
       override def generate(obj: IdentifiedWork): String = ""
     }
 
-  // The ingestor doesn't send messages so doesn't need a topic.
-  // This is needed because MessageConfig (which is used be MessageReader) needs one
-  // TODO remove this once MessageConfig gets split into MessageReaderConfig and MessageWriterConfig
-  val topic = Topic("")
-
   def createMiroWork(
     canonicalId: String,
     sourceId: String,
@@ -125,7 +120,7 @@ class IngestorWorkerServiceTest
       withLocalS3Bucket { bucket =>
         withMessageReader[IdentifiedWork, Assertion](
           bucket,
-          topic,
+          queue,
           identifiedWorkKeyPrefixGenerator) { messageReader =>
           withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
             withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
@@ -133,8 +128,6 @@ class IngestorWorkerServiceTest
                 indexNameV1,
                 indexNameV2,
                 identifiedWorkIndexer = workIndexer,
-                sqsReader =
-                  new SQSReader(sqsClient, SQSConfig(queue.url, 1.second, 1)),
                 messageReader = messageReader,
                 system = actorSystem,
                 metrics = metricsSender
@@ -172,7 +165,7 @@ class IngestorWorkerServiceTest
       withLocalS3Bucket { bucket =>
         withMessageReader[IdentifiedWork, Assertion](
           bucket,
-          topic,
+          queue,
           identifiedWorkKeyPrefixGenerator) { messageReader =>
           withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
             withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
@@ -180,8 +173,6 @@ class IngestorWorkerServiceTest
                 indexNameV1,
                 indexNameV2,
                 identifiedWorkIndexer = workIndexer,
-                sqsReader =
-                  new SQSReader(sqsClient, SQSConfig(queue.url, 1.second, 1)),
                 messageReader = messageReader,
                 system = actorSystem,
                 metrics = metricsSender
@@ -220,7 +211,7 @@ class IngestorWorkerServiceTest
       withLocalS3Bucket { bucket =>
         withMessageReader[IdentifiedWork, Assertion](
           bucket,
-          topic,
+          queue,
           identifiedWorkKeyPrefixGenerator) { messageReader =>
           withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
             withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
@@ -228,8 +219,6 @@ class IngestorWorkerServiceTest
                 indexNameV1,
                 indexNameV2,
                 identifiedWorkIndexer = workIndexer,
-                sqsReader =
-                  new SQSReader(sqsClient, SQSConfig(queue.url, 1.second, 1)),
                 messageReader = messageReader,
                 system = actorSystem,
                 metrics = metricsSender
@@ -274,14 +263,12 @@ class IngestorWorkerServiceTest
       withLocalS3Bucket { bucket =>
         withMessageReader[IdentifiedWork, Assertion](
           bucket,
-          topic,
+          queue,
           identifiedWorkKeyPrefixGenerator) { messageReader =>
           val service = new IngestorWorkerService(
             "works-v1",
             "works-v2",
             identifiedWorkIndexer = brokenWorkIndexer,
-            sqsReader =
-              new SQSReader(sqsClient, SQSConfig(queue.url, 1.second, 1)),
             messageReader = messageReader,
             system = actorSystem,
             metrics = metricsSender

--- a/catalogue_pipeline/ingestor/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/ingestor/src/universal/conf/application.ini.template
@@ -4,9 +4,9 @@
 -es.index.v1=${es_index_v1}
 -es.index.v2=${es_index_v2}
 -es.type=${es_doc_type}
--aws.sqs.queue.url=${ingest_queue_id}
 -aws.metrics.namespace=${metrics_namespace}
 -es.username=${es_username}
 -es.password=${es_password}
 -es.protocol=${es_protocol}
 -aws.message.s3.bucketName=${message_bucket_name}
+-aws.message.sqs.queue.url=${ingest_queue_id}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
@@ -56,7 +56,9 @@ class CalmTransformerFeatureTest
             val flags: Map[String, String] = Map(
               "aws.metrics.namespace" -> "sierra-transformer"
             ) ++ s3LocalFlags(storageBucket) ++
-              sqsLocalFlags(queue) ++ messageWriterLocalFlags(messageBucket, topic)
+              sqsLocalFlags(queue) ++ messageWriterLocalFlags(
+              messageBucket,
+              topic)
 
             withServer(flags) { _ =>
               eventually {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
@@ -56,7 +56,7 @@ class CalmTransformerFeatureTest
             val flags: Map[String, String] = Map(
               "aws.metrics.namespace" -> "sierra-transformer"
             ) ++ s3LocalFlags(storageBucket) ++
-              sqsLocalFlags(queue) ++ messagingLocalFlags(messageBucket, topic)
+              sqsLocalFlags(queue) ++ messageWriterLocalFlags(messageBucket, topic)
 
             withServer(flags) { _ =>
               eventually {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
@@ -58,7 +58,7 @@ class MiroTransformerFeatureTest
             val flags: Map[String, String] = Map(
               "aws.metrics.namespace" -> "sierra-transformer"
             ) ++ s3LocalFlags(storageBucket) ++
-              sqsLocalFlags(queue) ++ messagingLocalFlags(messageBucket, topic)
+              sqsLocalFlags(queue) ++ messageWriterLocalFlags(messageBucket, topic)
 
             withServer(flags) { _ =>
               eventually {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
@@ -58,7 +58,9 @@ class MiroTransformerFeatureTest
             val flags: Map[String, String] = Map(
               "aws.metrics.namespace" -> "sierra-transformer"
             ) ++ s3LocalFlags(storageBucket) ++
-              sqsLocalFlags(queue) ++ messageWriterLocalFlags(messageBucket, topic)
+              sqsLocalFlags(queue) ++ messageWriterLocalFlags(
+              messageBucket,
+              topic)
 
             withServer(flags) { _ =>
               eventually {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
@@ -58,7 +58,9 @@ class SierraTransformerFeatureTest
             val flags: Map[String, String] = Map(
               "aws.metrics.namespace" -> "sierra-transformer"
             ) ++ s3LocalFlags(storageBucket) ++
-              sqsLocalFlags(queue) ++ messageWriterLocalFlags(messagingBucket, topic)
+              sqsLocalFlags(queue) ++ messageWriterLocalFlags(
+              messagingBucket,
+              topic)
 
             withServer(flags) { _ =>
               eventually {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/SierraTransformerFeatureTest.scala
@@ -58,9 +58,7 @@ class SierraTransformerFeatureTest
             val flags: Map[String, String] = Map(
               "aws.metrics.namespace" -> "sierra-transformer"
             ) ++ s3LocalFlags(storageBucket) ++
-              sqsLocalFlags(queue) ++ messagingLocalFlags(
-              messagingBucket,
-              topic)
+              sqsLocalFlags(queue) ++ messageWriterLocalFlags(messagingBucket, topic)
 
             withServer(flags) { _ =>
               eventually {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.messaging.message.{MessageWriterConfig, MessageWriter}
+import uk.ac.wellcome.messaging.message.{MessageWriter, MessageWriterConfig}
 import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.messaging.sqs.SQSMessage

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.messaging.message.{MessageConfig, MessageWriter}
+import uk.ac.wellcome.messaging.message.{MessageWriterConfig, MessageWriter}
 import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.messaging.sqs.SQSMessage
@@ -78,7 +78,7 @@ class SQSMessageReceiverTest
 
     val s3Config = S3Config(bucket.name)
 
-    val messageConfig = MessageConfig(SNSConfig(topic.arn), s3Config)
+    val messageConfig = MessageWriterConfig(SNSConfig(topic.arn), s3Config)
 
     val messageWriter =
       new MessageWriter[UnidentifiedWork](

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageConfig.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageConfig.scala
@@ -1,9 +1,0 @@
-package uk.ac.wellcome.messaging.message
-
-import uk.ac.wellcome.messaging.sns.SNSConfig
-import uk.ac.wellcome.storage.s3.S3Config
-
-case class MessageConfig(
-  snsConfig: SNSConfig,
-  s3Config: S3Config
-)

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageConfigModule.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageConfigModule.scala
@@ -3,9 +3,10 @@ package uk.ac.wellcome.messaging.message
 import com.google.inject.Provides
 import com.twitter.inject.TwitterModule
 import javax.inject.Singleton
-
 import uk.ac.wellcome.messaging.sns.SNSConfig
+import uk.ac.wellcome.messaging.sqs.SQSConfig
 import uk.ac.wellcome.storage.s3.S3Config
+import scala.concurrent.duration._
 
 object MessageConfigModule extends TwitterModule {
   private val topicArn = flag[String](
@@ -19,11 +20,28 @@ object MessageConfigModule extends TwitterModule {
       "",
       "Name of the S3 bucket holding messaging pointers")
 
+  private val queueUrl =
+    flag[String]("aws.message.sqs.queue.url", "", "URL of the SQS Queue")
+  val waitTime = flag(
+    "aws.message.sqs.waitTime",
+    20,
+    "Time to wait (in seconds) for a message to arrive on the queue before returning")
+  val maxMessages =
+    flag("aws.message.sqs.maxMessages", 10, "Maximum number of SQS messages to return")
+
   @Singleton
   @Provides
-  def providesMessageConfig(): MessageConfig = {
+  def providesMessageWriterConfig(): MessageWriterConfig = {
     val snsConfig = SNSConfig(topicArn = topicArn())
     val s3Config = S3Config(bucketName = bucketName())
-    MessageConfig(snsConfig = snsConfig, s3Config = s3Config)
+    MessageWriterConfig(snsConfig = snsConfig, s3Config = s3Config)
+  }
+
+  @Singleton
+  @Provides
+  def providesMessageReaderConfig(): MessageReaderConfig = {
+    val sqsConfig = SQSConfig(queueUrl(), waitTime() seconds, maxMessages())
+    val s3Config = S3Config(bucketName = bucketName())
+    MessageReaderConfig(sqsConfig = sqsConfig, s3Config = s3Config)
   }
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageConfigModule.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageConfigModule.scala
@@ -27,7 +27,10 @@ object MessageConfigModule extends TwitterModule {
     20,
     "Time to wait (in seconds) for a message to arrive on the queue before returning")
   val maxMessages =
-    flag("aws.message.sqs.maxMessages", 10, "Maximum number of SQS messages to return")
+    flag(
+      "aws.message.sqs.maxMessages",
+      10,
+      "Maximum number of SQS messages to return")
 
   @Singleton
   @Provides

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageReader.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageReader.scala
@@ -29,15 +29,15 @@ class MessageReader[T] @Inject()(
     keyPrefixGenerator = keyPrefixGenerator
   )
 
-  def readAndDelete(f: T => Future[Unit])(
+  def readAndDelete(process: T => Future[Unit])(
     implicit decoderN: Decoder[NotificationMessage],
     decoderT: Decoder[T]
   ): Future[Unit] = {
     sqsReader.retrieveAndDeleteMessages { message =>
       for {
         t <- read(message)
-        r <- f(t)
-      } yield r
+        result <- process(t)
+      } yield result
     }
   }
 

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageReader.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageReader.scala
@@ -16,10 +16,10 @@ case class MessageReaderConfig(sqsConfig: SQSConfig, s3Config: S3Config)
 import scala.concurrent.Future
 
 class MessageReader[T] @Inject()(
-                                  messageReaderConfig: MessageReaderConfig,
-                                  s3Client: AmazonS3,
-                                  sqsClient: AmazonSQS,
-                                  keyPrefixGenerator: KeyPrefixGenerator[T]
+  messageReaderConfig: MessageReaderConfig,
+  s3Client: AmazonS3,
+  sqsClient: AmazonSQS,
+  keyPrefixGenerator: KeyPrefixGenerator[T]
 ) {
   val sqsReader = new SQSReader(sqsClient, messageReaderConfig.sqsConfig)
 

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageReader.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageReader.scala
@@ -8,24 +8,24 @@ import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.utils.JsonUtil._
 import com.google.inject.Inject
 import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSReader}
-import uk.ac.wellcome.storage.s3.{KeyPrefixGenerator, S3ObjectStore}
+import uk.ac.wellcome.storage.s3.{KeyPrefixGenerator, S3Config, S3ObjectStore}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
+
+case class MessageReaderConfig(sqsConfig: SQSConfig, s3Config: S3Config)
 
 import scala.concurrent.Future
 
 class MessageReader[T] @Inject()(
-                                  messageConfig: MessageConfig,
+                                  messageReaderConfig: MessageReaderConfig,
                                   s3Client: AmazonS3,
-                                  keyPrefixGenerator: KeyPrefixGenerator[T],
                                   sqsClient: AmazonSQS,
-                                  sqsConfig: SQSConfig
-
+                                  keyPrefixGenerator: KeyPrefixGenerator[T]
 ) {
-  val sqsReader = new SQSReader(sqsClient, sqsConfig)
+  val sqsReader = new SQSReader(sqsClient, messageReaderConfig.sqsConfig)
 
   val s3ObjectStore = new S3ObjectStore[T](
     s3Client = s3Client,
-    s3Config = messageConfig.s3Config,
+    s3Config = messageReaderConfig.s3Config,
     keyPrefixGenerator = keyPrefixGenerator
   )
 

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWorker.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWorker.scala
@@ -33,7 +33,6 @@ abstract class MessageWorker[T](messageReader: MessageReader[T],
   private def processMessages()(
     implicit decoderN: Decoder[NotificationMessage]): Future[Unit] = {
     messageReader.readAndDelete { t =>
-
       val metricName = s"${workerName}_ProcessMessage"
 
       debug(s"Processing message: $t")

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -13,15 +13,15 @@ import uk.ac.wellcome.utils.JsonUtil._
 import scala.concurrent.Future
 
 case class MessageWriterConfig(
-                                snsConfig: SNSConfig,
-                                s3Config: S3Config
-                              )
+  snsConfig: SNSConfig,
+  s3Config: S3Config
+)
 
 class MessageWriter[T] @Inject()(
-                                  messageConfig: MessageWriterConfig,
-                                  snsClient: AmazonSNS,
-                                  s3Client: AmazonS3,
-                                  keyPrefixGenerator: KeyPrefixGenerator[T]
+  messageConfig: MessageWriterConfig,
+  snsClient: AmazonSNS,
+  s3Client: AmazonS3,
+  keyPrefixGenerator: KeyPrefixGenerator[T]
 ) extends Logging {
 
   private val sns = new SNSWriter(

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -1,25 +1,27 @@
 package uk.ac.wellcome.messaging.message
 
-import java.net.URI
-
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sns.AmazonSNS
 import com.google.inject.Inject
 import com.twitter.inject.Logging
-import uk.ac.wellcome.utils.GlobalExecutionContext.context
-
 import io.circe.Encoder
-import uk.ac.wellcome.messaging.sns.SNSWriter
-import uk.ac.wellcome.storage.s3.{KeyPrefixGenerator, S3ObjectStore}
+import uk.ac.wellcome.messaging.sns.{SNSConfig, SNSWriter}
+import uk.ac.wellcome.storage.s3.{KeyPrefixGenerator, S3Config, S3ObjectStore}
+import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil._
 
-import scala.concurrent.{blocking, Future}
+import scala.concurrent.Future
+
+case class MessageWriterConfig(
+                                snsConfig: SNSConfig,
+                                s3Config: S3Config
+                              )
 
 class MessageWriter[T] @Inject()(
-  messageConfig: MessageConfig,
-  snsClient: AmazonSNS,
-  s3Client: AmazonS3,
-  keyPrefixGenerator: KeyPrefixGenerator[T]
+                                  messageConfig: MessageWriterConfig,
+                                  snsClient: AmazonSNS,
+                                  s3Client: AmazonS3,
+                                  keyPrefixGenerator: KeyPrefixGenerator[T]
 ) extends Logging {
 
   private val sns = new SNSWriter(
@@ -35,9 +37,6 @@ class MessageWriter[T] @Inject()(
 
   def write(message: T, subject: String)(
     implicit encoder: Encoder[T]): Future[Unit] = {
-
-    val bucket = messageConfig.s3Config.bucketName
-
     for {
       location <- s3.put(message)
       pointer <- Future.fromTry(toJson(MessagePointer(location)))

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageReaderTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageReaderTest.scala
@@ -2,26 +2,17 @@ package uk.ac.wellcome.messaging.message
 
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import org.scalatest._
-import io.circe.Decoder
 import org.scalatest.FunSpec
-import uk.ac.wellcome.test.fixtures.TestWith
-import com.amazonaws.services.sqs.model.Message
 import org.scalatest.concurrent.ScalaFutures
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.Messaging
-import uk.ac.wellcome.storage.s3.{
-  KeyPrefixGenerator,
-  S3Config,
-  S3ObjectLocation,
-  S3ObjectStore
-}
+import uk.ac.wellcome.storage.s3.{S3ObjectLocation}
 import uk.ac.wellcome.storage.test.fixtures.S3
-import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.test.fixtures._
 
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.Future
+
 
 class MessageReaderTest
     extends FunSpec
@@ -30,98 +21,113 @@ class MessageReaderTest
     with Messaging
     with S3 {
 
-  describe("reads a NotificationMessage from an sqs.model.Message") {
-    it("converts to type T") {
-      withExampleObjectMessageReaderFixtures {
-        case (bucket, messageReader) =>
-          val key = "key.json"
-          val expectedObject = ExampleObject("some value")
-          val serialisedExampleObject = toJson(expectedObject).get
 
-          s3Client.putObject(bucket.name, key, serialisedExampleObject)
+  it("reads and deletes messages") {
+    withExampleObjectMessageReaderFixtures {
+      case (bucket, messageReader, queue) =>
 
-          val examplePointer =
-            MessagePointer(S3ObjectLocation(bucket.name, key))
-          val serialisedExamplePointer = toJson(examplePointer).get
+        val key = "message-key"
+        val exampleObject = ExampleObject("some value")
 
-          val exampleNotification = NotificationMessage(
-            MessageId = "MessageId",
-            TopicArn = "TopicArn",
-            Subject = "Subject",
-            Message = serialisedExamplePointer
-          )
+        val notice = put(exampleObject, S3ObjectLocation(bucket.name, key))
 
-          val serialisedExampleNotification = toJson(exampleNotification).get
+        sqsClient.sendMessage(
+          queue.url,
+          notice
+        )
 
-          val exampleMessage = new Message()
-            .withBody(serialisedExampleNotification)
+        var received: List[ExampleObject] = Nil
+        val f = (o: ExampleObject) => {
 
-          val actualObjectFuture = messageReader.read(exampleMessage)
-
-          whenReady(actualObjectFuture) { actualObject =>
-            actualObject shouldBe expectedObject
+          synchronized {
+            received = o :: received
           }
-      }
+
+          Future.successful(())
+        }
+
+        val future = messageReader.readAndDelete(f)
+
+        whenReady(future) { _ =>
+          received shouldBe List(exampleObject)
+
+          assertQueueEmpty(queue)
+        }
     }
+  }
 
-    it("fail gracefully when NotificationMessage cannot be deserialised") {
-      withExampleObjectMessageReaderFixtures {
-        case (bucket, messageReader) =>
-          val key = "key.json"
-          val expectedObject = ExampleObject("some value")
-          val serialisedExampleObject = toJson(expectedObject).get
+  it("fail gracefully when NotificationMessage cannot be deserialised") {
+    withExampleObjectMessageReaderFixtures {
+      case (bucket, messageReader, queue) =>
+        sqsClient.sendMessage(
+          queue.url,
+          "not valid json"
+        )
 
-          s3Client.putObject(bucket.name, key, serialisedExampleObject)
+        var received: List[ExampleObject] = Nil
+        val f = (o: ExampleObject) => {
 
-          val serialisedExamplePointer = "Not even close to valid json."
-
-          val exampleNotification = NotificationMessage(
-            MessageId = "MessageId",
-            TopicArn = "TopicArn",
-            Subject = "Subject",
-            Message = serialisedExamplePointer
-          )
-
-          val serialisedExampleNotification = toJson(exampleNotification).get
-
-          val exampleMessage = new Message()
-            .withBody(serialisedExampleNotification)
-
-          val actualObjectFuture = messageReader.read(exampleMessage)
-
-          whenReady(actualObjectFuture.failed) { throwable =>
-            throwable shouldBe a[GracefulFailureException]
+          synchronized {
+            received = o :: received
           }
-      }
+
+          Future.successful(())
+        }
+
+        val future = messageReader.readAndDelete(f)
+
+        whenReady(future) { _ =>
+          received shouldBe Nil
+
+          assertQueueNotEmpty(queue)
+        }
     }
+  }
 
-    it("does not fail gracefully when the s3 object cannot be retrieved") {
-      withExampleObjectMessageReaderFixtures {
-        case (bucket, messageReader) =>
-          val key = "key.json"
+  it("does not fail gracefully when the s3 object cannot be retrieved") {
+    withExampleObjectMessageReaderFixtures {
+      case (bucket, messageReader, queue) =>
+        val key = "key.json"
 
-          val examplePointer =
-            MessagePointer(S3ObjectLocation(bucket.name, key))
-          val serialisedExamplePointer = toJson(examplePointer).get
+        // Do NOT put S3 object here
 
-          val exampleNotification = NotificationMessage(
-            MessageId = "MessageId",
-            TopicArn = "TopicArn",
-            Subject = "Subject",
-            Message = serialisedExamplePointer
-          )
+        val examplePointer =
+          MessagePointer(S3ObjectLocation(bucket.name, key))
+        val serialisedExamplePointer = toJson(examplePointer).get
 
-          val serialisedExampleNotification = toJson(exampleNotification).get
+        val exampleNotification = NotificationMessage(
+          MessageId = "MessageId",
+          TopicArn = "TopicArn",
+          Subject = "Subject",
+          Message = serialisedExamplePointer
+        )
 
-          val exampleMessage = new Message()
-            .withBody(serialisedExampleNotification)
+        val serialisedExampleNotification = toJson(exampleNotification).get
 
-          val actualObjectFuture = messageReader.read(exampleMessage)
+        sqsClient.sendMessage(
+          queue.url,
+          serialisedExampleNotification
+        )
 
-          whenReady(actualObjectFuture.failed) { throwable =>
-            throwable shouldBe a[AmazonS3Exception]
+        var received: List[ExampleObject] = Nil
+        val f = (o: ExampleObject) => {
+
+          synchronized {
+            received = o :: received
           }
-      }
+
+          Future.successful(())
+        }
+
+        val future = messageReader.readAndDelete(f)
+
+        whenReady(future.failed) { throwable =>
+          throwable shouldBe a[AmazonS3Exception]
+
+          received shouldBe Nil
+
+          assertQueueNotEmpty(queue)
+        }
     }
   }
 }

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageReaderTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageReaderTest.scala
@@ -6,10 +6,11 @@ import org.scalatest.FunSpec
 import org.scalatest.concurrent.ScalaFutures
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.Messaging
-import uk.ac.wellcome.storage.s3.{S3ObjectLocation}
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.test.fixtures._
+import uk.ac.wellcome.test.utils.ExtendedPatience
 
 import scala.concurrent.Future
 
@@ -19,7 +20,7 @@ class MessageReaderTest
     with Matchers
     with ScalaFutures
     with Messaging
-    with S3 {
+    with S3 with ExtendedPatience {
 
 
   it("reads and deletes messages") {

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageReaderTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageReaderTest.scala
@@ -12,19 +12,17 @@ import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.Future
 
-
 class MessageReaderTest
     extends FunSpec
     with Matchers
     with ScalaFutures
     with Messaging
-    with S3 with ExtendedPatience {
-
+    with S3
+    with ExtendedPatience {
 
   it("reads and deletes messages") {
     withExampleObjectMessageReaderFixtures {
       case (bucket, messageReader, queue) =>
-
         val key = "message-key"
         val exampleObject = ExampleObject("some value")
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageReaderTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageReaderTest.scala
@@ -1,16 +1,14 @@
 package uk.ac.wellcome.messaging.message
 
 import com.amazonaws.services.s3.model.AmazonS3Exception
-import org.scalatest._
-import org.scalatest.FunSpec
+import org.scalatest.{FunSpec, _}
 import org.scalatest.concurrent.ScalaFutures
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.Messaging
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.test.fixtures.S3
-import uk.ac.wellcome.utils.JsonUtil._
-import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.test.utils.ExtendedPatience
+import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.Future
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageWorkerTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageWorkerTest.scala
@@ -22,7 +22,7 @@ class MessageWorkerTest
     with Messaging {
 
   it("processes messages") {
-    withMessageWorkerFixtures {
+    withExampleObjectMessageWorkerFixtures {
       case (_, queue, bucket, worker) =>
         val key = "message-key"
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessagingIntegrationTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessagingIntegrationTest.scala
@@ -38,7 +38,7 @@ class MessagingIntegrationTest
   private def withLocalStackMessageWriter[R](
     testWith: TestWith[(ExampleMessageWorker, MessageWriter[ExampleObject]),
                        R]) = {
-    withMessageWorkerFixtures {
+    withExampleObjectMessageWorkerFixtures {
       case (metricsSender, queue, bucket, worker) =>
         withLocalStackSnsTopic { topic =>
           withLocalStackSubscription(queue, topic) { _ =>

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -2,43 +2,31 @@ package uk.ac.wellcome.messaging.test.fixtures
 
 import akka.actor.ActorSystem
 import com.amazonaws.services.sns.AmazonSNS
-import com.amazonaws.services.sns.model.{
-  SubscribeRequest,
-  SubscribeResult,
-  UnsubscribeRequest
-}
-import com.amazonaws.services.sqs.model.ReceiveMessageRequest
-import io.circe.{Decoder, Encoder}
+import com.amazonaws.services.sns.model.{SubscribeRequest, SubscribeResult, UnsubscribeRequest}
 import io.circe.generic.semiauto._
+import io.circe.{Decoder, Encoder}
 import org.scalatest.Matchers
-import uk.ac.wellcome.messaging.message.{MessageConfig, MessageReader, MessageWorker, MessageWriter, _}
+import uk.ac.wellcome.messaging.message.{MessageReader, MessageWorker, MessageWriter, _}
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSReader}
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
-import uk.ac.wellcome.storage.s3.{
-  KeyPrefixGenerator,
-  S3Config,
-  S3ObjectLocation
-}
+import uk.ac.wellcome.monitoring
+import uk.ac.wellcome.monitoring.test.fixtures.{MetricsSender => MetricsSenderFixture}
+import uk.ac.wellcome.storage.s3.{KeyPrefixGenerator, S3Config, S3ObjectLocation}
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.utils.JsonUtil._
 
-import scala.collection.JavaConversions._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Success
-import uk.ac.wellcome.monitoring
-import uk.ac.wellcome.monitoring.test.fixtures.{
-  MetricsSender => MetricsSenderFixture
-}
 
 trait Messaging
   extends Akka
-    with MetricsSender
+    with MetricsSenderFixture
     with SQS
     with SNS
     with S3

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -234,6 +234,9 @@ trait Messaging
   }
 
   def assertQueueEmpty(queue: Queue) = {
+    // The visibility timeout is set to 1 second for test queues.
+    // Wait for slightly longer than that to make sure that messages
+    // that fail processing become visible again before asserting.
     Thread.sleep(1500)
 
     val messages = sqsClient
@@ -248,6 +251,9 @@ trait Messaging
   }
 
   def assertQueueNotEmpty(queue: Queue) = {
+    // The visibility timeout is set to 1 second for test queues.
+    // Wait for slightly longer than that to make sure that messages
+    // that fail processing become visible again before asserting.
     Thread.sleep(1500)
 
     val messages = sqsClient

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -233,40 +233,6 @@ trait Messaging
     }
   }
 
-  def assertQueueEmpty(queue: Queue) = {
-    // The visibility timeout is set to 1 second for test queues.
-    // Wait for slightly longer than that to make sure that messages
-    // that fail processing become visible again before asserting.
-    Thread.sleep(1500)
-
-    val messages = sqsClient
-      .receiveMessage(
-        new ReceiveMessageRequest(queue.url)
-          .withMaxNumberOfMessages(1)
-      )
-      .getMessages
-      .toList
-
-    messages shouldBe empty
-  }
-
-  def assertQueueNotEmpty(queue: Queue) = {
-    // The visibility timeout is set to 1 second for test queues.
-    // Wait for slightly longer than that to make sure that messages
-    // that fail processing become visible again before asserting.
-    Thread.sleep(1500)
-
-    val messages = sqsClient
-      .receiveMessage(
-        new ReceiveMessageRequest(queue.url)
-          .withMaxNumberOfMessages(1)
-      )
-      .getMessages
-      .toList
-
-    messages should not be empty
-  }
-
   def put[T](obj: T, location: S3ObjectLocation)(
     implicit encoder: Encoder[T]) = {
     val serialisedExampleObject = toJson[T](obj).get

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -51,7 +51,16 @@ trait Messaging
       }
     )
 
-  def messagingLocalFlags(bucket: Bucket, topic: Topic) =
+  def messagingLocalFlags(bucket: Bucket, topic: Topic, queue: Queue) =
+    messageReaderLocalFlags(bucket, queue) ++ messageWriterLocalFlags(bucket, topic)
+
+  def messageReaderLocalFlags(bucket: Bucket, queue: Queue) =
+    Map(
+      "aws.message.s3.bucketName" -> bucket.name,
+      "aws.message.sqs.queue.url" -> queue.url
+    ) ++ s3ClientLocalFlags ++ sqsLocalClientFlags
+
+  def messageWriterLocalFlags(bucket: Bucket, topic: Topic) =
     Map(
       "aws.message.sns.topic.arn" -> topic.arn,
       "aws.message.s3.bucketName" -> bucket.name

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -2,18 +2,33 @@ package uk.ac.wellcome.messaging.test.fixtures
 
 import akka.actor.ActorSystem
 import com.amazonaws.services.sns.AmazonSNS
-import com.amazonaws.services.sns.model.{SubscribeRequest, SubscribeResult, UnsubscribeRequest}
+import com.amazonaws.services.sns.model.{
+  SubscribeRequest,
+  SubscribeResult,
+  UnsubscribeRequest
+}
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
 import org.scalatest.Matchers
-import uk.ac.wellcome.messaging.message.{MessageReader, MessageWorker, MessageWriter, _}
+import uk.ac.wellcome.messaging.message.{
+  MessageReader,
+  MessageWorker,
+  MessageWriter,
+  _
+}
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSReader}
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.monitoring
-import uk.ac.wellcome.monitoring.test.fixtures.{MetricsSender => MetricsSenderFixture}
-import uk.ac.wellcome.storage.s3.{KeyPrefixGenerator, S3Config, S3ObjectLocation}
+import uk.ac.wellcome.monitoring.test.fixtures.{
+  MetricsSender => MetricsSenderFixture
+}
+import uk.ac.wellcome.storage.s3.{
+  KeyPrefixGenerator,
+  S3Config,
+  S3ObjectLocation
+}
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures._
@@ -25,7 +40,7 @@ import scala.concurrent.duration._
 import scala.util.Success
 
 trait Messaging
-  extends Akka
+    extends Akka
     with MetricsSenderFixture
     with SQS
     with SNS

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -142,7 +142,7 @@ trait Messaging
                             testWith: TestWith[MessageWriter[ExampleObject], R]) = {
     val s3Config = S3Config(bucketName = bucket.name)
     val snsConfig = SNSConfig(topicArn = topic.arn)
-    val messageConfig = MessageConfig(
+    val messageConfig = MessageWriterConfig(
       s3Config = s3Config,
       snsConfig = snsConfig
     )

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -36,13 +36,16 @@ trait SQS {
   def localStackEndpoint(queue: Queue) =
     s"sqs://${queue.name}"
 
-  def sqsLocalFlags(queue: Queue) = Map(
+  def sqsLocalFlags(queue: Queue) = sqsLocalClientFlags ++ Map(
+    "aws.sqs.queue.url" -> queue.url,
+    "aws.sqs.waitTime" -> "1"
+  )
+
+  def sqsLocalClientFlags = Map(
     "aws.sqs.endpoint" -> sqsEndpointUrl,
     "aws.sqs.accessKey" -> accessKey,
     "aws.sqs.secretKey" -> secretKey,
-    "aws.region" -> "localhost",
-    "aws.sqs.queue.url" -> queue.url,
-    "aws.sqs.waitTime" -> "1"
+    "aws.region" -> "localhost"
   )
 
   private val credentials = new AWSStaticCredentialsProvider(

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.messaging.test.fixtures
 
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.sqs._
-import com.amazonaws.services.sqs.model.{PurgeQueueRequest, ReceiveMessageRequest}
+import com.amazonaws.services.sqs.model.{
+  PurgeQueueRequest,
+  ReceiveMessageRequest
+}
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import org.scalatest.Matchers


### PR DESCRIPTION
### What is this PR trying to achieve?

Simplify the `MessageWorker` by pushing the `SQSReader` inside the `MessageReader` class.

### Who is this change for?

🍔 

### Have the following been considered/are they needed?

- [ ] Deployed new versions