### PR TITLE
Minor refactoring in SierraGenres and SierraSubjects

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -1,0 +1,14 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+import uk.ac.wellcome.transformer.source.MarcSubfield
+
+trait SierraConcepts {
+
+  // Get the label.  This is populated by the label of subfield $a, followed
+  // by other subfields, in the order they come from MARC.  The labels are
+  // joined by " - ".
+  protected def getLabel(primarySubfields: List[MarcSubfield], subdivisionSubfields: List[MarcSubfield]): String = {
+    val orderedSubfields = primarySubfields ++ subdivisionSubfields
+    orderedSubfields.map { _.content }.mkString(" - ")
+  }
+}

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -15,4 +15,16 @@ trait SierraConcepts {
 
   protected def buildPrimaryConcept[T <: AbstractConcept](subfield: MarcSubfield): MaybeDisplayable[AbstractConcept] =
     Unidentifiable(T(label = subfield.content))
+
+  // Extract the subdivisions, which come from everything except subfield $a.
+  // These are never identified.  We preserve the order from MARC.
+  protected def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
+    subdivisionSubfields.map { subfield =>
+      subfield.tag match {
+        case "v" | "w" => Unidentifiable(Concept(label = subfield.content))
+        case "y" => Unidentifiable(Period(label = subfield.content))
+        case "z" => Unidentifiable(Place(label = subfield.content))
+      }
+    }
+  }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
+import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.transformer.source.MarcSubfield
 
 trait SierraConcepts {
@@ -11,4 +12,7 @@ trait SierraConcepts {
     val orderedSubfields = primarySubfields ++ subdivisionSubfields
     orderedSubfields.map { _.content }.mkString(" - ")
   }
+
+  protected def buildPrimaryConcept[T <: AbstractConcept](subfield: MarcSubfield): MaybeDisplayable[AbstractConcept] =
+    Unidentifiable(T(label = subfield.content))
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -21,7 +21,7 @@ trait SierraConcepts {
   protected def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
     subdivisionSubfields.map { subfield =>
       subfield.tag match {
-        case "v" | "w" => Unidentifiable(Concept(label = subfield.content))
+        case "v" | "x" => Unidentifiable(Concept(label = subfield.content))
         case "y" => Unidentifiable(Period(label = subfield.content))
         case "z" => Unidentifiable(Place(label = subfield.content))
       }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -13,8 +13,10 @@ trait SierraConcepts {
     orderedSubfields.map { _.content }.mkString(" - ")
   }
 
-  protected def buildPrimaryConcept[T <: AbstractConcept](subfield: MarcSubfield): MaybeDisplayable[AbstractConcept] =
-    Unidentifiable(T(label = subfield.content))
+  protected def buildPrimaryConcept[T <: AbstractConcept](
+    concept: AbstractConcept,
+    bibData: SierraBibData): MaybeDisplayable[AbstractConcept] =
+    Unidentifiable(agent = concept)
 
   // Extract the subdivisions, which come from everything except subfield $a.
   // These are never identified.  We preserve the order from MARC.

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -61,7 +61,7 @@ trait SierraGenres extends MarcUtils with SierraConcepts {
   // only concept which might be identified.
   private def getPrimaryConcept(primarySubfields: List[MarcSubfield]): List[MaybeDisplayable[Concept]] = {
     primarySubfields.map { subfield =>
-      Unidentifiable(Concept(label = subfield.content))
+      buildPrimaryConcept[Concept](subfield)
     }
   }
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -64,16 +64,4 @@ trait SierraGenres extends MarcUtils with SierraConcepts {
       buildPrimaryConcept[Concept](subfield)
     }
   }
-
-  // Extract the subdivisions, which come from everything except subfield $a.
-  // These are never identified.  We preserve the order from MARC.
-  private def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
-    subdivisionSubfields.map { subfield =>
-      subfield.tag match {
-        case "v" | "w" => Unidentifiable(Concept(label = subfield.content))
-        case "y" => Unidentifiable(Period(label = subfield.content))
-        case "z" => Unidentifiable(Place(label = subfield.content))
-      }
-    }
-  }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -75,7 +75,7 @@ trait SierraGenres extends MarcUtils {
 
   // Extract the subdivisions, which come from everything except subfield $a.
   // These are never identified.  We preserve the order from MARC.
-  private def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[Unidentifiable[AbstractConcept]] = {
+  private def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
     subdivisionSubfields.map { subfield =>
       subfield.tag match {
         case "v" | "w" => Unidentifiable(Concept(label = subfield.content))

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -1,53 +1,87 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
-import uk.ac.wellcome.models.work.internal.{
-  AbstractConcept,
-  Concept,
-  Genre,
-  MaybeDisplayable,
-  Period,
-  Place,
-  Unidentifiable
-}
-import uk.ac.wellcome.transformer.source.SierraBibData
+import uk.ac.wellcome.models.work.internal.{AbstractConcept, Concept, Genre, MaybeDisplayable, Period, Place, Unidentifiable}
+import uk.ac.wellcome.transformer.source.{MarcSubfield, SierraBibData}
 
 trait SierraGenres extends MarcUtils {
 
+  // Populate wwork:genres
+  //
+  // Use MARC field "655".
+  //
+  // Within a MARC 655 tag, there's:
+  //
+  //    - a primary concept (subfield $a); and
+  //    - subdivisions (subfields $v, $x, $y and $z)
+  //
+  // The primary concept can be identified, and the subdivisions serve
+  // to add extra context.
+  //
+  // We construct the Genre as follows:
+  //
+  //    - label is the concatenation of $a, $v, $x, $y and $z in order,
+  //      separated by a hyphen ' - '.
+  //    - concepts is a List[Concept] populated in order of the subfields:
+  //
+  //        * $a => Concept
+  //          Optionally with an identifier.  We look in subfield $0 for the
+  //          identifier value, then second indicator for the authority.
+  //
+  //        * $v => Concept
+  //        * $x => Concept
+  //        * $y => Period
+  //        * $z => Place
+  //
+  //      Note that only concepts from subfield $a are identified; everything
+  //      else is unidentified.
+  //
   def getGenres(
     bibData: SierraBibData): List[Genre[MaybeDisplayable[AbstractConcept]]] = {
     getGenresForMarcTag(bibData, "655")
   }
 
-  // Populate wwork:genres
-  //
-  // Use MARC field "655"
-  //
-  // Each Genre type is populated with label and concepts
-  //
-  //   - Genre.label is concatenated subfields a,v,x,y,z in order separated by a hyphen ' - '.
-  //   - Genre.concepts is a List populated with subfield 'a', then Concepts from subfields v,x,y,z in order with types:
-  //       * v => Concept
-  //       * x => Concept
-  //       * y => Period
-  //       * z => Place
-  //
   private def getGenresForMarcTag(bibData: SierraBibData, marcTag: String) = {
     val subfieldsList =
       getMatchingSubfields(bibData, marcTag, List("a", "v", "x", "y", "z"))
+
     subfieldsList.map(subfields => {
-      val (subfieldsA, rest) = subfields.partition(_.tag == "a")
-      val orderedSubfields = subfieldsA ++ rest
-      val label = orderedSubfields.map(_.content).mkString(" - ")
-      val concepts = orderedSubfields.map(subfield =>
-        subfield.tag match {
-          case "y" => Unidentifiable(Period(label = subfield.content))
-          case "z" => Unidentifiable(Place(label = subfield.content))
-          case _ => Unidentifiable(Concept(label = subfield.content))
-      })
+      val (primarySubfields, subdivisionSubfields) = subfields.partition { _.tag == "a" }
+
+      val label = getGenreLabel(primarySubfields, subdivisionSubfields)
+      val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(primarySubfields) ++ getSubdivisions(subdivisionSubfields)
+
       Genre[MaybeDisplayable[AbstractConcept]](
         label = label,
         concepts = concepts
       )
     })
+  }
+
+  // Get the genre label.  This is populated by the label of subfield $a, followed
+  // by other subfields, in the order they come from MARC.  The labels are
+  // joined by " - ".
+  private def getGenreLabel(primarySubfields: List[MarcSubfield], subdivisionSubfields: List[MarcSubfield]): String = {
+    val orderedSubfields = primarySubfields ++ subdivisionSubfields
+    orderedSubfields.map { _.content }.mkString(" - ")
+  }
+
+  // Extract the primary concept, which comes from subfield $a.  This is the
+  // only concept which might be identified.
+  private def getPrimaryConcept(primarySubfields: List[MarcSubfield]): List[MaybeDisplayable[Concept]] = {
+    primarySubfields.map { subfield =>
+      Unidentifiable(Concept(label = subfield.content))
+    }
+  }
+
+  // Extract the subdivisions, which come from everything except subfield $a.
+  // These are never identified.  We preserve the order from MARC.
+  private def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[Unidentifiable[AbstractConcept]] = {
+    subdivisionSubfields.map { subfield =>
+      subfield.tag match {
+        case "v" | "w" => Unidentifiable(Concept(label = subfield.content))
+        case "y" => Unidentifiable(Period(label = subfield.content))
+        case "z" => Unidentifiable(Place(label = subfield.content))
+      }
+    }
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -48,7 +48,7 @@ trait SierraGenres extends MarcUtils with SierraConcepts {
       val (primarySubfields, subdivisionSubfields) = subfields.partition { _.tag == "a" }
 
       val label = getLabel(primarySubfields, subdivisionSubfields)
-      val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(primarySubfields) ++ getSubdivisions(subdivisionSubfields)
+      val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(primarySubfields, bibData = bibData) ++ getSubdivisions(subdivisionSubfields)
 
       Genre[MaybeDisplayable[AbstractConcept]](
         label = label,
@@ -59,9 +59,12 @@ trait SierraGenres extends MarcUtils with SierraConcepts {
 
   // Extract the primary concept, which comes from subfield $a.  This is the
   // only concept which might be identified.
-  private def getPrimaryConcept(primarySubfields: List[MarcSubfield]): List[MaybeDisplayable[Concept]] = {
+  private def getPrimaryConcept(primarySubfields: List[MarcSubfield], bibData: SierraBibData): List[MaybeDisplayable[AbstractConcept]] = {
     primarySubfields.map { subfield =>
-      buildPrimaryConcept[Concept](subfield)
+      identifyPrimaryConcept(
+        concept = Concept(label = subfield.content),
+        bibData = bibData
+      )
     }
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.transformer.transformers.sierra
 import uk.ac.wellcome.models.work.internal.{AbstractConcept, Concept, Genre, MaybeDisplayable, Period, Place, Unidentifiable}
 import uk.ac.wellcome.transformer.source.{MarcSubfield, SierraBibData}
 
-trait SierraGenres extends MarcUtils {
+trait SierraGenres extends MarcUtils with SierraConcepts {
 
   // Populate wwork:genres
   //
@@ -47,7 +47,7 @@ trait SierraGenres extends MarcUtils {
     subfieldsList.map(subfields => {
       val (primarySubfields, subdivisionSubfields) = subfields.partition { _.tag == "a" }
 
-      val label = getGenreLabel(primarySubfields, subdivisionSubfields)
+      val label = getLabel(primarySubfields, subdivisionSubfields)
       val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(primarySubfields) ++ getSubdivisions(subdivisionSubfields)
 
       Genre[MaybeDisplayable[AbstractConcept]](
@@ -55,14 +55,6 @@ trait SierraGenres extends MarcUtils {
         concepts = concepts
       )
     })
-  }
-
-  // Get the genre label.  This is populated by the label of subfield $a, followed
-  // by other subfields, in the order they come from MARC.  The labels are
-  // joined by " - ".
-  private def getGenreLabel(primarySubfields: List[MarcSubfield], subdivisionSubfields: List[MarcSubfield]): String = {
-    val orderedSubfields = primarySubfields ++ subdivisionSubfields
-    orderedSubfields.map { _.content }.mkString(" - ")
   }
 
   // Extract the primary concept, which comes from subfield $a.  This is the

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -1,15 +1,7 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
-import uk.ac.wellcome.models.work.internal.{
-  AbstractConcept,
-  Concept,
-  MaybeDisplayable,
-  Period,
-  Place,
-  Subject,
-  Unidentifiable
-}
-import uk.ac.wellcome.transformer.source.SierraBibData
+import uk.ac.wellcome.models.work.internal.{AbstractConcept, Concept, MaybeDisplayable, Period, Place, Subject, Unidentifiable}
+import uk.ac.wellcome.transformer.source.{MarcSubfield, SierraBibData}
 
 trait SierraSubjects extends MarcUtils {
 
@@ -20,52 +12,88 @@ trait SierraSubjects extends MarcUtils {
       getSubjectsForMarcTag(bibData, "651")
   }
 
-  // Populate wwork:subjects
+  // Populate wwork:subject
   //
-  // Use MARC fields "650", "648", "651"
+  // Use MARC field "650", "648" and "651".
   //
-  // Each Subject type is populated with label and concepts
+  // Within these MARC tags, we have:
   //
-  //   - Subject.label is concatenated subfields a,v,x,y,z in order separated by a hyphen ' - '.
-  //   - Subject.concepts is a List populated with a primary Concept with label from subfield 'a', and
-  //     type:
-  //       650 => Concept
-  //       648 => Period
-  //       651 => Place
-  //     for subfields v,x,y,z Subject.concepts are populated in order with Concept.label and type:
-  //       * v => Concept
-  //       * x => Concept
-  //       * y => Period
-  //       * z => Place
+  //    - a primary concept (subfield $a); and
+  //    - subdivisions (subfields $v, $x, $y and $z)
+  //
+  // The primary concept can be identified, and the subdivisions serve
+  // to add extra context.
+  //
+  // We construct the Subject as follows:
+  //
+  //    - label is the concatenation of $a, $v, $x, $y and $z in order,
+  //      separated by a hyphen ' - '.
+  //    - concepts is a List[Concept] populated in order of the subfields:
+  //
+  //        * $a => {Concept, Period, Place}
+  //          Optionally with an identifier.  We look in subfield $0 for the
+  //          identifier value, then second indicator for the authority.
+  //          These are decided as follows:
+  //
+  //            - 650 => Concept
+  //            - 648 => Period
+  //            - 651 => Place
+  //
+  //        * $v => Concept
+  //        * $x => Concept
+  //        * $y => Period
+  //        * $z => Place
+  //
+  //      Note that only concepts from subfield $a are identified; everything
+  //      else is unidentified.
   //
   private def getSubjectsForMarcTag(bibData: SierraBibData, marcTag: String) = {
     val subfieldsList = getMatchingSubfields(
-      bibData,
-      marcTag = marcTag,
-      marcSubfieldTags = List("a", "v", "x", "y", "z"))
+      bibData, marcTag, marcSubfieldTags = List("a", "v", "x", "y", "z"))
+
     subfieldsList.map(subfields => {
-      val (subfieldsA, rest) = subfields.partition(_.tag == "a")
-      val orderedSubfields = subfieldsA ++ rest
-      val subjectLabel = orderedSubfields.map(_.content).mkString(" - ")
-      val concepts = orderedSubfields.map(subfield =>
-        subfield.tag match {
-          case "a" => Unidentifiable(primaryConcept(marcTag, subfield.content))
-          case "y" => Unidentifiable(Period(label = subfield.content))
-          case "z" => Unidentifiable(Place(label = subfield.content))
-          case _ => Unidentifiable(Concept(label = subfield.content))
-      })
+      val (primarySubfields, subdivisionSubfields) = subfields.partition { _.tag == "a" }
+
+      val label = getSubjectLabel(primarySubfields, subdivisionSubfields)
+      val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(marcTag, primarySubfields) ++ getSubdivisions(subdivisionSubfields)
+
       Subject[MaybeDisplayable[AbstractConcept]](
-        label = subjectLabel,
+        label = label,
         concepts = concepts
       )
     })
   }
 
-  private def primaryConcept(marcTag: String, label: String) = {
-    marcTag match {
-      case "650" => Concept(label)
-      case "648" => Period(label)
-      case "651" => Place(label)
+  // Get the subject label.  This is populated by the label of subfield $a, followed
+  // by other subfields, in the order they come from MARC.  The labels are
+  // joined by " - ".
+  private def getSubjectLabel(primarySubfields: List[MarcSubfield], subdivisionSubfields: List[MarcSubfield]): String = {
+    val orderedSubfields = primarySubfields ++ subdivisionSubfields
+    orderedSubfields.map { _.content }.mkString(" - ")
+  }
+
+  // Extract the primary concept, which comes from subfield $a.  This is the
+  // only concept which might be identified.
+  private def getPrimaryConcept(marcTag: String, primarySubfields: List[MarcSubfield]): List[MaybeDisplayable[Concept]] = {
+    primarySubfields.map { subfield =>
+      marcTag match {
+        case "650" => Unidentifiable(Concept(label = subfield.content))
+        case "648" => Unidentifiable(Period(label = subfield.content))
+        case "651" => Unidentifiable(Place(label = subfield.content))
+      }
+
+    }
+  }
+
+  // Extract the subdivisions, which come from everything except subfield $a.
+  // These are never identified.  We preserve the order from MARC.
+  private def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[Unidentifiable[AbstractConcept]] = {
+    subdivisionSubfields.map { subfield =>
+      subfield.tag match {
+        case "v" | "w" => Unidentifiable(Concept(label = subfield.content))
+        case "y" => Unidentifiable(Period(label = subfield.content))
+        case "z" => Unidentifiable(Place(label = subfield.content))
+      }
     }
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -69,9 +69,9 @@ trait SierraSubjects extends MarcUtils with SierraConcepts {
   private def getPrimaryConcept(marcTag: String, primarySubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
     primarySubfields.map { subfield =>
       marcTag match {
-        case "650" => Unidentifiable(Concept(label = subfield.content))
-        case "648" => Unidentifiable(Period(label = subfield.content))
-        case "651" => Unidentifiable(Place(label = subfield.content))
+        case "650" => buildPrimaryConcept[Concept](subfield)
+        case "648" => buildPrimaryConcept[Period](subfield)
+        case "651" => buildPrimaryConcept[Place](subfield)
       }
 
     }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -55,7 +55,7 @@ trait SierraSubjects extends MarcUtils with SierraConcepts {
       val (primarySubfields, subdivisionSubfields) = subfields.partition { _.tag == "a" }
 
       val label = getLabel(primarySubfields, subdivisionSubfields)
-      val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(marcTag, primarySubfields) ++ getSubdivisions(subdivisionSubfields)
+      val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(marcTag, primarySubfields, bibData = bibData) ++ getSubdivisions(subdivisionSubfields)
 
       Subject[MaybeDisplayable[AbstractConcept]](
         label = label,
@@ -66,12 +66,21 @@ trait SierraSubjects extends MarcUtils with SierraConcepts {
 
   // Extract the primary concept, which comes from subfield $a.  This is the
   // only concept which might be identified.
-  private def getPrimaryConcept(marcTag: String, primarySubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
+  private def getPrimaryConcept(marcTag: String, primarySubfields: List[MarcSubfield], bibData: SierraBibData): List[MaybeDisplayable[AbstractConcept]] = {
     primarySubfields.map { subfield =>
       marcTag match {
-        case "650" => buildPrimaryConcept[Concept](subfield)
-        case "648" => buildPrimaryConcept[Period](subfield)
-        case "651" => buildPrimaryConcept[Place](subfield)
+        case "650" => identifyPrimaryConcept(
+          concept = Concept(label = subfield.content),
+          bibData = bibData
+        )
+        case "648" => identifyPrimaryConcept(
+          concept = Period(label = subfield.content),
+          bibData = bibData
+        )
+        case "651" => identifyPrimaryConcept(
+          concept = Place(label = subfield.content),
+          bibData = bibData
+        )
       }
 
     }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -74,7 +74,7 @@ trait SierraSubjects extends MarcUtils {
 
   // Extract the primary concept, which comes from subfield $a.  This is the
   // only concept which might be identified.
-  private def getPrimaryConcept(marcTag: String, primarySubfields: List[MarcSubfield]): List[MaybeDisplayable[Concept]] = {
+  private def getPrimaryConcept(marcTag: String, primarySubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
     primarySubfields.map { subfield =>
       marcTag match {
         case "650" => Unidentifiable(Concept(label = subfield.content))
@@ -87,7 +87,7 @@ trait SierraSubjects extends MarcUtils {
 
   // Extract the subdivisions, which come from everything except subfield $a.
   // These are never identified.  We preserve the order from MARC.
-  private def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[Unidentifiable[AbstractConcept]] = {
+  private def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
     subdivisionSubfields.map { subfield =>
       subfield.tag match {
         case "v" | "w" => Unidentifiable(Concept(label = subfield.content))

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -76,16 +76,4 @@ trait SierraSubjects extends MarcUtils with SierraConcepts {
 
     }
   }
-
-  // Extract the subdivisions, which come from everything except subfield $a.
-  // These are never identified.  We preserve the order from MARC.
-  private def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
-    subdivisionSubfields.map { subfield =>
-      subfield.tag match {
-        case "v" | "w" => Unidentifiable(Concept(label = subfield.content))
-        case "y" => Unidentifiable(Period(label = subfield.content))
-        case "z" => Unidentifiable(Place(label = subfield.content))
-      }
-    }
-  }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.transformer.transformers.sierra
 import uk.ac.wellcome.models.work.internal.{AbstractConcept, Concept, MaybeDisplayable, Period, Place, Subject, Unidentifiable}
 import uk.ac.wellcome.transformer.source.{MarcSubfield, SierraBibData}
 
-trait SierraSubjects extends MarcUtils {
+trait SierraSubjects extends MarcUtils with SierraConcepts {
 
   def getSubjects(bibData: SierraBibData)
     : List[Subject[MaybeDisplayable[AbstractConcept]]] = {
@@ -54,7 +54,7 @@ trait SierraSubjects extends MarcUtils {
     subfieldsList.map(subfields => {
       val (primarySubfields, subdivisionSubfields) = subfields.partition { _.tag == "a" }
 
-      val label = getSubjectLabel(primarySubfields, subdivisionSubfields)
+      val label = getLabel(primarySubfields, subdivisionSubfields)
       val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(marcTag, primarySubfields) ++ getSubdivisions(subdivisionSubfields)
 
       Subject[MaybeDisplayable[AbstractConcept]](
@@ -62,14 +62,6 @@ trait SierraSubjects extends MarcUtils {
         concepts = concepts
       )
     })
-  }
-
-  // Get the subject label.  This is populated by the label of subfield $a, followed
-  // by other subfields, in the order they come from MARC.  The labels are
-  // joined by " - ".
-  private def getSubjectLabel(primarySubfields: List[MarcSubfield], subdivisionSubfields: List[MarcSubfield]): String = {
-    val orderedSubfields = primarySubfields ++ subdivisionSubfields
-    orderedSubfields.map { _.content }.mkString(" - ")
   }
 
   // Extract the primary concept, which comes from subfield $a.  This is the

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdentifierSchemes.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdentifierSchemes.scala
@@ -50,8 +50,19 @@ object IdentifierSchemes {
     override def toString: String = "marc-countries"
   }
 
+  // Note: these are two different schemes.  The Library of Congress (LC)
+  // publishes Subject Headings and a Name Authority File, and they aren't
+  // the same!
   case object libraryOfCongressNames extends IdentifierScheme {
-    override def toString: String = "lc-names"
+    override def toString: String = "library-of-congress-names"
+  }
+
+  case object libraryOfCongressSubjectHeadings extends IdentifierScheme {
+    override def toString: String = "library-of-congress-subject-headings"
+  }
+
+  case object medicalSubjectHeadings extends IdentifierScheme {
+    override def toString: String = "medical-subject-headings"
   }
 
   private final val knownIdentifierSchemes = Seq(
@@ -62,7 +73,9 @@ object IdentifierSchemes {
     sierraSystemNumber,
     sierraIdentifier,
     libraryOfCongressNames,
-    marcCountries)
+    libraryOfCongressSubjectHeadings,
+    marcCountries,
+    medicalSubjectHeadings)
 
   private def createIdentifierScheme(
     identifierScheme: String): IdentifierSchemes.IdentifierScheme = {


### PR DESCRIPTION
### What is this PR trying to achieve?

This refactors these two transformers to more strongly highlight the difference between "primary concept" and "subdivision" (even if we don't expose those concepts in the public API). Only primary concepts get identifiers – separating them out will make this logic easier to add. The existing code was getting a bit thorny for my liking.

For #1959.

### Who is this change for?

Me, as I add identifiers!