### PR TITLE
Add identifier pieces to the Concept model

### DIFF
--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -133,16 +133,16 @@ class ApiV2WorksTest extends ApiWorksTestBase {
                |     "type": "${subject.ontologyType}",
                |     "concepts":[
                |       {
-               |         "label": "${subject.concepts(0).label}",
-               |         "type":  "${subject.concepts(0).ontologyType}"
+               |         "label": "${subject.concepts(0).agent.label}",
+               |         "type":  "${subject.concepts(0).agent.ontologyType}"
                |       },
                |       {
-               |         "label": "${subject.concepts(1).label}",
-               |         "type":  "${subject.concepts(1).ontologyType}"
+               |         "label": "${subject.concepts(1).agent.label}",
+               |         "type":  "${subject.concepts(1).agent.ontologyType}"
                |       },
                |       {
-               |         "label": "${subject.concepts(2).label}",
-               |         "type":  "${subject.concepts(2).ontologyType}"
+               |         "label": "${subject.concepts(2).agent.label}",
+               |         "type":  "${subject.concepts(2).agent.ontologyType}"
                |       }]}
                | ],
                | "genres": [
@@ -150,16 +150,16 @@ class ApiV2WorksTest extends ApiWorksTestBase {
                |     "type": "${genre.ontologyType}",
                |     "concepts":[
                |       {
-               |         "label": "${genre.concepts(0).label}",
-               |         "type":  "${genre.concepts(0).ontologyType}"
+               |         "label": "${genre.concepts(0).agent.label}",
+               |         "type":  "${genre.concepts(0).agent.ontologyType}"
                |       },
                |       {
-               |         "label": "${genre.concepts(1).label}",
-               |         "type":  "${genre.concepts(1).ontologyType}"
+               |         "label": "${genre.concepts(1).agent.label}",
+               |         "type":  "${genre.concepts(1).agent.ontologyType}"
                |       },
                |       {
-               |         "label": "${genre.concepts(2).label}",
-               |         "type":  "${genre.concepts(2).ontologyType}"
+               |         "label": "${genre.concepts(2).agent.label}",
+               |         "type":  "${genre.concepts(2).agent.ontologyType}"
                |       }]}
                | ],
                | "publishers": [ ],

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenres.scala
@@ -1,21 +1,15 @@
 package uk.ac.wellcome.transformer.transformers.miro
 
