### PR TITLE
No really, don't publish on test-only changes

### DIFF
--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -54,6 +54,18 @@ def does_file_affect_build_task(path, task):
     ] or path.startswith(('misc/', 'ontologies/', 'data_science/scripts/')):
         raise IgnoredPath()
 
+    # If this is a test file and we're in a publish task, we can skip
+    # running the task.
+    if task.endswith('-publish') and (
+
+        # Scala test files
+        'src/test/scala/uk/ac/wellcome' in path or
+
+        # Python test files
+        path.endswith(('conftest.py', '.coveragerc'))
+    ):
+        raise ChangesToTestsDontGetPublished()
+
     # Some directories only affect one task.
     #
     # For example, the ``catalogue_api/api`` directory only contains code
@@ -69,18 +81,6 @@ def does_file_affect_build_task(path, task):
                 raise ExclusivelyAffectsThisTask()
             else:
                 raise ExclusivelyAffectsAnotherTask(task_prefix)
-
-    # If this is a test file and we're in a publish task, we can skip
-    # running the task.
-    if task.endswith('-publish') and (
-
-        # Scala test files
-        'src/test/scala/uk/ac/wellcome' in path or
-
-        # Python test files
-        path.endswith(('conftest.py', '.coveragerc'))
-    ):
-        raise ChangesToTestsDontGetPublished()
 
     # We have a couple of sbt common libs and files scattered around the
     # repository; changes to any of these don't affect non-sbt applications.

--- a/travistooling/tests/test_decisionmaker.py
+++ b/travistooling/tests/test_decisionmaker.py
@@ -71,6 +71,7 @@ from travistooling.decisions import (
     # a -publish task.
     ('sbt_common/src/test/scala/uk/ac/wellcome/MyTest.scala', 'sierra_adapter-publish', ChangesToTestsDontGetPublished, False),
     ('sbt_common/src/test/scala/uk/ac/wellcome/MyTest.scala', 'sierra_adapter-test', UnrecognisedFile, True),
+    ('catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala', 'ingestor-publish', ChangesToTestsDontGetPublished, False),
 
     # Changes to Python test files never trigger a -publish task.
     ('lambda_conftest.py', 'loris-publish', ChangesToTestsDontGetPublished, False),


### PR DESCRIPTION
### What is this PR trying to achieve?

Merging #1986 triggered three pushes to ECR – even though it only contained changes to test code.

We're meant to catch this and skip publishing if that's the case, but we were running the checks in the wrong order. If code was an exclusive dependency of one project, we'd publish regardless of whether it was test-related. This patch fixes that bug.

### Who is this change for?

🚤 👩‍🚀 