### PR TITLE
Make use of WorksUtil in the ingestor tests

### DIFF
--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
@@ -1,0 +1,33 @@
+package uk.ac.wellcome.platform.ingestor.fixtures
+
+import com.sksamuel.elastic4s.http.HttpClient
+import org.scalatest.Suite
+import uk.ac.wellcome.monitoring.MetricsSender
+import uk.ac.wellcome.monitoring.test.fixtures.{MetricsSender => MetricsSenderFixture}
+import uk.ac.wellcome.platform.ingestor.services.WorkIndexer
+import uk.ac.wellcome.test.fixtures._
+
+trait WorkIndexerFixtures extends Akka with MetricsSenderFixture { this: Suite =>
+  def withWorkIndexer[R](
+    esType: String,
+    elasticClient: HttpClient,
+    metricsSender: MetricsSender)(testWith: TestWith[WorkIndexer, R]): R = {
+    val workIndexer = new WorkIndexer(
+      esType = esType,
+      elasticClient = elasticClient,
+      metricsSender = metricsSender
+    )
+
+    testWith(workIndexer)
+  }
+
+  def withWorkIndexerFixtures[R](esType: String, elasticClient: HttpClient)(testWith: TestWith[WorkIndexer, R]): R = {
+    withActorSystem { actorSystem =>
+      withMetricsSender(actorSystem) { metricsSender =>
+        withWorkIndexer(esType, elasticClient, metricsSender) { workIndexer =>
+          testWith(workIndexer)
+        }
+      }
+    }
+  }
+}

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -3,19 +3,14 @@ package uk.ac.wellcome.platform.ingestor.services
 import java.net.ConnectException
 
 import akka.actor.ActorSystem
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.sksamuel.elastic4s.http.HttpClient
 import org.apache.http.HttpHost
 import org.elasticsearch.client.RestClient
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.finatra.modules.ElasticCredentials
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.monitoring.MetricsSender
-import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSReader}
-import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
 import uk.ac.wellcome.models.work.internal.{
   IdentifiedWork,
@@ -23,8 +18,10 @@ import uk.ac.wellcome.models.work.internal.{
   SourceIdentifier
 }
 import uk.ac.wellcome.models.work.test.util.WorksUtil
+import uk.ac.wellcome.monitoring.MetricsSender
+import uk.ac.wellcome.platform.ingestor.fixtures.WorkIndexerFixtures
 import uk.ac.wellcome.storage.test.fixtures.S3
-import uk.ac.wellcome.test.utils.JsonTestUtil
+import uk.ac.wellcome.test.fixtures.TestWith
 
 import scala.concurrent.duration._
 
@@ -32,24 +29,14 @@ class IngestorWorkerServiceTest
     extends FunSpec
     with ScalaFutures
     with Matchers
-    with MockitoSugar
-    with JsonTestUtil
     with ElasticsearchFixtures
     with SQS
     with S3
+    with WorkIndexerFixtures
     with Messaging
     with WorksUtil {
 
   val itemType = "work"
-
-  val metricsSender: MetricsSender =
-    new MetricsSender(
-      namespace = "reindexer-tests",
-      flushInterval = 100 milliseconds,
-      amazonCloudWatch = mock[AmazonCloudWatch],
-      actorSystem = ActorSystem())
-
-  val actorSystem = ActorSystem()
 
   it("inserts an Miro identified Work into v1 and v2 indices") {
     val miroSourceIdentifier = SourceIdentifier(
@@ -60,37 +47,20 @@ class IngestorWorkerServiceTest
 
     val work = createWork().copy(sourceIdentifier = miroSourceIdentifier)
 
-    val workIndexer =
-      new WorkIndexer(itemType, elasticClient, metricsSender)
+    withLocalElasticsearchIndex(itemType = itemType) { esIndexV1 =>
+      withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
+        withIngestorWorkerService[Assertion](esIndexV1, esIndexV2) { service =>
+          service.processMessage(work)
 
-    withLocalSqsQueue { queue =>
-      withLocalS3Bucket { bucket =>
-        withMessageReader[IdentifiedWork, Assertion](bucket, queue) {
-          messageReader =>
-            withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
-              withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
-                val service = new IngestorWorkerService(
-                  indexNameV1,
-                  indexNameV2,
-                  identifiedWorkIndexer = workIndexer,
-                  messageReader = messageReader,
-                  system = actorSystem,
-                  metrics = metricsSender
-                )
+          assertElasticsearchEventuallyHasWork(
+            work,
+            indexName = esIndexV1,
+            itemType = itemType)
 
-                service.processMessage(work)
-
-                assertElasticsearchEventuallyHasWork(
-                  work,
-                  indexName = indexNameV1,
-                  itemType = itemType)
-
-                assertElasticsearchEventuallyHasWork(
-                  work,
-                  indexName = indexNameV2,
-                  itemType = itemType)
-              }
-            }
+          assertElasticsearchEventuallyHasWork(
+            work,
+            indexName = esIndexV2,
+            itemType = itemType)
         }
       }
     }
@@ -105,38 +75,20 @@ class IngestorWorkerServiceTest
 
     val work = createWork().copy(sourceIdentifier = sierraSourceIdentifier)
 
-    val workIndexer =
-      new WorkIndexer(itemType, elasticClient, metricsSender)
+    withLocalElasticsearchIndex(itemType = itemType) { esIndexV1 =>
+      withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
+        withIngestorWorkerService[Assertion](esIndexV1, esIndexV2) { service =>
+          service.processMessage(work)
 
-    withLocalSqsQueue { queue =>
-      withLocalS3Bucket { bucket =>
-        withMessageReader[IdentifiedWork, Assertion](bucket, queue) {
-          messageReader =>
-            withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
-              withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
-                val service = new IngestorWorkerService(
-                  indexNameV1,
-                  indexNameV2,
-                  identifiedWorkIndexer = workIndexer,
-                  messageReader = messageReader,
-                  system = actorSystem,
-                  metrics = metricsSender
-                )
+          assertElasticsearchNeverHasWork(
+            work,
+            indexName = esIndexV1,
+            itemType = itemType)
 
-                service.processMessage(work)
-
-                assertElasticsearchNeverHasWork(
-                  work,
-                  indexName = indexNameV1,
-                  itemType = itemType)
-
-                assertElasticsearchEventuallyHasWork(
-                  work,
-                  indexName = indexNameV2,
-                  itemType = itemType)
-
-              }
-            }
+          assertElasticsearchEventuallyHasWork(
+            work,
+            indexName = esIndexV2,
+            itemType = itemType)
         }
       }
     }
@@ -151,33 +103,15 @@ class IngestorWorkerServiceTest
 
     val work = createWork().copy(sourceIdentifier = calmSourceIdentifier)
 
-    val workIndexer =
-      new WorkIndexer(itemType, elasticClient, metricsSender)
+    withLocalElasticsearchIndex(itemType = itemType) { esIndexV1 =>
+      withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
+        withIngestorWorkerService[Assertion](esIndexV1, esIndexV2) { service =>
+          val future = service.processMessage(work)
 
-    withLocalSqsQueue { queue =>
-      withLocalS3Bucket { bucket =>
-        withMessageReader[IdentifiedWork, Assertion](bucket, queue) {
-          messageReader =>
-            withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
-              withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
-                val service = new IngestorWorkerService(
-                  indexNameV1,
-                  indexNameV2,
-                  identifiedWorkIndexer = workIndexer,
-                  messageReader = messageReader,
-                  system = actorSystem,
-                  metrics = metricsSender
-                )
-
-                val future = service.processMessage(work)
-
-                whenReady(future.failed) { ex =>
-                  ex shouldBe a[GracefulFailureException]
-                  ex.getMessage shouldBe s"Cannot ingest work with identifierScheme: ${IdentifierSchemes.calmAltRefNo}"
-
-                }
-              }
-            }
+          whenReady(future.failed) { ex =>
+            ex shouldBe a[GracefulFailureException]
+            ex.getMessage shouldBe s"Cannot ingest work with identifierScheme: ${IdentifierSchemes.calmAltRefNo}"
+          }
         }
       }
     }
@@ -193,37 +127,72 @@ class IngestorWorkerServiceTest
     val brokenElasticClient: HttpClient =
       HttpClient.fromRestClient(brokenRestClient)
 
-    val brokenWorkIndexer = new WorkIndexer(
-      esType = "work",
-      elasticClient = brokenElasticClient,
-      metricsSender = metricsSender
-    )
+    withActorSystem { actorSystem =>
+      withMetricsSender(actorSystem) { metricsSender =>
+        val brokenWorkIndexer = new WorkIndexer(
+          esType = "work",
+          elasticClient = brokenElasticClient,
+          metricsSender = metricsSender
+        )
 
-    val miroSourceIdentifier = SourceIdentifier(
-      identifierScheme = IdentifierSchemes.miroImageNumber,
-      ontologyType = "Work",
-      value = "B000675"
-    )
+        val miroSourceIdentifier = SourceIdentifier(
+          identifierScheme = IdentifierSchemes.miroImageNumber,
+          ontologyType = "Work",
+          value = "B000675"
+        )
 
-    val work = createWork().copy(sourceIdentifier = miroSourceIdentifier)
+        val work = createWork().copy(sourceIdentifier = miroSourceIdentifier)
 
+        withIngestorWorkerService[Assertion](
+          esIndexV1 = "works-v1",
+          esIndexV2 = "works-v2",
+          actorSystem = actorSystem,
+          metricsSender = metricsSender,
+          workIndexer = brokenWorkIndexer) { service =>
+          val future = service.processMessage(work)
+          whenReady(future.failed) { result =>
+            result shouldBe a[ConnectException]
+          }
+        }
+      }
+    }
+  }
+
+  private def withIngestorWorkerService[R](
+    esIndexV1: String,
+    esIndexV2: String)(testWith: TestWith[IngestorWorkerService, R]): R = {
+    withActorSystem { actorSystem =>
+      withMetricsSender(actorSystem) { metricsSender =>
+        withWorkIndexer[R](itemType, elasticClient, metricsSender) { workIndexer =>
+          withIngestorWorkerService[R](esIndexV1, esIndexV2, actorSystem, metricsSender, workIndexer) { service =>
+            testWith(service)
+          }
+        }
+      }
+    }
+  }
+
+  private def withIngestorWorkerService[R](
+    esIndexV1: String,
+    esIndexV2: String,
+    actorSystem: ActorSystem,
+    metricsSender: MetricsSender,
+    workIndexer: WorkIndexer)(testWith: TestWith[IngestorWorkerService, R]): R = {
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        withMessageReader[IdentifiedWork, Assertion](bucket, queue) {
-          messageReader =>
+        withMessageReader[IdentifiedWork, R](bucket, queue) { messageReader =>
+          withWorkIndexer[R](itemType, elasticClient, metricsSender) { workIndexer =>
             val service = new IngestorWorkerService(
-              "works-v1",
-              "works-v2",
-              identifiedWorkIndexer = brokenWorkIndexer,
+              esIndexV1 = esIndexV1,
+              esIndexV2 = esIndexV2,
+              identifiedWorkIndexer = workIndexer,
               messageReader = messageReader,
               system = actorSystem,
               metrics = metricsSender
             )
 
-            val future = service.processMessage(work)
-            whenReady(future.failed) { result =>
-              result shouldBe a[ConnectException]
-            }
+            testWith(service)
+          }
         }
       }
     }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -199,7 +199,13 @@ class IngestorWorkerServiceTest
       metricsSender = metricsSender
     )
 
-    val work = createMiroWork(sourceId = "B000765")
+    val miroSourceIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.miroImageNumber,
+      ontologyType = "Work",
+      value = "B000675"
+    )
+
+    val work = createWork().copy(sourceIdentifier = miroSourceIdentifier)
 
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -53,38 +53,33 @@ class IngestorWorkerServiceTest
     canonicalId: String,
     sourceId: String,
     title: String,
-    visible: Boolean = true,
-    version: Int = 1
+    visible: Boolean = true
   ): IdentifiedWork =
     createWork(
       canonicalId,
       sourceId,
       title,
       IdentifierSchemes.miroImageNumber,
-      visible,
-      version)
+      visible)
 
   def createSierraWork(
     canonicalId: String,
     sourceId: String,
     title: String,
-    visible: Boolean = true,
-    version: Int = 1
+    visible: Boolean = true
   ): IdentifiedWork =
     createWork(
       canonicalId,
       sourceId,
       title,
       IdentifierSchemes.sierraSystemNumber,
-      visible,
-      version)
+      visible)
 
   def createWork(canonicalId: String,
                  sourceId: String,
                  title: String,
                  identifierScheme: IdentifierSchemes.IdentifierScheme,
-                 visible: Boolean = true,
-                 version: Int = 1): IdentifiedWork = {
+                 visible: Boolean = true): IdentifiedWork = {
     val sourceIdentifier = SourceIdentifier(
       identifierScheme = identifierScheme,
       ontologyType = "Work",
@@ -94,10 +89,10 @@ class IngestorWorkerServiceTest
     IdentifiedWork(
       title = Some(title),
       sourceIdentifier = sourceIdentifier,
-      version = version,
       identifiers = List(sourceIdentifier),
       canonicalId = canonicalId,
-      visible = visible)
+      visible = visible,
+      version = 1)
   }
 
   it("inserts an Miro identified Work into v1 and v2 indices") {

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -52,34 +52,29 @@ class IngestorWorkerServiceTest
   def createMiroWork(
     canonicalId: String,
     sourceId: String,
-    title: String,
-    visible: Boolean = true
+    title: String
   ): IdentifiedWork =
     createWork(
       canonicalId,
       sourceId,
       title,
-      IdentifierSchemes.miroImageNumber,
-      visible)
+      IdentifierSchemes.miroImageNumber)
 
   def createSierraWork(
     canonicalId: String,
     sourceId: String,
-    title: String,
-    visible: Boolean = true
+    title: String
   ): IdentifiedWork =
     createWork(
       canonicalId,
       sourceId,
       title,
-      IdentifierSchemes.sierraSystemNumber,
-      visible)
+      IdentifierSchemes.sierraSystemNumber)
 
   def createWork(canonicalId: String,
                  sourceId: String,
                  title: String,
-                 identifierScheme: IdentifierSchemes.IdentifierScheme,
-                 visible: Boolean = true): IdentifiedWork = {
+                 identifierScheme: IdentifierSchemes.IdentifierScheme): IdentifiedWork = {
     val sourceIdentifier = SourceIdentifier(
       identifierScheme = identifierScheme,
       ontologyType = "Work",
@@ -91,7 +86,6 @@ class IngestorWorkerServiceTest
       sourceIdentifier = sourceIdentifier,
       identifiers = List(sourceIdentifier),
       canonicalId = canonicalId,
-      visible = visible,
       version = 1)
   }
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -51,32 +51,14 @@ class IngestorWorkerServiceTest
 
   val actorSystem = ActorSystem()
 