-import uk.ac.wellcome.models.work.internal.{
-  AbstractConcept,
-  Concept,
-  Genre,
-  MaybeDisplayable,
-  Unidentifiable
-}
+import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.transformer.source.MiroTransformableData
 
 trait MiroGenres {
   def getGenres(miroData: MiroTransformableData)
-    : List[Genre[MaybeDisplayable[AbstractConcept]]] = {
+    : List[Genre[Unidentifiable[Concept]]] = {
     // Populate the genres field.  This is based on two fields in the XML,
     // <image_phys_format> and <image_lc_genre>.
     (miroData.physFormat.toList ++ miroData.lcGenre.toList).map { label =>
-      Genre[MaybeDisplayable[AbstractConcept]](
+      Genre[Unidentifiable[Concept]](
         label = label,
         concepts = List(Unidentifiable(Concept(label)))
       )

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenres.scala
@@ -1,17 +1,17 @@
 package uk.ac.wellcome.transformer.transformers.miro
 
-import uk.ac.wellcome.models.work.internal.{AbstractConcept, Concept, Genre}
+import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.transformer.source.MiroTransformableData
 
 trait MiroGenres {
   def getGenres(
-    miroData: MiroTransformableData): List[Genre[AbstractConcept]] = {
+    miroData: MiroTransformableData): List[Genre[MaybeDisplayable[AbstractConcept]]] = {
     // Populate the genres field.  This is based on two fields in the XML,
     // <image_phys_format> and <image_lc_genre>.
     (miroData.physFormat.toList ++ miroData.lcGenre.toList).map { label =>
-      Genre[AbstractConcept](
+      Genre[MaybeDisplayable[AbstractConcept]](
         label = label,
-        concepts = List(Concept(label))
+        concepts = List(MaybeDisplayable[Concept](label))
       )
     }.distinct
   }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenres.scala
@@ -4,8 +4,8 @@ import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.transformer.source.MiroTransformableData
 
 trait MiroGenres {
-  def getGenres(miroData: MiroTransformableData)
-    : List[Genre[Unidentifiable[Concept]]] = {
+  def getGenres(
+    miroData: MiroTransformableData): List[Genre[Unidentifiable[Concept]]] = {
     // Populate the genres field.  This is based on two fields in the XML,
     // <image_phys_format> and <image_lc_genre>.
     (miroData.physFormat.toList ++ miroData.lcGenre.toList).map { label =>

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenres.scala
@@ -10,8 +10,8 @@ import uk.ac.wellcome.models.work.internal.{
 import uk.ac.wellcome.transformer.source.MiroTransformableData
 
 trait MiroGenres {
-  def getGenres(
-    miroData: MiroTransformableData): List[Genre[MaybeDisplayable[AbstractConcept]]] = {
+  def getGenres(miroData: MiroTransformableData)
+    : List[Genre[MaybeDisplayable[AbstractConcept]]] = {
     // Populate the genres field.  This is based on two fields in the XML,
     // <image_phys_format> and <image_lc_genre>.
     (miroData.physFormat.toList ++ miroData.lcGenre.toList).map { label =>

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenres.scala
@@ -1,6 +1,12 @@
 package uk.ac.wellcome.transformer.transformers.miro
 
-import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.internal.{
+  AbstractConcept,
+  Concept,
+  Genre,
+  MaybeDisplayable,
+  Unidentifiable
+}
 import uk.ac.wellcome.transformer.source.MiroTransformableData
 
 trait MiroGenres {
@@ -11,7 +17,7 @@ trait MiroGenres {
     (miroData.physFormat.toList ++ miroData.lcGenre.toList).map { label =>
       Genre[MaybeDisplayable[AbstractConcept]](
         label = label,
-        concepts = List(MaybeDisplayable[Concept](label))
+        concepts = List(Unidentifiable(Concept(label)))
       )
     }.distinct
   }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjects.scala
@@ -17,31 +17,15 @@ trait MiroSubjects {
    */
   def getSubjects(
     miroData: MiroTransformableData): List[Subject[AbstractConcept]] = {
-    val keywords: List[Subject[AbstractConcept]] = miroData.keywords match {
-      case Some(k) =>
-        k.map { keyword =>
-          Subject[AbstractConcept](
-            label = keyword,
-            concepts = List(Concept(keyword))
-          )
-        }
-      case None =>
-        List()
+    val keywords: List[String] = miroData.keywords.getOrElse(List())
+
+    val keywordsUnauth: List[String] = miroData.keywordsUnauth.getOrElse(List())
+
+    (keywords ++ keywordsUnauth).map { keyword =>
+      Subject[AbstractConcept](
+        label = keyword,
+        concepts = List(Unidentifiable(Concept(keyword)))
+      )
     }
-
-    val keywordsUnauth: List[Subject[AbstractConcept]] =
-      miroData.keywordsUnauth match {
-        case Some(k) =>
-          k.map { keyword =>
-            Subject[AbstractConcept](
-              label = keyword,
-              concepts = List(Concept(keyword))
-            )
-          }
-        case None =>
-          List()
-      }
-
-    keywords ++ keywordsUnauth
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjects.scala
@@ -21,11 +21,12 @@ trait MiroSubjects {
    *  e.g. where keywords were pulled directly from Sierra -- but we don't
    *  have enough information in Miro to determine which ones those are.
    */
-  def getSubjects(
-    miroData: MiroTransformableData): List[Subject[MaybeDisplayable[AbstractConcept]]] = {
+  def getSubjects(miroData: MiroTransformableData)
+    : List[Subject[MaybeDisplayable[AbstractConcept]]] = {
     val keywords: List[String] = miroData.keywords.getOrElse(List())
 
-    val keywordsUnauth: List[String] = miroData.keywordsUnauth.getOrElse(List())
+    val keywordsUnauth: List[String] =
+      miroData.keywordsUnauth.getOrElse(List())
 
     (keywords ++ keywordsUnauth).map { keyword =>
       Subject[MaybeDisplayable[AbstractConcept]](

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjects.scala
@@ -1,6 +1,12 @@
 package uk.ac.wellcome.transformer.transformers.miro
 
-import uk.ac.wellcome.models.work.internal.{AbstractConcept, Concept, Subject}
+import uk.ac.wellcome.models.work.internal.{
+  AbstractConcept,
+  Concept,
+  MaybeDisplayable,
+  Subject,
+  Unidentifiable
+}
 import uk.ac.wellcome.transformer.source.MiroTransformableData
 
 trait MiroSubjects {
@@ -16,13 +22,13 @@ trait MiroSubjects {
    *  have enough information in Miro to determine which ones those are.
    */
   def getSubjects(
-    miroData: MiroTransformableData): List[Subject[AbstractConcept]] = {
+    miroData: MiroTransformableData): List[Subject[MaybeDisplayable[AbstractConcept]]] = {
     val keywords: List[String] = miroData.keywords.getOrElse(List())
 
     val keywordsUnauth: List[String] = miroData.keywordsUnauth.getOrElse(List())
 
     (keywords ++ keywordsUnauth).map { keyword =>
-      Subject[AbstractConcept](
+      Subject[MaybeDisplayable[AbstractConcept]](
         label = keyword,
         concepts = List(Unidentifiable(Concept(keyword)))
       )

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjects.scala
@@ -1,12 +1,6 @@
 package uk.ac.wellcome.transformer.transformers.miro
 
-import uk.ac.wellcome.models.work.internal.{
-  AbstractConcept,
-  Concept,
-  MaybeDisplayable,
-  Subject,
-  Unidentifiable
-}
+import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.transformer.source.MiroTransformableData
 
 trait MiroSubjects {
@@ -22,14 +16,14 @@ trait MiroSubjects {
    *  have enough information in Miro to determine which ones those are.
    */
   def getSubjects(miroData: MiroTransformableData)
-    : List[Subject[MaybeDisplayable[AbstractConcept]]] = {
+    : List[Subject[Unidentifiable[Concept]]] = {
     val keywords: List[String] = miroData.keywords.getOrElse(List())
 
     val keywordsUnauth: List[String] =
       miroData.keywordsUnauth.getOrElse(List())
 
     (keywords ++ keywordsUnauth).map { keyword =>
-      Subject[MaybeDisplayable[AbstractConcept]](
+      Subject[Unidentifiable[Concept]](
         label = keyword,
         concepts = List(Unidentifiable(Concept(keyword)))
       )

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -1,17 +1,11 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
-import uk.ac.wellcome.models.work.internal.{
-  AbstractConcept,
-  Concept,
-  Genre,
-  Period,
-  Place
-}
+import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.transformer.source.SierraBibData
 
 trait SierraGenres extends MarcUtils {
 
-  def getGenres(bibData: SierraBibData): List[Genre[AbstractConcept]] = {
+  def getGenres(bibData: SierraBibData): List[Genre[MaybeDisplayable[AbstractConcept]]] = {
     getGenresForMarcTag(bibData, "655")
   }
 
@@ -37,11 +31,14 @@ trait SierraGenres extends MarcUtils {
       val label = orderedSubfields.map(_.content).mkString(" - ")
       val concepts = orderedSubfields.map(subfield =>
         subfield.tag match {
-          case "y" => Period(label = subfield.content)
-          case "z" => Place(label = subfield.content)
-          case _ => Concept(label = subfield.content)
+          case "y" => MaybeDisplayable[Period](label = subfield.content)
+          case "z" => MaybeDisplayable[Place](label = subfield.content)
+          case _ => MaybeDisplayable[Concept](label = subfield.content)
       })
-      Genre[AbstractConcept](label = label, concepts = concepts)
+      Genre[MaybeDisplayable[AbstractConcept]](
+        label = label,
+        concepts = concepts
+      )
     })
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -1,6 +1,14 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
-import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.internal.{
+  AbstractConcept,
+  Concept,
+  Genre,
+  MaybeDisplayable,
+  Period,
+  Place,
+  Unidentifiable
+}
 import uk.ac.wellcome.transformer.source.SierraBibData
 
 trait SierraGenres extends MarcUtils {
@@ -31,9 +39,9 @@ trait SierraGenres extends MarcUtils {
       val label = orderedSubfields.map(_.content).mkString(" - ")
       val concepts = orderedSubfields.map(subfield =>
         subfield.tag match {
-          case "y" => MaybeDisplayable[Period](label = subfield.content)
-          case "z" => MaybeDisplayable[Place](label = subfield.content)
-          case _ => MaybeDisplayable[Concept](label = subfield.content)
+          case "y" => Unidentifiable(Period(label = subfield.content))
+          case "z" => Unidentifiable(Place(label = subfield.content))
+          case _ => Unidentifiable(Concept(label = subfield.content))
       })
       Genre[MaybeDisplayable[AbstractConcept]](
         label = label,

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -13,7 +13,8 @@ import uk.ac.wellcome.transformer.source.SierraBibData
 
 trait SierraGenres extends MarcUtils {
 
-  def getGenres(bibData: SierraBibData): List[Genre[MaybeDisplayable[AbstractConcept]]] = {
+  def getGenres(
+    bibData: SierraBibData): List[Genre[MaybeDisplayable[AbstractConcept]]] = {
     getGenresForMarcTag(bibData, "655")
   }
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -3,15 +3,17 @@ package uk.ac.wellcome.transformer.transformers.sierra
 import uk.ac.wellcome.models.work.internal.{
   AbstractConcept,
   Concept,
+  MaybeDisplayable,
   Period,
   Place,
-  Subject
+  Subject,
+  Unidentifiable
 }
 import uk.ac.wellcome.transformer.source.SierraBibData
 
 trait SierraSubjects extends MarcUtils {
 
-  def getSubjects(bibData: SierraBibData): List[Subject[AbstractConcept]] = {
+  def getSubjects(bibData: SierraBibData): List[Subject[MaybeDisplayable[AbstractConcept]]] = {
     getSubjectsForMarcTag(bibData, "650") ++
       getSubjectsForMarcTag(bibData, "648") ++
       getSubjectsForMarcTag(bibData, "651")
@@ -51,7 +53,10 @@ trait SierraSubjects extends MarcUtils {
           case "z" => Unidentifiable(Place(label = subfield.content))
           case _ => Unidentifiable(Concept(label = subfield.content))
       })
-      Subject[AbstractConcept](label = subjectLabel, concepts = concepts)
+      Subject[MaybeDisplayable[AbstractConcept]](
+        label = subjectLabel,
+        concepts = concepts
+      )
     })
   }
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -46,10 +46,10 @@ trait SierraSubjects extends MarcUtils {
       val subjectLabel = orderedSubfields.map(_.content).mkString(" - ")
       val concepts = orderedSubfields.map(subfield =>
         subfield.tag match {
-          case "a" => primaryConcept(marcTag, subfield.content)
-          case "y" => Period(label = subfield.content)
-          case "z" => Place(label = subfield.content)
-          case _ => Concept(label = subfield.content)
+          case "a" => Unidentifiable(primaryConcept(marcTag, subfield.content))
+          case "y" => Unidentifiable(Period(label = subfield.content))
+          case "z" => Unidentifiable(Place(label = subfield.content))
+          case _ => Unidentifiable(Concept(label = subfield.content))
       })
       Subject[AbstractConcept](label = subjectLabel, concepts = concepts)
     })

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -13,7 +13,8 @@ import uk.ac.wellcome.transformer.source.SierraBibData
 
 trait SierraSubjects extends MarcUtils {
 
-  def getSubjects(bibData: SierraBibData): List[Subject[MaybeDisplayable[AbstractConcept]]] = {
+  def getSubjects(bibData: SierraBibData)
+    : List[Subject[MaybeDisplayable[AbstractConcept]]] = {
     getSubjectsForMarcTag(bibData, "650") ++
       getSubjectsForMarcTag(bibData, "648") ++
       getSubjectsForMarcTag(bibData, "651")

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -712,7 +712,7 @@ class SierraTransformableTransformerTest
     transformedSierraRecord.isSuccess shouldBe true
 
     transformedSierraRecord.get.get.subjects shouldBe List(
-      Subject(content, List(Concept(content))))
+      Subject(content, List(Unidentifiable(Concept(content)))))
   }
 
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenresTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenresTest.scala
@@ -1,7 +1,13 @@
 package uk.ac.wellcome.transformer.transformers.miro
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal.{AbstractConcept, Concept, Genre}
+import uk.ac.wellcome.models.work.internal.{
+  AbstractConcept,
+  Concept,
+  Genre,
+  MaybeDisplayable,
+  Unidentifiable
+}
 import uk.ac.wellcome.transformer.transformers.MiroTransformableWrapper
 
 class MiroGenresTest
@@ -22,7 +28,7 @@ class MiroGenresTest
         "image_title": "A goat grazes on some grass",
         "image_phys_format": "painting"
       """,
-      expectedGenres = List(Genre("painting", List(Concept("painting"))))
+      expectedGenres = List(Genre("painting", List(Unidentifiable(Concept("painting")))))
     )
   }
 
@@ -32,7 +38,7 @@ class MiroGenresTest
         "image_title": "Grouchy geese are good as guards",
         "image_lc_genre": "sculpture"
       """,
-      expectedGenres = List(Genre("sculpture", List(Concept("sculpture"))))
+      expectedGenres = List(Genre("sculpture", List(Unidentifiable(Concept("sculpture")))))
     )
   }
 
@@ -44,8 +50,8 @@ class MiroGenresTest
         "image_lc_genre": "woodwork"
       """,
       expectedGenres = List(
-        Genre("etching", List(Concept("etching"))),
-        Genre("woodwork", List(Concept("woodwork")))
+        Genre("etching", List(Unidentifiable(Concept("etching")))),
+        Genre("woodwork", List(Unidentifiable(Concept("woodwork"))))
       )
     )
   }
@@ -58,13 +64,13 @@ class MiroGenresTest
         "image_lc_genre": "oil painting"
       """,
       expectedGenres =
-        List(Genre("oil painting", List(Concept("oil painting"))))
+        List(Genre("oil painting", List(Unidentifiable(Concept("oil painting")))))
     )
   }
 
   private def transformRecordAndCheckGenres(
     data: String,
-    expectedGenres: List[Genre[AbstractConcept]] = List()
+    expectedGenres: List[Genre[MaybeDisplayable[AbstractConcept]]] = List()
   ) = {
     val transformedWork = transformWork(data = data)
     transformedWork.genres shouldBe expectedGenres

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenresTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/miro/MiroGenresTest.scala
@@ -28,7 +28,8 @@ class MiroGenresTest
         "image_title": "A goat grazes on some grass",
         "image_phys_format": "painting"
       """,
-      expectedGenres = List(Genre("painting", List(Unidentifiable(Concept("painting")))))
+      expectedGenres =
+        List(Genre("painting", List(Unidentifiable(Concept("painting")))))
     )
   }
 
@@ -38,7 +39,8 @@ class MiroGenresTest
         "image_title": "Grouchy geese are good as guards",
         "image_lc_genre": "sculpture"
       """,
-      expectedGenres = List(Genre("sculpture", List(Unidentifiable(Concept("sculpture")))))
+      expectedGenres =
+        List(Genre("sculpture", List(Unidentifiable(Concept("sculpture")))))
     )
   }
 
@@ -63,8 +65,8 @@ class MiroGenresTest
         "image_phys_format": "oil painting",
         "image_lc_genre": "oil painting"
       """,
-      expectedGenres =
-        List(Genre("oil painting", List(Unidentifiable(Concept("oil painting")))))
+      expectedGenres = List(
+        Genre("oil painting", List(Unidentifiable(Concept("oil painting")))))
     )
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjectsTest.scala
@@ -60,7 +60,7 @@ class MiroSubjectsTest
   ) = {
     val transformedWork = transformWork(data = data)
     val expectedSubjects = expectedSubjectLabels.map { label =>
-      Subject(label = label, concepts = List(Concept(label)))
+      Subject(label = label, concepts = List(Unidentifiable(Concept(label))))
     }
     transformedWork.subjects shouldBe expectedSubjects
   }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjectsTest.scala
@@ -18,7 +18,7 @@ class MiroSubjectsTest
   it("puts an empty subject list on records without keywords") {
     transformRecordAndCheckSubjects(
       data = s""""image_title": "A snail without a subject"""",
-      expectedSubjects = List()
+      expectedSubjectLabels = List()
     )
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/miro/MiroSubjectsTest.scala
@@ -28,11 +28,7 @@ class MiroSubjectsTest
         "image_title": "A scorpion with a strawberry",
         "image_keywords": ["animals", "arachnids", "fruit"]
       """,
-      expectedSubjects = List(
-        Subject(label = "animals", concepts = List(Concept("animals"))),
-        Subject(label = "arachnids", concepts = List(Concept("arachnids"))),
-        Subject(label = "fruit", concepts = List(Concept("fruit")))
-      )
+      expectedSubjectLabels = List("animals", "arachnids", "fruit")
     )
   }
 
@@ -42,10 +38,7 @@ class MiroSubjectsTest
         "image_title": "A sweet seal gives you a sycamore",
         "image_keywords_unauth": ["altruism", "mammals"]
       """,
-      expectedSubjects = List(
-        Subject(label = "altruism", concepts = List(Concept("altruism"))),
-        Subject(label = "mammals", concepts = List(Concept("mammals")))
-      )
+      expectedSubjectLabels = List("altruism", "mammals")
     )
   }
 
@@ -57,20 +50,18 @@ class MiroSubjectsTest
         "image_keywords": ["humour"],
         "image_keywords_unauth": ["marine creatures"]
       """,
-      expectedSubjects = List(
-        Subject(label = "humour", concepts = List(Concept("humour"))),
-        Subject(
-          label = "marine creatures",
-          concepts = List(Concept("marine creatures")))
-      )
+      expectedSubjectLabels = List("humour", "marine creatures")
     )
   }
 
   private def transformRecordAndCheckSubjects(
     data: String,
-    expectedSubjects: List[Subject[AbstractConcept]] = List()
+    expectedSubjectLabels: List[String] = List()
   ) = {
     val transformedWork = transformWork(data = data)
+    val expectedSubjects = expectedSubjectLabels.map { label =>
+      Subject(label = label, concepts = List(Concept(label)))
+    }
     transformedWork.subjects shouldBe expectedSubjects
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenresTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenresTest.scala
@@ -44,13 +44,12 @@ class SierraGenresTest extends FunSpec with Matchers {
       List(
         Genre[MaybeDisplayable[AbstractConcept]](
           label = "A Content - V Content",
-          concepts =
-            List(
-              Unidentifiable(Concept(label = "A Content")),
-              Unidentifiable(Concept(label = "V Content"))
-            )
+          concepts = List(
+            Unidentifiable(Concept(label = "A Content")),
+            Unidentifiable(Concept(label = "V Content"))
           )
         )
+      )
 
     assertExtractsGenres(
       bibData(
@@ -68,13 +67,12 @@ class SierraGenresTest extends FunSpec with Matchers {
       List(
         Genre[MaybeDisplayable[AbstractConcept]](
           label = "A Content - V Content",
-          concepts =
-            List(
-              Unidentifiable(Concept(label = "A Content")),
-              Unidentifiable(Concept(label = "V Content"))
-            )
+          concepts = List(
+            Unidentifiable(Concept(label = "A Content")),
+            Unidentifiable(Concept(label = "V Content"))
           )
         )
+      )
 
     assertExtractsGenres(
       bibData(
@@ -95,7 +93,8 @@ class SierraGenresTest extends FunSpec with Matchers {
             Unidentifiable(Concept(label = "A Content")),
             Unidentifiable(Concept(label = "X Content")),
             Unidentifiable(Concept(label = "V Content"))
-          )))
+          )
+        ))
 
     assertExtractsGenres(
       bibData(
@@ -197,8 +196,9 @@ class SierraGenresTest extends FunSpec with Matchers {
 
   private val transformer = new SierraGenres {}
 
-  private def assertExtractsGenres(bibData: SierraBibData,
-                                   expected: List[Genre[MaybeDisplayable[AbstractConcept]]]) = {
+  private def assertExtractsGenres(
+    bibData: SierraBibData,
+    expected: List[Genre[MaybeDisplayable[AbstractConcept]]]) = {
     transformer.getGenres(bibData) shouldBe expected
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenresTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenresTest.scala
@@ -5,8 +5,10 @@ import uk.ac.wellcome.models.work.internal.{
   AbstractConcept,
   Concept,
   Genre,
+  MaybeDisplayable,
   Period,
-  Place
+  Place,
+  Unidentifiable
 }
 import uk.ac.wellcome.transformer.source.{
   MarcSubfield,
@@ -28,9 +30,9 @@ class SierraGenresTest extends FunSpec with Matchers {
   it("returns genres for tag 655 with only subfield a") {
     val expectedGenres =
       List(
-        Genre[AbstractConcept](
+        Genre[MaybeDisplayable[AbstractConcept]](
           label = "A Content",
-          concepts = List(Concept(label = "A Content"))))
+          concepts = List(Unidentifiable(Concept(label = "A Content")))))
 
     assertExtractsGenres(
       bibData("655", List(MarcSubfield(tag = "a", content = "A Content"))),
@@ -40,10 +42,15 @@ class SierraGenresTest extends FunSpec with Matchers {
   it("returns subjects for tag 655 with subfields a and v") {
     val expectedGenres =
       List(
-        Genre[AbstractConcept](
+        Genre[MaybeDisplayable[AbstractConcept]](
           label = "A Content - V Content",
           concepts =
-            List(Concept(label = "A Content"), Concept(label = "V Content"))))
+            List(
+              Unidentifiable(Concept(label = "A Content")),
+              Unidentifiable(Concept(label = "V Content"))
+            )
+          )
+        )
 
     assertExtractsGenres(
       bibData(
@@ -59,10 +66,15 @@ class SierraGenresTest extends FunSpec with Matchers {
     "subfield a is always first concept when returning subjects for tag 655 with subfields a, v") {
     val expectedGenres =
       List(
-        Genre[AbstractConcept](
+        Genre[MaybeDisplayable[AbstractConcept]](
           label = "A Content - V Content",
           concepts =
-            List(Concept(label = "A Content"), Concept(label = "V Content"))))
+            List(
+              Unidentifiable(Concept(label = "A Content")),
+              Unidentifiable(Concept(label = "V Content"))
+            )
+          )
+        )
 
     assertExtractsGenres(
       bibData(
@@ -77,12 +89,12 @@ class SierraGenresTest extends FunSpec with Matchers {
   it("returns genres for tag 655 subfields a, v, and x") {
     val expectedGenres =
       List(
-        Genre[AbstractConcept](
+        Genre[MaybeDisplayable[AbstractConcept]](
           label = "A Content - X Content - V Content",
           concepts = List(
-            Concept(label = "A Content"),
-            Concept(label = "X Content"),
-            Concept(label = "V Content")
+            Unidentifiable(Concept(label = "A Content")),
+            Unidentifiable(Concept(label = "X Content")),
+            Unidentifiable(Concept(label = "V Content"))
           )))
 
     assertExtractsGenres(
@@ -100,11 +112,11 @@ class SierraGenresTest extends FunSpec with Matchers {
   it("returns subjects for tag 655 with subfields a, y") {
     val expectedGenres =
       List(
-        Genre[AbstractConcept](
+        Genre[MaybeDisplayable[AbstractConcept]](
           label = "A Content - Y Content",
           concepts = List(
-            Concept(label = "A Content"),
-            Period(label = "Y Content")
+            Unidentifiable(Concept(label = "A Content")),
+            Unidentifiable(Period(label = "Y Content"))
           )))
 
     assertExtractsGenres(
@@ -120,11 +132,11 @@ class SierraGenresTest extends FunSpec with Matchers {
   it("returns subjects for tag 655 with subfields a, z") {
     val expectedGenres =
       List(
-        Genre[AbstractConcept](
+        Genre[MaybeDisplayable[AbstractConcept]](
           label = "A Content - Z Content",
           concepts = List(
-            Concept(label = "A Content"),
-            Place(label = "Z Content")
+            Unidentifiable(Concept(label = "A Content")),
+            Unidentifiable(Place(label = "Z Content"))
           )))
 
     assertExtractsGenres(
@@ -167,17 +179,17 @@ class SierraGenresTest extends FunSpec with Matchers {
 
     val expectedSubjects =
       List(
-        Genre[AbstractConcept](
+        Genre[MaybeDisplayable[AbstractConcept]](
           label = "A1 Content - Z1 Content",
           concepts = List(
-            Concept(label = "A1 Content"),
-            Place(label = "Z1 Content")
+            Unidentifiable(Concept(label = "A1 Content")),
+            Unidentifiable(Place(label = "Z1 Content"))
           )),
-        Genre[AbstractConcept](
+        Genre[MaybeDisplayable[AbstractConcept]](
           label = "A2 Content - V2 Content",
           concepts = List(
-            Concept(label = "A2 Content"),
-            Concept(label = "V2 Content")
+            Unidentifiable(Concept(label = "A2 Content")),
+            Unidentifiable(Concept(label = "V2 Content"))
           ))
       )
     assertExtractsGenres(bibData, expectedSubjects)
@@ -186,7 +198,7 @@ class SierraGenresTest extends FunSpec with Matchers {
   private val transformer = new SierraGenres {}
 
   private def assertExtractsGenres(bibData: SierraBibData,
-                                   expected: List[Genre[AbstractConcept]]) = {
+                                   expected: List[Genre[MaybeDisplayable[AbstractConcept]]]) = {
     transformer.getGenres(bibData) shouldBe expected
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjectsTest.scala
@@ -1,13 +1,7 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal.{
-  AbstractConcept,
-  Concept,
-  Period,
-  Place,
-  Subject
-}
+import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.transformer.source.{
   MarcSubfield,
   SierraBibData,
@@ -28,7 +22,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   it("returns subjects for tag 650 with only subfield a") {
     val expectedSubjects =
       List(
-        Subject[AbstractConcept](
+        Subject[MaybeDisplayable[AbstractConcept]](
           label = "A Content",
           concepts = List(Unidentifiable(Concept(label = "A Content")))))
 
@@ -44,7 +38,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   it("returns subjects for tag 650 with only subfields a and v") {
     val expectedSubjects =
       List(
-        Subject[AbstractConcept](
+        Subject[MaybeDisplayable[AbstractConcept]](
           label = "A Content - V Content",
           concepts = List(
             Unidentifiable(Concept(label = "A Content")),
@@ -64,7 +58,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
     "subfield a is always first concept when returning subjects for tag 650 with subfields a, v") {
     val expectedSubjects =
       List(
-        Subject[AbstractConcept](
+        Subject[MaybeDisplayable[AbstractConcept]](
           label = "A Content - V Content",
           concepts = List(
             Unidentifiable(Concept(label = "A Content")),
@@ -83,7 +77,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   it("returns subjects for tag 650 subfields a, v, and x") {
     val expectedSubjects =
       List(
-        Subject[AbstractConcept](
+        Subject[MaybeDisplayable[AbstractConcept]](
           label = "A Content - X Content - V Content",
           concepts = List(
             Unidentifiable(Concept(label = "A Content")),
@@ -107,7 +101,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   it("returns subjects for tag 650 with subfields a, y") {
     val expectedSubjects =
       List(
-        Subject[AbstractConcept](
+        Subject[MaybeDisplayable[AbstractConcept]](
           label = "A Content - Y Content",
           concepts = List(
             Unidentifiable(Concept(label = "A Content")),
@@ -127,7 +121,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   it("returns subjects for tag 650 with subfields a, z") {
     val expectedSubjects =
       List(
-        Subject[AbstractConcept](
+        Subject[MaybeDisplayable[AbstractConcept]](
           label = "A Content - Z Content",
           concepts = List(
             Unidentifiable(Concept(label = "A Content")),
@@ -174,13 +168,13 @@ class SierraSubjectsTest extends FunSpec with Matchers {
 
     val expectedSubjects =
       List(
-        Subject[AbstractConcept](
+        Subject[MaybeDisplayable[AbstractConcept]](
           label = "A1 Content - Z1 Content",
           concepts = List(
             Unidentifiable(Concept(label = "A1 Content")),
             Unidentifiable(Place(label = "Z1 Content"))
           )),
-        Subject[AbstractConcept](
+        Subject[MaybeDisplayable[AbstractConcept]](
           label = "A2 Content - V2 Content",
           concepts = List(
             Unidentifiable(Concept(label = "A2 Content")),
@@ -194,7 +188,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   it("returns subjects with primary concept Period for tag 648") {
     val expectedSubjects =
       List(
-        Subject[AbstractConcept](
+        Subject[MaybeDisplayable[AbstractConcept]](
           label = "A Content - X Content - V Content",
           concepts = List(
             Unidentifiable(Period(label = "A Content")),
@@ -218,7 +212,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   it("returns subjects with primary concept Place for tag 651") {
     val expectedSubjects =
       List(
-        Subject[AbstractConcept](
+        Subject[MaybeDisplayable[AbstractConcept]](
           label = "A Content - X Content - V Content",
           concepts = List(
             Unidentifiable(Place(label = "A Content")),
@@ -243,7 +237,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
 
   private def assertExtractsSubjects(
     bibData: SierraBibData,
-    expected: List[Subject[AbstractConcept]]) = {
+    expected: List[Subject[MaybeDisplayable[AbstractConcept]]]) = {
     transformer.getSubjects(bibData = bibData) shouldBe expected
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjectsTest.scala
@@ -89,7 +89,8 @@ class SierraSubjectsTest extends FunSpec with Matchers {
             Unidentifiable(Concept(label = "A Content")),
             Unidentifiable(Concept(label = "X Content")),
             Unidentifiable(Concept(label = "V Content"))
-          )))
+          )
+        ))
 
     assertExtractsSubjects(
       bibData(
@@ -199,7 +200,8 @@ class SierraSubjectsTest extends FunSpec with Matchers {
             Unidentifiable(Period(label = "A Content")),
             Unidentifiable(Concept(label = "X Content")),
             Unidentifiable(Concept(label = "V Content"))
-          )))
+          )
+        ))
 
     assertExtractsSubjects(
       bibData(
@@ -222,7 +224,8 @@ class SierraSubjectsTest extends FunSpec with Matchers {
             Unidentifiable(Place(label = "A Content")),
             Unidentifiable(Concept(label = "X Content")),
             Unidentifiable(Concept(label = "V Content"))
-          )))
+          )
+        ))
 
     assertExtractsSubjects(
       bibData(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjectsTest.scala
@@ -30,7 +30,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
       List(
         Subject[AbstractConcept](
           label = "A Content",
-          concepts = List(Concept(label = "A Content"))))
+          concepts = List(Unidentifiable(Concept(label = "A Content")))))
 
     assertExtractsSubjects(
       bibData(
@@ -46,8 +46,9 @@ class SierraSubjectsTest extends FunSpec with Matchers {
       List(
         Subject[AbstractConcept](
           label = "A Content - V Content",
-          concepts =
-            List(Concept(label = "A Content"), Concept(label = "V Content"))))
+          concepts = List(
+            Unidentifiable(Concept(label = "A Content")),
+            Unidentifiable(Concept(label = "V Content")))))
 
     assertExtractsSubjects(
       bibData(
@@ -65,8 +66,9 @@ class SierraSubjectsTest extends FunSpec with Matchers {
       List(
         Subject[AbstractConcept](
           label = "A Content - V Content",
-          concepts =
-            List(Concept(label = "A Content"), Concept(label = "V Content"))))
+          concepts = List(
+            Unidentifiable(Concept(label = "A Content")),
+            Unidentifiable(Concept(label = "V Content")))))
 
     assertExtractsSubjects(
       bibData(
@@ -84,9 +86,9 @@ class SierraSubjectsTest extends FunSpec with Matchers {
         Subject[AbstractConcept](
           label = "A Content - X Content - V Content",
           concepts = List(
-            Concept(label = "A Content"),
-            Concept(label = "X Content"),
-            Concept(label = "V Content")
+            Unidentifiable(Concept(label = "A Content")),
+            Unidentifiable(Concept(label = "X Content")),
+            Unidentifiable(Concept(label = "V Content"))
           )))
 
     assertExtractsSubjects(
@@ -107,8 +109,8 @@ class SierraSubjectsTest extends FunSpec with Matchers {
         Subject[AbstractConcept](
           label = "A Content - Y Content",
           concepts = List(
-            Concept(label = "A Content"),
-            Period(label = "Y Content")
+            Unidentifiable(Concept(label = "A Content")),
+            Unidentifiable(Period(label = "Y Content"))
           )))
 
     assertExtractsSubjects(
@@ -127,8 +129,8 @@ class SierraSubjectsTest extends FunSpec with Matchers {
         Subject[AbstractConcept](
           label = "A Content - Z Content",
           concepts = List(
-            Concept(label = "A Content"),
-            Place(label = "Z Content")
+            Unidentifiable(Concept(label = "A Content")),
+            Unidentifiable(Place(label = "Z Content"))
           )))
 
     assertExtractsSubjects(
@@ -174,14 +176,14 @@ class SierraSubjectsTest extends FunSpec with Matchers {
         Subject[AbstractConcept](
           label = "A1 Content - Z1 Content",
           concepts = List(
-            Concept(label = "A1 Content"),
-            Place(label = "Z1 Content")
+            Unidentifiable(Concept(label = "A1 Content")),
+            Unidentifiable(Place(label = "Z1 Content"))
           )),
         Subject[AbstractConcept](
           label = "A2 Content - V2 Content",
           concepts = List(
-            Concept(label = "A2 Content"),
-            Concept(label = "V2 Content")
+            Unidentifiable(Concept(label = "A2 Content")),
+            Unidentifiable(Concept(label = "V2 Content"))
           ))
       )
 
@@ -194,9 +196,9 @@ class SierraSubjectsTest extends FunSpec with Matchers {
         Subject[AbstractConcept](
           label = "A Content - X Content - V Content",
           concepts = List(
-            Period(label = "A Content"),
-            Concept(label = "X Content"),
-            Concept(label = "V Content")
+            Unidentifiable(Period(label = "A Content")),
+            Unidentifiable(Concept(label = "X Content")),
+            Unidentifiable(Concept(label = "V Content"))
           )))
 
     assertExtractsSubjects(
@@ -217,9 +219,9 @@ class SierraSubjectsTest extends FunSpec with Matchers {
         Subject[AbstractConcept](
           label = "A Content - X Content - V Content",
           concepts = List(
-            Place(label = "A Content"),
-            Concept(label = "X Content"),
-            Concept(label = "V Content")
+            Unidentifiable(Place(label = "A Content")),
+            Unidentifiable(Concept(label = "X Content")),
+            Unidentifiable(Concept(label = "V Content"))
           )))
 
     assertExtractsSubjects(

--- a/functions.Makefile
+++ b/functions.Makefile
@@ -221,6 +221,9 @@ $(1)-build:
 $(1)-test:
 	$(call sbt_test,$(1))
 
+$(1)-test-no_docker:
+	$(call sbt_test_no_docker,$(1))
+
 $(1)-publish: $(1)-build
 	$(call publish_service,$(1))
 endef

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayConceptV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayConceptV1.scala
@@ -2,7 +2,12 @@ package uk.ac.wellcome.display.models.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.work.internal.AbstractConcept
+import uk.ac.wellcome.models.work.internal.{
+  AbstractConcept,
+  Displayable,
+  Identified,
+  Unidentifiable
+}
 
 @ApiModel(
   value = "Concept",
@@ -17,7 +22,11 @@ case class DisplayConceptV1(
 }
 
 case object DisplayConceptV1 {
-  def apply(concept: AbstractConcept): DisplayConceptV1 = DisplayConceptV1(
-    label = concept.label
-  )
+  def apply(concept: Displayable[AbstractConcept]): DisplayConceptV1 = {
+    val label = concept match {
+      case Identified(c: AbstractConcept, _, _) => c.label
+      case Unidentifiable(c: AbstractConcept) => c.label
+    }
+    DisplayConceptV1(label = label)
+  }
 }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.models.work.internal._
 
 @ApiModel(
@@ -10,14 +11,44 @@ import uk.ac.wellcome.models.work.internal._
 sealed trait DisplayAbstractConcept
 
 case object DisplayAbstractConcept {
-  def apply(abstractConcept: AbstractConcept): DisplayAbstractConcept =
+  def apply(abstractConcept: Displayable[AbstractConcept]): DisplayAbstractConcept =
     abstractConcept match {
-      case concept: Concept =>
-        DisplayConcept(concept.label)
-      case period: Period =>
-        DisplayPeriod(period.label)
-      case place: Place =>
-        DisplayPlace(place.label)
+      case Unidentifiable(concept: Concept) =>
+        DisplayConcept(
+          id = None,
+          identifiers = None,
+          label = concept.label
+        )
+      case Identified(concept: Concept, id, identifiers) =>
+        DisplayConcept(
+          id = Some(id),
+          identifiers = Some(identifiers.map { DisplayIdentifier(_) }),
+          label = concept.label
+        )
+      case Unidentifiable(period: Period) =>
+        DisplayPeriod(
+          id = None,
+          identifiers = None,
+          label = period.label
+        )
+      case Identified(period: Period, id, identifiers) =>
+        DisplayPeriod(
+          id = Some(id),
+          identifiers = Some(identifiers.map { DisplayIdentifier(_) }),
+          label = period.label
+        )
+      case Unidentifiable(place: Place) =>
+        DisplayPlace(
+          id = None,
+          identifiers = None,
+          label = place.label
+        )
+      case Identified(place: Place, id, identifiers) =>
+        DisplayPlace(
+          id = Some(id),
+          identifiers = Some(identifiers.map { DisplayIdentifier(_) }),
+          label = place.label
+        )
     }
 }
 
@@ -26,6 +57,15 @@ case object DisplayAbstractConcept {
   description = "A broad concept"
 )
 case class DisplayConcept(
+  @ApiModelProperty(
+    dataType = "String",
+    value = "The canonical identifier given to a thing"
+  ) id: Option[String] = None,
+  @ApiModelProperty(
+    dataType = "List[uk.ac.wellcome.display.models.DisplayIdentifier]",
+    value =
+      "Relates the item to a unique system-generated identifier that governs interaction between systems and is regarded as canonical within the Wellcome data ecosystem."
+  ) identifiers: Option[List[DisplayIdentifier]] = None,
   @ApiModelProperty(
     dataType = "String"
   ) label: String
@@ -44,6 +84,15 @@ case object DisplayConcept {
 )
 case class DisplayPeriod(
   @ApiModelProperty(
+    dataType = "String",
+    value = "The canonical identifier given to a thing"
+  ) id: Option[String] = None,
+  @ApiModelProperty(
+    dataType = "List[uk.ac.wellcome.display.models.DisplayIdentifier]",
+    value =
+      "Relates the item to a unique system-generated identifier that governs interaction between systems and is regarded as canonical within the Wellcome data ecosystem."
+  ) identifiers: Option[List[DisplayIdentifier]] = None,
+  @ApiModelProperty(
     dataType = "String"
   ) label: String
 ) extends DisplayAbstractConcept {
@@ -60,6 +109,15 @@ case object DisplayPeriod {
   description = "A place"
 )
 case class DisplayPlace(
+  @ApiModelProperty(
+    dataType = "String",
+    value = "The canonical identifier given to a thing"
+  ) id: Option[String] = None,
+  @ApiModelProperty(
+    dataType = "List[uk.ac.wellcome.display.models.DisplayIdentifier]",
+    value =
+      "Relates the item to a unique system-generated identifier that governs interaction between systems and is regarded as canonical within the Wellcome data ecosystem."
+  ) identifiers: Option[List[DisplayIdentifier]] = None,
   @ApiModelProperty(
     dataType = "String"
   ) label: String

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
@@ -93,6 +93,11 @@ case class DisplayPeriod(
 ) extends DisplayAbstractConcept {
   @JsonProperty("type") val ontologyType: String = "Period"
 }
+case object DisplayPeriod {
+  def apply(period: Period): DisplayPeriod = DisplayPeriod(
+    label = period.label
+  )
+}
 
 @ApiModel(
   value = "Place",
@@ -113,4 +118,9 @@ case class DisplayPlace(
   ) label: String
 ) extends DisplayAbstractConcept {
   @JsonProperty("type") val ontologyType: String = "Place"
+}
+case object DisplayPlace {
+  def apply(place: Place): DisplayPlace = DisplayPlace(
+    label = place.label
+  )
 }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
@@ -72,11 +72,6 @@ case class DisplayConcept(
 ) extends DisplayAbstractConcept {
   @JsonProperty("type") val ontologyType: String = "Concept"
 }
-case object DisplayConcept {
-  def apply(concept: AbstractConcept): DisplayConcept = DisplayConcept(
-    label = concept.label
-  )
-}
 
 @ApiModel(
   value = "Period",
@@ -98,11 +93,6 @@ case class DisplayPeriod(
 ) extends DisplayAbstractConcept {
   @JsonProperty("type") val ontologyType: String = "Period"
 }
-case object DisplayPeriod {
-  def apply(period: Period): DisplayPeriod = DisplayPeriod(
-    label = period.label
-  )
-}
 
 @ApiModel(
   value = "Place",
@@ -123,9 +113,4 @@ case class DisplayPlace(
   ) label: String
 ) extends DisplayAbstractConcept {
   @JsonProperty("type") val ontologyType: String = "Place"
-}
-case object DisplayPlace {
-  def apply(place: Place): DisplayPlace = DisplayPlace(
-    label = place.label
-  )
 }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
@@ -11,7 +11,8 @@ import uk.ac.wellcome.models.work.internal._
 sealed trait DisplayAbstractConcept
 
 case object DisplayAbstractConcept {
-  def apply(abstractConcept: Displayable[AbstractConcept]): DisplayAbstractConcept =
+  def apply(
+    abstractConcept: Displayable[AbstractConcept]): DisplayAbstractConcept =
     abstractConcept match {
       case Unidentifiable(concept: Concept) =>
         DisplayConcept(

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayGenre.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayGenre.scala
@@ -1,14 +1,14 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import uk.ac.wellcome.models.work.internal.{AbstractConcept, Genre}
+import uk.ac.wellcome.models.work.internal.{AbstractConcept, Displayable, Genre}
 
 case class DisplayGenre(label: String,
                         concepts: List[DisplayAbstractConcept],
                         @JsonProperty("type") ontologyType: String = "Genre")
 
 object DisplayGenre {
-  def apply(genre: Genre[AbstractConcept]): DisplayGenre =
+  def apply(genre: Genre[Displayable[AbstractConcept]]): DisplayGenre =
     DisplayGenre(label = genre.label, concepts = genre.concepts.map {
       DisplayAbstractConcept(_)
     }, ontologyType = genre.ontologyType)

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayGenre.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayGenre.scala
@@ -1,7 +1,11 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import uk.ac.wellcome.models.work.internal.{AbstractConcept, Displayable, Genre}
+import uk.ac.wellcome.models.work.internal.{
+  AbstractConcept,
+  Displayable,
+  Genre
+}
 
 case class DisplayGenre(label: String,
                         concepts: List[DisplayAbstractConcept],

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplaySubject.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplaySubject.scala
@@ -1,7 +1,11 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import uk.ac.wellcome.models.work.internal.{AbstractConcept, Subject}
+import uk.ac.wellcome.models.work.internal.{
+  AbstractConcept,
+  Displayable,
+  Subject
+}
 
 case class DisplaySubject(label: String,
                           concepts: List[DisplayAbstractConcept],
@@ -9,7 +13,7 @@ case class DisplaySubject(label: String,
                             "Subject")
 
 object DisplaySubject {
-  def apply(subject: Subject[AbstractConcept]): DisplaySubject =
+  def apply(subject: Subject[Displayable[AbstractConcept]]): DisplaySubject =
     DisplaySubject(label = subject.label, concepts = subject.concepts.map {
       DisplayAbstractConcept(_)
     }, ontologyType = subject.ontologyType)

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -140,14 +140,14 @@ trait DisplaySerialisationTestBase { this: Suite =>
     }
     """
 
-  def concepts(concepts: List[AbstractConcept]) =
+  def concepts(concepts: List[Displayable[AbstractConcept]]) =
     concepts
-      .map {
-        concept(_)
+      .map { c =>
+        identifiedOrUnidentifiable(c, concept)
       }
       .mkString(",")
 
-  def subject(s: Subject[AbstractConcept]) =
+  def subject(s: Subject[Displayable[AbstractConcept]]) =
     s"""
     {
       "label": "${s.label}",
@@ -156,12 +156,12 @@ trait DisplaySerialisationTestBase { this: Suite =>
     }
     """
 
-  def subjects(subjects: List[Subject[AbstractConcept]]) =
+  def subjects(subjects: List[Subject[Displayable[AbstractConcept]]]) =
     subjects
       .map { subject(_) }
       .mkString(",")
 
-  def genre(g: Genre[AbstractConcept]) =
+  def genre(g: Genre[Displayable[AbstractConcept]]) =
     s"""
     {
       "label": "${g.label}",
@@ -170,7 +170,7 @@ trait DisplaySerialisationTestBase { this: Suite =>
     }
     """
 
-  def genres(genres: List[Genre[AbstractConcept]]) =
+  def genres(genres: List[Genre[Displayable[AbstractConcept]]]) =
     genres
       .map { genre(_) }
       .mkString(",")

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -185,8 +185,8 @@ class DisplayWorkV1SerialisationTest
                           |     "title": "${workWithSubjects.title.get}",
                           |     "creators": [],
                           |     "subjects": [
-                          |       ${concept(concept0)},
-                          |       ${concept(concept1)} ],
+                          |       ${concept(concept0.agent)},
+                          |       ${concept(concept1.agent)} ],
                           |     "genres": [ ],
                           |     "publishers": [ ],
                           |     "placesOfPublication": [ ]

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -163,6 +163,9 @@ class DisplayWorkV1SerialisationTest
   }
 
   it("includes subject information in DisplayWorkV1 serialisation") {
+    val concept0 = Unidentifiable(Concept("fish"))
+    val concept1 = Unidentifiable(Concept("gardening"))
+
     val workWithSubjects = IdentifiedWork(
       title = Some("A seal selling seaweed sandwiches in Scotland"),
       sourceIdentifier = sourceIdentifier,
@@ -170,8 +173,9 @@ class DisplayWorkV1SerialisationTest
       identifiers = List(),
       canonicalId = "test_subject1",
       subjects = List(
-        Subject("label", List(Concept("fish"))),
-        Subject("label", List(Concept("gardening"))))
+        Subject("label", List(concept0)),
+        Subject("label", List(concept1))
+      )
     )
     val actualJson =
       objectMapper.writeValueAsString(DisplayWorkV1(workWithSubjects))
@@ -181,10 +185,8 @@ class DisplayWorkV1SerialisationTest
                           |     "title": "${workWithSubjects.title.get}",
                           |     "creators": [],
                           |     "subjects": [
-                          |       ${concept(
-                            workWithSubjects.subjects(0).concepts(0))},
-                          |       ${concept(
-                            workWithSubjects.subjects(1).concepts(0))} ],
+                          |       ${concept(concept0)},
+                          |       ${concept(concept1)} ],
                           |     "genres": [ ],
                           |     "publishers": [ ],
                           |     "placesOfPublication": [ ]
@@ -194,30 +196,32 @@ class DisplayWorkV1SerialisationTest
   }
 
   it("includes genre information in DisplayWorkV1 serialisation") {
-    val workWithSubjects = IdentifiedWork(
+    val concept0 = Unidentifiable(Concept("woodwork"))
+    val concept1 = Unidentifiable(Concept("etching"))
+
+    val wotkWithGenres = IdentifiedWork(
       title = Some("A guppy in a greenhouse"),
       sourceIdentifier = sourceIdentifier,
       version = 1,
       identifiers = List(),
       canonicalId = "test_subject1",
       genres = List(
-        Genre("label", List(Concept("woodwork"))),
-        Genre("label", List(Concept("etching"))))
+        Genre("label", List(concept0)),
+        Genre("label", List(concept1))
+      )
     )
     val actualJson =
-      objectMapper.writeValueAsString(DisplayWorkV1(workWithSubjects))
+      objectMapper.writeValueAsString(DisplayWorkV1(wotkWithGenres))
     val expectedJson = s"""
                           |{
                           |     "type": "Work",
-                          |     "id": "${workWithSubjects.canonicalId}",
-                          |     "title": "${workWithSubjects.title.get}",
+                          |     "id": "${wotkWithGenres.canonicalId}",
+                          |     "title": "${wotkWithGenres.title.get}",
                           |     "creators": [ ],
                           |     "subjects": [ ],
                           |     "genres": [
-                          |             ${concept(
-                            workWithSubjects.genres(0).concepts(0))},
-                          |             ${concept(
-                            workWithSubjects.genres(1).concepts(0))} ],
+                          |             ${concept(concept0.agent)},
+                          |             ${concept(concept1.agent)} ],
                           |     "publishers": [ ],
                           |     "placesOfPublication": [ ]
                           |   }""".stripMargin

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -134,7 +134,7 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
     }
   }
 
-  it("extracts creators from a Work with unidentified Contributors") {
+  it("extracts creators from a Work with Unidentifiable Contributors") {
     val work = IdentifiedWork(
       title = Some("Jumping over jackals in Japan"),
       sourceIdentifier = sourceIdentifier,
@@ -170,7 +170,7 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
   }
 
   it(
-    "extracts creators from a Work with a mixture of identified/unidentified Contributors") {
+    "extracts creators from a Work with a mixture of identified/Unidentifiable Contributors") {
     val canonicalId = "abcdefgh"
     val sourceIdentifier = SourceIdentifier(
       IdentifierSchemes.libraryOfCongressNames,
@@ -306,19 +306,19 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
   }
 
   it("treats genres as a list of Concepts") {
-    val genres = List[Genre[AbstractConcept]](
+    val genres = List[Genre[Displayable[AbstractConcept]]](
       Genre(
         label = "a genre created by DisplayWorkV1Test",
         concepts = List(
-          Concept("a genre concept"),
-          Place("a genre place"),
-          Period("a genre period")
+          Unidentifiable(Concept("a genre concept")),
+          Unidentifiable(Place("a genre place")),
+          Unidentifiable(Period("a genre period"))
         )
       ),
       Genre(
         label = "a second genre created for DisplayWorkV1Test",
         concepts = List(
-          Concept("a second generic concept")
+          Unidentifiable(Concept("a second generic concept"))
         )
       )
     )
@@ -335,26 +335,26 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
     val expectedGenres = genres
       .map { _.concepts }
       .flatten
-      .map { label =>
-        DisplayConceptV1(label)
+      .map { case Unidentifiable(concept: Concept) =>
+        DisplayConceptV1(label = concept.label)
       }
     displayWork.genres shouldBe expectedGenres
   }
 
   it("treats subjects as a list of Concepts") {
-    val subjects = List[Subject[AbstractConcept]](
+    val subjects = List[Subject[Displayable[AbstractConcept]]](
       Subject(
         label = "a subject created by DisplayWorkV1Test",
         concepts = List(
-          Concept("a subject concept"),
-          Place("a subject place"),
-          Period("a subject period")
+          Unidentifiable(Concept("a subject concept")),
+          Unidentifiable(Place("a subject place")),
+          Unidentifiable(Period("a subject period"))
         )
       ),
       Subject(
         label = "a second subject created for DisplayWorkV1Test",
         concepts = List(
-          Concept("a second generic concept")
+          Unidentifiable(Concept("a second generic concept"))
         )
       )
     )
@@ -371,8 +371,8 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
     val expectedSubjects = subjects
       .map { _.concepts }
       .flatten
-      .map { label =>
-        DisplayConceptV1(label)
+      .map { case Unidentifiable(concept: Concept) =>
+        DisplayConceptV1(label = concept.label)
       }
     displayWork.subjects shouldBe expectedSubjects
   }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -340,7 +340,9 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
 
     val displayWork = DisplayWorkV1(work)
     val expectedGenres = concepts
-      .map { c: AbstractConcept => DisplayConceptV1(c.label) }
+      .map { c: AbstractConcept =>
+        DisplayConceptV1(c.label)
+      }
     displayWork.genres shouldBe expectedGenres
   }
 
@@ -379,7 +381,9 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
 
     val displayWork = DisplayWorkV1(work)
     val expectedSubjects = concepts
-      .map { c: AbstractConcept => DisplayConceptV1(c.label) }
+      .map { c: AbstractConcept =>
+        DisplayConceptV1(c.label)
+      }
     displayWork.subjects shouldBe expectedSubjects
   }
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -306,19 +306,26 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
   }
 
   it("treats genres as a list of Concepts") {
+    val concepts = List(
+      Concept("a genre concept"),
+      Place("a genre place"),
+      Period("a genre period"),
+      Concept("a second generic concept")
+    )
+
     val genres = List[Genre[Displayable[AbstractConcept]]](
       Genre(
         label = "a genre created by DisplayWorkV1Test",
         concepts = List(
-          Unidentifiable(Concept("a genre concept")),
-          Unidentifiable(Place("a genre place")),
-          Unidentifiable(Period("a genre period"))
+          Unidentifiable(concepts(0)),
+          Unidentifiable(concepts(1)),
+          Unidentifiable(concepts(2))
         )
       ),
       Genre(
         label = "a second genre created for DisplayWorkV1Test",
         concepts = List(
-          Unidentifiable(Concept("a second generic concept"))
+          Unidentifiable(concepts(3))
         )
       )
     )
@@ -332,29 +339,32 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
     )
 
     val displayWork = DisplayWorkV1(work)
-    val expectedGenres = genres
-      .map { _.concepts }
-      .flatten
-      .map { case Unidentifiable(concept: Concept) =>
-        DisplayConceptV1(label = concept.label)
-      }
+    val expectedGenres = concepts
+      .map { c: AbstractConcept => DisplayConceptV1(c.label) }
     displayWork.genres shouldBe expectedGenres
   }
 
   it("treats subjects as a list of Concepts") {
+    val concepts = List(
+      Concept("a subject concept"),
+      Place("a subject place"),
+      Period("a subject period"),
+      Concept("a second generic concept")
+    )
+
     val subjects = List[Subject[Displayable[AbstractConcept]]](
       Subject(
         label = "a subject created by DisplayWorkV1Test",
         concepts = List(
-          Unidentifiable(Concept("a subject concept")),
-          Unidentifiable(Place("a subject place")),
-          Unidentifiable(Period("a subject period"))
+          Unidentifiable(concepts(0)),
+          Unidentifiable(concepts(1)),
+          Unidentifiable(concepts(2))
         )
       ),
       Subject(
         label = "a second subject created for DisplayWorkV1Test",
         concepts = List(
-          Unidentifiable(Concept("a second generic concept"))
+          Unidentifiable(concepts(3))
         )
       )
     )
@@ -368,12 +378,8 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
     )
 
     val displayWork = DisplayWorkV1(work)
-    val expectedSubjects = subjects
-      .map { _.concepts }
-      .flatten
-      .map { case Unidentifiable(concept: Concept) =>
-        DisplayConceptV1(label = concept.label)
-      }
+    val expectedSubjects = concepts
+      .map { c: AbstractConcept => DisplayConceptV1(c.label) }
     displayWork.subjects shouldBe expectedSubjects
   }
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
@@ -10,9 +10,13 @@ class DisplayAbstractConceptSerialisationTest
     with DisplaySerialisationTestBase
     with JsonMapperTestUtil {
 
-  it("constructs a DisplayConcept from a Concept correctly") {
+  it("serialises an unidentified DisplayConcept") {
     assertObjectMapsToJson(
-      DisplayConcept(Unidentifiable(Concept("conceptLabel"))),
+      DisplayConcept(
+        id = None,
+        identifiers = None,
+        label = "conceptLabel"
+      ),
       expectedJson = s"""
          |  {
          |    "label" : "conceptLabel",
@@ -22,9 +26,13 @@ class DisplayAbstractConceptSerialisationTest
     )
   }
 
-  it("serialises a DisplayPeriod constructed from a Period correctly") {
+  it("serialises an unidentified DisplayPeriod") {
     assertObjectMapsToJson(
-      DisplayPeriod(Unidentifiable(Period("periodLabel"))),
+      DisplayPeriod(
+        id = None,
+        identifiers = None,
+        label = "periodLabel"
+      ),
       expectedJson = s"""
          |  {
          |    "label" : "periodLabel",
@@ -34,9 +42,13 @@ class DisplayAbstractConceptSerialisationTest
     )
   }
 
-  it("serialises a DisplayPlace constructed from a Place correctly") {
+  it("serialises an unidentified DisplayPlace") {
     assertObjectMapsToJson(
-      DisplayPlace(Unidentifiable(Place("placeLabel"))),
+      DisplayPlace(
+        id = None,
+        identifiers = None,
+        label = "placeLabel"
+      ),
       expectedJson = s"""
          |  {
          |    "label" : "placeLabel",
@@ -48,7 +60,7 @@ class DisplayAbstractConceptSerialisationTest
 
   it("constructs a DisplayConcept from an identified") {
     val concept = Identified(
-      id = "uq4bt5us",
+      canonicalId = "uq4bt5us",
       identifiers = List(SourceIdentifier(
         identifierScheme = IdentifierSchemes.libraryOfCongressNames,
         ontologyType = "Concept",
@@ -61,36 +73,12 @@ class DisplayAbstractConceptSerialisationTest
       DisplayConcept(concept),
       expectedJson = s"""
          |  {
-         |    "id": "${concept.id}",
+         |    "id": "${concept.canonicalId}",
          |    "identifiers": [${concept.identifiers}],
          |    "label" : "${concept.agent.label}",
          |    "type"  : "${concept.agent.ontologyType}"
          |  }
           """.stripMargin
-    )
-  }
-
-  it("serialises a DisplayPeriod constructed from a Period correctly") {
-    assertObjectMapsToJson(
-      DisplayPeriod(Unidentifiable(Period("periodLabel"))),
-      expectedJson = s"""
-         |  {
-         |    "label" : "periodLabel",
-         |    "type"  : "Period"
-         |  }
-          """.stripMargin
-    )
-  }
-
-  it("serialises a DisplayPlace constructed from a Place correctly") {
-    assertObjectMapsToJson(
-      DisplayPlace(Unidentifiable(Place("placeLabel"))),
-      expectedJson = s"""
-         |  {
-         |    "label" : "placeLabel",
-         |    "type"  : "Place"
-         |  }
-         """.stripMargin
     )
   }
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
@@ -74,7 +74,7 @@ class DisplayAbstractConceptSerialisationTest
       expectedJson = s"""
          |  {
          |    "id": "${concept.canonicalId}",
-         |    "identifiers": [${concept.identifiers}],
+         |    "identifiers": [${identifier(concept.identifiers(0))}],
          |    "label" : "${concept.agent.label}",
          |    "type"  : "${concept.agent.ontologyType}"
          |  }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
@@ -61,11 +61,12 @@ class DisplayAbstractConceptSerialisationTest
   it("constructs a DisplayConcept from an identified Concept") {
     val concept = Identified(
       canonicalId = "uq4bt5us",
-      identifiers = List(SourceIdentifier(
-        identifierScheme = IdentifierSchemes.libraryOfCongressNames,
-        ontologyType = "Concept",
-        value = "lcsh/uq4"
-      )),
+      identifiers = List(
+        SourceIdentifier(
+          identifierScheme = IdentifierSchemes.libraryOfCongressNames,
+          ontologyType = "Concept",
+          value = "lcsh/uq4"
+        )),
       agent = Concept("conceptLabel")
     )
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
@@ -3,12 +3,7 @@ package uk.ac.wellcome.display.models.v2
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
-import uk.ac.wellcome.models.work.internal.{
-  AbstractConcept,
-  Concept,
-  Period,
-  Place
-}
+import uk.ac.wellcome.models.work.internal._
 
 class DisplayAbstractConceptSerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
@@ -58,19 +58,19 @@ class DisplayAbstractConceptSerialisationTest
     )
   }
 
-  it("constructs a DisplayConcept from an identified") {
+  it("constructs a DisplayConcept from an identified Concept") {
     val concept = Identified(
       canonicalId = "uq4bt5us",
       identifiers = List(SourceIdentifier(
         identifierScheme = IdentifierSchemes.libraryOfCongressNames,
         ontologyType = "Concept",
         value = "lcsh/uq4"
-      ))
+      )),
       agent = Concept("conceptLabel")
     )
 
     assertObjectMapsToJson(
-      DisplayConcept(concept),
+      DisplayAbstractConcept(concept),
       expectedJson = s"""
          |  {
          |    "id": "${concept.canonicalId}",
@@ -85,7 +85,7 @@ class DisplayAbstractConceptSerialisationTest
   it(
     "serialises AbstractDisplayConcepts constructed from AbstractConcepts correctly") {
     assertObjectMapsToJson(
-      List[AbstractConcept](
+      List[Displayable[AbstractConcept]](
         Unidentifiable(Concept("conceptLabel")),
         Unidentifiable(Place("placeLabel")),
         Unidentifiable(Period("periodLabel"))

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
+import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal.{
   AbstractConcept,
@@ -11,11 +12,12 @@ import uk.ac.wellcome.models.work.internal.{
 
 class DisplayAbstractConceptSerialisationTest
     extends FunSpec
+    with DisplaySerialisationTestBase
     with JsonMapperTestUtil {
 
   it("constructs a DisplayConcept from a Concept correctly") {
     assertObjectMapsToJson(
-      DisplayConcept(Concept("conceptLabel")),
+      DisplayConcept(Unidentifiable(Concept("conceptLabel"))),
       expectedJson = s"""
          |  {
          |    "label" : "conceptLabel",
@@ -27,7 +29,7 @@ class DisplayAbstractConceptSerialisationTest
 
   it("serialises a DisplayPeriod constructed from a Period correctly") {
     assertObjectMapsToJson(
-      DisplayPeriod(Period("periodLabel")),
+      DisplayPeriod(Unidentifiable(Period("periodLabel"))),
       expectedJson = s"""
          |  {
          |    "label" : "periodLabel",
@@ -37,9 +39,57 @@ class DisplayAbstractConceptSerialisationTest
     )
   }
 
-  it("serialises a DisplayPlace constructed from a place correctly") {
+  it("serialises a DisplayPlace constructed from a Place correctly") {
     assertObjectMapsToJson(
-      DisplayPlace(Place("placeLabel")),
+      DisplayPlace(Unidentifiable(Place("placeLabel"))),
+      expectedJson = s"""
+         |  {
+         |    "label" : "placeLabel",
+         |    "type"  : "Place"
+         |  }
+         """.stripMargin
+    )
+  }
+
+  it("constructs a DisplayConcept from an identified") {
+    val concept = Identified(
+      id = "uq4bt5us",
+      identifiers = List(SourceIdentifier(
+        identifierScheme = IdentifierSchemes.libraryOfCongressNames,
+        ontologyType = "Concept",
+        value = "lcsh/uq4"
+      ))
+      agent = Concept("conceptLabel")
+    )
+
+    assertObjectMapsToJson(
+      DisplayConcept(concept),
+      expectedJson = s"""
+         |  {
+         |    "id": "${concept.id}",
+         |    "identifiers": [${concept.identifiers}],
+         |    "label" : "${concept.agent.label}",
+         |    "type"  : "${concept.agent.ontologyType}"
+         |  }
+          """.stripMargin
+    )
+  }
+
+  it("serialises a DisplayPeriod constructed from a Period correctly") {
+    assertObjectMapsToJson(
+      DisplayPeriod(Unidentifiable(Period("periodLabel"))),
+      expectedJson = s"""
+         |  {
+         |    "label" : "periodLabel",
+         |    "type"  : "Period"
+         |  }
+          """.stripMargin
+    )
+  }
+
+  it("serialises a DisplayPlace constructed from a Place correctly") {
+    assertObjectMapsToJson(
+      DisplayPlace(Unidentifiable(Place("placeLabel"))),
       expectedJson = s"""
          |  {
          |    "label" : "placeLabel",
@@ -53,9 +103,9 @@ class DisplayAbstractConceptSerialisationTest
     "serialises AbstractDisplayConcepts constructed from AbstractConcepts correctly") {
     assertObjectMapsToJson(
       List[AbstractConcept](
-        Concept("conceptLabel"),
-        Place("placeLabel"),
-        Period("periodLabel")
+        Unidentifiable(Concept("conceptLabel")),
+        Unidentifiable(Place("placeLabel")),
+        Unidentifiable(Period("periodLabel"))
       ).map(DisplayAbstractConcept(_)),
       expectedJson = s"""
           | [

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
@@ -52,7 +52,7 @@ class DisplayConceptTest extends FunSpec with Matchers {
         identifiers = List(sourceIdentifier),
         agent = Concept(label = "darkness")
       ),
-      expectedDisplayConcept = DisplayPeriod(
+      expectedDisplayConcept = DisplayConcept(
         id = Some("dj4kndg5"),
         identifiers = Some(List(DisplayIdentifier(sourceIdentifier))),
         label = "darkness"

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
@@ -48,7 +48,7 @@ class DisplayConceptTest extends FunSpec with Matchers {
 
     assertDisplayConceptIsCorrect(
       concept = Identified(
-        id = "dj4kndg5",
+        canonicalId = "dj4kndg5",
         identifiers = List(sourceIdentifier),
         agent = Concept(label = "darkness")
       ),
@@ -69,7 +69,7 @@ class DisplayConceptTest extends FunSpec with Matchers {
 
     assertDisplayConceptIsCorrect(
       concept = Identified(
-        id = "nrzbm3ah",
+        canonicalId = "nrzbm3ah",
         identifiers = List(sourceIdentifier),
         agent = Period(label = "never")
       ),
@@ -90,7 +90,7 @@ class DisplayConceptTest extends FunSpec with Matchers {
 
     assertDisplayConceptIsCorrect(
       concept = Identified(
-        id = "axtswq4z",
+        canonicalId = "axtswq4z",
         identifiers = List(sourceIdentifier),
         agent = Place(label = "anywhere")
       ),

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
@@ -1,0 +1,112 @@
+package uk.ac.wellcome.display.models.v2
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.display.models._
+import uk.ac.wellcome.models.work.internal._
+
+class DisplayConceptTest extends FunSpec with Matchers {
+
+  it("reads an unidentified generic Concept as a DisplayConcept") {
+    assertDisplayConceptIsCorrect(
+      concept = Unidentifiable(Concept(label = "evil")),
+      expectedDisplayConcept = DisplayConcept(
+        id = None,
+        identifiers = None,
+        label = "evil"
+      )
+    )
+  }
+
+  it("reads an unidentified Period as a DisplayPeriod") {
+    assertDisplayConceptIsCorrect(
+      concept = Unidentifiable(Period(label = "darkness")),
+      expectedDisplayConcept = DisplayPeriod(
+        id = None,
+        identifiers = None,
+        label = "darkness"
+      )
+    )
+  }
+
+  it("reads an unidentified Place as a DisplayPlace") {
+    assertDisplayConceptIsCorrect(
+      concept = Unidentifiable(Place(label = "nowhere")),
+      expectedDisplayConcept = DisplayPlace(
+        id = None,
+        identifiers = None,
+        label = "nowhere"
+      )
+    )
+  }
+
+  it("reads an identified Concept as a DisplayConcept with identifiers") {
+    val sourceIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.libraryOfCongressNames,
+      ontologyType = "Concept",
+      value = "lcsh/ehw"
+    )
+
+    assertDisplayConceptIsCorrect(
+      concept = Identified(
+        id = "dj4kndg5",
+        identifiers = List(sourceIdentifier),
+        agent = Concept(label = "darkness")
+      ),
+      expectedDisplayConcept = DisplayPeriod(
+        id = Some("dj4kndg5"),
+        identifiers = Some(List(DisplayIdentifier(sourceIdentifier))),
+        label = "darkness"
+      )
+    )
+  }
+
+  it("reads an identified Period as a DisplayPeriod with identifiers") {
+    val sourceIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.libraryOfCongressNames,
+      ontologyType = "Period",
+      value = "lcsh/zbm"
+    )
+
+    assertDisplayPeriodIsCorrect(
+      concept = Identified(
+        id = "nrzbm3ah",
+        identifiers = List(sourceIdentifier),
+        agent = Period(label = "never")
+      ),
+      expectedDisplayPeriod = DisplayPeriod(
+        id = Some("nrzbm3ah"),
+        identifiers = Some(List(DisplayIdentifier(sourceIdentifier))),
+        label = "never"
+      )
+    )
+  }
+
+  it("reads an identified Place as a DisplayPlace with identifiers") {
+    val sourceIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.libraryOfCongressNames,
+      ontologyType = "Place",
+      value = "lcsh/axt"
+    )
+
+    assertDisplayPlaceIsCorrect(
+      concept = Identified(
+        id = "axtswq4z",
+        identifiers = List(sourceIdentifier),
+        agent = Place(label = "anywhere")
+      ),
+      expectedDisplayPlace = DisplayPlace(
+        id = Some("axtswq4z"),
+        identifiers = Some(List(DisplayIdentifier(sourceIdentifier))),
+        label = "anywhere"
+      )
+    )
+  }
+
+  private def assertDisplayConceptIsCorrect(
+    concept: Displayable[Concept],
+    expectedDisplayConcept: DisplayAbstractConcept
+  ) = {
+    val displayConcept = DisplayAbstractConcept(concept)
+    displayConcept shouldBe expectedDisplayConcept
+  }
+}

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
@@ -67,13 +67,13 @@ class DisplayConceptTest extends FunSpec with Matchers {
       value = "lcsh/zbm"
     )
 
-    assertDisplayPeriodIsCorrect(
+    assertDisplayConceptIsCorrect(
       concept = Identified(
         id = "nrzbm3ah",
         identifiers = List(sourceIdentifier),
         agent = Period(label = "never")
       ),
-      expectedDisplayPeriod = DisplayPeriod(
+      expectedDisplayConcept = DisplayPeriod(
         id = Some("nrzbm3ah"),
         identifiers = Some(List(DisplayIdentifier(sourceIdentifier))),
         label = "never"
@@ -88,13 +88,13 @@ class DisplayConceptTest extends FunSpec with Matchers {
       value = "lcsh/axt"
     )
 
-    assertDisplayPlaceIsCorrect(
+    assertDisplayConceptIsCorrect(
       concept = Identified(
         id = "axtswq4z",
         identifiers = List(sourceIdentifier),
         agent = Place(label = "anywhere")
       ),
-      expectedDisplayPlace = DisplayPlace(
+      expectedDisplayConcept = DisplayPlace(
         id = Some("axtswq4z"),
         identifiers = Some(List(DisplayIdentifier(sourceIdentifier))),
         label = "anywhere"
@@ -103,7 +103,7 @@ class DisplayConceptTest extends FunSpec with Matchers {
   }
 
   private def assertDisplayConceptIsCorrect(
-    concept: Displayable[Concept],
+    concept: Displayable[AbstractConcept],
     expectedDisplayConcept: DisplayAbstractConcept
   ) = {
     val displayConcept = DisplayAbstractConcept(concept)

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
@@ -17,7 +17,7 @@ class DisplayGenreV2SerialisationTest
         Unidentifiable(Concept("conceptLabel")),
         Unidentifiable(Place("placeLabel")),
         Identified(
-          id = "sqwyavpj",
+          canonicalId = "sqwyavpj",
           identifiers = List(SourceIdentifier(
             identifierScheme = IdentifierSchemes.libraryOfCongressNames,
             value = "lcsh/sqw",
@@ -43,7 +43,7 @@ class DisplayGenreV2SerialisationTest
          |        "type" : "${genre.concepts(1).agent.ontologyType}"
          |      },
          |      {
-         |        "id": "${genre.concepts(2).id}",
+         |        "id": "${genre.concepts(2).canonicalId}",
          |        "identifiers": [${identifier(genre.concepts(2).identifiers(0))}],
          |        "label" : "${genre.concepts(2).agent.label}",
          |        "type" : "${genre.concepts(2).agent.ontologyType}"

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
@@ -11,21 +11,21 @@ class DisplayGenreV2SerialisationTest
   with JsonMapperTestUtil {
 
   it("serialises a DisplayGenre constructed from a Genre correctly") {
+    val concept0 = Unidentifiable(Concept("conceptLabel"))
+    val concept1 = Unidentifiable(Place("placeLabel"))
+    val concept2 = Identified(
+      canonicalId = "sqwyavpj",
+      identifiers = List(SourceIdentifier(
+        identifierScheme = IdentifierSchemes.libraryOfCongressNames,
+        value = "lcsh/sqw",
+        ontologyType = "Period"
+      )),
+      agent = Period("periodLabel")
+    )
+
     val genre = Genre(
       label = "genreLabel",
-      concepts = List(
-        Unidentifiable(Concept("conceptLabel")),
-        Unidentifiable(Place("placeLabel")),
-        Identified(
-          canonicalId = "sqwyavpj",
-          identifiers = List(SourceIdentifier(
-            identifierScheme = IdentifierSchemes.libraryOfCongressNames,
-            value = "lcsh/sqw",
-            ontologyType = "Period"
-          )),
-          agent = Period("periodLabel")
-        )
-      )
+      concepts = List(concept0, concept1, concept2)
     )
 
     assertObjectMapsToJson(
@@ -35,18 +35,18 @@ class DisplayGenreV2SerialisationTest
          |    "label" : "${genre.label}",
          |    "concepts" : [
          |      {
-         |        "label" : "${genre.concepts(0).agent.label}",
-         |        "type" : "${genre.concepts(0).agent.ontologyType}"
+         |        "label" : "${concept0.agent.label}",
+         |        "type" : "${concept0.agent.ontologyType}"
          |      },
          |      {
-         |        "label" : "${genre.concepts(1).agent.label}",
-         |        "type" : "${genre.concepts(1).agent.ontologyType}"
+         |        "label" : "${concept1.agent.label}",
+         |        "type" : "${concept1.agent.ontologyType}"
          |      },
          |      {
-         |        "id": "${genre.concepts(2).canonicalId}",
-         |        "identifiers": [${identifier(genre.concepts(2).identifiers(0))}],
-         |        "label" : "${genre.concepts(2).agent.label}",
-         |        "type" : "${genre.concepts(2).agent.ontologyType}"
+         |        "id": "${concept2.canonicalId}",
+         |        "identifiers": [${identifier(concept2.identifiers(0))}],
+         |        "label" : "${concept2.agent.label}",
+         |        "type" : "${concept2.agent.ontologyType}"
          |      }
          |    ],
          |    "type" : "${genre.ontologyType}"

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
@@ -1,31 +1,55 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
+import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
-import uk.ac.wellcome.models.work.internal.{Concept, Genre, Place}
+import uk.ac.wellcome.models.work.internal._
 
-class DisplayGenreV2SerialisationTest extends FunSpec with JsonMapperTestUtil {
+class DisplayGenreV2SerialisationTest
+  extends FunSpec
+  with DisplaySerialisationTestBase
+  with JsonMapperTestUtil {
 
   it("serialises a DisplayGenre constructed from a Genre correctly") {
+    val genre = Genre(
+      label = "genreLabel",
+      concepts = List(
+        Unidentifiable(Concept("conceptLabel")),
+        Unidentifiable(Place("placeLabel")),
+        Identified(
+          id = "sqwyavpj",
+          identifiers = List(SourceIdentifier(
+            identifierScheme = IdentifierSchemes.libraryOfCongressNames,
+            value = "lcsh/sqw",
+            ontologyType = "Period"
+          )),
+          agent = Period("periodLabel")
+        )
+      )
+    )
+
     assertObjectMapsToJson(
-      DisplayGenre(
-        Genre(
-          "genreLabel",
-          List(Concept("conceptLabel"), Place("placeLabel")))),
+      DisplayGenre(genre),
       expectedJson = s"""
          |  {
-         |    "label" : "genreLabel",
+         |    "label" : "${genre.label}",
          |    "concepts" : [
          |      {
-         |        "label" : "conceptLabel",
-         |        "type" : "Concept"
+         |        "label" : "${genre.concepts(0).agent.label}",
+         |        "type" : "${genre.concepts(0).agent.ontologyType}"
          |      },
          |      {
-         |        "label" : "placeLabel",
-         |        "type" : "Place"
+         |        "label" : "${genre.concepts(1).agent.label}",
+         |        "type" : "${genre.concepts(1).agent.ontologyType}"
+         |      },
+         |      {
+         |        "id": "${genre.concepts(2).id}",
+         |        "identifiers": [${identifier(genre.concepts(2).identifiers(0))}],
+         |        "label" : "${genre.concepts(2).agent.label}",
+         |        "type" : "${genre.concepts(2).agent.ontologyType}"
          |      }
          |    ],
-         |    "type" : "Genre"
+         |    "type" : "${genre.ontologyType}"
          |  }
           """.stripMargin
     )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
@@ -6,20 +6,21 @@ import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
 
 class DisplayGenreV2SerialisationTest
-  extends FunSpec
-  with DisplaySerialisationTestBase
-  with JsonMapperTestUtil {
+    extends FunSpec
+    with DisplaySerialisationTestBase
+    with JsonMapperTestUtil {
 
   it("serialises a DisplayGenre constructed from a Genre correctly") {
     val concept0 = Unidentifiable(Concept("conceptLabel"))
     val concept1 = Unidentifiable(Place("placeLabel"))
     val concept2 = Identified(
       canonicalId = "sqwyavpj",
-      identifiers = List(SourceIdentifier(
-        identifierScheme = IdentifierSchemes.libraryOfCongressNames,
-        value = "lcsh/sqw",
-        ontologyType = "Period"
-      )),
+      identifiers = List(
+        SourceIdentifier(
+          identifierScheme = IdentifierSchemes.libraryOfCongressNames,
+          value = "lcsh/sqw",
+          ontologyType = "Period"
+        )),
       agent = Period("periodLabel")
     )
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
@@ -15,11 +15,12 @@ class DisplaySubjectV2SerialisationTest
     val concept1 = Unidentifiable(Period("periodLabel"))
     val concept2 = Identified(
       canonicalId = "p4xe8u22",
-      identifiers = List(SourceIdentifier(
-        identifierScheme = IdentifierSchemes.libraryOfCongressNames,
-        value = "lcsh/p4x",
-        ontologyType = "Place"
-      )),
+      identifiers = List(
+        SourceIdentifier(
+          identifierScheme = IdentifierSchemes.libraryOfCongressNames,
+          value = "lcsh/p4x",
+          ontologyType = "Place"
+        )),
       agent = Place("placeLabel")
     )
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
@@ -16,7 +16,7 @@ class DisplaySubjectV2SerialisationTest
         Unidentifiable(Concept("conceptLabel")),
         Unidentifiable(Period("periodLabel")),
         Identified(
-          id = "p4xe8u22",
+          canonicalId = "p4xe8u22",
           identifiers = List(SourceIdentifier(
             identifierScheme = IdentifierSchemes.libraryOfCongressNames,
             value = "lcsh/p4x",
@@ -42,7 +42,7 @@ class DisplaySubjectV2SerialisationTest
          |        "type" : "${subject.concepts(1).agent.ontologyType}"
          |      },
          |      {
-         |        "id": "${subject.concepts(2).id}",
+         |        "id": "${subject.concepts(2).canonicalId}",
          |        "identifiers": [${identifier(subject.concepts(2).identifiers(0))}],
          |        "label" : "${subject.concepts(2).agent.label}",
          |        "type" : "${subject.concepts(2).agent.ontologyType}"

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
@@ -7,24 +7,25 @@ import uk.ac.wellcome.models.work.internal._
 
 class DisplaySubjectV2SerialisationTest
     extends FunSpec
+    with DisplaySerialisationTestBase
     with JsonMapperTestUtil {
 
   it("serialises a DisplaySubject constructed from a Subject correctly") {
+    val concept0 = Unidentifiable(Concept("conceptLabel"))
+    val concept1 = Unidentifiable(Period("periodLabel"))
+    val concept2 = Identified(
+      canonicalId = "p4xe8u22",
+      identifiers = List(SourceIdentifier(
+        identifierScheme = IdentifierSchemes.libraryOfCongressNames,
+        value = "lcsh/p4x",
+        ontologyType = "Place"
+      )),
+      agent = Place("placeLabel")
+    )
+
     val subject = Subject(
       label = "subjectLabel",
-      concepts = List(
-        Unidentifiable(Concept("conceptLabel")),
-        Unidentifiable(Period("periodLabel")),
-        Identified(
-          canonicalId = "p4xe8u22",
-          identifiers = List(SourceIdentifier(
-            identifierScheme = IdentifierSchemes.libraryOfCongressNames,
-            value = "lcsh/p4x",
-            ontologyType = "Place"
-          )),
-          agent = Place("placeLabel")
-        )
-      )
+      concepts = List(concept0, concept1, concept2)
     )
 
     assertObjectMapsToJson(
@@ -34,18 +35,18 @@ class DisplaySubjectV2SerialisationTest
          |    "label" : "${subject.label}",
          |    "concepts" : [
          |      {
-         |        "label" : "${subject.concepts(0).agent.label}",
-         |        "type" : "${subject.concepts(0).agent.ontologyType}"
+         |        "label" : "${concept0.agent.label}",
+         |        "type" : "${concept0.agent.ontologyType}"
          |      },
          |      {
-         |        "label" : "${subject.concepts(1).agent.label}",
-         |        "type" : "${subject.concepts(1).agent.ontologyType}"
+         |        "label" : "${concept1.agent.label}",
+         |        "type" : "${concept1.agent.ontologyType}"
          |      },
          |      {
-         |        "id": "${subject.concepts(2).canonicalId}",
-         |        "identifiers": [${identifier(subject.concepts(2).identifiers(0))}],
-         |        "label" : "${subject.concepts(2).agent.label}",
-         |        "type" : "${subject.concepts(2).agent.ontologyType}"
+         |        "id": "${concept2.canonicalId}",
+         |        "identifiers": [${identifier(concept2.identifiers(0))}],
+         |        "label" : "${concept2.agent.label}",
+         |        "type" : "${concept2.agent.ontologyType}"
          |      }
          |    ],
          |    "type" : "${subject.ontologyType}"

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
@@ -1,33 +1,54 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
+import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
-import uk.ac.wellcome.models.work.internal.{Concept, Period, Subject}
+import uk.ac.wellcome.models.work.internal._
 
 class DisplaySubjectV2SerialisationTest
     extends FunSpec
     with JsonMapperTestUtil {
 
   it("serialises a DisplaySubject constructed from a Subject correctly") {
+    val subject = Subject(
+      label = "subjectLabel",
+      concepts = List(
+        Unidentifiable(Concept("conceptLabel")),
+        Unidentifiable(Period("periodLabel")),
+        Identified(
+          id = "p4xe8u22",
+          identifiers = List(SourceIdentifier(
+            identifierScheme = IdentifierSchemes.libraryOfCongressNames,
+            value = "lcsh/p4x",
+            ontologyType = "Place"
+          )),
+          agent = Place("placeLabel")
+        )
+      )
+    )
+
     assertObjectMapsToJson(
-      DisplaySubject(
-        Subject(
-          "subjectLabel",
-          List(Concept("conceptLabel"), Period("periodLabel")))),
+      DisplaySubject(subject),
       expectedJson = s"""
          |  {
-         |    "label" : "subjectLabel",
+         |    "label" : "${subject.label}",
          |    "concepts" : [
          |      {
-         |        "label" : "conceptLabel",
-         |        "type" : "Concept"
+         |        "label" : "${subject.concepts(0).agent.label}",
+         |        "type" : "${subject.concepts(0).agent.ontologyType}"
          |      },
          |      {
-         |        "label" : "periodLabel",
-         |        "type" : "Period"
+         |        "label" : "${subject.concepts(1).agent.label}",
+         |        "type" : "${subject.concepts(1).agent.ontologyType}"
+         |      },
+         |      {
+         |        "id": "${subject.concepts(2).id}",
+         |        "identifiers": [${identifier(subject.concepts(2).identifiers(0))}],
+         |        "label" : "${subject.concepts(2).agent.label}",
+         |        "type" : "${subject.concepts(2).agent.ontologyType}"
          |      }
          |    ],
-         |    "type" : "Subject"
+         |    "type" : "${subject.ontologyType}"
          |  }
           """.stripMargin
     )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -178,8 +178,8 @@ class DisplayWorkV2SerialisationTest
       identifiers = List(),
       canonicalId = "test_subject1",
       subjects = List(
-        Subject("label", List(Concept("fish"))),
-        Subject("label", List(Concept("gardening"))))
+        Subject("label", List(Unidentified(Concept("fish")))),
+        Subject("label", List(Unidentified(Concept("gardening")))))
     )
     val actualJson =
       objectMapper.writeValueAsString(DisplayWorkV2(workWithSubjects))
@@ -205,8 +205,13 @@ class DisplayWorkV2SerialisationTest
       version = 1,
       identifiers = List(),
       canonicalId = "test_subject1",
-      genres =
-        List(Genre("genre", List(Concept("woodwork"), Concept("etching"))))
+      genres = List(Genre(
+        label = "genre",
+        concepts = List(
+          Unidentifiable(Concept("woodwork")),
+          Unidentifiable(Concept("etching"))
+        )
+      ))
     )
     val actualJson =
       objectMapper.writeValueAsString(DisplayWorkV2(workWithSubjects))

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -178,8 +178,8 @@ class DisplayWorkV2SerialisationTest
       identifiers = List(),
       canonicalId = "test_subject1",
       subjects = List(
-        Subject("label", List(Unidentified(Concept("fish")))),
-        Subject("label", List(Unidentified(Concept("gardening")))))
+        Subject("label", List(Unidentifiable(Concept("fish")))),
+        Subject("label", List(Unidentifiable(Concept("gardening")))))
     )
     val actualJson =
       objectMapper.writeValueAsString(DisplayWorkV2(workWithSubjects))

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -205,13 +205,14 @@ class DisplayWorkV2SerialisationTest
       version = 1,
       identifiers = List(),
       canonicalId = "test_subject1",
-      genres = List(Genre(
-        label = "genre",
-        concepts = List(
-          Unidentifiable(Concept("woodwork")),
-          Unidentifiable(Concept("etching"))
-        )
-      ))
+      genres = List(
+        Genre(
+          label = "genre",
+          concepts = List(
+            Unidentifiable(Concept("woodwork")),
+            Unidentifiable(Concept("etching"))
+          )
+        ))
     )
     val actualJson =
       objectMapper.writeValueAsString(DisplayWorkV2(workWithSubjects))

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
@@ -144,7 +144,11 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
     )
 
     val displayWork = DisplayWorkV2(work)
-    displayWork.publicationDate shouldBe Some(DisplayPeriod("c1900"))
+    displayWork.publicationDate shouldBe Some(DisplayPeriod(
+      id = None,
+      identifiers = None,
+      label = "c1900"
+    ))
   }
 
   it("gets the physicalDescription from a Work") {

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
@@ -144,11 +144,12 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
     )
 
     val displayWork = DisplayWorkV2(work)
-    displayWork.publicationDate shouldBe Some(DisplayPeriod(
-      id = None,
-      identifiers = None,
-      label = "c1900"
-    ))
+    displayWork.publicationDate shouldBe Some(
+      DisplayPeriod(
+        id = None,
+        identifiers = None,
+        label = "c1900"
+      ))
   }
 
   it("gets the physicalDescription from a Work") {

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -65,36 +65,19 @@ class WorksIndex @Inject()(client: HttpClient,
   def subject(fieldName: String) = objectField(fieldName).fields(
     textField("label"),
     keywordField("ontologyType"),
-    concept("concepts")
+    identified("concepts", concept)
   )
 
   def genre(fieldName: String) = objectField(fieldName).fields(
     textField("label"),
     keywordField("ontologyType"),
-    concept("concepts")
+    identified("concepts", concept)
   )
 
-  def concept(fieldName: String) = objectField(fieldName).fields(
+  val concept = Seq(
     textField("label"),
     keywordField("ontologyType"),
-    keywordField("type"),
-    keywordField("qualifierType"),
-    objectField("qualifiers").fields(
-      textField("label"),
-      keywordField("ontologyType"),
-      keywordField("qualifierType")
-    ),
-    // Nested concept -- if qualified concept
-    objectField("concept").fields(
-      textField("label"),
-      keywordField("ontologyType"),
-      keywordField("qualifierType"),
-      objectField("qualifiers").fields(
-        textField("label"),
-        keywordField("ontologyType"),
-        keywordField("qualifierType")
-      )
-    )
+    keywordField("type")
   )
 
   def labelledTextField(fieldName: String) = objectField(fieldName).fields(

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Genre.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Genre.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.models.work.internal
 
-case class Genre[T <: AbstractConcept](
+case class Genre[+T <: IdentityState[AbstractConcept]](
   label: String,
   concepts: List[T],
   ontologyType: String = "Genre"

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Subject.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Subject.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.models.work.internal
 
-case class Subject[T <: AbstractConcept](
+case class Subject[+T <: IdentityState[AbstractConcept]](
   label: String,
   concepts: List[T],
   ontologyType: String = "Subject"

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -14,7 +14,7 @@ trait Work extends Versioned {
   val extent: Option[String]
   val lettering: Option[String]
   val createdDate: Option[Period]
-  val subjects: List[Subject[AbstractConcept]]
+  val subjects: List[Subject[IdentityState[AbstractConcept]]]
   val contributors: List[Contributor[IdentityState[AbstractAgent]]]
   val genres: List[Genre[IdentityState[AbstractConcept]]]
   val thumbnail: Option[Location]
@@ -37,7 +37,7 @@ case class UnidentifiedWork(
   extent: Option[String] = None,
   lettering: Option[String] = None,
   createdDate: Option[Period] = None,
-  subjects: List[Subject[AbstractConcept]] = Nil,
+  subjects: List[Subject[MaybeDisplayable[AbstractConcept]]] = Nil,
   contributors: List[Contributor[MaybeDisplayable[AbstractAgent]]] = Nil,
   genres: List[Genre[MaybeDisplayable[AbstractConcept]]] = Nil,
   thumbnail: Option[Location] = None,
@@ -63,7 +63,7 @@ case class IdentifiedWork(
   extent: Option[String] = None,
   lettering: Option[String] = None,
   createdDate: Option[Period] = None,
-  subjects: List[Subject[AbstractConcept]] = Nil,
+  subjects: List[Subject[Displayable[AbstractConcept]]] = Nil,
   contributors: List[Contributor[Displayable[AbstractAgent]]] = Nil,
   genres: List[Genre[Displayable[AbstractConcept]]] = Nil,
   thumbnail: Option[Location] = None,

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -16,7 +16,7 @@ trait Work extends Versioned {
   val createdDate: Option[Period]
   val subjects: List[Subject[AbstractConcept]]
   val contributors: List[Contributor[IdentityState[AbstractAgent]]]
-  val genres: List[Genre[AbstractConcept]]
+  val genres: List[Genre[IdentityState[AbstractConcept]]]
   val thumbnail: Option[Location]
   val publishers: List[IdentityState[AbstractAgent]]
   val publicationDate: Option[Period]
@@ -39,7 +39,7 @@ case class UnidentifiedWork(
   createdDate: Option[Period] = None,
   subjects: List[Subject[AbstractConcept]] = Nil,
   contributors: List[Contributor[MaybeDisplayable[AbstractAgent]]] = Nil,
-  genres: List[Genre[AbstractConcept]] = Nil,
+  genres: List[Genre[MaybeDisplayable[AbstractConcept]]] = Nil,
   thumbnail: Option[Location] = None,
   items: List[UnidentifiedItem] = Nil,
   publishers: List[MaybeDisplayable[AbstractAgent]] = Nil,
@@ -65,7 +65,7 @@ case class IdentifiedWork(
   createdDate: Option[Period] = None,
   subjects: List[Subject[AbstractConcept]] = Nil,
   contributors: List[Contributor[Displayable[AbstractAgent]]] = Nil,
-  genres: List[Genre[AbstractConcept]] = Nil,
+  genres: List[Genre[Displayable[AbstractConcept]]] = Nil,
   thumbnail: Option[Location] = None,
   items: List[IdentifiedItem] = Nil,
   publishers: List[Displayable[AbstractAgent]] = Nil,

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
@@ -80,25 +80,25 @@ class IdentifiedWorkTest
       |      "concepts" : [
       |        {
       |          "agent": {
-      |            "label" : "${genre.concepts(0).agent.label}",
-      |            "ontologyType" : "${genre.concepts(0).agent.ontologyType}",
-      |            "type" : "${genre.concepts(0).agent.ontologyType}"
+      |            "label" : "${subject.concepts(0).agent.label}",
+      |            "ontologyType" : "${subject.concepts(0).agent.ontologyType}",
+      |            "type" : "${subject.concepts(0).agent.ontologyType}"
       |          },
       |          "type": "Unidentifiable"
       |        },
       |        {
       |          "agent": {
-      |            "label" : "${genre.concepts(1).agent.label}",
-      |            "ontologyType" : "${genre.concepts(1).agent.ontologyType}",
-      |            "type" : "${genre.concepts(1).agent.ontologyType}"
+      |            "label" : "${subject.concepts(1).agent.label}",
+      |            "ontologyType" : "${subject.concepts(1).agent.ontologyType}",
+      |            "type" : "${subject.concepts(1).agent.ontologyType}"
       |          },
       |          "type": "Unidentifiable"
       |        },
       |        {
       |          "agent": {
-      |            "label" : "${genre.concepts(2).agent.label}",
-      |            "ontologyType" : "${genre.concepts(2).agent.ontologyType}",
-      |            "type" : "${genre.concepts(2).agent.ontologyType}"
+      |            "label" : "${subject.concepts(2).agent.label}",
+      |            "ontologyType" : "${subject.concepts(2).agent.ontologyType}",
+      |            "type" : "${subject.concepts(2).agent.ontologyType}"
       |          },
       |          "type": "Unidentifiable"
       |        }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
@@ -115,19 +115,19 @@ class IdentifiedWorkTest
       |      "ontologyType": "${genre.ontologyType}",
       |      "concepts" : [
       |        {
-      |          "label" : "${genre.concepts(0).label}",
-      |          "ontologyType" : "${genre.concepts(0).ontologyType}",
-      |          "type" : "${genre.concepts(0).ontologyType}"
+      |          "label" : "${genre.concepts(0).agent.label}",
+      |          "ontologyType" : "${genre.concepts(0).agent.ontologyType}",
+      |          "type" : "${genre.concepts(0).agent.ontologyType}"
       |        },
       |        {
-      |          "label" : "${genre.concepts(1).label}",
-      |          "ontologyType" : "${genre.concepts(1).ontologyType}",
-      |          "type" : "${genre.concepts(1).ontologyType}"
+      |          "label" : "${genre.concepts(1).agent.label}",
+      |          "ontologyType" : "${genre.concepts(1).agent.ontologyType}",
+      |          "type" : "${genre.concepts(1).agent.ontologyType}"
       |        },
       |        {
-      |          "label" : "${genre.concepts(2).label}",
-      |          "ontologyType" : "${genre.concepts(2).ontologyType}",
-      |          "type" : "${genre.concepts(2).ontologyType}"
+      |          "label" : "${genre.concepts(2).agent.label}",
+      |          "ontologyType" : "${genre.concepts(2).agent.ontologyType}",
+      |          "type" : "${genre.concepts(2).agent.ontologyType}"
       |        }
       |      ]
       |    }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
@@ -79,19 +79,28 @@ class IdentifiedWorkTest
       |      "ontologyType": "${subject.ontologyType}",
       |      "concepts" : [
       |        {
-      |          "label" : "${subject.concepts(0).label}",
-      |          "ontologyType" : "${subject.concepts(0).ontologyType}",
-      |          "type" : "${subject.concepts(0).ontologyType}"
+      |          "agent": {
+      |            "label" : "${genre.concepts(0).agent.label}",
+      |            "ontologyType" : "${genre.concepts(0).agent.ontologyType}",
+      |            "type" : "${genre.concepts(0).agent.ontologyType}"
+      |          },
+      |          "type": "Unidentifiable"
       |        },
       |        {
-      |          "label" : "${subject.concepts(1).label}",
-      |          "ontologyType" : "${subject.concepts(1).ontologyType}",
-      |          "type" : "${subject.concepts(1).ontologyType}"
+      |          "agent": {
+      |            "label" : "${genre.concepts(1).agent.label}",
+      |            "ontologyType" : "${genre.concepts(1).agent.ontologyType}",
+      |            "type" : "${genre.concepts(1).agent.ontologyType}"
+      |          },
+      |          "type": "Unidentifiable"
       |        },
       |        {
-      |          "label" : "${subject.concepts(2).label}",
-      |          "ontologyType" : "${subject.concepts(2).ontologyType}",
-      |          "type" : "${subject.concepts(2).ontologyType}"
+      |          "agent": {
+      |            "label" : "${genre.concepts(2).agent.label}",
+      |            "ontologyType" : "${genre.concepts(2).agent.ontologyType}",
+      |            "type" : "${genre.concepts(2).agent.ontologyType}"
+      |          },
+      |          "type": "Unidentifiable"
       |        }
       |      ]
       |    }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
@@ -81,7 +81,10 @@ class IdentifiedWorkTest
       |        {
       |          "agent": {
       |            "label" : "${subject.concepts(0).agent.label}",
-      |            "ontologyType" : "${subject.concepts(0).agent.ontologyType}",
+      |            "ontologyType" : "${subject
+         .concepts(0)
+         .agent
+         .ontologyType}",
       |            "type" : "${subject.concepts(0).agent.ontologyType}"
       |          },
       |          "type": "Unidentifiable"
@@ -89,7 +92,10 @@ class IdentifiedWorkTest
       |        {
       |          "agent": {
       |            "label" : "${subject.concepts(1).agent.label}",
-      |            "ontologyType" : "${subject.concepts(1).agent.ontologyType}",
+      |            "ontologyType" : "${subject
+         .concepts(1)
+         .agent
+         .ontologyType}",
       |            "type" : "${subject.concepts(1).agent.ontologyType}"
       |          },
       |          "type": "Unidentifiable"
@@ -97,7 +103,10 @@ class IdentifiedWorkTest
       |        {
       |          "agent": {
       |            "label" : "${subject.concepts(2).agent.label}",
-      |            "ontologyType" : "${subject.concepts(2).agent.ontologyType}",
+      |            "ontologyType" : "${subject
+         .concepts(2)
+         .agent
+         .ontologyType}",
       |            "type" : "${subject.concepts(2).agent.ontologyType}"
       |          },
       |          "type": "Unidentifiable"

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
@@ -124,19 +124,28 @@ class IdentifiedWorkTest
       |      "ontologyType": "${genre.ontologyType}",
       |      "concepts" : [
       |        {
-      |          "label" : "${genre.concepts(0).agent.label}",
-      |          "ontologyType" : "${genre.concepts(0).agent.ontologyType}",
-      |          "type" : "${genre.concepts(0).agent.ontologyType}"
+      |          "agent": {
+      |            "label" : "${genre.concepts(0).agent.label}",
+      |            "ontologyType" : "${genre.concepts(0).agent.ontologyType}",
+      |            "type" : "${genre.concepts(0).agent.ontologyType}"
+      |          },
+      |          "type": "Unidentifiable"
       |        },
       |        {
-      |          "label" : "${genre.concepts(1).agent.label}",
-      |          "ontologyType" : "${genre.concepts(1).agent.ontologyType}",
-      |          "type" : "${genre.concepts(1).agent.ontologyType}"
+      |          "agent": {
+      |            "label" : "${genre.concepts(1).agent.label}",
+      |            "ontologyType" : "${genre.concepts(1).agent.ontologyType}",
+      |            "type" : "${genre.concepts(1).agent.ontologyType}"
+      |          },
+      |          "type": "Unidentifiable"
       |        },
       |        {
-      |          "label" : "${genre.concepts(2).agent.label}",
-      |          "ontologyType" : "${genre.concepts(2).agent.ontologyType}",
-      |          "type" : "${genre.concepts(2).agent.ontologyType}"
+      |          "agent": {
+      |            "label" : "${genre.concepts(2).agent.label}",
+      |            "ontologyType" : "${genre.concepts(2).agent.ontologyType}",
+      |            "type" : "${genre.concepts(2).agent.ontologyType}"
+      |          },
+      |          "type": "Unidentifiable"
       |        }
       |      ]
       |    }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedWorkTest.scala
@@ -79,7 +79,10 @@ class UnidentifiedWorkTest
       |        {
       |          "agent": {
       |            "label" : "${subject.concepts(0).agent.label}",
-      |            "ontologyType" : "${subject.concepts(0).agent.ontologyType}",
+      |            "ontologyType" : "${subject
+         .concepts(0)
+         .agent
+         .ontologyType}",
       |            "type" : "${subject.concepts(0).agent.ontologyType}"
       |          },
       |          "type": "Unidentifiable"
@@ -87,7 +90,10 @@ class UnidentifiedWorkTest
       |        {
       |          "agent": {
       |            "label" : "${subject.concepts(1).agent.label}",
-      |            "ontologyType" : "${subject.concepts(1).agent.ontologyType}",
+      |            "ontologyType" : "${subject
+         .concepts(1)
+         .agent
+         .ontologyType}",
       |            "type" : "${subject.concepts(1).agent.ontologyType}"
       |          },
       |          "type": "Unidentifiable"
@@ -95,7 +101,10 @@ class UnidentifiedWorkTest
       |        {
       |          "agent": {
       |            "label" : "${subject.concepts(2).agent.label}",
-      |            "ontologyType" : "${subject.concepts(2).agent.ontologyType}",
+      |            "ontologyType" : "${subject
+         .concepts(2)
+         .agent
+         .ontologyType}",
       |            "type" : "${subject.concepts(2).agent.ontologyType}"
       |          },
       |          "type": "Unidentifiable"

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedWorkTest.scala
@@ -113,19 +113,28 @@ class UnidentifiedWorkTest
       |      "ontologyType": "${genre.ontologyType}",
       |      "concepts" : [
       |        {
-      |          "label" : "${genre.concepts(0).agent.label}",
-      |          "ontologyType" : "${genre.concepts(0).agent.ontologyType}",
-      |          "type" : "${genre.concepts(0).agent.ontologyType}"
+      |          "agent": {
+      |            "label" : "${genre.concepts(0).agent.label}",
+      |            "ontologyType" : "${genre.concepts(0).agent.ontologyType}",
+      |            "type" : "${genre.concepts(0).agent.ontologyType}"
+      |          },
+      |          "type": "Unidentifiable"
       |        },
       |        {
-      |          "label" : "${genre.concepts(1).agent.label}",
-      |          "ontologyType" : "${genre.concepts(1).agent.ontologyType}",
-      |          "type" : "${genre.concepts(1).agent.ontologyType}"
+      |          "agent": {
+      |            "label" : "${genre.concepts(1).agent.label}",
+      |            "ontologyType" : "${genre.concepts(1).agent.ontologyType}",
+      |            "type" : "${genre.concepts(1).agent.ontologyType}"
+      |          },
+      |          "type": "Unidentifiable"
       |        },
       |        {
-      |          "label" : "${genre.concepts(2).agent.label}",
-      |          "ontologyType" : "${genre.concepts(2).agent.ontologyType}",
-      |          "type" : "${genre.concepts(2).agent.ontologyType}"
+      |          "agent": {
+      |            "label" : "${genre.concepts(2).agent.label}",
+      |            "ontologyType" : "${genre.concepts(2).agent.ontologyType}",
+      |            "type" : "${genre.concepts(2).agent.ontologyType}"
+      |          },
+      |          "type": "Unidentifiable"
       |        }
       |      ]
       |    }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedWorkTest.scala
@@ -77,19 +77,28 @@ class UnidentifiedWorkTest
       |      "ontologyType": "${subject.ontologyType}",
       |      "concepts" : [
       |        {
-      |          "label" : "${subject.concepts(0).label}",
-      |          "ontologyType" : "${subject.concepts(0).ontologyType}",
-      |          "type" : "${subject.concepts(0).ontologyType}"
+      |          "agent": {
+      |            "label" : "${subject.concepts(0).agent.label}",
+      |            "ontologyType" : "${subject.concepts(0).agent.ontologyType}",
+      |            "type" : "${subject.concepts(0).agent.ontologyType}"
+      |          },
+      |          "type": "Unidentifiable"
       |        },
       |        {
-      |          "label" : "${subject.concepts(1).label}",
-      |          "ontologyType" : "${subject.concepts(1).ontologyType}",
-      |          "type" : "${subject.concepts(1).ontologyType}"
+      |          "agent": {
+      |            "label" : "${subject.concepts(1).agent.label}",
+      |            "ontologyType" : "${subject.concepts(1).agent.ontologyType}",
+      |            "type" : "${subject.concepts(1).agent.ontologyType}"
+      |          },
+      |          "type": "Unidentifiable"
       |        },
       |        {
-      |          "label" : "${subject.concepts(2).label}",
-      |          "ontologyType" : "${subject.concepts(2).ontologyType}",
-      |          "type" : "${subject.concepts(2).ontologyType}"
+      |          "agent": {
+      |            "label" : "${subject.concepts(2).agent.label}",
+      |            "ontologyType" : "${subject.concepts(2).agent.ontologyType}",
+      |            "type" : "${subject.concepts(2).agent.ontologyType}"
+      |          },
+      |          "type": "Unidentifiable"
       |        }
       |      ]
       |    }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedWorkTest.scala
@@ -113,19 +113,19 @@ class UnidentifiedWorkTest
       |      "ontologyType": "${genre.ontologyType}",
       |      "concepts" : [
       |        {
-      |          "label" : "${genre.concepts(0).label}",
-      |          "ontologyType" : "${genre.concepts(0).ontologyType}",
-      |          "type" : "${genre.concepts(0).ontologyType}"
+      |          "label" : "${genre.concepts(0).agent.label}",
+      |          "ontologyType" : "${genre.concepts(0).agent.ontologyType}",
+      |          "type" : "${genre.concepts(0).agent.ontologyType}"
       |        },
       |        {
-      |          "label" : "${genre.concepts(1).label}",
-      |          "ontologyType" : "${genre.concepts(1).ontologyType}",
-      |          "type" : "${genre.concepts(1).ontologyType}"
+      |          "label" : "${genre.concepts(1).agent.label}",
+      |          "ontologyType" : "${genre.concepts(1).agent.ontologyType}",
+      |          "type" : "${genre.concepts(1).agent.ontologyType}"
       |        },
       |        {
-      |          "label" : "${genre.concepts(2).label}",
-      |          "ontologyType" : "${genre.concepts(2).ontologyType}",
-      |          "type" : "${genre.concepts(2).ontologyType}"
+      |          "label" : "${genre.concepts(2).agent.label}",
+      |          "ontologyType" : "${genre.concepts(2).agent.ontologyType}",
+      |          "type" : "${genre.concepts(2).agent.ontologyType}"
       |        }
       |      ]
       |    }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -15,7 +15,7 @@ trait WorksUtil {
   )
   val subject = Subject[Unidentifiable[AbstractConcept]](
     label = "a subject created by WorksUtil",
-    concept = List(
+    concepts = List(
       Unidentifiable(Concept("a subject concept")),
       Unidentifiable(Place("a subject place")),
       Unidentifiable(Period("a subject period"))))

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -18,14 +18,16 @@ trait WorksUtil {
     concepts = List(
       Unidentifiable(Concept("a subject concept")),
       Unidentifiable(Place("a subject place")),
-      Unidentifiable(Period("a subject period"))))
+      Unidentifiable(Period("a subject period")))
+  )
 
   val genre = Genre[Unidentifiable[AbstractConcept]](
     label = "an unidentified genre created by WorksUtil",
     concepts = List(
       Unidentifiable(Concept("a genre concept")),
       Unidentifiable(Place("a genre place")),
-      Unidentifiable(Period("a genre period"))))
+      Unidentifiable(Period("a genre period")))
+  )
 
   val sourceIdentifier = SourceIdentifier(
     IdentifierSchemes.miroImageNumber,

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -20,12 +20,12 @@ trait WorksUtil {
       Place("a subject place"),
       Period("a subject period")))
 
-  val genre = Genre[AbstractConcept](
-    label = "a genre created by WorksUtil",
+  val genre = Genre[Unidentifiable[AbstractConcept]](
+    label = "an unidentified genre created by WorksUtil",
     concepts = List(
-      Concept("a genre concept"),
-      Place("a genre place"),
-      Period("a genre period")))
+      Unidentifiable(Concept("a genre concept")),
+      Unidentifiable(Place("a genre place")),
+      Unidentifiable(Period("a genre period"))))
 
   val sourceIdentifier = SourceIdentifier(
     IdentifierSchemes.miroImageNumber,
@@ -133,7 +133,7 @@ trait WorksUtil {
                createdDate: Period,
                creator: Agent,
                subjects: List[Subject[AbstractConcept]],
-               genres: List[Genre[AbstractConcept]],
+               genres: List[Genre[Displayable[AbstractConcept]]],
                items: List[IdentifiedItem],
                visible: Boolean): IdentifiedWork =
     IdentifiedWork(

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -132,7 +132,7 @@ trait WorksUtil {
                lettering: String,
                createdDate: Period,
                creator: Agent,
-               subjects: List[Subject[AbstractConcept]],
+               subjects: List[Subject[Displayable[AbstractConcept]]],
                genres: List[Genre[Displayable[AbstractConcept]]],
                items: List[IdentifiedItem],
                visible: Boolean): IdentifiedWork =

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -13,7 +13,7 @@ trait WorksUtil {
     id = "1dz4yn34va",
     label = "An aggregation of angry archipelago aged ankylosaurs."
   )
-  val subject = Subject[AbstractConcept](
+  val subject = Subject[Unidentifiable[AbstractConcept]](
     label = "a subject created by WorksUtil",
     concept = List(
       Unidentifiable(Concept("a subject concept")),

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -14,11 +14,11 @@ trait WorksUtil {
     label = "An aggregation of angry archipelago aged ankylosaurs."
   )
   val subject = Subject[AbstractConcept](
-    "a subject created by WorksUtil",
-    List(
-      Concept("a subject concept"),
-      Place("a subject place"),
-      Period("a subject period")))
+    label = "a subject created by WorksUtil",
+    concept = List(
+      Unidentifiable(Concept("a subject concept")),
+      Unidentifiable(Place("a subject place")),
+      Unidentifiable(Period("a subject period"))))
 
   val genre = Genre[Unidentifiable[AbstractConcept]](
     label = "an unidentified genre created by WorksUtil",


### PR DESCRIPTION
### What is this PR trying to achieve?

Now we a Concept model that takes a type parameter (#1991), and we've split off the V1 and V2 DisplayConcepts (#1995), we can modify the Concept model to support identifiers.

This patch only includes model changes – the logic to actually add identifiers will be another patch.

Another part of #1959.

### Who is this change for?

📴 🔢 