### PR TITLE
Remove our Jackson dependency from sbt-messaging

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -110,7 +110,8 @@ object Dependencies {
     "com.amazonaws" % "aws-java-sdk-sns" % versions.aws,
     "com.amazonaws" % "aws-java-sdk-sqs" % versions.aws,
     "com.amazonaws" % "aws-java-sdk-s3" % versions.aws,
-    "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % versions.akkaStreamAlpakkaS3
+    "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % versions.akkaStreamAlpakkaS3,
+    "io.circe" %% "circe-yaml" % "0.8.0"
   )
 
   val commonStorageDependencies = commonDependencies ++ dynamoDependencies ++ Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,6 @@ object Dependencies {
     val junitInterface = "0.11"
     val elastic4s = "5.6.5"
     val scanamo = "1.0.0-M3"
-    val jacksonYamlVersion = "2.8.8"
     val circeVersion = "0.9.0"
     val scalaCheckVersion = "1.13.4"
     val scalaCheckShapelessVersion = "1.1.6"
@@ -55,10 +54,6 @@ object Dependencies {
     "io.circe" %% "circe-parser"% versions.circeVersion,
     "io.circe" %% "circe-optics" % versions.circeVersion,
     "io.circe" %% "circe-java8" % versions.circeVersion
-  )
-
-  val jacksonDependencies = Seq(
-    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % versions.jacksonYamlVersion % " test"
   )
 
   val swaggerDependencies = Seq(
@@ -102,10 +97,7 @@ object Dependencies {
 
   val commonElasticsearchDependencies = commonDependencies ++ esDependencies ++ scalacheckDependencies
 
-  // We use Circe for all our JSON serialisation, but our local SNS container
-  // returns YAML, and currently we use Jackson to parse that YAML.
-  // TODO: Rewrite the SNS fixture to use https://github.com/circe/circe-yaml
-  val commonMessagingDependencies = commonDependencies ++ jacksonDependencies ++ Seq(
+  val commonMessagingDependencies = commonDependencies ++ Seq(
     "com.amazonaws" % "aws-java-sdk-dynamodb" % versions.aws,
     "com.amazonaws" % "aws-java-sdk-sns" % versions.aws,
     "com.amazonaws" % "aws-java-sdk-sqs" % versions.aws,

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
@@ -4,14 +4,13 @@ import com.amazonaws.services.sns._
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.auth.AWSStaticCredentialsProvider
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe._
+import io.circe.yaml
+import io.circe.generic.extras.JsonKey
+import io.circe.generic.semiauto._
 import uk.ac.wellcome.test.fixtures._
 
+import scala.collection.immutable.Seq
 import scala.util.Random
 
 object SNS {
@@ -86,12 +85,9 @@ trait SNS {
     }
   )
 
-  private val mapper =
-    (new ObjectMapper(new YAMLFactory()) with ScalaObjectMapper)
-      .registerModule(DefaultScalaModule)
-      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+  implicit val decoder: Decoder[MessageInfo] = deriveDecoder[MessageInfo]
 
-  def listMessagesReceivedFromSNS(topic: Topic): List[MessageInfo] = {
+  def listMessagesReceivedFromSNS(topic: Topic): Seq[MessageInfo] = {
     /*
     This is a sample returned by the fake-sns implementation:
     ---
@@ -103,23 +99,30 @@ trait SNS {
     messages:
     - :id: acbca1e1-e3c5-4c74-86af-06a9418e8fe4
       :subject: Foo
-  :message: '{"identifiers":[{"source":"Miro","sourceId":"MiroID","value":"1234"}],"title":"some
-    image title","accessStatus":null}'
-  :topic_arn: arn:aws:sns:us-east-1:123456789012:id_minter
-  :structure:
-  :target_arn:
-  :received_at: 2017-04-18 13:20:45.289912607 +00:00
+      :message: '{"identifiers":[{"source":"Miro","sourceId":"MiroID","value":"1234"}],"title":"some
+        image title","accessStatus":null}'
+      :topic_arn: arn:aws:sns:us-east-1:123456789012:id_minter
+      :structure:
+      :target_arn:
+      :received_at: 2017-04-18 13:20:45.289912607 +00:00
      */
-
     val string = scala.io.Source.fromURL(localSNSEndpointUrl).mkString
-    val messages = mapper.readValue(string, classOf[Messages])
-    messages.messages.filter(_.topic_arn == topic.arn)
+
+    val jsons: Either[ParsingFailure, Json] = yaml.parser.parse(string)
+
+    val allMessages = jsons
+      .right.get
+      .\\("messages")
+      .map { _.as[MessageInfo].right.get }
+
+    allMessages
+      .filter { _.topicArn == topic.arn }
   }
 }
 
-case class Messages(topics: List[TopicInfo], messages: List[MessageInfo])
-case class TopicInfo(arn: String, name: String)
-case class MessageInfo(@JsonProperty(":id") messageId: String,
-                       @JsonProperty(":message") message: String,
-                       @JsonProperty(":subject") subject: String,
-                       @JsonProperty(":topic_arn") topic_arn: String)
+case class MessageInfo(
+  @JsonKey(":id") messageId: String,
+  @JsonKey(":message") message: String,
+  @JsonKey(":subject") subject: String,
+  @JsonKey(":topic_arn") topicArn: String
+)

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
@@ -85,12 +85,14 @@ trait SNS {
   )
 
   implicit val topicInfoDecoder: Decoder[TopicInfo] = deriveDecoder[TopicInfo]
-  implicit val snsResponseDecoder: Decoder[SNSResponse] = deriveDecoder[SNSResponse]
+  implicit val snsResponseDecoder: Decoder[SNSResponse] =
+    deriveDecoder[SNSResponse]
 
   // For some reason, Circe struggles to decode MessageInfo if you use @JsonKey
   // to annotate the fields, and I don't care enough to work out why right now.
-  implicit val messageInfoDecoder: Decoder[MessageInfo] = Decoder.forProduct4(
-    ":id", ":message", ":subject", ":topic_arn")(MessageInfo.apply)
+  implicit val messageInfoDecoder: Decoder[MessageInfo] =
+    Decoder.forProduct4(":id", ":message", ":subject", ":topic_arn")(
+      MessageInfo.apply)
 
   def listMessagesReceivedFromSNS(topic: Topic): Seq[MessageInfo] = {
     /*
@@ -115,13 +117,12 @@ trait SNS {
 
     val json: Either[ParsingFailure, Json] = yaml.parser.parse(string)
 
-    val snsResponse: SNSResponse = json
-      .right.get
+    val snsResponse: SNSResponse = json.right.get
       .as[SNSResponse]
-      .right.get
+      .right
+      .get
 
-    snsResponse
-      .messages
+    snsResponse.messages
       .filter { _.topicArn == topic.arn }
   }
 }


### PR DESCRIPTION
This one’s been on my hit list for a while; a last use of Jackson to parse the YAML we get from the SNS container we use in tests. Long live Circe!