### PR TITLE
Scala changes shouldn't trigger the travistooling tests

### DIFF
--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -91,6 +91,9 @@ def does_file_affect_build_task(path, task):
         'build.sbt',
         'sbt_common/'
     )):
+        if task == 'travistooling-test':
+            raise ScalaChangeAndNotScalaApp()
+
         for project in PROJECTS:
             if task.startswith(project.name):
                 if project.type == 'sbt_app':

--- a/travistooling/tests/test_decisionmaker.py
+++ b/travistooling/tests/test_decisionmaker.py
@@ -63,6 +63,7 @@ from travistooling.decisions import (
     ('sierra_adapter/common/main.scala', 'loris-test', ScalaChangeAndNotScalaApp, False),
     ('sierra_adapter/common/main.scala', 's3_demultiplexer-test', ScalaChangeAndNotScalaApp, False),
     ('sierra_adapter/common/main.scala', 'sierra_window_generator-test', ScalaChangeAndNotScalaApp, False),
+    ('sierra_adapter/common/main.scala', 'travistooling-test', ScalaChangeAndNotScalaApp, False),
     ('sbt_common/display/model.scala', 'id_minter-test', ScalaChangeAndIsScalaApp, True),
     ('sbt_common/display/model.scala', 'loris-publish', ScalaChangeAndNotScalaApp, False),
     ('sbt_common/display/model.scala', 'sierra_adapter-publish', UnrecognisedFile, True),


### PR DESCRIPTION
Spotted in the tests on #1996.

Since a lot of our changes are pure Scala, this should reduce the critical path on a number of pull requests.