### PR TITLE
Only bring in the bits of the AWS SDK that we actually use

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -106,7 +106,6 @@ object Dependencies {
   // returns YAML, and currently we use Jackson to parse that YAML.
   // TODO: Rewrite the SNS fixture to use https://github.com/circe/circe-yaml
   val commonMessagingDependencies = commonDependencies ++ jacksonDependencies ++ Seq(
-    "com.amazonaws" % "aws-java-sdk-cloudwatch" % versions.aws,
     "com.amazonaws" % "aws-java-sdk-dynamodb" % versions.aws,
     "com.amazonaws" % "aws-java-sdk-sns" % versions.aws,
     "com.amazonaws" % "aws-java-sdk-sqs" % versions.aws,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,10 +29,6 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-stream" % versions.akka
   )
 
-  val awsDependencies: Seq[ModuleID] = Seq(
-    "com.amazonaws" % "aws-java-sdk" % versions.aws
-  )
-
   val dynamoDependencies: Seq[ModuleID] = Seq(
     "com.gu" %% "scanamo" % versions.scanamo
   )
@@ -109,13 +105,23 @@ object Dependencies {
   // We use Circe for all our JSON serialisation, but our local SNS container
   // returns YAML, and currently we use Jackson to parse that YAML.
   // TODO: Rewrite the SNS fixture to use https://github.com/circe/circe-yaml
-  val commonMessagingDependencies = commonDependencies ++ awsDependencies ++ jacksonDependencies ++ Seq(
+  val commonMessagingDependencies = commonDependencies ++ jacksonDependencies ++ Seq(
+    "com.amazonaws" % "aws-java-sdk-cloudwatch" % versions.aws,
+    "com.amazonaws" % "aws-java-sdk-dynamodb" % versions.aws,
+    "com.amazonaws" % "aws-java-sdk-sns" % versions.aws,
+    "com.amazonaws" % "aws-java-sdk-sqs" % versions.aws,
+    "com.amazonaws" % "aws-java-sdk-s3" % versions.aws,
     "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % versions.akkaStreamAlpakkaS3
   )
 
-  val commonStorageDependencies = commonDependencies ++ awsDependencies ++ dynamoDependencies
+  val commonStorageDependencies = commonDependencies ++ dynamoDependencies ++ Seq(
+    "com.amazonaws" % "aws-java-sdk-dynamodb" % versions.aws,
+    "com.amazonaws" % "aws-java-sdk-s3" % versions.aws
+  )
 
-  val commonMonitoringDependencies = commonDependencies ++ awsDependencies
+  val commonMonitoringDependencies = commonDependencies ++ Seq(
+    "com.amazonaws" % "aws-java-sdk-cloudwatch" % versions.aws
+  )
 
   val sierraAdapterCommonDependencies: Seq[ModuleID] = Seq()
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSWorkerToDynamoTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSWorkerToDynamoTest.scala
@@ -1,12 +1,8 @@
 package uk.ac.wellcome.messaging.sqs
 
 import akka.actor.ActorSystem
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch
-import com.amazonaws.services.cloudwatch.model.PutMetricDataResult
 import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
 import io.circe.Decoder
-import org.mockito.Matchers.any
-import org.mockito.Mockito.when
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.Matchers
@@ -14,6 +10,7 @@ import org.scalatest.FunSpec
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
+import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.test.fixtures._
@@ -31,29 +28,18 @@ class SQSWorkerToDynamoTest
     with Eventually
     with ExtendedPatience
     with Akka
+    with MetricsSenderFixture
     with SQS {
-
-  val mockPutMetricDataResult = mock[PutMetricDataResult]
-  val mockCloudWatch = mock[AmazonCloudWatch]
-
-  when(mockCloudWatch.putMetricData(any())).thenReturn(mockPutMetricDataResult)
-
-  private val metricsSender: MetricsSender =
-    new MetricsSender(
-      "namespace",
-      100 milliseconds,
-      mockCloudWatch,
-      ActorSystem())
 
   val testMessage = TestSqsMessage()
 
   val testMessageJson = toJson(testMessage).get
 
-  class TestWorker(queue: Queue, system: ActorSystem)
+  class TestWorker(metrics: MetricsSender, queue: Queue, system: ActorSystem)
       extends SQSWorkerToDynamo[TestObject](
         new SQSReader(sqsClient, SQSConfig(queue.url, 1.second, 1)),
         system,
-        metricsSender) {
+        metrics) {
 
     override lazy val poll = 100 millisecond
 
@@ -71,31 +57,32 @@ class SQSWorkerToDynamoTest
     }
   }
 
-  type TestWorkerFactory = (Queue, ActorSystem) => TestWorker
+  type TestWorkerFactory = (MetricsSender, Queue, ActorSystem) => TestWorker
 
-  def defaultTestWorkerFactory(queue: Queue, system: ActorSystem) =
-    new TestWorker(queue, system)
+  def defaultTestWorkerFactory(metrics: MetricsSender, queue: Queue, system: ActorSystem) =
+    new TestWorker(metrics, queue, system)
 
-  def conditionalCheckFailingTestWorkerFactory(queue: Queue,
+  def conditionalCheckFailingTestWorkerFactory(metrics: MetricsSender,
+                                               queue: Queue,
                                                system: ActorSystem) =
-    new TestWorker(queue, system) {
+    new TestWorker(metrics, queue, system) {
       override def store(record: TestObject): Future[Unit] = Future {
         throw new ConditionalCheckFailedException("Wrong!")
       }
     }
 
-  def terminalTestWorkerFactory(queue: Queue, system: ActorSystem) =
-    new TestWorker(queue, system) {
+  def terminalTestWorkerFactory(metrics: MetricsSender, queue: Queue, system: ActorSystem) =
+    new TestWorker(metrics, queue, system) {
       override def store(record: TestObject): Future[Unit] = Future {
         throw new RuntimeException("Wrong!")
       }
     }
 
   def withTestWorker[R](
-    testWorkFactory: TestWorkerFactory)(system: ActorSystem, queue: Queue) =
+    testWorkFactory: TestWorkerFactory)(metrics: MetricsSender, queue: Queue, system: ActorSystem) =
     fixture[TestWorker, R](
       create = {
-        testWorkFactory(queue, system)
+        testWorkFactory(metrics, queue, system)
       },
       destroy = { worker =>
         worker.stop()
@@ -106,9 +93,11 @@ class SQSWorkerToDynamoTest
     testWorkFactory: TestWorkerFactory = defaultTestWorkerFactory
   )(testWith: TestWith[(ActorSystem, Queue, TestWorker), R]): R =
     withActorSystem[R] { actorSystem =>
-      withLocalSqsQueue[R] { q =>
-        withTestWorker[R](testWorkFactory)(actorSystem, q) { worker =>
-          testWith((actorSystem, q, worker))
+      withMetricsSender(actorSystem) { metrics =>
+        withLocalSqsQueue[R] { queue =>
+          withTestWorker[R](testWorkFactory)(metrics, queue, actorSystem) { worker =>
+            testWith((actorSystem, queue, worker))
+          }
         }
       }
     }

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSWorkerToDynamoTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSWorkerToDynamoTest.scala
@@ -59,7 +59,9 @@ class SQSWorkerToDynamoTest
 
   type TestWorkerFactory = (MetricsSender, Queue, ActorSystem) => TestWorker
 
-  def defaultTestWorkerFactory(metrics: MetricsSender, queue: Queue, system: ActorSystem) =
+  def defaultTestWorkerFactory(metrics: MetricsSender,
+                               queue: Queue,
+                               system: ActorSystem) =
     new TestWorker(metrics, queue, system)
 
   def conditionalCheckFailingTestWorkerFactory(metrics: MetricsSender,
@@ -71,15 +73,19 @@ class SQSWorkerToDynamoTest
       }
     }
 
-  def terminalTestWorkerFactory(metrics: MetricsSender, queue: Queue, system: ActorSystem) =
+  def terminalTestWorkerFactory(metrics: MetricsSender,
+                                queue: Queue,
+                                system: ActorSystem) =
     new TestWorker(metrics, queue, system) {
       override def store(record: TestObject): Future[Unit] = Future {
         throw new RuntimeException("Wrong!")
       }
     }
 
-  def withTestWorker[R](
-    testWorkFactory: TestWorkerFactory)(metrics: MetricsSender, queue: Queue, system: ActorSystem) =
+  def withTestWorker[R](testWorkFactory: TestWorkerFactory)(
+    metrics: MetricsSender,
+    queue: Queue,
+    system: ActorSystem) =
     fixture[TestWorker, R](
       create = {
         testWorkFactory(metrics, queue, system)
@@ -95,8 +101,9 @@ class SQSWorkerToDynamoTest
     withActorSystem[R] { actorSystem =>
       withMetricsSender(actorSystem) { metrics =>
         withLocalSqsQueue[R] { queue =>
-          withTestWorker[R](testWorkFactory)(metrics, queue, actorSystem) { worker =>
-            testWith((actorSystem, queue, worker))
+          withTestWorker[R](testWorkFactory)(metrics, queue, actorSystem) {
+            worker =>
+              testWith((actorSystem, queue, worker))
           }
         }
       }


### PR DESCRIPTION
### What is this PR trying to achieve?

Reduce the size of the classpath, which means:

* Smaller images in ECR, so faster pushes
* Less stuff in our Travis cache

I don't expect this to make a big difference, but it shouldn't make it worse either!

### Who is this change for?

🛩