-  def createMiroWork(sourceId: String): IdentifiedWork =
-    createWork(
-      sourceId = canonicalId,
-      identifierScheme = IdentifierSchemes.miroImageNumber
-    )
-
-  def createSierraWork(sourceId: String): IdentifiedWork =
-    createWork(
-      sourceId = sourceId,
-      identifierScheme = IdentifierSchemes.sierraSystemNumber
-    )
-
-  def createWork(sourceId: String,
-                 identifierScheme: IdentifierSchemes.IdentifierScheme): IdentifiedWork = {
-    val sourceIdentifier = SourceIdentifier(
-      identifierScheme = identifierScheme,
-      ontologyType = "Work",
-      value = sourceId
-    )
-
-    val work = createWorks(count = 1).head
-    work.copy(sourceIdentifier = sourceIdentifier)
-  }
-
   it("inserts an Miro identified Work into v1 and v2 indices") {
-    val work: IdentifiedWork = createMiroWork(sourceId = "M000765")
+    val miroSourceIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.miroImageNumber,
+      ontologyType = "Work",
+      value = "M000765"
+    )
+
+    val work = createWork().copy(sourceIdentifier = miroSourceIdentifier)
 
     val workIndexer =
       new WorkIndexer(itemType, elasticClient, metricsSender)
