### PR TITLE
Add identifiers to primary concepts

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/MarcUtils.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/MarcUtils.scala
@@ -19,9 +19,8 @@ trait MarcUtils {
           }
       }
 
-  def getMatchingVarFields(
-    bibData: SierraBibData,
-    marcTag: String): List[VarField] =
+  def getMatchingVarFields(bibData: SierraBibData,
+                           marcTag: String): List[VarField] =
     bibData.varFields
       .filter { _.marcTag == Some(marcTag) }
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/MarcUtils.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/MarcUtils.scala
@@ -19,6 +19,12 @@ trait MarcUtils {
           }
       }
 
+  def getMatchingVarFields(
+    bibData: SierraBibData,
+    marcTag: String): List[VarField] =
+    bibData.varFields
+      .filter { _.marcTag == Some(marcTag) }
+
   def getMatchingSubfields(bibData: SierraBibData,
                            marcTag: String,
                            marcSubfieldTag: String): List[List[MarcSubfield]] =

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -1,0 +1,14 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+import uk.ac.wellcome.transformer.source.MarcSubfield
+
+trait SierraConcepts {
+
+  // Get the label.  This is populated by the label of subfield $a, followed
+  // by other subfields, in the order they come from MARC.  The labels are
+  // joined by " - ".
+  protected def getLabel(primarySubfields: List[MarcSubfield], subdivisionSubfields: List[MarcSubfield]): String = {
+    val orderedSubfields = primarySubfields ++ subdivisionSubfields
+    orderedSubfields.map { _.content }.mkString(" - ")
+  }
+}

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -1,9 +1,9 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.transformer.source.{MarcSubfield, SierraBibData}
+import uk.ac.wellcome.transformer.source.{MarcSubfield, SierraBibData, VarField}
 
