### PR TITLE
[RFC] Remove shared-infra tests from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,10 +109,10 @@ jobs:
     - env: TASK=sierra_item_merger-test
     - env: TASK=s3_demultiplexer-test
 
-    # Shared infra stack
-    - env: TASK=shared_infra-test
-
     # (not under active development)
+
+    # Shared infra stack
+    # - env: TASK=shared_infra-test
 
     # nginx stack
     # - env: TASK=nginx-build


### PR DESCRIPTION
The last non-Terraform change to this stack was in February:

```console
$ git log -1 (find shared_infra -type f | grep -v '\.tf$')
commit f3c1644f90c2cbc009ddac4787f72d452960716e
Author: Alex Chan <a.chan@wellcome.ac.uk>
Date:   Mon Feb 19 14:09:18 2018 +0000

    Makefile: pass the entire repo into the Terraform containers

    This means that Git info -- in particular `.git` -- is accessible when
    running inside the containers.
```

So as a short-term fix for our build problem, I think we can drop this for now.