### PR TITLE
Remove optics from the sbt-common classpath

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,7 +53,6 @@ object Dependencies {
     "io.circe" %% "circe-generic"% versions.circeVersion,
     "io.circe" %% "circe-generic-extras"% versions.circeVersion,
     "io.circe" %% "circe-parser"% versions.circeVersion,
-    "io.circe" %% "circe-optics" % versions.circeVersion,
     "io.circe" %% "circe-java8" % versions.circeVersion
   )
 
@@ -100,7 +99,9 @@ object Dependencies {
 
   val commonDisplayDependencies: Seq[ModuleID] = swaggerDependencies
 
-  val commonElasticsearchDependencies = commonDependencies ++ esDependencies ++ scalacheckDependencies
+  val commonElasticsearchDependencies = commonDependencies ++ esDependencies ++ scalacheckDependencies ++ Seq(
+    "io.circe" %% "circe-optics" % versions.circeVersion
+  )
 
   // We use Circe for all our JSON serialisation, but our local SNS container
   // returns YAML, and currently we use Jackson to parse that YAML.
@@ -122,7 +123,9 @@ object Dependencies {
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % versions.aws
   )
 
-  val sierraAdapterCommonDependencies: Seq[ModuleID] = Seq()
+  val sierraAdapterCommonDependencies = Seq(
+    "io.circe" %% "circe-optics" % versions.circeVersion
+  )
 
   val apiDependencies = commonDependencies ++ commonElasticsearchDependencies
 
@@ -135,7 +138,8 @@ object Dependencies {
   val ingestorDependencies = commonDependencies ++ commonElasticsearchDependencies
 
   val idminterDependencies = commonDependencies ++ mysqlDependencies ++ Seq(
-    "com.amazonaws" % "aws-java-sdk-rds" % versions.aws
+    "com.amazonaws" % "aws-java-sdk-rds" % versions.aws,
+    "io.circe" %% "circe-optics" % versions.circeVersion
   )
 
   val reindexerDependencies: Seq[ModuleID] = commonDependencies

--- a/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/models/SierraRecord.scala
+++ b/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/models/SierraRecord.scala
@@ -1,10 +1,11 @@
-package uk.ac.wellcome.models.transformable.sierra
+package uk.ac.wellcome.sierra_adapter.models
 
 import java.time.Instant
 
 import io.circe.optics.JsonPath.root
 import io.circe.parser._
 import cats.syntax.either._
+import uk.ac.wellcome.models.transformable.sierra.{SierraBibRecord, SierraItemRecord}
 
 import scala.util.Try
 

--- a/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/models/SierraRecord.scala
+++ b/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/models/SierraRecord.scala
@@ -5,7 +5,10 @@ import java.time.Instant
 import io.circe.optics.JsonPath.root
 import io.circe.parser._
 import cats.syntax.either._
-import uk.ac.wellcome.models.transformable.sierra.{SierraBibRecord, SierraItemRecord}
+import uk.ac.wellcome.models.transformable.sierra.{
+  SierraBibRecord,
+  SierraItemRecord
+}
 
 import scala.util.Try
 

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/models/SierraRecordTest.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/models/SierraRecordTest.scala
@@ -1,9 +1,10 @@
-package uk.ac.wellcome.models.transformable.sierra
+package uk.ac.wellcome.sierra_adapter.models
 
 import java.time.Instant
 
 import io.circe.ParsingFailure
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 
 import scala.util.{Failure, Success}
 

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerService.scala
@@ -4,11 +4,11 @@ import akka.actor.ActorSystem
 import com.google.inject.Inject
 import io.circe.Decoder
 import uk.ac.wellcome.messaging.sqs.{SQSReader, SQSWorkerToDynamo}
-import uk.ac.wellcome.models.transformable.sierra.SierraRecord
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import io.circe.generic.extras.semiauto._
 import uk.ac.wellcome.monitoring.MetricsSender
+import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 
 import scala.concurrent.Future
 

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerService.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerService.scala
@@ -6,11 +6,11 @@ import io.circe.Decoder
 import uk.ac.wellcome.messaging.sqs.SQSWorkerToDynamo
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.messaging.sqs.SQSReader
-import uk.ac.wellcome.models.transformable.sierra.SierraRecord
 import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.utils.GlobalExecutionContext._
 import io.circe.generic.extras.semiauto._
 import uk.ac.wellcome.monitoring.MetricsSender
+import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 
 import scala.concurrent.Future
 

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
@@ -10,10 +10,8 @@ import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.messaging.sqs.SQSMessage
 import uk.ac.wellcome.messaging.test.fixtures.SQS
-import uk.ac.wellcome.models.transformable.sierra.{
-  SierraItemRecord,
-  SierraRecord
-}
+import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
+import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -7,18 +7,16 @@ import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSMessage, SQSReader}
 import uk.ac.wellcome.test.utils.ExtendedPatience
-import uk.ac.wellcome.models.transformable.sierra.{
-  SierraItemRecord,
-  SierraRecord
-}
 import com.gu.scanamo.syntax._
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
+import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.fixtures.DynamoInserterFixture
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.merger.SierraItemRecordMerger
+import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
@@ -8,7 +8,7 @@ import akka.stream.scaladsl.Flow
 import com.twitter.inject.Logging
 import io.circe.Json
 import io.circe.optics.JsonPath.root
-import uk.ac.wellcome.models.transformable.sierra.SierraRecord
+import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 
 import scala.concurrent.ExecutionContext
 

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
@@ -8,7 +8,7 @@ import org.apache.commons.io.IOUtils
 import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.models.transformable.sierra.SierraRecord
+import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlowTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlowTest.scala
@@ -9,7 +9,7 @@ import io.circe.parser._
 import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.transformable.sierra.SierraRecord
+import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -6,8 +6,8 @@ import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.models.transformable.sierra.SierraRecord
 import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
+import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -8,9 +8,9 @@ import org.scalatest.FunSpec
 import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.models.transformable.sierra.SierraRecord
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.sierra_reader.modules.WindowManager
+import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket


### PR DESCRIPTION
### What is this PR trying to achieve?

Per the commit messages:

> **Move SierraRecord into the sierra_adapter common lib**
>
> This model is internal to the Sierra adapter pipeline -- by the time it reaches the VHS, it's been coerced into a BibRecord or an ItemRecord. It doesn't need to be available to the transformer or other applications.

> **Move optics out of the sbt-common classpath**
>
> Now that SierraRecord is out of sbt-common, we don't need optics everywhere.  Since it brings in a dependency on Scalaz and cats, there's likely a small benefit to getting it out of some of our applications.

Will this make a massive difference to build times? Unlikely. But it continues to reduce the footprint of sbt-common.

### Who is this change for?

🚢 🤖