-trait SierraConcepts {
+trait SierraConcepts extends MarcUtils {
 
   // Get the label.  This is populated by the label of subfield $a, followed
   // by other subfields, in the order they come from MARC.  The labels are
@@ -15,10 +15,49 @@ trait SierraConcepts {
 
   // Apply an identifier to the primary concept.  We look in subfield $0
   // for the identifier value, then second indicator for the authority.
+  //
+  // Note that some identifiers have an identifier scheme in
+  // indicator 2, but no ID.  In this case, we just ignore it.
   protected def identifyPrimaryConcept(
     concept: AbstractConcept,
-    bibData: SierraBibData): MaybeDisplayable[AbstractConcept] =
-    Unidentifiable(agent = concept)
+    varField: VarField): MaybeDisplayable[AbstractConcept] = {
+    val identifierSubfields = varField.subfields.filter { _.tag == "0" }
+
+    identifierSubfields.size match {
+      case 0 => Unidentifiable(agent = concept)
+      case 1 => {
+
+        // The mapping from indicator 2 to the identifier scheme is provided
+        // by the MARC spec.
+        // https://www.loc.gov/marc/bibliographic/bd655.html
+        val maybeIdentifierScheme = varField.indicator2 match {
+          case None => None
+          case Some("0") => Some(IdentifierSchemes.libraryOfCongressSubjectHeadings)
+          case Some("2") => Some(IdentifierSchemes.medicalSubjectHeadings)
+          case _ => throw new RuntimeException("Unrecognised identifier scheme: ")
+        }
+
+        maybeIdentifierScheme match {
+          case None => Unidentifiable(agent = concept)
+          case Some(identifierScheme) => {
+            val sourceIdentifier = SourceIdentifier(
+              identifierScheme = identifierScheme,
+              value = identifierSubfields.head.content,
+              ontologyType = concept.ontologyType
+            )
+
+            Identifiable(
+              agent = concept,
+              sourceIdentifier = sourceIdentifier,
+              identifiers = List(sourceIdentifier)
+            )
+          }
+        }
+      }
+
+      case _ => throw new RuntimeException(s"Too many identifiers fields: $identifierSubfields")
+    }
+  }
 
   // Extract the subdivisions, which come from everything except subfield $a.
   // These are never identified.  We preserve the order from MARC.

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -13,10 +13,9 @@ trait SierraConcepts {
     orderedSubfields.map { _.content }.mkString(" - ")
   }
 
-  // Get the primary concept, which is based on subfield $a.  This may
-  // be identified.  We look in subfield $0 for the identifier value, then
-  // second indicator for the authority.
-  protected def buildPrimaryConcept[T <: AbstractConcept](
+  // Apply an identifier to the primary concept.  We look in subfield $0
+  // for the identifier value, then second indicator for the authority.
+  protected def identifyPrimaryConcept(
     concept: AbstractConcept,
     bibData: SierraBibData): MaybeDisplayable[AbstractConcept] =
     Unidentifiable(agent = concept)

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -1,14 +1,19 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.transformer.source.{MarcSubfield, SierraBibData, VarField}
+import uk.ac.wellcome.transformer.source.{
+  MarcSubfield,
+  SierraBibData,
+  VarField
+}
 
 trait SierraConcepts extends MarcUtils {
 
   // Get the label.  This is populated by the label of subfield $a, followed
   // by other subfields, in the order they come from MARC.  The labels are
   // joined by " - ".
-  protected def getLabel(primarySubfields: List[MarcSubfield], subdivisionSubfields: List[MarcSubfield]): String = {
+  protected def getLabel(primarySubfields: List[MarcSubfield],
+                         subdivisionSubfields: List[MarcSubfield]): String = {
     val orderedSubfields = primarySubfields ++ subdivisionSubfields
     orderedSubfields.map { _.content }.mkString(" - ")
   }
@@ -32,9 +37,12 @@ trait SierraConcepts extends MarcUtils {
         // https://www.loc.gov/marc/bibliographic/bd655.html
         val maybeIdentifierScheme = varField.indicator2 match {
           case None => None
-          case Some("0") => Some(IdentifierSchemes.libraryOfCongressSubjectHeadings)
+          case Some("0") =>
+            Some(IdentifierSchemes.libraryOfCongressSubjectHeadings)
           case Some("2") => Some(IdentifierSchemes.medicalSubjectHeadings)
-          case Some(scheme) => throw new RuntimeException(s"Unrecognised identifier scheme: $scheme")
+          case Some(scheme) =>
+            throw new RuntimeException(
+              s"Unrecognised identifier scheme: $scheme")
         }
 
         maybeIdentifierScheme match {
@@ -55,19 +63,23 @@ trait SierraConcepts extends MarcUtils {
         }
       }
 
-      case _ => throw new RuntimeException(s"Too many identifiers fields: $identifierSubfields")
+      case _ =>
+        throw new RuntimeException(
+          s"Too many identifiers fields: $identifierSubfields")
     }
   }
 
   // Extract the subdivisions, which come from everything except subfield $a.
   // These are never identified.  We preserve the order from MARC.
-  protected def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[Unidentifiable[AbstractConcept]] = {
-    val concepts: List[AbstractConcept] = subdivisionSubfields.map { subfield =>
-      subfield.tag match {
-        case "v" | "x" => Concept(label = subfield.content)
-        case "y" => Period(label = subfield.content)
-        case "z" => Place(label = subfield.content)
-      }
+  protected def getSubdivisions(subdivisionSubfields: List[MarcSubfield])
+    : List[Unidentifiable[AbstractConcept]] = {
+    val concepts: List[AbstractConcept] = subdivisionSubfields.map {
+      subfield =>
+        subfield.tag match {
+          case "v" | "x" => Concept(label = subfield.content)
+          case "y" => Period(label = subfield.content)
+          case "z" => Place(label = subfield.content)
+        }
     }
 
     concepts.map { Unidentifiable(_) }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -18,9 +18,9 @@ trait SierraConcepts extends MarcUtils {
   //
   // Note that some identifiers have an identifier scheme in
   // indicator 2, but no ID.  In this case, we just ignore it.
-  protected def identifyPrimaryConcept(
-    concept: AbstractConcept,
-    varField: VarField): MaybeDisplayable[AbstractConcept] = {
+  protected def identifyPrimaryConcept[T <: AbstractConcept](
+    concept: T,
+    varField: VarField): MaybeDisplayable[T] = {
     val identifierSubfields = varField.subfields.filter { _.tag == "0" }
 
     identifierSubfields.size match {

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -34,7 +34,7 @@ trait SierraConcepts extends MarcUtils {
           case None => None
           case Some("0") => Some(IdentifierSchemes.libraryOfCongressSubjectHeadings)
           case Some("2") => Some(IdentifierSchemes.medicalSubjectHeadings)
-          case _ => throw new RuntimeException("Unrecognised identifier scheme: ")
+          case Some(scheme) => throw new RuntimeException(s"Unrecognised identifier scheme: $scheme")
         }
 
         maybeIdentifierScheme match {

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -15,4 +15,16 @@ trait SierraConcepts {
 
   protected def buildPrimaryConcept[T <: AbstractConcept](subfield: MarcSubfield): MaybeDisplayable[AbstractConcept] =
     Unidentifiable(T(label = subfield.content))
+
+  // Extract the subdivisions, which come from everything except subfield $a.
+  // These are never identified.  We preserve the order from MARC.
+  protected def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
+    subdivisionSubfields.map { subfield =>
+      subfield.tag match {
+        case "v" | "w" => Unidentifiable(Concept(label = subfield.content))
+        case "y" => Unidentifiable(Period(label = subfield.content))
+        case "z" => Unidentifiable(Place(label = subfield.content))
+      }
+    }
+  }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
+import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.transformer.source.MarcSubfield
 
 trait SierraConcepts {
@@ -11,4 +12,7 @@ trait SierraConcepts {
     val orderedSubfields = primarySubfields ++ subdivisionSubfields
     orderedSubfields.map { _.content }.mkString(" - ")
   }
+
+  protected def buildPrimaryConcept[T <: AbstractConcept](subfield: MarcSubfield): MaybeDisplayable[AbstractConcept] =
+    Unidentifiable(T(label = subfield.content))
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.transformer.source.MarcSubfield
+import uk.ac.wellcome.transformer.source.{MarcSubfield, SierraBibData}
 
 trait SierraConcepts {
 
@@ -13,6 +13,9 @@ trait SierraConcepts {
     orderedSubfields.map { _.content }.mkString(" - ")
   }
 
+  // Get the primary concept, which is based on subfield $a.  This may
+  // be identified.  We look in subfield $0 for the identifier value, then
+  // second indicator for the authority.
   protected def buildPrimaryConcept[T <: AbstractConcept](
     concept: AbstractConcept,
     bibData: SierraBibData): MaybeDisplayable[AbstractConcept] =

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -21,7 +21,7 @@ trait SierraConcepts {
   protected def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
     subdivisionSubfields.map { subfield =>
       subfield.tag match {
-        case "v" | "w" => Unidentifiable(Concept(label = subfield.content))
+        case "v" | "x" => Unidentifiable(Concept(label = subfield.content))
         case "y" => Unidentifiable(Period(label = subfield.content))
         case "z" => Unidentifiable(Place(label = subfield.content))
       }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -61,13 +61,15 @@ trait SierraConcepts extends MarcUtils {
 
   // Extract the subdivisions, which come from everything except subfield $a.
   // These are never identified.  We preserve the order from MARC.
-  protected def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
-    subdivisionSubfields.map { subfield =>
+  protected def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[Unidentifiable[AbstractConcept]] = {
+    val concepts: List[AbstractConcept] = subdivisionSubfields.map { subfield =>
       subfield.tag match {
-        case "v" | "x" => Unidentifiable(Concept(label = subfield.content))
-        case "y" => Unidentifiable(Period(label = subfield.content))
-        case "z" => Unidentifiable(Place(label = subfield.content))
+        case "v" | "x" => Concept(label = subfield.content)
+        case "y" => Period(label = subfield.content)
+        case "z" => Place(label = subfield.content)
       }
     }
+
+    concepts.map { Unidentifiable(_) }
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -30,11 +30,12 @@ trait SierraConcepts extends MarcUtils {
 
     identifierSubfields match {
       case Seq() => Unidentifiable(agent = concept)
-      case Seq(identifierSubfield) => maybeAddIdentifier[T](
-        concept = concept,
-        varField = varField,
-        identifierSubfield = identifierSubfield
-      )
+      case Seq(identifierSubfield) =>
+        maybeAddIdentifier[T](
+          concept = concept,
+          varField = varField,
+          identifierSubfield = identifierSubfield
+        )
       case _ =>
         throw new RuntimeException(
           s"Too many identifiers fields: $identifierSubfields")
@@ -57,8 +58,7 @@ trait SierraConcepts extends MarcUtils {
         Some(IdentifierSchemes.libraryOfCongressSubjectHeadings)
       case Some("2") => Some(IdentifierSchemes.medicalSubjectHeadings)
       case Some(scheme) =>
-        throw new RuntimeException(
-          s"Unrecognised identifier scheme: $scheme")
+        throw new RuntimeException(s"Unrecognised identifier scheme: $scheme")
     }
 
     maybeIdentifierScheme match {

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -13,8 +13,10 @@ trait SierraConcepts {
     orderedSubfields.map { _.content }.mkString(" - ")
   }
 
-  protected def buildPrimaryConcept[T <: AbstractConcept](subfield: MarcSubfield): MaybeDisplayable[AbstractConcept] =
-    Unidentifiable(T(label = subfield.content))
+  protected def buildPrimaryConcept[T <: AbstractConcept](
+    concept: AbstractConcept,
+    bibData: SierraBibData): MaybeDisplayable[AbstractConcept] =
+    Unidentifiable(agent = concept)
 
   // Extract the subdivisions, which come from everything except subfield $a.
   // These are never identified.  We preserve the order from MARC.

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -28,44 +28,54 @@ trait SierraConcepts extends MarcUtils {
     varField: VarField): MaybeDisplayable[T] = {
     val identifierSubfields = varField.subfields.filter { _.tag == "0" }
 
-    identifierSubfields.size match {
-      case 0 => Unidentifiable(agent = concept)
-      case 1 => {
-
-        // The mapping from indicator 2 to the identifier scheme is provided
-        // by the MARC spec.
-        // https://www.loc.gov/marc/bibliographic/bd655.html
-        val maybeIdentifierScheme = varField.indicator2 match {
-          case None => None
-          case Some("0") =>
-            Some(IdentifierSchemes.libraryOfCongressSubjectHeadings)
-          case Some("2") => Some(IdentifierSchemes.medicalSubjectHeadings)
-          case Some(scheme) =>
-            throw new RuntimeException(
-              s"Unrecognised identifier scheme: $scheme")
-        }
-
-        maybeIdentifierScheme match {
-          case None => Unidentifiable(agent = concept)
-          case Some(identifierScheme) => {
-            val sourceIdentifier = SourceIdentifier(
-              identifierScheme = identifierScheme,
-              value = identifierSubfields.head.content,
-              ontologyType = concept.ontologyType
-            )
-
-            Identifiable(
-              agent = concept,
-              sourceIdentifier = sourceIdentifier,
-              identifiers = List(sourceIdentifier)
-            )
-          }
-        }
-      }
-
+    identifierSubfields match {
+      case Seq() => Unidentifiable(agent = concept)
+      case Seq(identifierSubfield) => maybeAddIdentifier[T](
+        concept = concept,
+        varField = varField,
+        identifierSubfield = identifierSubfield
+      )
       case _ =>
         throw new RuntimeException(
           s"Too many identifiers fields: $identifierSubfields")
+    }
+  }
+
+  // If there's exactly one subfield $0 on the VarField, add an identifier
+  // if possible.
+  private def maybeAddIdentifier[T <: AbstractConcept](
+    concept: T,
+    varField: VarField,
+    identifierSubfield: MarcSubfield): MaybeDisplayable[T] = {
+
+    // The mapping from indicator 2 to the identifier scheme is provided
+    // by the MARC spec.
+    // https://www.loc.gov/marc/bibliographic/bd655.html
+    val maybeIdentifierScheme = varField.indicator2 match {
+      case None => None
+      case Some("0") =>
+        Some(IdentifierSchemes.libraryOfCongressSubjectHeadings)
+      case Some("2") => Some(IdentifierSchemes.medicalSubjectHeadings)
+      case Some(scheme) =>
+        throw new RuntimeException(
+          s"Unrecognised identifier scheme: $scheme")
+    }
+
+    maybeIdentifierScheme match {
+      case None => Unidentifiable(agent = concept)
+      case Some(identifierScheme) => {
+        val sourceIdentifier = SourceIdentifier(
+          identifierScheme = identifierScheme,
+          value = identifierSubfield.content,
+          ontologyType = concept.ontologyType
+        )
+
+        Identifiable(
+          agent = concept,
+          sourceIdentifier = sourceIdentifier,
+          identifiers = List(sourceIdentifier)
+        )
+      }
     }
   }
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -61,7 +61,7 @@ trait SierraGenres extends MarcUtils with SierraConcepts {
   // only concept which might be identified.
   private def getPrimaryConcept(primarySubfields: List[MarcSubfield]): List[MaybeDisplayable[Concept]] = {
     primarySubfields.map { subfield =>
-      Unidentifiable(Concept(label = subfield.content))
+      buildPrimaryConcept[Concept](subfield)
     }
   }
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -64,16 +64,4 @@ trait SierraGenres extends MarcUtils with SierraConcepts {
       buildPrimaryConcept[Concept](subfield)
     }
   }
-
-  // Extract the subdivisions, which come from everything except subfield $a.
-  // These are never identified.  We preserve the order from MARC.
-  private def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
-    subdivisionSubfields.map { subfield =>
-      subfield.tag match {
-        case "v" | "w" => Unidentifiable(Concept(label = subfield.content))
-        case "y" => Unidentifiable(Period(label = subfield.content))
-        case "z" => Unidentifiable(Place(label = subfield.content))
-      }
-    }
-  }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -75,7 +75,7 @@ trait SierraGenres extends MarcUtils {
 
   // Extract the subdivisions, which come from everything except subfield $a.
   // These are never identified.  We preserve the order from MARC.
-  private def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[Unidentifiable[AbstractConcept]] = {
+  private def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
     subdivisionSubfields.map { subfield =>
       subfield.tag match {
         case "v" | "w" => Unidentifiable(Concept(label = subfield.content))

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -1,53 +1,87 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
-import uk.ac.wellcome.models.work.internal.{
-  AbstractConcept,
-  Concept,
-  Genre,
-  MaybeDisplayable,
-  Period,
-  Place,
-  Unidentifiable
-}
-import uk.ac.wellcome.transformer.source.SierraBibData
+import uk.ac.wellcome.models.work.internal.{AbstractConcept, Concept, Genre, MaybeDisplayable, Period, Place, Unidentifiable}
+import uk.ac.wellcome.transformer.source.{MarcSubfield, SierraBibData}
 
 trait SierraGenres extends MarcUtils {
 
+  // Populate wwork:genres
+  //
+  // Use MARC field "655".
+  //
+  // Within a MARC 655 tag, there's:
+  //
+  //    - a primary concept (subfield $a); and
+  //    - subdivisions (subfields $v, $x, $y and $z)
+  //
+  // The primary concept can be identified, and the subdivisions serve
+  // to add extra context.
+  //
+  // We construct the Genre as follows:
+  //
+  //    - label is the concatenation of $a, $v, $x, $y and $z in order,
+  //      separated by a hyphen ' - '.
+  //    - concepts is a List[Concept] populated in order of the subfields:
+  //
+  //        * $a => Concept
+  //          Optionally with an identifier.  We look in subfield $0 for the
+  //          identifier value, then second indicator for the authority.
+  //
+  //        * $v => Concept
+  //        * $x => Concept
+  //        * $y => Period
+  //        * $z => Place
+  //
+  //      Note that only concepts from subfield $a are identified; everything
+  //      else is unidentified.
+  //
   def getGenres(
     bibData: SierraBibData): List[Genre[MaybeDisplayable[AbstractConcept]]] = {
     getGenresForMarcTag(bibData, "655")
   }
 
-  // Populate wwork:genres
-  //
-  // Use MARC field "655"
-  //
-  // Each Genre type is populated with label and concepts
-  //
-  //   - Genre.label is concatenated subfields a,v,x,y,z in order separated by a hyphen ' - '.
-  //   - Genre.concepts is a List populated with subfield 'a', then Concepts from subfields v,x,y,z in order with types:
-  //       * v => Concept
-  //       * x => Concept
-  //       * y => Period
-  //       * z => Place
-  //
   private def getGenresForMarcTag(bibData: SierraBibData, marcTag: String) = {
     val subfieldsList =
       getMatchingSubfields(bibData, marcTag, List("a", "v", "x", "y", "z"))
+
     subfieldsList.map(subfields => {
-      val (subfieldsA, rest) = subfields.partition(_.tag == "a")
-      val orderedSubfields = subfieldsA ++ rest
-      val label = orderedSubfields.map(_.content).mkString(" - ")
-      val concepts = orderedSubfields.map(subfield =>
-        subfield.tag match {
-          case "y" => Unidentifiable(Period(label = subfield.content))
-          case "z" => Unidentifiable(Place(label = subfield.content))
-          case _ => Unidentifiable(Concept(label = subfield.content))
-      })
+      val (primarySubfields, subdivisionSubfields) = subfields.partition { _.tag == "a" }
+
+      val label = getGenreLabel(primarySubfields, subdivisionSubfields)
+      val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(primarySubfields) ++ getSubdivisions(subdivisionSubfields)
+
       Genre[MaybeDisplayable[AbstractConcept]](
         label = label,
         concepts = concepts
       )
     })
+  }
+
+  // Get the genre label.  This is populated by the label of subfield $a, followed
+  // by other subfields, in the order they come from MARC.  The labels are
+  // joined by " - ".
+  private def getGenreLabel(primarySubfields: List[MarcSubfield], subdivisionSubfields: List[MarcSubfield]): String = {
+    val orderedSubfields = primarySubfields ++ subdivisionSubfields
+    orderedSubfields.map { _.content }.mkString(" - ")
+  }
+
+  // Extract the primary concept, which comes from subfield $a.  This is the
+  // only concept which might be identified.
+  private def getPrimaryConcept(primarySubfields: List[MarcSubfield]): List[MaybeDisplayable[Concept]] = {
+    primarySubfields.map { subfield =>
+      Unidentifiable(Concept(label = subfield.content))
+    }
+  }
+
+  // Extract the subdivisions, which come from everything except subfield $a.
+  // These are never identified.  We preserve the order from MARC.
+  private def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[Unidentifiable[AbstractConcept]] = {
+    subdivisionSubfields.map { subfield =>
+      subfield.tag match {
+        case "v" | "w" => Unidentifiable(Concept(label = subfield.content))
+        case "y" => Unidentifiable(Period(label = subfield.content))
+        case "z" => Unidentifiable(Place(label = subfield.content))
+      }
+    }
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -48,7 +48,7 @@ trait SierraGenres extends MarcUtils with SierraConcepts {
       val (primarySubfields, subdivisionSubfields) = subfields.partition { _.tag == "a" }
 
       val label = getLabel(primarySubfields, subdivisionSubfields)
-      val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(primarySubfields) ++ getSubdivisions(subdivisionSubfields)
+      val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(primarySubfields, bibData = bibData) ++ getSubdivisions(subdivisionSubfields)
 
       Genre[MaybeDisplayable[AbstractConcept]](
         label = label,
@@ -59,9 +59,12 @@ trait SierraGenres extends MarcUtils with SierraConcepts {
 
   // Extract the primary concept, which comes from subfield $a.  This is the
   // only concept which might be identified.
-  private def getPrimaryConcept(primarySubfields: List[MarcSubfield]): List[MaybeDisplayable[Concept]] = {
+  private def getPrimaryConcept(primarySubfields: List[MarcSubfield], bibData: SierraBibData): List[MaybeDisplayable[AbstractConcept]] = {
     primarySubfields.map { subfield =>
-      buildPrimaryConcept[Concept](subfield)
+      identifyPrimaryConcept(
+        concept = Concept(label = subfield.content),
+        bibData = bibData
+      )
     }
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.transformer.transformers.sierra
 import uk.ac.wellcome.models.work.internal.{AbstractConcept, Concept, Genre, MaybeDisplayable, Period, Place, Unidentifiable}
 import uk.ac.wellcome.transformer.source.{MarcSubfield, SierraBibData}
 
-trait SierraGenres extends MarcUtils {
+trait SierraGenres extends MarcUtils with SierraConcepts {
 
   // Populate wwork:genres
   //
@@ -47,7 +47,7 @@ trait SierraGenres extends MarcUtils {
     subfieldsList.map(subfields => {
       val (primarySubfields, subdivisionSubfields) = subfields.partition { _.tag == "a" }
 
-      val label = getGenreLabel(primarySubfields, subdivisionSubfields)
+      val label = getLabel(primarySubfields, subdivisionSubfields)
       val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(primarySubfields) ++ getSubdivisions(subdivisionSubfields)
 
       Genre[MaybeDisplayable[AbstractConcept]](
@@ -55,14 +55,6 @@ trait SierraGenres extends MarcUtils {
         concepts = concepts
       )
     })
-  }
-
-  // Get the genre label.  This is populated by the label of subfield $a, followed
-  // by other subfields, in the order they come from MARC.  The labels are
-  // joined by " - ".
-  private def getGenreLabel(primarySubfields: List[MarcSubfield], subdivisionSubfields: List[MarcSubfield]): String = {
-    val orderedSubfields = primarySubfields ++ subdivisionSubfields
-    orderedSubfields.map { _.content }.mkString(" - ")
   }
 
   // Extract the primary concept, which comes from subfield $a.  This is the

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenres.scala
@@ -1,7 +1,19 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
-import uk.ac.wellcome.models.work.internal.{AbstractConcept, Concept, Genre, MaybeDisplayable, Period, Place, Unidentifiable}
-import uk.ac.wellcome.transformer.source.{MarcSubfield, SierraBibData, VarField}
+import uk.ac.wellcome.models.work.internal.{
+  AbstractConcept,
+  Concept,
+  Genre,
+  MaybeDisplayable,
+  Period,
+  Place,
+  Unidentifiable
+}
+import uk.ac.wellcome.transformer.source.{
+  MarcSubfield,
+  SierraBibData,
+  VarField
+}
 
 trait SierraGenres extends MarcUtils with SierraConcepts {
 
@@ -47,12 +59,17 @@ trait SierraGenres extends MarcUtils with SierraConcepts {
 
     marcVarFields.map { varField =>
       val subfields = varField.subfields.filter { subfield =>
-        List("a", "v", "x", "y", "z").contains( subfield.tag )
+        List("a", "v", "x", "y", "z").contains(subfield.tag)
       }
-      val (primarySubfields, subdivisionSubfields) = subfields.partition { _.tag == "a" }
+      val (primarySubfields, subdivisionSubfields) = subfields.partition {
+        _.tag == "a"
+      }
 
       val label = getLabel(primarySubfields, subdivisionSubfields)
-      val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(primarySubfields, varField = varField) ++ getSubdivisions(subdivisionSubfields)
+      val concepts
+        : List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(
+        primarySubfields,
+        varField = varField) ++ getSubdivisions(subdivisionSubfields)
 
       Genre[MaybeDisplayable[AbstractConcept]](
         label = label,
@@ -63,7 +80,9 @@ trait SierraGenres extends MarcUtils with SierraConcepts {
 
   // Extract the primary concept, which comes from subfield $a.  This is the
   // only concept which might be identified.
-  private def getPrimaryConcept(primarySubfields: List[MarcSubfield], varField: VarField): List[MaybeDisplayable[AbstractConcept]] = {
+  private def getPrimaryConcept(
+    primarySubfields: List[MarcSubfield],
+    varField: VarField): List[MaybeDisplayable[AbstractConcept]] = {
     primarySubfields.map { subfield =>
       identifyPrimaryConcept(
         concept = Concept(label = subfield.content),

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -1,15 +1,7 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
-import uk.ac.wellcome.models.work.internal.{
-  AbstractConcept,
-  Concept,
-  MaybeDisplayable,
-  Period,
-  Place,
-  Subject,
-  Unidentifiable
-}
-import uk.ac.wellcome.transformer.source.SierraBibData
+import uk.ac.wellcome.models.work.internal.{AbstractConcept, Concept, MaybeDisplayable, Period, Place, Subject, Unidentifiable}
+import uk.ac.wellcome.transformer.source.{MarcSubfield, SierraBibData}
 
 trait SierraSubjects extends MarcUtils {
 
@@ -20,52 +12,88 @@ trait SierraSubjects extends MarcUtils {
       getSubjectsForMarcTag(bibData, "651")
   }
 
-  // Populate wwork:subjects
+  // Populate wwork:subject
   //
-  // Use MARC fields "650", "648", "651"
+  // Use MARC field "650", "648" and "651".
   //
-  // Each Subject type is populated with label and concepts
+  // Within these MARC tags, we have:
   //
-  //   - Subject.label is concatenated subfields a,v,x,y,z in order separated by a hyphen ' - '.
-  //   - Subject.concepts is a List populated with a primary Concept with label from subfield 'a', and
-  //     type:
-  //       650 => Concept
-  //       648 => Period
-  //       651 => Place
-  //     for subfields v,x,y,z Subject.concepts are populated in order with Concept.label and type:
-  //       * v => Concept
-  //       * x => Concept
-  //       * y => Period
-  //       * z => Place
+  //    - a primary concept (subfield $a); and
+  //    - subdivisions (subfields $v, $x, $y and $z)
+  //
+  // The primary concept can be identified, and the subdivisions serve
+  // to add extra context.
+  //
+  // We construct the Subject as follows:
+  //
+  //    - label is the concatenation of $a, $v, $x, $y and $z in order,
+  //      separated by a hyphen ' - '.
+  //    - concepts is a List[Concept] populated in order of the subfields:
+  //
+  //        * $a => {Concept, Period, Place}
+  //          Optionally with an identifier.  We look in subfield $0 for the
+  //          identifier value, then second indicator for the authority.
+  //          These are decided as follows:
+  //
+  //            - 650 => Concept
+  //            - 648 => Period
+  //            - 651 => Place
+  //
+  //        * $v => Concept
+  //        * $x => Concept
+  //        * $y => Period
+  //        * $z => Place
+  //
+  //      Note that only concepts from subfield $a are identified; everything
+  //      else is unidentified.
   //
   private def getSubjectsForMarcTag(bibData: SierraBibData, marcTag: String) = {
     val subfieldsList = getMatchingSubfields(
-      bibData,
-      marcTag = marcTag,
-      marcSubfieldTags = List("a", "v", "x", "y", "z"))
+      bibData, marcTag, marcSubfieldTags = List("a", "v", "x", "y", "z"))
+
     subfieldsList.map(subfields => {
-      val (subfieldsA, rest) = subfields.partition(_.tag == "a")
-      val orderedSubfields = subfieldsA ++ rest
-      val subjectLabel = orderedSubfields.map(_.content).mkString(" - ")
-      val concepts = orderedSubfields.map(subfield =>
-        subfield.tag match {
-          case "a" => Unidentifiable(primaryConcept(marcTag, subfield.content))
-          case "y" => Unidentifiable(Period(label = subfield.content))
-          case "z" => Unidentifiable(Place(label = subfield.content))
-          case _ => Unidentifiable(Concept(label = subfield.content))
-      })
+      val (primarySubfields, subdivisionSubfields) = subfields.partition { _.tag == "a" }
+
+      val label = getSubjectLabel(primarySubfields, subdivisionSubfields)
+      val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(marcTag, primarySubfields) ++ getSubdivisions(subdivisionSubfields)
+
       Subject[MaybeDisplayable[AbstractConcept]](
-        label = subjectLabel,
+        label = label,
         concepts = concepts
       )
     })
   }
 
-  private def primaryConcept(marcTag: String, label: String) = {
-    marcTag match {
-      case "650" => Concept(label)
-      case "648" => Period(label)
-      case "651" => Place(label)
+  // Get the subject label.  This is populated by the label of subfield $a, followed
+  // by other subfields, in the order they come from MARC.  The labels are
+  // joined by " - ".
+  private def getSubjectLabel(primarySubfields: List[MarcSubfield], subdivisionSubfields: List[MarcSubfield]): String = {
+    val orderedSubfields = primarySubfields ++ subdivisionSubfields
+    orderedSubfields.map { _.content }.mkString(" - ")
+  }
+
+  // Extract the primary concept, which comes from subfield $a.  This is the
+  // only concept which might be identified.
+  private def getPrimaryConcept(marcTag: String, primarySubfields: List[MarcSubfield]): List[MaybeDisplayable[Concept]] = {
+    primarySubfields.map { subfield =>
+      marcTag match {
+        case "650" => Unidentifiable(Concept(label = subfield.content))
+        case "648" => Unidentifiable(Period(label = subfield.content))
+        case "651" => Unidentifiable(Place(label = subfield.content))
+      }
+
+    }
+  }
+
+  // Extract the subdivisions, which come from everything except subfield $a.
+  // These are never identified.  We preserve the order from MARC.
+  private def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[Unidentifiable[AbstractConcept]] = {
+    subdivisionSubfields.map { subfield =>
+      subfield.tag match {
+        case "v" | "w" => Unidentifiable(Concept(label = subfield.content))
+        case "y" => Unidentifiable(Period(label = subfield.content))
+        case "z" => Unidentifiable(Place(label = subfield.content))
+      }
     }
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -69,9 +69,9 @@ trait SierraSubjects extends MarcUtils with SierraConcepts {
   private def getPrimaryConcept(marcTag: String, primarySubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
     primarySubfields.map { subfield =>
       marcTag match {
-        case "650" => Unidentifiable(Concept(label = subfield.content))
-        case "648" => Unidentifiable(Period(label = subfield.content))
-        case "651" => Unidentifiable(Place(label = subfield.content))
+        case "650" => buildPrimaryConcept[Concept](subfield)
+        case "648" => buildPrimaryConcept[Period](subfield)
+        case "651" => buildPrimaryConcept[Place](subfield)
       }
 
     }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -1,7 +1,11 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.transformer.source.{MarcSubfield, SierraBibData, VarField}
+import uk.ac.wellcome.transformer.source.{
+  MarcSubfield,
+  SierraBibData,
+  VarField
+}
 
 trait SierraSubjects extends MarcUtils with SierraConcepts {
 
@@ -52,12 +56,17 @@ trait SierraSubjects extends MarcUtils with SierraConcepts {
 
     marcVarFields.map { varField =>
       val subfields = varField.subfields.filter { subfield =>
-        List("a", "v", "x", "y", "z").contains( subfield.tag )
+        List("a", "v", "x", "y", "z").contains(subfield.tag)
       }
-      val (primarySubfields, subdivisionSubfields) = subfields.partition { _.tag == "a" }
+      val (primarySubfields, subdivisionSubfields) = subfields.partition {
+        _.tag == "a"
+      }
 
       val label = getLabel(primarySubfields, subdivisionSubfields)
-      val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(primarySubfields, varField = varField) ++ getSubdivisions(subdivisionSubfields)
+      val concepts
+        : List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(
+        primarySubfields,
+        varField = varField) ++ getSubdivisions(subdivisionSubfields)
 
       Subject[MaybeDisplayable[AbstractConcept]](
         label = label,
@@ -68,21 +77,26 @@ trait SierraSubjects extends MarcUtils with SierraConcepts {
 
   // Extract the primary concept, which comes from subfield $a.  This is the
   // only concept which might be identified.
-  private def getPrimaryConcept(primarySubfields: List[MarcSubfield], varField: VarField): List[MaybeDisplayable[AbstractConcept]] = {
+  private def getPrimaryConcept(
+    primarySubfields: List[MarcSubfield],
+    varField: VarField): List[MaybeDisplayable[AbstractConcept]] = {
     primarySubfields.map { subfield =>
       varField.marcTag.get match {
-        case "650" => identifyPrimaryConcept(
-          concept = Concept(label = subfield.content),
-          varField = varField
-        )
-        case "648" => identifyPrimaryConcept(
-          concept = Period(label = subfield.content),
-          varField = varField
-        )
-        case "651" => identifyPrimaryConcept(
-          concept = Place(label = subfield.content),
-          varField = varField
-        )
+        case "650" =>
+          identifyPrimaryConcept(
+            concept = Concept(label = subfield.content),
+            varField = varField
+          )
+        case "648" =>
+          identifyPrimaryConcept(
+            concept = Period(label = subfield.content),
+            varField = varField
+          )
+        case "651" =>
+          identifyPrimaryConcept(
+            concept = Place(label = subfield.content),
+            varField = varField
+          )
       }
 
     }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -55,7 +55,7 @@ trait SierraSubjects extends MarcUtils with SierraConcepts {
       val (primarySubfields, subdivisionSubfields) = subfields.partition { _.tag == "a" }
 
       val label = getLabel(primarySubfields, subdivisionSubfields)
-      val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(marcTag, primarySubfields) ++ getSubdivisions(subdivisionSubfields)
+      val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(marcTag, primarySubfields, bibData = bibData) ++ getSubdivisions(subdivisionSubfields)
 
       Subject[MaybeDisplayable[AbstractConcept]](
         label = label,
@@ -66,12 +66,21 @@ trait SierraSubjects extends MarcUtils with SierraConcepts {
 
   // Extract the primary concept, which comes from subfield $a.  This is the
   // only concept which might be identified.
-  private def getPrimaryConcept(marcTag: String, primarySubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
+  private def getPrimaryConcept(marcTag: String, primarySubfields: List[MarcSubfield], bibData: SierraBibData): List[MaybeDisplayable[AbstractConcept]] = {
     primarySubfields.map { subfield =>
       marcTag match {
-        case "650" => buildPrimaryConcept[Concept](subfield)
-        case "648" => buildPrimaryConcept[Period](subfield)
-        case "651" => buildPrimaryConcept[Place](subfield)
+        case "650" => identifyPrimaryConcept(
+          concept = Concept(label = subfield.content),
+          bibData = bibData
+        )
+        case "648" => identifyPrimaryConcept(
+          concept = Period(label = subfield.content),
+          bibData = bibData
+        )
+        case "651" => identifyPrimaryConcept(
+          concept = Place(label = subfield.content),
+          bibData = bibData
+        )
       }
 
     }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -74,7 +74,7 @@ trait SierraSubjects extends MarcUtils {
 
   // Extract the primary concept, which comes from subfield $a.  This is the
   // only concept which might be identified.
-  private def getPrimaryConcept(marcTag: String, primarySubfields: List[MarcSubfield]): List[MaybeDisplayable[Concept]] = {
+  private def getPrimaryConcept(marcTag: String, primarySubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
     primarySubfields.map { subfield =>
       marcTag match {
         case "650" => Unidentifiable(Concept(label = subfield.content))
@@ -87,7 +87,7 @@ trait SierraSubjects extends MarcUtils {
 
   // Extract the subdivisions, which come from everything except subfield $a.
   // These are never identified.  We preserve the order from MARC.
-  private def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[Unidentifiable[AbstractConcept]] = {
+  private def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
     subdivisionSubfields.map { subfield =>
       subfield.tag match {
         case "v" | "w" => Unidentifiable(Concept(label = subfield.content))

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -76,16 +76,4 @@ trait SierraSubjects extends MarcUtils with SierraConcepts {
 
     }
   }
-
-  // Extract the subdivisions, which come from everything except subfield $a.
-  // These are never identified.  We preserve the order from MARC.
-  private def getSubdivisions(subdivisionSubfields: List[MarcSubfield]): List[MaybeDisplayable[AbstractConcept]] = {
-    subdivisionSubfields.map { subfield =>
-      subfield.tag match {
-        case "v" | "w" => Unidentifiable(Concept(label = subfield.content))
-        case "y" => Unidentifiable(Period(label = subfield.content))
-        case "z" => Unidentifiable(Place(label = subfield.content))
-      }
-    }
-  }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjects.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.transformer.transformers.sierra
 import uk.ac.wellcome.models.work.internal.{AbstractConcept, Concept, MaybeDisplayable, Period, Place, Subject, Unidentifiable}
 import uk.ac.wellcome.transformer.source.{MarcSubfield, SierraBibData}
 
-trait SierraSubjects extends MarcUtils {
+trait SierraSubjects extends MarcUtils with SierraConcepts {
 
   def getSubjects(bibData: SierraBibData)
     : List[Subject[MaybeDisplayable[AbstractConcept]]] = {
@@ -54,7 +54,7 @@ trait SierraSubjects extends MarcUtils {
     subfieldsList.map(subfields => {
       val (primarySubfields, subdivisionSubfields) = subfields.partition { _.tag == "a" }
 
-      val label = getSubjectLabel(primarySubfields, subdivisionSubfields)
+      val label = getLabel(primarySubfields, subdivisionSubfields)
       val concepts: List[MaybeDisplayable[AbstractConcept]] = getPrimaryConcept(marcTag, primarySubfields) ++ getSubdivisions(subdivisionSubfields)
 
       Subject[MaybeDisplayable[AbstractConcept]](
@@ -62,14 +62,6 @@ trait SierraSubjects extends MarcUtils {
         concepts = concepts
       )
     })
-  }
-
-  // Get the subject label.  This is populated by the label of subfield $a, followed
-  // by other subfields, in the order they come from MARC.  The labels are
-  // joined by " - ".
-  private def getSubjectLabel(primarySubfields: List[MarcSubfield], subdivisionSubfields: List[MarcSubfield]): String = {
-    val orderedSubfields = primarySubfields ++ subdivisionSubfields
-    orderedSubfields.map { _.content }.mkString(" - ")
   }
 
   // Extract the primary concept, which comes from subfield $a.  This is the

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenresTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenresTest.scala
@@ -1,15 +1,7 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal.{
-  AbstractConcept,
-  Concept,
-  Genre,
-  MaybeDisplayable,
-  Period,
-  Place,
-  Unidentifiable
-}
+import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.transformer.source.{
   MarcSubfield,
   SierraBibData,
@@ -192,6 +184,58 @@ class SierraGenresTest extends FunSpec with Matchers {
           ))
       )
     assertExtractsGenres(bibData, expectedSubjects)
+  }
+
+  it(s"gets identifiers from subfield $$0") {
+    val bibData = SierraBibData(
+      id = "b3478621",
+      title = Some("Impish iguanas inside igloos"),
+      varFields = List(
+        VarField(
+          fieldTag = "p",
+          marcTag = "655",
+          indicator1 = "",
+
+          // LCSH heading
+          indicator2 = "0",
+          subfields = List(
+            MarcSubfield(tag = "0", content = "lcsh/123")
+          )
+        ),
+        VarField(
+          fieldTag = "p",
+          marcTag = "655",
+          indicator1 = "",
+
+          // MESH heading
+          indicator2 = "2",
+          subfields = List(
+            MarcSubfield(tag = "0", content = "mesh/456")
+          )
+        )
+      )
+    )
+
+    val expectedSourceIdentifiers = List(
+      SourceIdentifier(
+        identifierScheme = IdentifierSchemes.libraryOfCongressSubjectHeadings,
+        value = "lcsh/123",
+        ontologyType = "Concept"
+      ),
+      SourceIdentifier(
+        identifierScheme = IdentifierSchemes.medicalSubjectHeadings,
+        value = "mesh/456",
+        ontologyType = "Concept"
+      )
+    )
+
+    val genre = transformer.getGenres(bibData).head
+    val actualSourceIdentifiers = genre.concepts.map {
+      case Identifiable(_: Concept, sourceIdentifier, _) => sourceIdentifier
+      case other => assert(false, other)
+    }
+
+    expectedSourceIdentifiers shouldBe actualSourceIdentifiers
   }
 
   private val transformer = new SierraGenres {}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenresTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraGenresTest.scala
@@ -195,7 +195,6 @@ class SierraGenresTest extends FunSpec with Matchers {
           fieldTag = "p",
           marcTag = "655",
           indicator1 = "",
-
           // LCSH heading
           indicator2 = "0",
           subfields = List(
@@ -207,7 +206,6 @@ class SierraGenresTest extends FunSpec with Matchers {
           fieldTag = "p",
           marcTag = "655",
           indicator1 = "",
-
           // MESH heading
           indicator2 = "2",
           subfields = List(
@@ -231,7 +229,8 @@ class SierraGenresTest extends FunSpec with Matchers {
       )
     )
 
-    val actualSourceIdentifiers = transformer.getGenres(bibData)
+    val actualSourceIdentifiers = transformer
+      .getGenres(bibData)
       .map { _.concepts.head }
       .map {
         case Identifiable(_: Concept, sourceIdentifier, _) => sourceIdentifier

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjectsTest.scala
@@ -241,23 +241,25 @@ class SierraSubjectsTest extends FunSpec with Matchers {
       varFields = List(
         VarField(
           fieldTag = "p",
-          marcTag = "655",
+          marcTag = "650",
           indicator1 = "",
 
           // LCSH heading
           indicator2 = "0",
           subfields = List(
+            MarcSubfield(tag = "a", content = "absence"),
             MarcSubfield(tag = "0", content = "lcsh/123")
           )
         ),
         VarField(
           fieldTag = "p",
-          marcTag = "655",
+          marcTag = "650",
           indicator1 = "",
 
           // MESH heading
           indicator2 = "2",
           subfields = List(
+            MarcSubfield(tag = "a", content = "abolition"),
             MarcSubfield(tag = "0", content = "mesh/456")
           )
         )
@@ -277,11 +279,12 @@ class SierraSubjectsTest extends FunSpec with Matchers {
       )
     )
 
-    val subject = transformer.getSubjects(bibData).head
-    val actualSourceIdentifiers = subject.concepts.map {
-      case Identifiable(_: Concept, sourceIdentifier, _) => sourceIdentifier
-      case other => assert(false, other)
-    }
+    val actualSourceIdentifiers = transformer.getSubjects(bibData)
+      .map { _.concepts.head }
+      .map {
+        case Identifiable(_: Concept, sourceIdentifier, _) => sourceIdentifier
+        case other => assert(false, other)
+      }
 
     expectedSourceIdentifiers shouldBe actualSourceIdentifiers
   }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjectsTest.scala
@@ -233,6 +233,59 @@ class SierraSubjectsTest extends FunSpec with Matchers {
     )
   }
 
+
+  it(s"gets identifiers from subfield $$0") {
+    val bibData = SierraBibData(
+      id = "b8911791",
+      title = Some("Impish iguanas inside igloos"),
+      varFields = List(
+        VarField(
+          fieldTag = "p",
+          marcTag = "655",
+          indicator1 = "",
+
+          // LCSH heading
+          indicator2 = "0",
+          subfields = List(
+            MarcSubfield(tag = "0", content = "lcsh/123")
+          )
+        ),
+        VarField(
+          fieldTag = "p",
+          marcTag = "655",
+          indicator1 = "",
+
+          // MESH heading
+          indicator2 = "2",
+          subfields = List(
+            MarcSubfield(tag = "0", content = "mesh/456")
+          )
+        )
+      )
+    )
+
+    val expectedSourceIdentifiers = List(
+      SourceIdentifier(
+        identifierScheme = IdentifierSchemes.libraryOfCongressSubjectHeadings,
+        value = "lcsh/123",
+        ontologyType = "Concept"
+      ),
+      SourceIdentifier(
+        identifierScheme = IdentifierSchemes.medicalSubjectHeadings,
+        value = "mesh/456",
+        ontologyType = "Concept"
+      )
+    )
+
+    val subject = transformer.getSubjects(bibData).head
+    val actualSourceIdentifiers = subject.concepts.map {
+      case Identifiable(_: Concept, sourceIdentifier, _) => sourceIdentifier
+      case other => assert(false, other)
+    }
+
+    expectedSourceIdentifiers shouldBe actualSourceIdentifiers
+  }
+
   private val transformer = new SierraSubjects {}
 
   private def assertExtractsSubjects(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjectsTest.scala
@@ -233,7 +233,6 @@ class SierraSubjectsTest extends FunSpec with Matchers {
     )
   }
 
-
   it(s"gets identifiers from subfield $$0") {
     val bibData = SierraBibData(
       id = "b8911791",
@@ -287,6 +286,57 @@ class SierraSubjectsTest extends FunSpec with Matchers {
       }
 
     expectedSourceIdentifiers shouldBe actualSourceIdentifiers
+  }
+
+  it(s"throws an error if it sees an unrecognised identifier scheme") {
+    val bibData = SierraBibData(
+      id = "b1987161",
+      title = Some("Under the universal umbrella"),
+      varFields = List(
+        VarField(
+          fieldTag = "p",
+          marcTag = "650",
+          indicator1 = "",
+          indicator2 = "7",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "absence"),
+            MarcSubfield(tag = "0", content = "u/xxx")
+          )
+        )
+      )
+    )
+
+    val caught = intercept[RuntimeException] {
+      transformer.getSubjects(bibData)
+    }
+
+    caught.getMessage shouldEqual "Unrecognised identifier scheme: 7"
+  }
+
+  it(s"throws an error if it sees too many subfield $$0 instances") {
+    val bibData = SierraBibData(
+      id = "b9171786",
+      title = Some("Zig, zag, zero"),
+      varFields = List(
+        VarField(
+          fieldTag = "p",
+          marcTag = "650",
+          indicator1 = "",
+          indicator2 = "2",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "zany"),
+            MarcSubfield(tag = "0", content = "u/xxx"),
+            MarcSubfield(tag = "0", content = "u/yyy")
+          )
+        )
+      )
+    )
+
+    val caught = intercept[RuntimeException] {
+      transformer.getSubjects(bibData)
+    }
+
+    caught.getMessage shouldEqual "Too many identifiers fields: List(MarcSubfield(0,u/xxx), MarcSubfield(0,u/yyy))"
   }
 
   private val transformer = new SierraSubjects {}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraSubjectsTest.scala
@@ -242,7 +242,6 @@ class SierraSubjectsTest extends FunSpec with Matchers {
           fieldTag = "p",
           marcTag = "650",
           indicator1 = "",
-
           // LCSH heading
           indicator2 = "0",
           subfields = List(
@@ -254,7 +253,6 @@ class SierraSubjectsTest extends FunSpec with Matchers {
           fieldTag = "p",
           marcTag = "650",
           indicator1 = "",
-
           // MESH heading
           indicator2 = "2",
           subfields = List(
@@ -278,7 +276,8 @@ class SierraSubjectsTest extends FunSpec with Matchers {
       )
     )
 
-    val actualSourceIdentifiers = transformer.getSubjects(bibData)
+    val actualSourceIdentifiers = transformer
+      .getSubjects(bibData)
       .map { _.concepts.head }
       .map {
         case Identifiable(_: Concept, sourceIdentifier, _) => sourceIdentifier

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdentifierSchemes.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdentifierSchemes.scala
@@ -50,8 +50,19 @@ object IdentifierSchemes {
     override def toString: String = "marc-countries"
   }
 
+  // Note: these are two different schemes.  The Library of Congress (LC)
+  // publishes Subject Headings and a Name Authority File, and they aren't
+  // the same!
   case object libraryOfCongressNames extends IdentifierScheme {
-    override def toString: String = "lc-names"
+    override def toString: String = "library-of-congress-names"
+  }
+
+  case object libraryOfCongressSubjectHeadings extends IdentifierScheme {
+    override def toString: String = "library-of-congress-subject-headings"
+  }
+
+  case object medicalSubjectHeadings extends IdentifierScheme {
+    override def toString: String = "medical-subject-headings"
   }
 
   private final val knownIdentifierSchemes = Seq(
@@ -62,7 +73,9 @@ object IdentifierSchemes {
     sierraSystemNumber,
     sierraIdentifier,
     libraryOfCongressNames,
-    marcCountries)
+    libraryOfCongressSubjectHeadings,
+    marcCountries,
+    medicalSubjectHeadings)
 
   private def createIdentifierScheme(
     identifierScheme: String): IdentifierSchemes.IdentifierScheme = {

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdentifierSchemes.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdentifierSchemes.scala
@@ -75,7 +75,8 @@ object IdentifierSchemes {
     libraryOfCongressNames,
     libraryOfCongressSubjectHeadings,
     marcCountries,
-    medicalSubjectHeadings)
+    medicalSubjectHeadings
+  )
 
   private def createIdentifierScheme(
     identifierScheme: String): IdentifierSchemes.IdentifierScheme = {


### PR DESCRIPTION
### What is this PR trying to achieve?

Resolves #1959.

This patch:

* Moves a bunch of common code shared between Genre/Subject into a SierraConcepts trait.
* Adds tests that we add identifiers for Concepts
* Add identifiers to the primary concept on a Genre/Subject

I can break it down further if it would be helpful.

### Who is this change for?

🌵 👽 