@@ -115,7 +97,13 @@ class IngestorWorkerServiceTest
   }
 
   it("inserts an Sierra identified Work only into the v2 index") {
-    val work = createSierraWork(sourceId = "M000765")
+    val sierraSourceIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.miroImageNumber,
+      ontologyType = "Work",
+      value = "b1027467"
+    )
+
+    val work = createWork().copy(sourceIdentifier = sierraSourceIdentifier)
 
     val workIndexer =
       new WorkIndexer(itemType, elasticClient, metricsSender)
@@ -155,10 +143,13 @@ class IngestorWorkerServiceTest
   }
 
   it("fails inserting a non sierra or miro identified work") {
-    val work = createWork(
-      sourceId = "MS/237",
-      identifierScheme = IdentifierSchemes.calmAltRefNo
+    val calmSourceIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.calmAltRefNo,
+      ontologyType = "Work",
+      value = "MS/237"
     )
+
+    val work = createWork().copy(sourceIdentifier = calmSourceIdentifier)
 
     val workIndexer =
       new WorkIndexer(itemType, elasticClient, metricsSender)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -107,5 +107,7 @@ class WorkIndexerTest
   }
 
   def createVersionedWork(version: Int = 1): IdentifiedWork =
-    createWorks(count = 1, version = version).head
+    createWorks(count = 1)
+      .head
+      .copy(version = version)
 }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -107,7 +107,5 @@ class WorkIndexerTest
   }
 
   def createVersionedWork(version: Int = 1): IdentifiedWork =
