### PR TITLE
Fork V1 and V2 DisplayConcept

### DIFF
--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayConceptV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayConceptV1.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.display.models.v1
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.models.work.internal.AbstractConcept
+
+@ApiModel(
+  value = "Concept",
+  description = "A broad concept"
+)
+case class DisplayConceptV1(
+  @ApiModelProperty(
+    dataType = "String"
+  ) label: String
+) {
+  @JsonProperty("type") val ontologyType: String = "Concept"
+}
+
+case object DisplayConceptV1 {
+  def apply(concept: AbstractConcept): DisplayConceptV1 = DisplayConceptV1(
+    label = concept.label
+  )
+}

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayPeriodV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayPeriodV1.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.display.models.v1
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.models.work.internal.Period
+
+@ApiModel(
+  value = "Period",
+  description = "A period of time"
+)
+case class DisplayPeriodV1(
+  @ApiModelProperty(
+    dataType = "String"
+  ) label: String
+) {
+  @JsonProperty("type") val ontologyType: String = "Period"
+}
+
+case object DisplayPeriodV1 {
+  def apply(period: Period): DisplayPeriodV1 = DisplayPeriodV1(
+    label = period.label
+  )
+}

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayPlaceV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayPlaceV1.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.display.models.v1
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.models.work.internal.Place
+
+@ApiModel(
+  value = "Place",
+  description = "A place"
+)
+case class DisplayPlaceV1(
+  @ApiModelProperty(
+    dataType = "String"
+  ) label: String
+) {
+  @JsonProperty("type") val ontologyType: String = "Place"
+}
+
+case object DisplayPlaceV1 {
+  def apply(place: Place): DisplayPlaceV1 = DisplayPlaceV1(
+    label = place.label
+  )
+}

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
@@ -59,12 +59,10 @@ case class DisplayWorkV1(
       "Relates the item to a unique system-generated identifier that governs interaction between systems and is regarded as canonical within the Wellcome data ecosystem."
   ) identifiers: Option[List[DisplayIdentifier]] = None,
   @ApiModelProperty(
-    dataType = "uk.ac.wellcome.display.models.DisplayConcept",
     value =
       "Relates a work to the general thesaurus-based concept that describes the work's content."
   ) subjects: List[DisplayConceptV1] = List(),
   @ApiModelProperty(
-    dataType = "List[uk.ac.wellcome.display.models.DisplayConcept]",
     value = "Relates a work to the genre that describes the work's content."
   ) genres: List[DisplayConceptV1] = List(),
   @ApiModelProperty(

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
@@ -44,7 +44,7 @@ case class DisplayWorkV1(
     value = "Recording written text on a (usually visual) work."
   ) lettering: Option[String] = None,
   @ApiModelProperty(
-    dataType = "uk.ac.wellcome.display.models.DisplayPeriod",
+    dataType = "uk.ac.wellcome.display.models.v1.DisplayPeriodV1",
     value =
       "Relates the creation of a work to a date, when the date of creation does not cover a range."
   ) createdDate: Option[DisplayPeriodV1] = None,
@@ -81,11 +81,11 @@ case class DisplayWorkV1(
     value = "Relates a published work to its publisher."
   ) publishers: List[DisplayAbstractAgent] = List(),
   @ApiModelProperty(
-    dataType = "List[uk.ac.wellcome.display.models.DisplayPlace]",
+    dataType = "List[uk.ac.wellcome.display.models.v1.DisplayPlaceV1]",
     value = "Show a list of places of publication."
   ) placesOfPublication: List[DisplayPlaceV1] = List(),
   @ApiModelProperty(
-    dataType = "uk.ac.wellcome.display.models.DisplayPeriod",
+    dataType = "uk.ac.wellcome.display.models.v1.DisplayPeriodV1",
     value =
       "Relates the publication of a work to a date when the work has been formally published."
   ) publicationDate: Option[DisplayPeriodV1] = None,

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
@@ -62,11 +62,11 @@ case class DisplayWorkV1(
     dataType = "uk.ac.wellcome.display.models.DisplayConcept",
     value =
       "Relates a work to the general thesaurus-based concept that describes the work's content."
-  ) subjects: List[DisplayConcept] = List(),
+  ) subjects: List[DisplayConceptV1] = List(),
   @ApiModelProperty(
     dataType = "List[uk.ac.wellcome.display.models.DisplayConcept]",
     value = "Relates a work to the genre that describes the work's content."
-  ) genres: List[DisplayConcept] = List(),
+  ) genres: List[DisplayConceptV1] = List(),
   @ApiModelProperty(
     dataType = "uk.ac.wellcome.display.models.DisplayLocation",
     value =
@@ -126,10 +126,10 @@ case object DisplayWorkV1 {
           DisplayAbstractAgent(contributor.agent)
       },
       subjects = work.subjects.flatMap { subject =>
-        subject.concepts.map { DisplayConcept(_) }
+        subject.concepts.map { DisplayConceptV1(_) }
       },
       genres = work.genres.flatMap { genre =>
-        genre.concepts.map { DisplayConcept(_) }
+        genre.concepts.map { DisplayConceptV1(_) }
       },
       identifiers =
         if (includes.identifiers)

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
@@ -47,7 +47,7 @@ case class DisplayWorkV1(
     dataType = "uk.ac.wellcome.display.models.DisplayPeriod",
     value =
       "Relates the creation of a work to a date, when the date of creation does not cover a range."
-  ) createdDate: Option[DisplayPeriod] = None,
+  ) createdDate: Option[DisplayPeriodV1] = None,
   @ApiModelProperty(
     dataType = "List[uk.ac.wellcome.display.models.DisplayAbstractAgent]",
     value =
@@ -83,12 +83,12 @@ case class DisplayWorkV1(
   @ApiModelProperty(
     dataType = "List[uk.ac.wellcome.display.models.DisplayPlace]",
     value = "Show a list of places of publication."
-  ) placesOfPublication: List[DisplayPlace] = List(),
+  ) placesOfPublication: List[DisplayPlaceV1] = List(),
   @ApiModelProperty(
     dataType = "uk.ac.wellcome.display.models.DisplayPeriod",
     value =
       "Relates the publication of a work to a date when the work has been formally published."
-  ) publicationDate: Option[DisplayPeriod] = None,
+  ) publicationDate: Option[DisplayPeriodV1] = None,
   @ApiModelProperty(
     dataType = "uk.ac.wellcome.display.models.DisplayLanguage",
     value = "Relates a work to its primary language."
@@ -120,7 +120,7 @@ case object DisplayWorkV1 {
       physicalDescription = work.physicalDescription,
       extent = work.extent,
       lettering = work.lettering,
-      createdDate = work.createdDate.map { DisplayPeriod(_) },
+      createdDate = work.createdDate.map { DisplayPeriodV1(_) },
       creators = work.contributors.map {
         contributor: Contributor[Displayable[AbstractAgent]] =>
           DisplayAbstractAgent(contributor.agent)
@@ -146,8 +146,8 @@ case object DisplayWorkV1 {
           })
         else None,
       publishers = work.publishers.map(DisplayAbstractAgent(_)),
-      publicationDate = work.publicationDate.map { DisplayPeriod(_) },
-      placesOfPublication = work.placesOfPublication.map { DisplayPlace(_) },
+      publicationDate = work.publicationDate.map { DisplayPeriodV1(_) },
+      placesOfPublication = work.placesOfPublication.map { DisplayPlaceV1(_) },
       language = work.language.map { DisplayLanguage(_) },
       dimensions = work.dimensions
     )

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.display.models
+package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayGenre.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayGenre.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import uk.ac.wellcome.display.models.DisplayAbstractConcept
 import uk.ac.wellcome.models.work.internal.{AbstractConcept, Genre}
 
 case class DisplayGenre(label: String,

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplaySubject.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplaySubject.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import uk.ac.wellcome.display.models.DisplayAbstractConcept
 import uk.ac.wellcome.models.work.internal.{AbstractConcept, Subject}
 
 case class DisplaySubject(label: String,

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
@@ -40,12 +40,11 @@ case class DisplayWorkV2(
     value = "Recording written text on a (usually visual) work."
   ) lettering: Option[String] = None,
   @ApiModelProperty(
-    dataType = "uk.ac.wellcome.display.models.DisplayPeriod",
+    dataType = "uk.ac.wellcome.display.models.v2.DisplayPeriod",
     value =
       "Relates the creation of a work to a date, when the date of creation does not cover a range."
   ) createdDate: Option[DisplayPeriod] = None,
   @ApiModelProperty(
-    dataType = "List[uk.ac.wellcome.display.models.v2.DisplayContributor]",
     value =
       "Relates a work to its author, compiler, editor, artist or other entity responsible for its coming into existence in the form that it has."
   ) contributors: List[DisplayContributor] = List(),
@@ -55,12 +54,10 @@ case class DisplayWorkV2(
       "Relates the item to a unique system-generated identifier that governs interaction between systems and is regarded as canonical within the Wellcome data ecosystem."
   ) identifiers: Option[List[DisplayIdentifier]] = None,
   @ApiModelProperty(
-    dataType = "uk.ac.wellcome.display.models.DisplayConcept",
     value =
       "Relates a work to the general thesaurus-based concept that describes the work's content."
   ) subjects: List[DisplaySubject] = List(),
   @ApiModelProperty(
-    dataType = "List[uk.ac.wellcome.display.models.DisplayConcept]",
     value = "Relates a work to the genre that describes the work's content."
   ) genres: List[DisplayGenre] = List(),
   @ApiModelProperty(
@@ -73,15 +70,13 @@ case class DisplayWorkV2(
     value = "List of items related to this work."
   ) items: Option[List[DisplayItem]] = None,
   @ApiModelProperty(
-    dataType = "List[uk.ac.wellcome.display.models.DisplayAbstractAgent]",
     value = "Relates a published work to its publisher."
   ) publishers: List[DisplayAbstractAgent] = List(),
   @ApiModelProperty(
-    dataType = "List[uk.ac.wellcome.display.models.DisplayPlace]",
     value = "Show a list of places of publication."
   ) placesOfPublication: List[DisplayPlace] = List(),
   @ApiModelProperty(
-    dataType = "uk.ac.wellcome.display.models.DisplayPeriod",
+    dataType = "uk.ac.wellcome.display.models.v2.DisplayPeriod",
     value =
       "Relates the publication of a work to a date when the work has been formally published."
   ) publicationDate: Option[DisplayPeriod] = None,

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -305,6 +305,74 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
     displayLanguage.label shouldBe language.label
   }
 
+  it("treats genres as a list of Concepts") {
+    val genres = List[Genre[AbstractConcept]](
+      Genre(
+        label = "a genre created by DisplayWorkV1Test",
+        concepts = List(
+          Concept("a genre concept"),
+          Place("a genre place"),
+          Period("a genre period")
+        )
+      ),
+      Genre(
+        label = "a second genre created for DisplayWorkV1Test",
+        concepts = List(
+          Concept("a second generic concept")
+        )
+      )
+    )
+
+    val work = IdentifiedWork(
+      title = Some("A work with genres"),
+      canonicalId = "b225839r",
+      sourceIdentifier = sourceIdentifier,
+      genres = genres,
+      version = 1
+    )
+
+    val displayWork = DisplayWorkV1(work)
+    val expectedGenres = genres
+      .map { _.concepts }
+      .flatten
+      .map { label => DisplayConceptV1(label) }
+    displayWork.genres shouldBe expectedGenres
+  }
+
+  it("treats subjects as a list of Concepts") {
+    val subjects = List[Subject[AbstractConcept]](
+      Subject(
+        label = "a subject created by DisplayWorkV1Test",
+        concepts = List(
+          Concept("a subject concept"),
+          Place("a subject place"),
+          Period("a subject period")
+        )
+      ),
+      Subject(
+        label = "a second subject created for DisplayWorkV1Test",
+        concepts = List(
+          Concept("a second generic concept")
+        )
+      )
+    )
+
+    val work = IdentifiedWork(
+      title = Some("A work with subjects"),
+      canonicalId = "nznaj8p5",
+      sourceIdentifier = sourceIdentifier,
+      subjects = subjects,
+      version = 1
+    )
+
+    val displayWork = DisplayWorkV1(work)
+    val expectedSubjects = subjects
+      .map { _.concepts }
+      .flatten
+      .map { label => DisplayConceptV1(label) }
+    displayWork.subjects shouldBe expectedSubjects
+  }
+
   it("gives a helpful error if you try to convert a work with visible=False") {
     val work = IdentifiedWork(
       canonicalId = "xpudrscx",

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -335,7 +335,9 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
     val expectedGenres = genres
       .map { _.concepts }
       .flatten
-      .map { label => DisplayConceptV1(label) }
+      .map { label =>
+        DisplayConceptV1(label)
+      }
     displayWork.genres shouldBe expectedGenres
   }
 
@@ -369,7 +371,9 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
     val expectedSubjects = subjects
       .map { _.concepts }
       .flatten
-      .map { label => DisplayConceptV1(label) }
+      .map { label =>
+        DisplayConceptV1(label)
+      }
     displayWork.subjects shouldBe expectedSubjects
   }
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -229,7 +229,7 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
     )
 
     val displayWork = DisplayWorkV1(work)
-    displayWork.publicationDate shouldBe Some(DisplayPeriod("c1900"))
+    displayWork.publicationDate shouldBe Some(DisplayPeriodV1("c1900"))
   }
 
   it("gets the physicalDescription from a Work") {

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.display.models
+package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil


### PR DESCRIPTION
### What is this PR trying to achieve?

As we add identifiers to concepts in #1959, the notion of a “DisplayConcept” is going to change more radically. This PR forks the models so we can add identifiers to V2 without breaking V1.

### Who is this change for?

🥇 🥈