### PR TITLE
Refactor some ingestor tests [Was: Move WorksUtil into the internal_models library]

### DIFF
--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -4,8 +4,8 @@ import com.sksamuel.elastic4s.http.get.GetResponse
 import com.sksamuel.elastic4s.http.search.SearchHit
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.display.test.util.WorksUtil
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.platform.api.fixtures.ElasticsearchServiceFixture
 import uk.ac.wellcome.utils.JsonUtil._
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.api.services
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.test.WorksUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.platform.api.fixtures.{
   ElasticsearchServiceFixture,
   WorksServiceFixture

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.api.services
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.display.test.util.WorksUtil
+import uk.ac.wellcome.models.work.test.WorksUtil
 import uk.ac.wellcome.platform.api.fixtures.{
   ElasticsearchServiceFixture,
   WorksServiceFixture

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -6,7 +6,7 @@ import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
-import uk.ac.wellcome.models.work.test.WorksUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.platform.api.Server
 import uk.ac.wellcome.test.fixtures.TestWith
 import uk.ac.wellcome.utils.JsonUtil._

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -4,9 +4,9 @@ import com.sksamuel.elastic4s.Indexable
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
-import uk.ac.wellcome.display.test.util.WorksUtil
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
+import uk.ac.wellcome.models.work.test.WorksUtil
 import uk.ac.wellcome.platform.api.Server
 import uk.ac.wellcome.test.fixtures.TestWith
 import uk.ac.wellcome.utils.JsonUtil._

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
@@ -3,11 +3,14 @@ package uk.ac.wellcome.platform.ingestor.fixtures
 import com.sksamuel.elastic4s.http.HttpClient
 import org.scalatest.Suite
 import uk.ac.wellcome.monitoring.MetricsSender
-import uk.ac.wellcome.monitoring.test.fixtures.{MetricsSender => MetricsSenderFixture}
+import uk.ac.wellcome.monitoring.test.fixtures.{
+  MetricsSender => MetricsSenderFixture
+}
 import uk.ac.wellcome.platform.ingestor.services.WorkIndexer
 import uk.ac.wellcome.test.fixtures._
 
-trait WorkIndexerFixtures extends Akka with MetricsSenderFixture { this: Suite =>
+trait WorkIndexerFixtures extends Akka with MetricsSenderFixture {
+  this: Suite =>
   def withWorkIndexer[R](
     esType: String,
     elasticClient: HttpClient,
@@ -21,7 +24,8 @@ trait WorkIndexerFixtures extends Akka with MetricsSenderFixture { this: Suite =
     testWith(workIndexer)
   }
 
-  def withWorkIndexerFixtures[R](esType: String, elasticClient: HttpClient)(testWith: TestWith[WorkIndexer, R]): R = {
+  def withWorkIndexerFixtures[R](esType: String, elasticClient: HttpClient)(
+    testWith: TestWith[WorkIndexer, R]): R = {
     withActorSystem { actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>
         withWorkIndexer(esType, elasticClient, metricsSender) { workIndexer =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -163,35 +163,42 @@ class IngestorWorkerServiceTest
     esIndexV2: String)(testWith: TestWith[IngestorWorkerService, R]): R = {
     withActorSystem { actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>
-        withWorkIndexer[R](itemType, elasticClient, metricsSender) { workIndexer =>
-          withIngestorWorkerService[R](esIndexV1, esIndexV2, actorSystem, metricsSender, workIndexer) { service =>
-            testWith(service)
-          }
+        withWorkIndexer[R](itemType, elasticClient, metricsSender) {
+          workIndexer =>
+            withIngestorWorkerService[R](
+              esIndexV1,
+              esIndexV2,
+              actorSystem,
+              metricsSender,
+              workIndexer) { service =>
+              testWith(service)
+            }
         }
       }
     }
   }
 
-  private def withIngestorWorkerService[R](
-    esIndexV1: String,
-    esIndexV2: String,
-    actorSystem: ActorSystem,
-    metricsSender: MetricsSender,
-    workIndexer: WorkIndexer)(testWith: TestWith[IngestorWorkerService, R]): R = {
+  private def withIngestorWorkerService[R](esIndexV1: String,
+                                           esIndexV2: String,
+                                           actorSystem: ActorSystem,
+                                           metricsSender: MetricsSender,
+                                           workIndexer: WorkIndexer)(
+    testWith: TestWith[IngestorWorkerService, R]): R = {
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withMessageReader[IdentifiedWork, R](bucket, queue) { messageReader =>
-          withWorkIndexer[R](itemType, elasticClient, metricsSender) { workIndexer =>
-            val service = new IngestorWorkerService(
-              esIndexV1 = esIndexV1,
-              esIndexV2 = esIndexV2,
-              identifiedWorkIndexer = workIndexer,
-              messageReader = messageReader,
-              system = actorSystem,
-              metrics = metricsSender
-            )
+          withWorkIndexer[R](itemType, elasticClient, metricsSender) {
+            workIndexer =>
+              val service = new IngestorWorkerService(
+                esIndexV1 = esIndexV1,
+                esIndexV2 = esIndexV2,
+                identifiedWorkIndexer = workIndexer,
+                messageReader = messageReader,
+                system = actorSystem,
+                metrics = metricsSender
+              )
 
-            testWith(service)
+              testWith(service)
           }
         }
       }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -68,7 +68,7 @@ class IngestorWorkerServiceTest
 
   it("inserts an Sierra identified Work only into the v2 index") {
     val sierraSourceIdentifier = SourceIdentifier(
-      identifierScheme = IdentifierSchemes.miroImageNumber,
+      identifierScheme = IdentifierSchemes.sierraSystemNumber,
       ontologyType = "Work",
       value = "b1027467"
     )
@@ -187,19 +187,16 @@ class IngestorWorkerServiceTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withMessageReader[IdentifiedWork, R](bucket, queue) { messageReader =>
-          withWorkIndexer[R](itemType, elasticClient, metricsSender) {
-            workIndexer =>
-              val service = new IngestorWorkerService(
-                esIndexV1 = esIndexV1,
-                esIndexV2 = esIndexV2,
-                identifiedWorkIndexer = workIndexer,
-                messageReader = messageReader,
-                system = actorSystem,
-                metrics = metricsSender
-              )
+          val service = new IngestorWorkerService(
+            esIndexV1 = esIndexV1,
+            esIndexV2 = esIndexV2,
+            identifiedWorkIndexer = workIndexer,
+            messageReader = messageReader,
+            system = actorSystem,
+            metrics = metricsSender
+          )
 
-              testWith(service)
-          }
+          testWith(service)
         }
       }
     }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -41,17 +41,18 @@ class WorkIndexerTest
     val work = createVersionedWork()
 
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withWorkIndexerFixtures[Assertion](itemType, elasticClient) { workIndexer =>
-        val future = Future.sequence(
-          (1 to 2).map(_ => workIndexer.indexWork(work, indexName))
-        )
+      withWorkIndexerFixtures[Assertion](itemType, elasticClient) {
+        workIndexer =>
+          val future = Future.sequence(
+            (1 to 2).map(_ => workIndexer.indexWork(work, indexName))
+          )
 
-        whenReady(future) { _ =>
-          assertElasticsearchEventuallyHasWork(
-            work,
-            indexName = indexName,
-            itemType = itemType)
-        }
+          whenReady(future) { _ =>
+            assertElasticsearchEventuallyHasWork(
+              work,
+              indexName = indexName,
+              itemType = itemType)
+          }
       }
     }
   }
@@ -100,7 +101,6 @@ class WorkIndexerTest
   }
 
   def createVersionedWork(version: Int = 1): IdentifiedWork =
-    createWorks(count = 1)
-      .head
+    createWorks(count = 1).head
       .copy(version = version)
 }

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models.AllWorksIncludes
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
-import uk.ac.wellcome.display.test.util.WorksUtil
+import uk.ac.wellcome.models.work.test.WorksUtil
 import uk.ac.wellcome.test.fixtures.Akka
 import uk.ac.wellcome.test.utils.ExtendedPatience
 

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models.AllWorksIncludes
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
-import uk.ac.wellcome.models.work.test.WorksUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.test.fixtures.Akka
 import uk.ac.wellcome.test.utils.ExtendedPatience
 

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -14,10 +14,10 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
 import uk.ac.wellcome.display.models.AllWorksIncludes
-import uk.ac.wellcome.display.test.util.WorksUtil
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.internal.IdentifierSchemes.sierraSystemNumber
 import uk.ac.wellcome.models.work.internal.{IdentifiedWork, SourceIdentifier}
+import uk.ac.wellcome.models.work.test.WorksUtil
 import uk.ac.wellcome.platform.snapshot_generator.fixtures.AkkaS3
 import uk.ac.wellcome.platform.snapshot_generator.models.{
   CompletedSnapshotJob,

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.display.models.AllWorksIncludes
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.internal.IdentifierSchemes.sierraSystemNumber
 import uk.ac.wellcome.models.work.internal.{IdentifiedWork, SourceIdentifier}
-import uk.ac.wellcome.models.work.test.WorksUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.platform.snapshot_generator.fixtures.AkkaS3
 import uk.ac.wellcome.platform.snapshot_generator.models.{
   CompletedSnapshotJob,

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElastisearchSourceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElastisearchSourceTest.scala
@@ -3,8 +3,8 @@ package uk.ac.wellcome.platform.snapshot_generator.source
 import akka.stream.scaladsl.Sink
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.display.test.util.WorksUtil
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
+import uk.ac.wellcome.models.work.test.WorksUtil
 import uk.ac.wellcome.test.fixtures.Akka
 import uk.ac.wellcome.test.utils.ExtendedPatience
 

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElastisearchSourceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElastisearchSourceTest.scala
@@ -4,7 +4,7 @@ import akka.stream.scaladsl.Sink
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.models.work.test.WorksUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.test.fixtures.Akka
 import uk.ac.wellcome.test.utils.ExtendedPatience
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
@@ -2,8 +2,9 @@ package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
-import uk.ac.wellcome.display.test.util.{JsonMapperTestUtil, WorksUtil}
+import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.test.WorksUtil
 
 class DisplayCreatorsV1SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.WorksUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayCreatorsV1SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
@@ -5,12 +5,14 @@ import uk.ac.wellcome.display.models.{
   DisplaySerialisationTestBase,
   WorksIncludes
 }
-import uk.ac.wellcome.display.test.util.{JsonMapperTestUtil, WorksUtil}
+import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal.{
   IdentifiedItem,
   IdentifiedWork,
   PhysicalLocation
 }
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.test.WorksUtil
 
 class DisplayLocationsV1SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.models.work.internal.{
   PhysicalLocation
 }
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.WorksUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayLocationsV1SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
@@ -11,7 +11,6 @@ import uk.ac.wellcome.models.work.internal.{
   IdentifiedWork,
   PhysicalLocation
 }
-import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayLocationsV1SerialisationTest

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPlaceOfPublicationV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPlaceOfPublicationV1SerialisationTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal.{IdentifiedWork, Place}
-import uk.ac.wellcome.models.work.test.WorksUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayPlaceOfPublicationV1SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPlaceOfPublicationV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPlaceOfPublicationV1SerialisationTest.scala
@@ -2,8 +2,9 @@ package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
-import uk.ac.wellcome.display.test.util.{JsonMapperTestUtil, WorksUtil}
+import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal.{IdentifiedWork, Place}
+import uk.ac.wellcome.models.work.test.WorksUtil
 
 class DisplayPlaceOfPublicationV1SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPublicationDateV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPublicationDateV1SerialisationTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal.{IdentifiedWork, Period}
-import uk.ac.wellcome.models.work.test.WorksUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayPublicationDateV1SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPublicationDateV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPublicationDateV1SerialisationTest.scala
@@ -2,8 +2,9 @@ package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
-import uk.ac.wellcome.display.test.util.{JsonMapperTestUtil, WorksUtil}
+import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal.{IdentifiedWork, Period}
+import uk.ac.wellcome.models.work.test.WorksUtil
 
 class DisplayPublicationDateV1SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPublishersV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPublishersV1SerialisationTest.scala
@@ -2,8 +2,9 @@ package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
-import uk.ac.wellcome.display.test.util.{JsonMapperTestUtil, WorksUtil}
+import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.test.WorksUtil
 
 class DisplayPublishersV1SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPublishersV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPublishersV1SerialisationTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.WorksUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayPublishersV1SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.display.models.{
 }
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.WorksUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayWorkV1SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -5,8 +5,9 @@ import uk.ac.wellcome.display.models.{
   DisplaySerialisationTestBase,
   WorksIncludes
 }
-import uk.ac.wellcome.display.test.util.{JsonMapperTestUtil, WorksUtil}
+import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.test.WorksUtil
 
 class DisplayWorkV1SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationsV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationsV2SerialisationTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.models.work.internal.{
   IdentifiedWork,
   PhysicalLocation
 }
-import uk.ac.wellcome.models.work.test.WorksUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayLocationsV2SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationsV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationsV2SerialisationTest.scala
@@ -5,12 +5,13 @@ import uk.ac.wellcome.display.models.{
   DisplaySerialisationTestBase,
   WorksIncludes
 }
-import uk.ac.wellcome.display.test.util.{JsonMapperTestUtil, WorksUtil}
+import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal.{
   IdentifiedItem,
   IdentifiedWork,
   PhysicalLocation
 }
+import uk.ac.wellcome.models.work.test.WorksUtil
 
 class DisplayLocationsV2SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPlaceOfPublicationV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPlaceOfPublicationV2SerialisationTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal.{IdentifiedWork, Place}
-import uk.ac.wellcome.models.work.test.WorksUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayPlaceOfPublicationV2SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPlaceOfPublicationV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPlaceOfPublicationV2SerialisationTest.scala
@@ -2,8 +2,9 @@ package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
-import uk.ac.wellcome.display.test.util.{JsonMapperTestUtil, WorksUtil}
+import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal.{IdentifiedWork, Place}
+import uk.ac.wellcome.models.work.test.WorksUtil
 
 class DisplayPlaceOfPublicationV2SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPublicationDateV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPublicationDateV2SerialisationTest.scala
@@ -2,8 +2,9 @@ package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
-import uk.ac.wellcome.display.test.util.{JsonMapperTestUtil, WorksUtil}
+import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal.{IdentifiedWork, Period}
+import uk.ac.wellcome.models.work.test.WorksUtil
 
 class DisplayPublicationDateV2SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPublicationDateV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPublicationDateV2SerialisationTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal.{IdentifiedWork, Period}
-import uk.ac.wellcome.models.work.test.WorksUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayPublicationDateV2SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPublishersV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPublishersV2SerialisationTest.scala
@@ -2,8 +2,9 @@ package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
-import uk.ac.wellcome.display.test.util.{JsonMapperTestUtil, WorksUtil}
+import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.test.WorksUtil
 
 class DisplayPublishersV2SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPublishersV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPublishersV2SerialisationTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.WorksUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayPublishersV2SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.display.models.{
 }
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.WorksUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayWorkV2SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -5,8 +5,9 @@ import uk.ac.wellcome.display.models.{
   DisplaySerialisationTestBase,
   WorksIncludes
 }
-import uk.ac.wellcome.display.test.util.{JsonMapperTestUtil, WorksUtil}
+import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.test.WorksUtil
 
 class DisplayWorkV2SerialisationTest
     extends FunSpec

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.display.test.util
+package uk.ac.wellcome.models.work.test.util
 
 import uk.ac.wellcome.models.work.internal._
 


### PR DESCRIPTION
As it doesn't actually contain any display-specific logic!

### Who is this change for?

Me, as I refactor one of the ingestor tests, and I want to use this utility!