### PR TITLE
Strip extra punctuation in identifiers for Sierra contributors

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraContributors.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraContributors.scala
@@ -141,12 +141,19 @@ trait SierraContributors extends MarcUtils {
                           agent: T,
                           ontologyType: String): MaybeDisplayable[T] = {
 
-    // We take the contents of subfield $0.  They may contain inconsistent spacing, such
-    // as " nr 82270463" vs "nr 82270463", which all refer to the same identifier.
+    // We take the contents of subfield $0.  They may contain inconsistent
+    // spacing and punctuation, such as:
     //
-    // For consistency, we remove all whitespace before continuing.
+    //    " nr 82270463"
+    //    "nr 82270463"
+    //    "nr 82270463.,"
+    //
+    // which all refer to the same identifier.
+    //
+    // For consistency, we remove all whitespace and some punctuation
+    // before continuing.
     val codes = subfields.collect {
-      case MarcSubfield("0", content) => content.replaceAll("\\s", "")
+      case MarcSubfield("0", content) => content.replaceAll("[.,\\s]", "")
     }
 
     codes.distinct match {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraContributorsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraContributorsTest.scala
@@ -361,7 +361,8 @@ class SierraContributorsTest extends FunSpec with Matchers {
         expectedContributors = expectedContributors)
     }
 
-    it("combines identifiers with inconsistent spacing/punctuation from subfield $$0") {
+    it(
+      "combines identifiers with inconsistent spacing/punctuation from subfield $$0") {
       val name = "Wanda the watercress"
       val lcshCodeCanonical = "lcsh2055034"
       val lcshCode1 = "lcsh 2055034"

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraContributorsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraContributorsTest.scala
@@ -368,8 +368,8 @@ class SierraContributorsTest extends FunSpec with Matchers {
       val lcshCode2 = "  lcsh2055034 "
       val lcshCode3 = " lc sh 2055034"
 
-      // See Sierra record b3017492
-      val lcshCode4 = "lcsh. 2055034.,"
+      // Based on an example from a real record; see Sierra b3017492.
+      val lcshCode4 = "lcsh 2055034.,"
 
       val varFields = List(
         VarField(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraContributorsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraContributorsTest.scala
@@ -361,12 +361,15 @@ class SierraContributorsTest extends FunSpec with Matchers {
         expectedContributors = expectedContributors)
     }
 
-    it("gets an identifier with inconsistent spacing from subfield $$0") {
+    it("combines identifiers with inconsistent spacing/punctuation from subfield $$0") {
       val name = "Wanda the watercress"
       val lcshCodeCanonical = "lcsh2055034"
       val lcshCode1 = "lcsh 2055034"
       val lcshCode2 = "  lcsh2055034 "
       val lcshCode3 = " lc sh 2055034"
+
+      // See Sierra record b3017492
+      val lcshCode4 = "lcsh. 2055034.,"
 
       val varFields = List(
         VarField(
@@ -378,7 +381,8 @@ class SierraContributorsTest extends FunSpec with Matchers {
             MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "0", content = lcshCode1),
             MarcSubfield(tag = "0", content = lcshCode2),
-            MarcSubfield(tag = "0", content = lcshCode3)
+            MarcSubfield(tag = "0", content = lcshCode3),
+            MarcSubfield(tag = "0", content = lcshCode4)
           )
         )
       )


### PR DESCRIPTION
### What is this PR trying to achieve?

Make sure we can handle seeing full stops and commas in identifiers for Sierra contributors. Resolves #2015.

### Who is this change for?

🍏 🇬🇷 