-    createWorks(count = 1)
-      .head
-      .copy(version = version)
+    createWorks(count = 1, version = version).head
 }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -1,51 +1,38 @@
 package uk.ac.wellcome.platform.ingestor.services
 
-import akka.actor.ActorSystem
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.models.work.test.util.WorksUtil
+import uk.ac.wellcome.platform.ingestor.fixtures.WorkIndexerFixtures
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.Future
-import scala.concurrent.duration._
 
 class WorkIndexerTest
     extends FunSpec
     with ScalaFutures
     with Matchers
-    with MockitoSugar
     with ElasticsearchFixtures
-    with WorksUtil {
+    with WorksUtil
+    with WorkIndexerFixtures {
 
-  val metricsSender: MetricsSender =
-    new MetricsSender(
-      namespace = "reindexer-tests",
-      100 milliseconds,
-      mock[AmazonCloudWatch],
-      ActorSystem())
-
-  val indexName = "works"
   val itemType = "work"
-
-  val workIndexer =
-    new WorkIndexer(itemType, elasticClient, metricsSender)
 
   it("inserts an identified Work into Elasticsearch") {
     val work = createVersionedWork()
 
-    withLocalElasticsearchIndex(indexName, itemType) { _ =>
-      val future = workIndexer.indexWork(work, indexName)
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withWorkIndexerFixtures(itemType, elasticClient) { workIndexer =>
+        val future = workIndexer.indexWork(work, indexName)
 
-      whenReady(future) { _ =>
-        assertElasticsearchEventuallyHasWork(
-          work,
-          indexName = indexName,
-          itemType = itemType)
+        whenReady(future) { _ =>
+          assertElasticsearchEventuallyHasWork(
+            work,
+            indexName = indexName,
+            itemType = itemType)
+        }
       }
     }
   }
@@ -53,16 +40,18 @@ class WorkIndexerTest
   it("only adds one record when the same ID is ingested multiple times") {
     val work = createVersionedWork()
 
-    withLocalElasticsearchIndex(indexName, itemType) { _ =>
-      val future = Future.sequence(
-        (1 to 2).map(_ => workIndexer.indexWork(work, indexName))
-      )
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withWorkIndexerFixtures[Assertion](itemType, elasticClient) { workIndexer =>
+        val future = Future.sequence(
+          (1 to 2).map(_ => workIndexer.indexWork(work, indexName))
+        )
 
-      whenReady(future) { _ =>
-        assertElasticsearchEventuallyHasWork(
-          work,
-          indexName = indexName,
-          itemType = itemType)
+        whenReady(future) { _ =>
+          assertElasticsearchEventuallyHasWork(
+            work,
+            indexName = indexName,
+            itemType = itemType)
+        }
       }
     }
   }
@@ -71,19 +60,21 @@ class WorkIndexerTest
     val work = createVersionedWork(version = 3)
     val olderWork = work.copy(version = 1)
 
-    withLocalElasticsearchIndex(indexName, itemType) { _ =>
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
       insertIntoElasticsearch(indexName = indexName, itemType = itemType, work)
 
-      val future = workIndexer.indexWork(olderWork, indexName)
+      withWorkIndexerFixtures(itemType, elasticClient) { workIndexer =>
+        val future = workIndexer.indexWork(olderWork, indexName)
 
-      whenReady(future) { _ =>
-        // Give Elasticsearch enough time to ingest the work
-        Thread.sleep(700)
+        whenReady(future) { _ =>
+          // Give Elasticsearch enough time to ingest the work
+          Thread.sleep(700)
 
-        assertElasticsearchEventuallyHasWork(
-          work,
-          indexName = indexName,
-          itemType = itemType)
+          assertElasticsearchEventuallyHasWork(
+            work,
+            indexName = indexName,
+            itemType = itemType)
+        }
       }
     }
   }
@@ -92,16 +83,18 @@ class WorkIndexerTest
     val work = createVersionedWork(version = 3)
     val updatedWork = work.copy(title = Some("boring title"))
 
-    withLocalElasticsearchIndex(indexName, itemType) { _ =>
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
       insertIntoElasticsearch(indexName = indexName, itemType = itemType, work)
 
-      val future = workIndexer.indexWork(updatedWork, indexName)
+      withWorkIndexerFixtures(itemType, elasticClient) { workIndexer =>
+        val future = workIndexer.indexWork(updatedWork, indexName)
 
-      whenReady(future) { _ =>
-        assertElasticsearchEventuallyHasWork(
-          updatedWork,
-          indexName = indexName,
-          itemType = itemType)
+        whenReady(future) { _ =>
+          assertElasticsearchEventuallyHasWork(
+            updatedWork,
+            indexName = indexName,
+            itemType = itemType)
+        }
       }
     }
   }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -36,8 +36,7 @@ trait WorksUtil {
 
   def createWorks(count: Int,
                   start: Int = 1,
-                  visible: Boolean = true,
-                  version: Int = 1): Seq[IdentifiedWork] =
+                  visible: Boolean = true): Seq[IdentifiedWork] =
     (start to count).map(
       (idx: Int) =>
         workWith(
@@ -48,8 +47,7 @@ trait WorksUtil {
           createdDate = Period(s"${idx}-${period.label}"),
           creator = Agent(s"${idx}-${agent.label}"),
           items = List(defaultItem),
-          visible = visible,
-          version = version
+          visible = visible
       ))
 
   def workWith(canonicalId: String, title: String): IdentifiedWork =
@@ -135,12 +133,11 @@ trait WorksUtil {
                subjects: List[Subject],
                genres: List[Genre],
                items: List[IdentifiedItem],
-               visible: Boolean,
-               version: Int): IdentifiedWork =
+               visible: Boolean): IdentifiedWork =
     IdentifiedWork(
       title = Some(title),
       sourceIdentifier = sourceIdentifier,
-      version = version,
+      version = 1,
       identifiers = List(sourceIdentifier),
       canonicalId = canonicalId,
       workType = Some(workType),

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -33,7 +33,8 @@ trait WorksUtil {
 
   def createWorks(count: Int,
                   start: Int = 1,
-                  visible: Boolean = true): Seq[IdentifiedWork] =
+                  visible: Boolean = true,
+                  version: Int = 1): Seq[IdentifiedWork] =
     (start to count).map(
       (idx: Int) =>
         workWith(
@@ -44,7 +45,8 @@ trait WorksUtil {
           createdDate = Period(s"${idx}-${period.label}"),
           creator = Agent(s"${idx}-${agent.label}"),
           items = List(defaultItem),
-          visible = visible
+          visible = visible,
+          version = version
       ))
 
   def workWith(canonicalId: String, title: String): IdentifiedWork =
@@ -130,11 +132,12 @@ trait WorksUtil {
                subjects: List[Subject],
                genres: List[Genre],
                items: List[IdentifiedItem],
-               visible: Boolean): IdentifiedWork =
+               visible: Boolean,
+               version: Int): IdentifiedWork =
     IdentifiedWork(
       title = Some(title),
       sourceIdentifier = sourceIdentifier,
-      version = 1,
+      version = version,
       identifiers = List(sourceIdentifier),
       canonicalId = canonicalId,
       workType = Some(workType),

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -31,8 +31,8 @@ trait WorksUtil {
     "sourceIdentifierFromWorksUtil"
   )
 
-  def createWork(visible: Boolean = true, version: Int = 1): IdentifiedWork =
-    createWorks(count = 1, visible = visible, version = version).head
+  def createWork(visible: Boolean = true): IdentifiedWork =
+    createWorks(count = 1, visible = visible).head
 
   def createWorks(count: Int,
                   start: Int = 1,

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -31,6 +31,9 @@ trait WorksUtil {
     "sourceIdentifierFromWorksUtil"
   )
 
+  def createWork(visible: Boolean = true, version: Int = 1): IdentifiedWork =
+    createWorks(count = 1, visible = visible, version = version).head
+
   def createWorks(count: Int,
                   start: Int = 1,
                   visible: Boolean = true,


### PR DESCRIPTION
A follow-up to #1986. Once WorksUtil is available to non-display applications, we can simplify a chunk of this code.