### PR TITLE
Add type parameters to Subject and Genre

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformer.scala
@@ -1,15 +1,16 @@
 package uk.ac.wellcome.transformer.transformers
 import uk.ac.wellcome.models.transformable.MiroTransformable
-import uk.ac.wellcome.models.work.internal
+
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.transformer.source.MiroTransformableData
-import uk.ac.wellcome.transformer.transformers.miro.MiroContributors
+import uk.ac.wellcome.transformer.transformers.miro._
 
 import scala.util.Try
 
 class MiroTransformableTransformer
     extends TransformableTransformer[MiroTransformable]
-    with MiroContributors {
+    with MiroContributors
+    with MiroGenres {
   // TODO this class is too big as the different test classes would suggest. Split it.
 
   override def transformForType(miroTransformable: MiroTransformable,
@@ -20,7 +21,7 @@ class MiroTransformableTransformer
       val (title, description) = getTitleAndDescription(miroData)
 
       Some(
-        internal.UnidentifiedWork(
+        UnidentifiedWork(
           title = Some(title),
           sourceIdentifier = SourceIdentifier(
             identifierScheme = IdentifierSchemes.miroImageNumber,
@@ -245,14 +246,6 @@ class MiroTransformableTransformer
     }
 
     keywords ++ keywordsUnauth
-  }
-
-  private def getGenres(miroData: MiroTransformableData): List[Genre] = {
-    // Populate the subjects field.  This is based on two fields in the XML,
-    // <image_phys_format> and <image_lc_genre>.
-    (miroData.physFormat.toList ++ miroData.lcGenre.toList).map { g =>
-      Genre(label = g, concepts = List(Concept(g)))
-    }.distinct
   }
 
   private def getThumbnail(miroData: MiroTransformableData,

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/MiroTransformableTransformer.scala
@@ -10,7 +10,8 @@ import scala.util.Try
 class MiroTransformableTransformer
     extends TransformableTransformer[MiroTransformable]
     with MiroContributors
-    with MiroGenres {
+    with MiroGenres
+    with MiroSubjects {
   // TODO this class is too big as the different test classes would suggest. Split it.
 
   override def transformForType(miroTransformable: MiroTransformable,
@@ -214,38 +215,6 @@ class MiroTransformableTransformer
         }
 
     miroIDList ++ sierraList ++ libraryRefsList
-  }
-
-  /* Populate the subjects field.  This is based on two fields in the XML,
-   *  <image_keywords> and <image_keywords_unauth>.  Both of these were
-   *  defined in part or whole by the human cataloguers, and in general do
-   *  not correspond to a controlled vocabulary.  (The latter was imported
-   *  directly from PhotoSoft.)
-   *
-   *  In some cases, these actually do correspond to controlled vocabs,
-   *  e.g. where keywords were pulled directly from Sierra -- but we don't
-   *  have enough information in Miro to determine which ones those are.
-   */
-  private def getSubjects(miroData: MiroTransformableData): List[Subject] = {
-    val keywords: List[Subject] = miroData.keywords match {
-      case Some(k) =>
-        k.map { keyword =>
-          Subject(label = keyword, concepts = List(Concept(keyword)))
-        }
-      case None =>
-        List()
-    }
-
-    val keywordsUnauth: List[Subject] = miroData.keywordsUnauth match {
-      case Some(k) =>
-        k.map { keyword =>
-          Subject(label = keyword, concepts = List(Concept(keyword)))
-        }
-      case None =>
-        List()
-    }
-
-    keywords ++ keywordsUnauth
   }
 
   private def getThumbnail(miroData: MiroTransformableData,

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenres.scala
@@ -1,0 +1,17 @@
+package uk.ac.wellcome.transformer.transformers.miro
+
+import uk.ac.wellcome.models.work.internal.{AbstractConcept, Concept, Genre}
+import uk.ac.wellcome.transformer.source.MiroTransformableData
+
+trait MiroGenres {
+  def getGenres(miroData: MiroTransformableData): List[Genre[AbstractConcept]] = {
+    // Populate the genres field.  This is based on two fields in the XML,
+    // <image_phys_format> and <image_lc_genre>.
+    (miroData.physFormat.toList ++ miroData.lcGenre.toList).map { label =>
+      Genre[AbstractConcept](
+        label = label,
+        concepts = List(Concept(label))
+      )
+    }.distinct
+  }
+}

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjects.scala
@@ -1,0 +1,45 @@
+package uk.ac.wellcome.transformer.transformers.miro
+
+import uk.ac.wellcome.models.work.internal.{AbstractConcept, Concept, Subject}
+import uk.ac.wellcome.transformer.source.MiroTransformableData
+
+trait MiroSubjects {
+
+  /* Populate the subjects field.  This is based on two fields in the XML,
+   *  <image_keywords> and <image_keywords_unauth>.  Both of these were
+   *  defined in part or whole by the human cataloguers, and in general do
+   *  not correspond to a controlled vocabulary.  (The latter was imported
+   *  directly from PhotoSoft.)
+   *
+   *  In some cases, these actually do correspond to controlled vocabs,
+   *  e.g. where keywords were pulled directly from Sierra -- but we don't
+   *  have enough information in Miro to determine which ones those are.
+   */
+  def getSubjects(miroData: MiroTransformableData): List[Subject[AbstractConcept]] = {
+    val keywords: List[Subject[AbstractConcept]] = miroData.keywords match {
+      case Some(k) =>
+        k.map { keyword =>
+          Subject[AbstractConcept](
+            label = keyword,
+            concepts = List(Concept(keyword))
+          )
+        }
+      case None =>
+        List()
+    }
+
+    val keywordsUnauth: List[Subject[AbstractConcept]] = miroData.keywordsUnauth match {
+      case Some(k) =>
+        k.map { keyword =>
+          Subject[AbstractConcept](
+            label = keyword,
+            concepts = List(Concept(keyword))
+          )
+        }
+      case None =>
+        List()
+    }
+
+    keywords ++ keywordsUnauth
+  }
+}

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -1,11 +1,17 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
-import uk.ac.wellcome.models.work.internal.{Concept, Genre, Period, Place}
+import uk.ac.wellcome.models.work.internal.{
+  AbstractConcept,
+  Concept,
+  Genre,
+  Period,
+  Place
+}
 import uk.ac.wellcome.transformer.source.SierraBibData
 
 trait SierraGenres extends MarcUtils {
 
-  def getGenres(bibData: SierraBibData): List[Genre] = {
+  def getGenres(bibData: SierraBibData): List[Genre[AbstractConcept]] = {
     getGenresForMarcTag(bibData, "655")
   }
 
@@ -35,7 +41,7 @@ trait SierraGenres extends MarcUtils {
           case "z" => Place(label = subfield.content)
           case _ => Concept(label = subfield.content)
       })
-      Genre(label, concepts)
+      Genre[AbstractConcept](label = label, concepts = concepts)
     })
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -1,11 +1,17 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
-import uk.ac.wellcome.models.work.internal.{Concept, Period, Place, Subject}
+import uk.ac.wellcome.models.work.internal.{
+  AbstractConcept,
+  Concept,
+  Period,
+  Place,
+  Subject
+}
 import uk.ac.wellcome.transformer.source.SierraBibData
 
 trait SierraSubjects extends MarcUtils {
 
-  def getSubjects(bibData: SierraBibData): List[Subject] = {
+  def getSubjects(bibData: SierraBibData): List[Subject[AbstractConcept]] = {
     getSubjectsForMarcTag(bibData, "650") ++
       getSubjectsForMarcTag(bibData, "648") ++
       getSubjectsForMarcTag(bibData, "651")
@@ -45,7 +51,7 @@ trait SierraSubjects extends MarcUtils {
           case "z" => Place(label = subfield.content)
           case _ => Concept(label = subfield.content)
       })
-      Subject(subjectLabel, concepts)
+      Subject[AbstractConcept](label = subjectLabel, concepts = concepts)
     })
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenresTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenresTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.transformer.transformers.miro
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal.{Concept, Genre}
+import uk.ac.wellcome.models.work.internal.{AbstractConcept, Concept, Genre}
 import uk.ac.wellcome.transformer.transformers.MiroTransformableWrapper
 
 class MiroGenresTest
@@ -9,14 +9,14 @@ class MiroGenresTest
     with Matchers
     with MiroTransformableWrapper {
 
-  it("should have an empty genre list on records without keywords") {
+  it("has an empty genre list on records without keywords") {
     transformRecordAndCheckGenres(
       data = s""""image_title": "The giraffe's genre is gone'"""",
-      expectedGenres = List[Genre]()
+      expectedGenres = List()
     )
   }
 
-  it("should use the image_phys_format field if present") {
+  it("uses the image_phys_format field if present") {
     transformRecordAndCheckGenres(
       data = s"""
         "image_title": "A goat grazes on some grass",
@@ -26,7 +26,7 @@ class MiroGenresTest
     )
   }
 
-  it("should use the image_lc_genre field if present") {
+  it("uses the image_lc_genre field if present") {
     transformRecordAndCheckGenres(
       data = s"""
         "image_title": "Grouchy geese are good as guards",
@@ -36,8 +36,7 @@ class MiroGenresTest
     )
   }
 
-  it(
-    "should use the image_phys_format and image_lc_genre fields if both present") {
+  it("uses the image_phys_format and image_lc_genre fields if both present") {
     transformRecordAndCheckGenres(
       data = s"""
         "image_title": "A gorilla and a gibbon in a garden",
@@ -51,7 +50,7 @@ class MiroGenresTest
     )
   }
 
-  it("should deduplicate entries in the genre field if necessary") {
+  it("deduplicates entries in the genre field") {
     transformRecordAndCheckGenres(
       data = s"""
         "image_title": "A duality of dancing dodos",
@@ -65,7 +64,7 @@ class MiroGenresTest
 
   private def transformRecordAndCheckGenres(
     data: String,
-    expectedGenres: List[Genre[Concept]] = List()
+    expectedGenres: List[Genre[AbstractConcept]] = List()
   ) = {
     val transformedWork = transformWork(data = data)
     transformedWork.genres shouldBe expectedGenres

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenresTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenresTest.scala
@@ -1,9 +1,10 @@
-package uk.ac.wellcome.transformer.transformers
+package uk.ac.wellcome.transformer.transformers.miro
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal.{Concept, Genre}
+import uk.ac.wellcome.transformer.transformers.MiroTransformableWrapper
 
-class MiroTransformableTransformerGenresTest
+class MiroGenresTest
     extends FunSpec
     with Matchers
     with MiroTransformableWrapper {
@@ -62,9 +63,10 @@ class MiroTransformableTransformerGenresTest
     )
   }
 
-  private def transformRecordAndCheckGenres(data: String,
-                                            expectedGenres: List[Genre] =
-                                              List()) = {
+  private def transformRecordAndCheckGenres(
+    data: String,
+    expectedGenres: List[Genre[Concept]] = List()
+  ) = {
     val transformedWork = transformWork(data = data)
     transformedWork.genres shouldBe expectedGenres
   }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjectsTest.scala
@@ -1,7 +1,8 @@
-package uk.ac.wellcome.transformer.transformers
+package uk.ac.wellcome.transformer.transformers.miro
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.transformer.transformers.MiroTransformableWrapper
 
 /** Tests that the Miro transformer extracts the "subjects" field correctly.
   *
@@ -9,19 +10,19 @@ import uk.ac.wellcome.models.work.internal._
   *  from Miro will need cleaning before it's presented in the API (casing,
   *  names, etc.) -- these tests will become more complicated.
   */
-class MiroTransformableTransformerSubjectsTest
+class MiroSubjectsTest
     extends FunSpec
     with Matchers
     with MiroTransformableWrapper {
 
-  it("should have an empty subject list on records without keywords") {
+  it("puts an empty subject list on records without keywords") {
     transformRecordAndCheckSubjects(
       data = s""""image_title": "A snail without a subject"""",
-      expectedSubjects = List[Subject]()
+      expectedSubjects = List()
     )
   }
 
-  it("should use the image_keywords field if present") {
+  it("uses the image_keywords field if present") {
     transformRecordAndCheckSubjects(
       data = s"""
         "image_title": "A scorpion with a strawberry",
@@ -35,7 +36,7 @@ class MiroTransformableTransformerSubjectsTest
     )
   }
 
-  it("should use the image_keywords_unauth field if present") {
+  it("uses the image_keywords_unauth field if present") {
     transformRecordAndCheckSubjects(
       data = s"""
         "image_title": "A sweet seal gives you a sycamore",
@@ -48,8 +49,7 @@ class MiroTransformableTransformerSubjectsTest
     )
   }
 
-  it(
-    "should use the image_keywords and image_keywords_unauth fields if both present") {
+  it("uses the image_keywords and image_keywords_unauth fields if both present") {
     transformRecordAndCheckSubjects(
       data = s"""
         "image_title": "A squid, a sponge and a stingray walk into a bar",
@@ -65,41 +65,9 @@ class MiroTransformableTransformerSubjectsTest
     )
   }
 
-  it("should create an Item for each Work") {
-    val title = "A woodcut of a Weevil"
-    val longTitle = "A wonderful woodcut of a weird weevil"
-    val descriptionBody = "Woodcut, by A.R. Thropod.  Welsh.  1789."
-    val description = s"$longTitle\\n\\n$descriptionBody"
-    val work = transformWork(data = s"""
-        "image_title": "$title",
-        "image_image_desc": "$description"
-      """)
-
-    val item = work.items.head
-
-    val identifier =
-      SourceIdentifier(
-        identifierScheme = IdentifierSchemes.miroImageNumber,
-        ontologyType = "Item",
-        value = "M0000001")
-
-    item shouldBe UnidentifiedItem(
-      identifier,
-      List(identifier),
-      List(
-        DigitalLocation(
-          locationType = "iiif-image",
-          url =
-            "https://iiif.wellcomecollection.org/image/M0000001.jpg/info.json",
-          license = License_CCBY
-        )
-      )
-    )
-  }
-
   private def transformRecordAndCheckSubjects(
     data: String,
-    expectedSubjects: List[Subject] = List()
+    expectedSubjects: List[Subject[AbstractConcept]] = List()
   ) = {
     val transformedWork = transformWork(data = data)
     transformedWork.subjects shouldBe expectedSubjects

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenresTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenresTest.scala
@@ -1,7 +1,13 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal.{Concept, Genre, Period, Place}
+import uk.ac.wellcome.models.work.internal.{
+  AbstractConcept,
+  Concept,
+  Genre,
+  Period,
+  Place
+}
 import uk.ac.wellcome.transformer.source.{
   MarcSubfield,
   SierraBibData,
@@ -22,7 +28,7 @@ class SierraGenresTest extends FunSpec with Matchers {
   it("returns genres for tag 655 with only subfield a") {
     val expectedGenres =
       List(
-        Genre(
+        Genre[AbstractConcept](
           label = "A Content",
           concepts = List(Concept(label = "A Content"))))
 
@@ -34,7 +40,7 @@ class SierraGenresTest extends FunSpec with Matchers {
   it("returns subjects for tag 655 with subfields a and v") {
     val expectedGenres =
       List(
-        Genre(
+        Genre[AbstractConcept](
           label = "A Content - V Content",
           concepts =
             List(Concept(label = "A Content"), Concept(label = "V Content"))))
@@ -53,7 +59,7 @@ class SierraGenresTest extends FunSpec with Matchers {
     "subfield a is always first concept when returning subjects for tag 655 with subfields a, v") {
     val expectedGenres =
       List(
-        Genre(
+        Genre[AbstractConcept](
           label = "A Content - V Content",
           concepts =
             List(Concept(label = "A Content"), Concept(label = "V Content"))))
@@ -71,7 +77,7 @@ class SierraGenresTest extends FunSpec with Matchers {
   it("returns genres for tag 655 subfields a, v, and x") {
     val expectedGenres =
       List(
-        Genre(
+        Genre[AbstractConcept](
           label = "A Content - X Content - V Content",
           concepts = List(
             Concept(label = "A Content"),
@@ -94,7 +100,7 @@ class SierraGenresTest extends FunSpec with Matchers {
   it("returns subjects for tag 655 with subfields a, y") {
     val expectedGenres =
       List(
-        Genre(
+        Genre[AbstractConcept](
           label = "A Content - Y Content",
           concepts = List(
             Concept(label = "A Content"),
@@ -114,7 +120,7 @@ class SierraGenresTest extends FunSpec with Matchers {
   it("returns subjects for tag 655 with subfields a, z") {
     val expectedGenres =
       List(
-        Genre(
+        Genre[AbstractConcept](
           label = "A Content - Z Content",
           concepts = List(
             Concept(label = "A Content"),
@@ -161,13 +167,13 @@ class SierraGenresTest extends FunSpec with Matchers {
 
     val expectedSubjects =
       List(
-        Genre(
+        Genre[AbstractConcept](
           label = "A1 Content - Z1 Content",
           concepts = List(
             Concept(label = "A1 Content"),
             Place(label = "Z1 Content")
           )),
-        Genre(
+        Genre[AbstractConcept](
           label = "A2 Content - V2 Content",
           concepts = List(
             Concept(label = "A2 Content"),
@@ -180,7 +186,7 @@ class SierraGenresTest extends FunSpec with Matchers {
   private val transformer = new SierraGenres {}
 
   private def assertExtractsGenres(bibData: SierraBibData,
-                                   expected: List[Genre]) = {
+                                   expected: List[Genre[AbstractConcept]]) = {
     transformer.getGenres(bibData) shouldBe expected
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjectsTest.scala
@@ -1,7 +1,13 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal.{Concept, Period, Place, Subject}
+import uk.ac.wellcome.models.work.internal.{
+  AbstractConcept,
+  Concept,
+  Period,
+  Place,
+  Subject
+}
 import uk.ac.wellcome.transformer.source.{
   MarcSubfield,
   SierraBibData,
@@ -22,7 +28,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   it("returns subjects for tag 650 with only subfield a") {
     val expectedSubjects =
       List(
-        Subject(
+        Subject[AbstractConcept](
           label = "A Content",
           concepts = List(Concept(label = "A Content"))))
 
@@ -38,7 +44,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   it("returns subjects for tag 650 with only subfields a and v") {
     val expectedSubjects =
       List(
-        Subject(
+        Subject[AbstractConcept](
           label = "A Content - V Content",
           concepts =
             List(Concept(label = "A Content"), Concept(label = "V Content"))))
@@ -57,7 +63,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
     "subfield a is always first concept when returning subjects for tag 650 with subfields a, v") {
     val expectedSubjects =
       List(
-        Subject(
+        Subject[AbstractConcept](
           label = "A Content - V Content",
           concepts =
             List(Concept(label = "A Content"), Concept(label = "V Content"))))
@@ -75,7 +81,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   it("returns subjects for tag 650 subfields a, v, and x") {
     val expectedSubjects =
       List(
-        Subject(
+        Subject[AbstractConcept](
           label = "A Content - X Content - V Content",
           concepts = List(
             Concept(label = "A Content"),
@@ -98,7 +104,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   it("returns subjects for tag 650 with subfields a, y") {
     val expectedSubjects =
       List(
-        Subject(
+        Subject[AbstractConcept](
           label = "A Content - Y Content",
           concepts = List(
             Concept(label = "A Content"),
@@ -118,7 +124,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   it("returns subjects for tag 650 with subfields a, z") {
     val expectedSubjects =
       List(
-        Subject(
+        Subject[AbstractConcept](
           label = "A Content - Z Content",
           concepts = List(
             Concept(label = "A Content"),
@@ -165,13 +171,13 @@ class SierraSubjectsTest extends FunSpec with Matchers {
 
     val expectedSubjects =
       List(
-        Subject(
+        Subject[AbstractConcept](
           label = "A1 Content - Z1 Content",
           concepts = List(
             Concept(label = "A1 Content"),
             Place(label = "Z1 Content")
           )),
-        Subject(
+        Subject[AbstractConcept](
           label = "A2 Content - V2 Content",
           concepts = List(
             Concept(label = "A2 Content"),
@@ -185,7 +191,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   it("returns subjects with primary concept Period for tag 648") {
     val expectedSubjects =
       List(
-        Subject(
+        Subject[AbstractConcept](
           label = "A Content - X Content - V Content",
           concepts = List(
             Period(label = "A Content"),
@@ -208,7 +214,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   it("returns subjects with primary concept Place for tag 651") {
     val expectedSubjects =
       List(
-        Subject(
+        Subject[AbstractConcept](
           label = "A Content - X Content - V Content",
           concepts = List(
             Place(label = "A Content"),
@@ -231,7 +237,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   private val transformer = new SierraSubjects {}
 
   private def assertExtractsSubjects(bibData: SierraBibData,
-                                     expected: List[Subject]) = {
+                                     expected: List[Subject[AbstractConcept]]) = {
     transformer.getSubjects(bibData = bibData) shouldBe expected
   }
 

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayGenre.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayGenre.scala
@@ -2,14 +2,14 @@ package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import uk.ac.wellcome.display.models.DisplayAbstractConcept
-import uk.ac.wellcome.models.work.internal.Genre
+import uk.ac.wellcome.models.work.internal.{AbstractConcept, Genre}
 
 case class DisplayGenre(label: String,
                         concepts: List[DisplayAbstractConcept],
                         @JsonProperty("type") ontologyType: String = "Genre")
 
 object DisplayGenre {
-  def apply(genre: Genre): DisplayGenre =
+  def apply(genre: Genre[AbstractConcept]): DisplayGenre =
     DisplayGenre(label = genre.label, concepts = genre.concepts.map {
       DisplayAbstractConcept(_)
     }, ontologyType = genre.ontologyType)

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplaySubject.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplaySubject.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import uk.ac.wellcome.display.models.DisplayAbstractConcept
-import uk.ac.wellcome.models.work.internal.Subject
+import uk.ac.wellcome.models.work.internal.{AbstractConcept, Subject}
 
 case class DisplaySubject(label: String,
                           concepts: List[DisplayAbstractConcept],
@@ -10,7 +10,7 @@ case class DisplaySubject(label: String,
                             "Subject")
 
 object DisplaySubject {
-  def apply(subject: Subject): DisplaySubject =
+  def apply(subject: Subject[AbstractConcept]): DisplaySubject =
     DisplaySubject(label = subject.label, concepts = subject.concepts.map {
       DisplayAbstractConcept(_)
     }, ontologyType = subject.ontologyType)

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -147,7 +147,7 @@ trait DisplaySerialisationTestBase { this: Suite =>
       }
       .mkString(",")
 
-  def subject(s: Subject) =
+  def subject(s: Subject[AbstractConcept]) =
     s"""
     {
       "label": "${s.label}",
@@ -156,7 +156,7 @@ trait DisplaySerialisationTestBase { this: Suite =>
     }
     """
 
-  def subjects(subjects: List[Subject]) =
+  def subjects(subjects: List[Subject[AbstractConcept]]) =
     subjects
       .map { subject(_) }
       .mkString(",")

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -161,7 +161,7 @@ trait DisplaySerialisationTestBase { this: Suite =>
       .map { subject(_) }
       .mkString(",")
 
-  def genre(g: Genre) =
+  def genre(g: Genre[AbstractConcept]) =
     s"""
     {
       "label": "${g.label}",
@@ -170,7 +170,7 @@ trait DisplaySerialisationTestBase { this: Suite =>
     }
     """
 
-  def genres(genres: List[Genre]) =
+  def genres(genres: List[Genre[AbstractConcept]]) =
     genres
       .map { genre(_) }
       .mkString(",")

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Genre.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Genre.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.models.work.internal
 
-case class Genre(label: String,
-                 concepts: List[AbstractConcept],
-                 ontologyType: String = "Genre")
+case class Genre[T <: AbstractConcept](
+  label: String,
+  concepts: List[T],
+  ontologyType: String = "Genre"
+)

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Subject.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Subject.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.models.work.internal
 
-case class Subject(label: String,
-                   concepts: List[AbstractConcept],
-                   ontologyType: String = "Subject")
+case class Subject[T <: AbstractConcept](
+  label: String,
+  concepts: List[T],
+  ontologyType: String = "Subject"
+)

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -16,7 +16,7 @@ trait Work extends Versioned {
   val createdDate: Option[Period]
   val subjects: List[Subject]
   val contributors: List[Contributor[IdentityState[AbstractAgent]]]
-  val genres: List[Genre]
+  val genres: List[Genre[AbstractConcept]]
   val thumbnail: Option[Location]
   val publishers: List[IdentityState[AbstractAgent]]
   val publicationDate: Option[Period]
@@ -39,7 +39,7 @@ case class UnidentifiedWork(
   createdDate: Option[Period] = None,
   subjects: List[Subject] = Nil,
   contributors: List[Contributor[MaybeDisplayable[AbstractAgent]]] = Nil,
-  genres: List[Genre] = Nil,
+  genres: List[Genre[AbstractConcept]] = Nil,
   thumbnail: Option[Location] = None,
   items: List[UnidentifiedItem] = Nil,
   publishers: List[MaybeDisplayable[AbstractAgent]] = Nil,
@@ -65,7 +65,7 @@ case class IdentifiedWork(
   createdDate: Option[Period] = None,
   subjects: List[Subject] = Nil,
   contributors: List[Contributor[Displayable[AbstractAgent]]] = Nil,
-  genres: List[Genre] = Nil,
+  genres: List[Genre[AbstractConcept]] = Nil,
   thumbnail: Option[Location] = None,
   items: List[IdentifiedItem] = Nil,
   publishers: List[Displayable[AbstractAgent]] = Nil,

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -14,7 +14,7 @@ trait Work extends Versioned {
   val extent: Option[String]
   val lettering: Option[String]
   val createdDate: Option[Period]
-  val subjects: List[Subject]
+  val subjects: List[Subject[AbstractConcept]]
   val contributors: List[Contributor[IdentityState[AbstractAgent]]]
   val genres: List[Genre[AbstractConcept]]
   val thumbnail: Option[Location]
@@ -37,7 +37,7 @@ case class UnidentifiedWork(
   extent: Option[String] = None,
   lettering: Option[String] = None,
   createdDate: Option[Period] = None,
-  subjects: List[Subject] = Nil,
+  subjects: List[Subject[AbstractConcept]] = Nil,
   contributors: List[Contributor[MaybeDisplayable[AbstractAgent]]] = Nil,
   genres: List[Genre[AbstractConcept]] = Nil,
   thumbnail: Option[Location] = None,
@@ -63,7 +63,7 @@ case class IdentifiedWork(
   extent: Option[String] = None,
   lettering: Option[String] = None,
   createdDate: Option[Period] = None,
-  subjects: List[Subject] = Nil,
+  subjects: List[Subject[AbstractConcept]] = Nil,
   contributors: List[Contributor[Displayable[AbstractAgent]]] = Nil,
   genres: List[Genre[AbstractConcept]] = Nil,
   thumbnail: Option[Location] = None,

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
@@ -75,13 +75,23 @@ class IdentifiedWorkTest
       |  },
       |  "subjects": [
       |    {
-      |      "label": "subject",
-      |      "ontologyType": "Subject",
+      |      "label": "${subject.label}",
+      |      "ontologyType": "${subject.ontologyType}",
       |      "concepts" : [
       |        {
-      |          "label" : "concept",
-      |          "ontologyType" : "Concept",
-      |          "type" : "Concept"
+      |          "label" : "${subject.concepts(0).label}",
+      |          "ontologyType" : "${subject.concepts(0).ontologyType}",
+      |          "type" : "${subject.concepts(0).ontologyType}"
+      |        },
+      |        {
+      |          "label" : "${subject.concepts(1).label}",
+      |          "ontologyType" : "${subject.concepts(1).ontologyType}",
+      |          "type" : "${subject.concepts(1).ontologyType}"
+      |        },
+      |        {
+      |          "label" : "${subject.concepts(2).label}",
+      |          "ontologyType" : "${subject.concepts(2).ontologyType}",
+      |          "type" : "${subject.concepts(2).ontologyType}"
       |        }
       |      ]
       |    }
@@ -229,7 +239,7 @@ class IdentifiedWorkTest
     extent = Some(extent),
     lettering = Some("lettering"),
     createdDate = Some(Period("period")),
-    subjects = List(Subject("subject", List(Concept("concept")))),
+    subjects = List(subject),
     contributors = List(Contributor(agent = Unidentifiable(Agent("47")))),
     genres = List(genre),
     thumbnail = Some(location),

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
@@ -1,10 +1,15 @@
 package uk.ac.wellcome.models.work.internal
 
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.test.utils.JsonTestUtil
 import uk.ac.wellcome.utils.JsonUtil._
 
-class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
+class IdentifiedWorkTest
+  extends FunSpec
+  with Matchers
+  with JsonTestUtil
+  with WorksUtil {
 
   private val license_CCBYJson =
     s"""{
@@ -55,9 +60,9 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |    }
       |  ],
       |  "workType": {
-      |    "id": "id",
-      |    "label": "label",
-      |    "ontologyType" : "WorkType"
+      |    "id": "${workType.id}",
+      |    "label": "${workType.label}",
+      |    "ontologyType" : "${workType.ontologyType}"
       |  },
       |  "canonicalId": "canonicalId",
       |  "description": "description",
@@ -96,13 +101,23 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |  ],
       |  "genres": [
       |    {
-      |      "label": "genre",
-      |      "ontologyType": "Genre",
+      |      "label": "${genre.label}",
+      |      "ontologyType": "${genre.ontologyType}",
       |      "concepts" : [
       |        {
-      |          "label" : "concept",
-      |          "ontologyType" : "Concept",
-      |          "type" : "Concept"
+      |          "label" : "${genre.concepts(0).label}",
+      |          "ontologyType" : "${genre.concepts(0).ontologyType}",
+      |          "type" : "${genre.concepts(0).ontologyType}"
+      |        },
+      |        {
+      |          "label" : "${genre.concepts(1).label}",
+      |          "ontologyType" : "${genre.concepts(1).ontologyType}",
+      |          "type" : "${genre.concepts(1).ontologyType}"
+      |        },
+      |        {
+      |          "label" : "${genre.concepts(2).label}",
+      |          "ontologyType" : "${genre.concepts(2).ontologyType}",
+      |          "type" : "${genre.concepts(2).ontologyType}"
       |        }
       |      ]
       |    }
@@ -200,11 +215,6 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
     label = "MIT Press"
   )
 
-  val workType = WorkType(
-    id = "id",
-    label = "label"
-  )
-
   val publishers = List(Unidentifiable(publisher))
 
   val identifiedWork = IdentifiedWork(
@@ -221,7 +231,7 @@ class IdentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
     createdDate = Some(Period("period")),
     subjects = List(Subject("subject", List(Concept("concept")))),
     contributors = List(Contributor(agent = Unidentifiable(Agent("47")))),
-    genres = List(Genre("genre", List(Concept("concept")))),
+    genres = List(genre),
     thumbnail = Some(location),
     items = List(item),
     publishers = publishers,

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedWorkTest.scala
@@ -1,10 +1,15 @@
 package uk.ac.wellcome.models.work.internal
 
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.test.utils.JsonTestUtil
 import uk.ac.wellcome.utils.JsonUtil._
 
-class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
+class UnidentifiedWorkTest
+  extends FunSpec
+  with Matchers
+  with JsonTestUtil
+  with WorksUtil {
 
   private val license_CCBYJson =
     s"""{
@@ -54,9 +59,9 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |    }
       |  ],
       |  "workType": {
-      |    "id": "id",
-      |    "label": "label",
-      |    "ontologyType" : "WorkType"
+      |    "id": "${workType.id}",
+      |    "label": "${workType.label}",
+      |    "ontologyType" : "${workType.ontologyType}"
       |  },
       |  "description": "description",
       |  "physicalDescription": "$physicalDescription",
@@ -94,13 +99,23 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       |  ],
       |  "genres": [
       |    {
-      |      "label": "genre",
-      |      "ontologyType": "Genre",
+      |      "label": "${genre.label}",
+      |      "ontologyType": "${genre.ontologyType}",
       |      "concepts" : [
       |        {
-      |          "label" : "concept",
-      |          "ontologyType" : "Concept",
-      |          "type" : "Concept"
+      |          "label" : "${genre.concepts(0).label}",
+      |          "ontologyType" : "${genre.concepts(0).ontologyType}",
+      |          "type" : "${genre.concepts(0).ontologyType}"
+      |        },
+      |        {
+      |          "label" : "${genre.concepts(1).label}",
+      |          "ontologyType" : "${genre.concepts(1).ontologyType}",
+      |          "type" : "${genre.concepts(1).ontologyType}"
+      |        },
+      |        {
+      |          "label" : "${genre.concepts(2).label}",
+      |          "ontologyType" : "${genre.concepts(2).ontologyType}",
+      |          "type" : "${genre.concepts(2).ontologyType}"
       |        }
       |      ]
       |    }
@@ -200,11 +215,6 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
 
   val publishers = List(Unidentifiable(publisher))
 
-  val workType = WorkType(
-    id = "id",
-    label = "label"
-  )
-
   val unidentifiedWork = UnidentifiedWork(
     title = Some("title"),
     sourceIdentifier = workIdentifier,
@@ -221,7 +231,7 @@ class UnidentifiedWorkTest extends FunSpec with Matchers with JsonTestUtil {
       Contributor(
         agent = Unidentifiable(Agent("47"))
       )),
-    genres = List(Genre("genre", List(Concept("concept")))),
+    genres = List(genre),
     thumbnail = Some(location),
     items = List(item),
     publishers = publishers,

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedWorkTest.scala
@@ -226,7 +226,7 @@ class UnidentifiedWorkTest
     extent = Some(extent),
     lettering = Some("lettering"),
     createdDate = Some(Period("period")),
-    subjects = List(Subject("subject", List(Concept("concept")))),
+    subjects = List(subject),
     contributors = List(
       Contributor(
         agent = Unidentifiable(Agent("47"))

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -13,8 +13,8 @@ trait WorksUtil {
     id = "1dz4yn34va",
     label = "An aggregation of angry archipelago aged ankylosaurs."
   )
-  val subject = Subject(
-    "a subject",
+  val subject = Subject[AbstractConcept](
+    "a subject created by WorksUtil",
     List(
       Concept("a subject concept"),
       Place("a subject place"),
@@ -25,9 +25,7 @@ trait WorksUtil {
     concepts = List(
       Concept("a genre concept"),
       Place("a genre place"),
-      Period("a genre period")
-    )
-  )
+      Period("a genre period")))
 
   val sourceIdentifier = SourceIdentifier(
     IdentifierSchemes.miroImageNumber,
@@ -134,7 +132,7 @@ trait WorksUtil {
                lettering: String,
                createdDate: Period,
                creator: Agent,
-               subjects: List[Subject],
+               subjects: List[Subject[AbstractConcept]],
                genres: List[Genre[AbstractConcept]],
                items: List[IdentifiedItem],
                visible: Boolean): IdentifiedWork =

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -19,12 +19,16 @@ trait WorksUtil {
       Concept("a subject concept"),
       Place("a subject place"),
       Period("a subject period")))
-  val genre = Genre(
-    "a genre",
-    List(
+
+  val genre = Genre[AbstractConcept](
+    label = "a genre created by WorksUtil",
+    concepts = List(
       Concept("a genre concept"),
       Place("a genre place"),
-      Period("a genre period")))
+      Period("a genre period")
+    )
+  )
+
   val sourceIdentifier = SourceIdentifier(
     IdentifierSchemes.miroImageNumber,
     "Work",
@@ -131,7 +135,7 @@ trait WorksUtil {
                createdDate: Period,
                creator: Agent,
                subjects: List[Subject],
-               genres: List[Genre],
+               genres: List[Genre[AbstractConcept]],
                items: List[IdentifiedItem],
                visible: Boolean): IdentifiedWork =
     IdentifiedWork(


### PR DESCRIPTION
A first step towards #1959.

### What is this PR trying to achieve?

We want to be able to put identifiers on Concept – but unlike Agent, instances of Concept aren’t used at the top level of a work; they’re wrapped by Genre and Subject. This patch adds a type parameter to both types, laying the groundwork to wrap them in the appropriate IdentityState / MaybeDisplayable / Displayable wrappers (**which will be a separate PR**).

cf. Contributor and Agent

### Who is this change for?

Me, as I add identifiers to Concept.