### PR TITLE
Use fixtures in the ingestor test

### DIFF
--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixture.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixture.scala
@@ -1,0 +1,33 @@
+package uk.ac.wellcome.platform.ingestor.fixtures
+
+import com.sksamuel.elastic4s.http.HttpClient
+import org.scalatest.Suite
+import uk.ac.wellcome.monitoring.MetricsSender
+import uk.ac.wellcome.monitoring.test.fixtures.{MetricsSender => MetricsSenderFixture}
+import uk.ac.wellcome.platform.ingestor.services.WorksIndexer
+import uk.ac.wellcome.test.fixtures._
+
+trait WorkIndexerFixture extends Akka with MetricsSenderFixture { this: Suite =>
+  def withWorkIndexer[R](
+    esType: String,
+    elasticClient: HttpClient,
+    metricsSender: MetricsSender)(testWith: TestWith[String, R]): R = {
+    val workIndexer = new WorkIndexer(
+      esType = esType,
+      elasticClient = elasticClient,
+      metricsSender = metricsSender
+    )
+
+    testWith(workIndexer)
+  }
+
+  def withWorkIndexerFixtures[R](esType: String, elasticClient: HttpClient)(testWith: TestWith[String, R]): R = {
+    withActorSystem { actorSystem =>
+      withMetricsSender(actorSystem) { metricsSender =>
+        withWorkIndexer(esType, elasticClient, metricsSender) { workIndexer =>
+          testWith(workIndexer)
+        }
+      }
+    }
+  }
+}

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixture.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixture.scala
@@ -4,14 +4,14 @@ import com.sksamuel.elastic4s.http.HttpClient
 import org.scalatest.Suite
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.test.fixtures.{MetricsSender => MetricsSenderFixture}
-import uk.ac.wellcome.platform.ingestor.services.WorksIndexer
+import uk.ac.wellcome.platform.ingestor.services.WorkIndexer
 import uk.ac.wellcome.test.fixtures._
 
 trait WorkIndexerFixture extends Akka with MetricsSenderFixture { this: Suite =>
   def withWorkIndexer[R](
     esType: String,
     elasticClient: HttpClient,
-    metricsSender: MetricsSender)(testWith: TestWith[String, R]): R = {
+    metricsSender: MetricsSender)(testWith: TestWith[WorkIndexer, R]): R = {
     val workIndexer = new WorkIndexer(
       esType = esType,
       elasticClient = elasticClient,
@@ -21,7 +21,7 @@ trait WorkIndexerFixture extends Akka with MetricsSenderFixture { this: Suite =>
     testWith(workIndexer)
   }
 
-  def withWorkIndexerFixtures[R](esType: String, elasticClient: HttpClient)(testWith: TestWith[String, R]): R = {
+  def withWorkIndexerFixtures[R](esType: String, elasticClient: HttpClient)(testWith: TestWith[WorkIndexer, R]): R = {
     withActorSystem { actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>
         withWorkIndexer(esType, elasticClient, metricsSender) { workIndexer =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.monitoring.test.fixtures.{MetricsSender => MetricsSenderFi
 import uk.ac.wellcome.platform.ingestor.services.WorkIndexer
 import uk.ac.wellcome.test.fixtures._
 
-trait WorkIndexerFixture extends Akka with MetricsSenderFixture { this: Suite =>
+trait WorkIndexerFixtures extends Akka with MetricsSenderFixture { this: Suite =>
   def withWorkIndexer[R](
     esType: String,
     elasticClient: HttpClient,

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -10,8 +10,6 @@ import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.finatra.modules.ElasticCredentials
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSReader}
-import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
 import uk.ac.wellcome.models.work.internal.{
   IdentifiedWork,

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -2,18 +2,14 @@ package uk.ac.wellcome.platform.ingestor.services
 
 import java.net.ConnectException
 
-import akka.actor.ActorSystem
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.sksamuel.elastic4s.http.HttpClient
 import org.apache.http.HttpHost
 import org.elasticsearch.client.RestClient
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.finatra.modules.ElasticCredentials
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSReader}
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
@@ -23,7 +19,9 @@ import uk.ac.wellcome.models.work.internal.{
   SourceIdentifier
 }
 import uk.ac.wellcome.models.work.test.util.WorksUtil
+import uk.ac.wellcome.platform.ingestor.fixtures.WorkIndexerFixture
 import uk.ac.wellcome.storage.test.fixtures.S3
+import uk.ac.wellcome.test.fixtures.TestWith
 import uk.ac.wellcome.test.utils.JsonTestUtil
 
 import scala.concurrent.duration._
@@ -32,24 +30,15 @@ class IngestorWorkerServiceTest
     extends FunSpec
     with ScalaFutures
     with Matchers
-    with MockitoSugar
     with JsonTestUtil
     with ElasticsearchFixtures
     with SQS
     with S3
+    with WorkIndexerFixture
     with Messaging
     with WorksUtil {
 
-  val itemType = "work"
-
-  val metricsSender: MetricsSender =
-    new MetricsSender(
-      namespace = "reindexer-tests",
-      flushInterval = 100 milliseconds,
-      amazonCloudWatch = mock[AmazonCloudWatch],
-      actorSystem = ActorSystem())
-
-  val actorSystem = ActorSystem()
+  val esType = "work"
 
   it("inserts an Miro identified Work into v1 and v2 indices") {
     val miroSourceIdentifier = SourceIdentifier(
@@ -60,37 +49,20 @@ class IngestorWorkerServiceTest
 
     val work = createWork().copy(sourceIdentifier = miroSourceIdentifier)
 
-    val workIndexer =
-      new WorkIndexer(itemType, elasticClient, metricsSender)
+    withLocalElasticsearchIndex(esType = esType) { esIndexV1 =>
+      withLocalElasticsearchIndex(esType = esType) { esIndexV2 =>
+        withIngestorWorkerService(esIndexV1, esIndexV2) { service =>
+          service.processMessage(work)
 
-    withLocalSqsQueue { queue =>
-      withLocalS3Bucket { bucket =>
-        withMessageReader[IdentifiedWork, Assertion](bucket, queue) {
-          messageReader =>
-            withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
-              withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
-                val service = new IngestorWorkerService(
-                  indexNameV1,
-                  indexNameV2,
-                  identifiedWorkIndexer = workIndexer,
-                  messageReader = messageReader,
-                  system = actorSystem,
-                  metrics = metricsSender
-                )
+          assertElasticsearchEventuallyHasWork(
+            work,
+            indexName = indexNameV1,
+            esType = esType)
 
-                service.processMessage(work)
-
-                assertElasticsearchEventuallyHasWork(
-                  work,
-                  indexName = indexNameV1,
-                  itemType = itemType)
-
-                assertElasticsearchEventuallyHasWork(
-                  work,
-                  indexName = indexNameV2,
-                  itemType = itemType)
-              }
-            }
+          assertElasticsearchEventuallyHasWork(
+            work,
+            indexName = indexNameV2,
+            esType = esType)
         }
       }
     }
@@ -105,38 +77,20 @@ class IngestorWorkerServiceTest
 
     val work = createWork().copy(sourceIdentifier = sierraSourceIdentifier)
 
-    val workIndexer =
-      new WorkIndexer(itemType, elasticClient, metricsSender)
+    withLocalElasticsearchIndex(esType = esType) { esIndexV1 =>
+      withLocalElasticsearchIndex(esType = esType) { esIndexV2 =>
+        withIngestorWorkerService(esIndexV1, esIndexV2) { service =>
+          service.processMessage(work)
 
-    withLocalSqsQueue { queue =>
-      withLocalS3Bucket { bucket =>
-        withMessageReader[IdentifiedWork, Assertion](bucket, queue) {
-          messageReader =>
-            withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
-              withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
-                val service = new IngestorWorkerService(
-                  indexNameV1,
-                  indexNameV2,
-                  identifiedWorkIndexer = workIndexer,
-                  messageReader = messageReader,
-                  system = actorSystem,
-                  metrics = metricsSender
-                )
+          assertElasticsearchNeverHasWork(
+            work,
+            indexName = indexNameV1,
+            esType = esType)
 
-                service.processMessage(work)
-
-                assertElasticsearchNeverHasWork(
-                  work,
-                  indexName = indexNameV1,
-                  itemType = itemType)
-
-                assertElasticsearchEventuallyHasWork(
-                  work,
-                  indexName = indexNameV2,
-                  itemType = itemType)
-
-              }
-            }
+          assertElasticsearchEventuallyHasWork(
+            work,
+            indexName = indexNameV2,
+            esType = esType)
         }
       }
     }
@@ -151,33 +105,15 @@ class IngestorWorkerServiceTest
 
     val work = createWork().copy(sourceIdentifier = calmSourceIdentifier)
 
-    val workIndexer =
-      new WorkIndexer(itemType, elasticClient, metricsSender)
+    withLocalElasticsearchIndex(esType = esType) { esIndexV1 =>
+      withLocalElasticsearchIndex(esType = esType) { esIndexV2 =>
+        withIngestorWorkerService(esIndexV1, esIndexV2) { service =>
+          val future = service.processMessage(work)
 
-    withLocalSqsQueue { queue =>
-      withLocalS3Bucket { bucket =>
-        withMessageReader[IdentifiedWork, Assertion](bucket, queue) {
-          messageReader =>
-            withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
-              withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
-                val service = new IngestorWorkerService(
-                  indexNameV1,
-                  indexNameV2,
-                  identifiedWorkIndexer = workIndexer,
-                  messageReader = messageReader,
-                  system = actorSystem,
-                  metrics = metricsSender
-                )
-
-                val future = service.processMessage(work)
-
-                whenReady(future.failed) { ex =>
-                  ex shouldBe a[GracefulFailureException]
-                  ex.getMessage shouldBe s"Cannot ingest work with identifierScheme: ${IdentifierSchemes.calmAltRefNo}"
-
-                }
-              }
-            }
+          whenReady(future.failed) { ex =>
+            ex shouldBe a[GracefulFailureException]
+            ex.getMessage shouldBe s"Cannot ingest work with identifierScheme: ${IdentifierSchemes.calmAltRefNo}"
+          }
         }
       }
     }
@@ -207,23 +143,51 @@ class IngestorWorkerServiceTest
 
     val work = createWork().copy(sourceIdentifier = miroSourceIdentifier)
 
+    withWorkIndexer(esType, elasticClient = brokenElasticClient) { workIndexer =>
+      withIngestorWorkerService("works-v1", "works-v2", workIndexer) { service =>
+        val future = service.processMessage(work)
+        whenReady(future.failed) { result =>
+          result shouldBe a[ConnectException]
+        }
+      }
+    }
+  }
+
+  private def withIngestorWorkerService[R](
+    esIndexV1: String,
+    esIndexV2: String)(testWith: TestWith[IngestorWorkerService, R]): R = {
+    withActorSystem { actorSystem =>
+      withMetricsSender(actorSystem) { metricsSender =>
+        withWorkIndexer(esType, elasticClient, metricsSender) { workIndexer =>
+          withIngestorWorkerService(esIndexV1, esIndexV2, actorSystem, metricsSender, workIndexer) { service =>
+            testWith(service)
+          }
+        }
+      }
+    }
+  }
+
+  private def withIngestorWorkerService[R](
+    esIndexV1: String,
+    esIndexV2: String,
+    actorSystem: ActorSystem,
+    metricsSender: MetricsSender,
+    workIndexer: WorkIndexer)(testWith: TestWith[IngestorWorkerService, R]): R = {
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        withMessageReader[IdentifiedWork, Assertion](bucket, queue) {
-          messageReader =>
+        withMessageReader[IdentifiedWork, Assertion](bucket, queue) { messageReader =>
+          withWorkIndexer(esType, elasticClient, metricsSender) { workIndexer =>
             val service = new IngestorWorkerService(
-              "works-v1",
-              "works-v2",
-              identifiedWorkIndexer = brokenWorkIndexer,
+              esIndexV1 = esIndexV1,
+              esIndexV2 = esIndexV2,
+              workIndexer = workIndexer,
               messageReader = messageReader,
               system = actorSystem,
               metrics = metricsSender
             )
 
-            val future = service.processMessage(work)
-            whenReady(future.failed) { result =>
-              result shouldBe a[ConnectException]
-            }
+            testWith(service)
+          }
         }
       }
     }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -19,7 +19,7 @@ import uk.ac.wellcome.models.work.internal.{
 }
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.monitoring.MetricsSender
-import uk.ac.wellcome.platform.ingestor.fixtures.WorkIndexerFixture
+import uk.ac.wellcome.platform.ingestor.fixtures.WorkIndexerFixtures
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.test.fixtures.TestWith
 import uk.ac.wellcome.test.utils.JsonTestUtil
@@ -34,7 +34,7 @@ class IngestorWorkerServiceTest
     with ElasticsearchFixtures
     with SQS
     with S3
-    with WorkIndexerFixture
+    with WorkIndexerFixtures
     with Messaging
     with WorksUtil {
 
@@ -132,7 +132,7 @@ class IngestorWorkerServiceTest
     withActorSystem { actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>
         val brokenWorkIndexer = new WorkIndexer(
-          itemType = "work",
+          esType = "work",
           elasticClient = brokenElasticClient,
           metricsSender = metricsSender
         )
@@ -165,8 +165,8 @@ class IngestorWorkerServiceTest
     esIndexV2: String)(testWith: TestWith[IngestorWorkerService, R]): R = {
     withActorSystem { actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>
-        withWorkIndexer(itemType, elasticClient, metricsSender) { workIndexer =>
-          withIngestorWorkerService(esIndexV1, esIndexV2, actorSystem, metricsSender, workIndexer) { service =>
+        withWorkIndexer[R](itemType, elasticClient, metricsSender) { workIndexer =>
+          withIngestorWorkerService[R](esIndexV1, esIndexV2, actorSystem, metricsSender, workIndexer) { service =>
             testWith(service)
           }
         }
@@ -183,7 +183,7 @@ class IngestorWorkerServiceTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withMessageReader[IdentifiedWork, Assertion](bucket, queue) { messageReader =>
-          withWorkIndexer(itemType, elasticClient, metricsSender) { workIndexer =>
+          withWorkIndexer[R](itemType, elasticClient, metricsSender) { workIndexer =>
             val service = new IngestorWorkerService(
               esIndexV1 = esIndexV1,
               esIndexV2 = esIndexV2,

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -1,50 +1,37 @@
 package uk.ac.wellcome.platform.ingestor.services
 
-import akka.actor.ActorSystem
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.models.work.test.util.WorksUtil
+import uk.ac.wellcome.platform.ingestor.fixtures.WorkIndexerFixture
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.Future
-import scala.concurrent.duration._
 
 class WorkIndexerTest
     extends FunSpec
     with ScalaFutures
     with Matchers
-    with MockitoSugar
     with ElasticsearchFixtures
     with WorksUtil {
 
-  val metricsSender: MetricsSender =
-    new MetricsSender(
-      namespace = "reindexer-tests",
-      100 milliseconds,
-      mock[AmazonCloudWatch],
-      ActorSystem())
-
-  val itemType = "work"
-
-  val workIndexer =
-    new WorkIndexer(itemType, elasticClient, metricsSender)
+  val esType = "work"
 
   it("inserts an identified Work into Elasticsearch") {
     val work = createVersionedWork()
 
-    withLocalElasticsearchIndex(itemType) { indexName =>
-      val future = workIndexer.indexWork(work, indexName)
+    withLocalElasticsearchIndex(esType) { indexName =>
+      withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
+        val future = workIndexer.indexWork(work, indexName)
 
-      whenReady(future) { _ =>
-        assertElasticsearchEventuallyHasWork(
-          work,
-          indexName = indexName,
-          itemType = itemType)
+        whenReady(future) { _ =>
+          assertElasticsearchEventuallyHasWork(
+            work,
+            indexName = indexName,
+            esType = esType)
+        }
       }
     }
   }
@@ -52,16 +39,18 @@ class WorkIndexerTest
   it("only adds one record when the same ID is ingested multiple times") {
     val work = createVersionedWork()
 
-    withLocalElasticsearchIndex(itemType) { indexName =>
-      val future = Future.sequence(
-        (1 to 2).map(_ => workIndexer.indexWork(work, indexName))
-      )
+    withLocalElasticsearchIndex(esType) { indexName =>
+      withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
+        val future = Future.sequence(
+          (1 to 2).map(_ => workIndexer.indexWork(work, indexName))
+        )
 
-      whenReady(future) { _ =>
-        assertElasticsearchEventuallyHasWork(
-          work,
-          indexName = indexName,
-          itemType = itemType)
+        whenReady(future) { _ =>
+          assertElasticsearchEventuallyHasWork(
+            work,
+            indexName = indexName,
+            esType = esType)
+        }
       }
     }
   }
@@ -70,19 +59,21 @@ class WorkIndexerTest
     val work = createVersionedWork(version = 3)
     val olderWork = work.copy(version = 1)
 
-    withLocalElasticsearchIndex(itemType) { indexName =>
-      insertIntoElasticsearch(indexName = indexName, itemType = itemType, work)
+    withLocalElasticsearchIndex(esType) { indexName =>
+      insertIntoElasticsearch(indexName = indexName, esType = esType, work)
 
-      val future = workIndexer.indexWork(olderWork, indexName)
+      withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
+        val future = workIndexer.indexWork(olderWork, indexName)
 
-      whenReady(future) { _ =>
-        // Give Elasticsearch enough time to ingest the work
-        Thread.sleep(700)
+        whenReady(future) { _ =>
+          // Give Elasticsearch enough time to ingest the work
+          Thread.sleep(700)
 
-        assertElasticsearchEventuallyHasWork(
-          work,
-          indexName = indexName,
-          itemType = itemType)
+          assertElasticsearchEventuallyHasWork(
+            work,
+            indexName = indexName,
+            esType = esType)
+        }
       }
     }
   }
@@ -91,16 +82,18 @@ class WorkIndexerTest
     val work = createVersionedWork(version = 3)
     val updatedWork = work.copy(title = Some("boring title"))
 
-    withLocalElasticsearchIndex(itemType) { indexName =>
-      insertIntoElasticsearch(indexName = indexName, itemType = itemType, work)
+    withLocalElasticsearchIndex(esType) { indexName =>
+      insertIntoElasticsearch(indexName = indexName, esType = esType, work)
 
-      val future = workIndexer.indexWork(updatedWork, indexName)
+      withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
+        val future = workIndexer.indexWork(updatedWork, indexName)
 
-      whenReady(future) { _ =>
-        assertElasticsearchEventuallyHasWork(
-          updatedWork,
-          indexName = indexName,
-          itemType = itemType)
+        whenReady(future) { _ =>
+          assertElasticsearchEventuallyHasWork(
+            updatedWork,
+            indexName = indexName,
+            esType = esType)
+        }
       }
     }
   }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.platform.ingestor.services
 
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.models.work.test.util.WorksUtil
-import uk.ac.wellcome.platform.ingestor.fixtures.WorkIndexerFixture
+import uk.ac.wellcome.platform.ingestor.fixtures.WorkIndexerFixtures
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.Future
@@ -15,7 +15,8 @@ class WorkIndexerTest
     with ScalaFutures
     with Matchers
     with ElasticsearchFixtures
-    with WorksUtil {
+    with WorksUtil
+    with WorkIndexerFixtures {
 
   val itemType = "work"
 
@@ -40,7 +41,7 @@ class WorkIndexerTest
     val work = createVersionedWork()
 
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withWorkIndexerFixtures(itemType, elasticClient) { workIndexer =>
+      withWorkIndexerFixtures[Assertion](itemType, elasticClient) { workIndexer =>
         val future = Future.sequence(
           (1 to 2).map(_ => workIndexer.indexWork(work, indexName))
         )

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -29,7 +29,6 @@ class WorkIndexerTest
       mock[AmazonCloudWatch],
       ActorSystem())
 
-  val indexName = "works"
   val itemType = "work"
 
   val workIndexer =
@@ -38,7 +37,7 @@ class WorkIndexerTest
   it("inserts an identified Work into Elasticsearch") {
     val work = createVersionedWork()
 
-    withLocalElasticsearchIndex(indexName, itemType) { _ =>
+    withLocalElasticsearchIndex(itemType) { indexName =>
       val future = workIndexer.indexWork(work, indexName)
 
       whenReady(future) { _ =>
@@ -53,7 +52,7 @@ class WorkIndexerTest
   it("only adds one record when the same ID is ingested multiple times") {
     val work = createVersionedWork()
 
-    withLocalElasticsearchIndex(indexName, itemType) { _ =>
+    withLocalElasticsearchIndex(itemType) { indexName =>
       val future = Future.sequence(
         (1 to 2).map(_ => workIndexer.indexWork(work, indexName))
       )
@@ -71,7 +70,7 @@ class WorkIndexerTest
     val work = createVersionedWork(version = 3)
     val olderWork = work.copy(version = 1)
 
-    withLocalElasticsearchIndex(indexName, itemType) { _ =>
+    withLocalElasticsearchIndex(itemType) { indexName =>
       insertIntoElasticsearch(indexName = indexName, itemType = itemType, work)
 
       val future = workIndexer.indexWork(olderWork, indexName)
@@ -92,7 +91,7 @@ class WorkIndexerTest
     val work = createVersionedWork(version = 3)
     val updatedWork = work.copy(title = Some("boring title"))
 
-    withLocalElasticsearchIndex(indexName, itemType) { _ =>
+    withLocalElasticsearchIndex(itemType) { indexName =>
       insertIntoElasticsearch(indexName = indexName, itemType = itemType, work)
 
       val future = workIndexer.indexWork(updatedWork, indexName)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -17,20 +17,20 @@ class WorkIndexerTest
     with ElasticsearchFixtures
     with WorksUtil {
 
-  val esType = "work"
+  val itemType = "work"
 
   it("inserts an identified Work into Elasticsearch") {
     val work = createVersionedWork()
 
-    withLocalElasticsearchIndex(esType) { indexName =>
-      withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withWorkIndexerFixtures(itemType, elasticClient) { workIndexer =>
         val future = workIndexer.indexWork(work, indexName)
 
         whenReady(future) { _ =>
           assertElasticsearchEventuallyHasWork(
             work,
             indexName = indexName,
-            esType = esType)
+            itemType = itemType)
         }
       }
     }
@@ -39,8 +39,8 @@ class WorkIndexerTest
   it("only adds one record when the same ID is ingested multiple times") {
     val work = createVersionedWork()
 
-    withLocalElasticsearchIndex(esType) { indexName =>
-      withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withWorkIndexerFixtures(itemType, elasticClient) { workIndexer =>
         val future = Future.sequence(
           (1 to 2).map(_ => workIndexer.indexWork(work, indexName))
         )
@@ -49,7 +49,7 @@ class WorkIndexerTest
           assertElasticsearchEventuallyHasWork(
             work,
             indexName = indexName,
-            esType = esType)
+            itemType = itemType)
         }
       }
     }
@@ -59,10 +59,10 @@ class WorkIndexerTest
     val work = createVersionedWork(version = 3)
     val olderWork = work.copy(version = 1)
 
-    withLocalElasticsearchIndex(esType) { indexName =>
-      insertIntoElasticsearch(indexName = indexName, esType = esType, work)
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      insertIntoElasticsearch(indexName = indexName, itemType = itemType, work)
 
-      withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
+      withWorkIndexerFixtures(itemType, elasticClient) { workIndexer =>
         val future = workIndexer.indexWork(olderWork, indexName)
 
         whenReady(future) { _ =>
@@ -72,7 +72,7 @@ class WorkIndexerTest
           assertElasticsearchEventuallyHasWork(
             work,
             indexName = indexName,
-            esType = esType)
+            itemType = itemType)
         }
       }
     }
@@ -82,17 +82,17 @@ class WorkIndexerTest
     val work = createVersionedWork(version = 3)
     val updatedWork = work.copy(title = Some("boring title"))
 
-    withLocalElasticsearchIndex(esType) { indexName =>
-      insertIntoElasticsearch(indexName = indexName, esType = esType, work)
+    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      insertIntoElasticsearch(indexName = indexName, itemType = itemType, work)
 
-      withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
+      withWorkIndexerFixtures(itemType, elasticClient) { workIndexer =>
         val future = workIndexer.indexWork(updatedWork, indexName)
 
         whenReady(future) { _ =>
           assertElasticsearchEventuallyHasWork(
             updatedWork,
             indexName = indexName,
-            esType = esType)
+            itemType = itemType)
         }
       }
     }


### PR DESCRIPTION
Follows-up #1987, and the idea I originally had when starting this set of PRs.

Simplifies these tests somewhat, and applies some isolation we were missing in the ingestor.