### PR TITLE
Separate an SQSStream from MessageStream

### DIFF
--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageStream.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageStream.scala
@@ -1,23 +1,16 @@
 package uk.ac.wellcome.messaging.message
 
-import akka.Done
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings, Supervision}
-import akka.stream.alpakka.sqs.MessageAction
-import akka.stream.alpakka.sqs.scaladsl.{SqsAckSink, SqsSource}
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs
 import com.amazonaws.services.sqs.AmazonSQSAsync
-import com.amazonaws.services.sqs.model.Message
 import com.google.inject.Inject
-import grizzled.slf4j.Logging
 import io.circe.Decoder
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.storage.s3.S3ObjectStore
-import uk.ac.wellcome.utils.JsonUtil.fromJson
-import uk.ac.wellcome.utils.JsonUtil._
+import uk.ac.wellcome.utils.JsonUtil.{fromJson, _}
 
 import scala.concurrent.Future
 
@@ -26,60 +19,19 @@ class MessageStream[T] @Inject()(actorSystem: ActorSystem,
                                  s3Client: AmazonS3,
                                  messageReaderConfig: MessageReaderConfig,
                                  metricsSender: MetricsSender)
-    extends Logging {
-  val decider: Supervision.Decider = {
-    case _: Exception => Supervision.Resume
-    case _ => Supervision.Stop
-  }
-  implicit val system = actorSystem
-  implicit val materializer = ActorMaterializer(
-    ActorMaterializerSettings(system).withSupervisionStrategy(decider))
-  implicit val dispatcher = system.dispatcher
+    extends SQSStream[T](
+      actorSystem = actorSystem,
+      sqsClient = sqsClient,
+      sqsConfig = messageReaderConfig.sqsConfig,
+      metricsSender = metricsSender
+    ) {
 
   val s3ObjectStore = new S3ObjectStore[T](
     s3Client = s3Client,
     s3Config = messageReaderConfig.s3Config
   )
 
-  def foreach(streamName: String, process: T => Future[Unit])(
-    implicit decoderT: Decoder[T]): Future[Done] =
-    SqsSource(messageReaderConfig.sqsConfig.queueUrl)(sqsClient)
-      .mapAsyncUnordered(10) { message =>
-        val metricName = s"${streamName}_ProcessMessage"
-        metricsSender.timeAndCount(
-          metricName,
-          () => readAndProcess(streamName, message, process))
-      }
-      .map { m =>
-        (m, MessageAction.Delete)
-      }
-      .runWith(SqsAckSink(messageReaderConfig.sqsConfig.queueUrl)(sqsClient))
-
-  private def readAndProcess(
-    streamName: String,
-    message: Message,
-    process: T => Future[Unit])(implicit decoderT: Decoder[T]) = {
-    val processMessageFuture = for {
-      t <- read(message)
-      _ <- process(t)
-    } yield message
-
-    processMessageFuture.onFailure {
-      case exception: GracefulFailureException =>
-        logger.warn(s"Failure processing message", exception)
-      case exception: Exception =>
-        logger.error(s"Failure while processing message.", exception)
-        metricsSender.incrementCount(
-          s"${streamName}_MessageProcessingFailure",
-          1.0)
-    }
-    processMessageFuture
-  }
-
-  private def read(message: sqs.model.Message)(
-    implicit decoderN: Decoder[NotificationMessage],
-    decoderT: Decoder[T]
-  ): Future[T] = {
+  override def read(message: sqs.model.Message)(implicit decoderT: Decoder[T]): Future[T] = {
     val deserialisedMessagePointerAttempt = for {
       notification <- fromJson[NotificationMessage](message.getBody)
       deserialisedMessagePointer <- fromJson[MessagePointer](
@@ -92,5 +44,4 @@ class MessageStream[T] @Inject()(actorSystem: ActorSystem,
       deserialisedObject <- s3ObjectStore.get(messagePointer.src)
     } yield deserialisedObject
   }
-
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
@@ -1,0 +1,70 @@
+package uk.ac.wellcome.messaging.sqs
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.stream.alpakka.sqs.MessageAction
+import akka.stream.alpakka.sqs.scaladsl.{SqsAckSink, SqsSource}
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings, Supervision}
+import com.amazonaws.services.sqs
+import com.amazonaws.services.sqs.AmazonSQSAsync
+import com.amazonaws.services.sqs.model.Message
+import com.google.inject.Inject
+import grizzled.slf4j.Logging
+import io.circe.Decoder
+import uk.ac.wellcome.exceptions.GracefulFailureException
+import uk.ac.wellcome.monitoring.MetricsSender
+import uk.ac.wellcome.utils.JsonUtil.fromJson
+
+import scala.concurrent.Future
+
+class SQSStream[T] @Inject()(
+  actorSystem: ActorSystem,
+  sqsClient: AmazonSQSAsync,
+  sqsConfig: SQSConfig,
+  metricsSender: MetricsSender) extends Logging {
+
+  val decider: Supervision.Decider = {
+    case _: Exception => Supervision.Resume
+    case _ => Supervision.Stop
+  }
+  implicit val system = actorSystem
+  implicit val materializer = ActorMaterializer(
+    ActorMaterializerSettings(system).withSupervisionStrategy(decider))
+  implicit val dispatcher = system.dispatcher
+
+  def foreach(streamName: String, process: T => Future[Unit])(
+    implicit decoderT: Decoder[T]): Future[Done] =
+    SqsSource(sqsConfig.queueUrl)(sqsClient)
+      .mapAsyncUnordered(10) { message =>
+        val metricName = s"${streamName}_ProcessMessage"
+        metricsSender.timeAndCount(
+          metricName,
+          () => readAndProcess(streamName, message, process))
+      }
+      .map { m =>
+        (m, MessageAction.Delete)
+      }
+      .runWith(SqsAckSink(sqsConfig.queueUrl)(sqsClient))
+
+  private def readAndProcess(
+    streamName: String,
+    message: Message,
+    process: T => Future[Unit])(implicit decoderT: Decoder[T]) = {
+    val processMessageFuture = for {
+      t <- read(message)
+      _ <- process(t)
+    } yield message
+
+    processMessageFuture.onFailure {
+      case exception: GracefulFailureException =>
+        logger.warn(s"Failure processing message", exception)
+      case exception: Exception =>
+        logger.error(s"Failure while processing message.", exception)
+        metricsSender.incrementCount(s"${streamName}_MessageProcessingFailure")
+    }
+    processMessageFuture
+  }
+
+  protected def read(message: sqs.model.Message)(implicit decoderT: Decoder[T]): Future[T] =
+    Future.fromTry(fromJson[T](message.getBody))
+}

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
@@ -60,7 +60,10 @@ class SQSStream[T] @Inject()(
         logger.warn(s"Failure processing message", exception)
       case exception: Exception =>
         logger.error(s"Failure while processing message.", exception)
-        metricsSender.incrementCount(s"${streamName}_MessageProcessingFailure")
+        metricsSender.incrementCount(
+          metricName = s"${streamName}_MessageProcessingFailure",
+          count = 1.0
+        )
     }
     processMessageFuture
   }

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
@@ -1,0 +1,171 @@
+package uk.ac.wellcome.messaging.sqs
+
+import java.util.concurrent.ConcurrentLinkedQueue
+
+import org.mockito.Matchers.{any, anyDouble, endsWith, eq => equalTo}
+import org.mockito.Mockito.{never, times, verify}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.messaging.test.fixtures.Messaging
+import uk.ac.wellcome.messaging.test.fixtures.SQS.{Queue, QueuePair}
+import uk.ac.wellcome.monitoring.MetricsSender
+import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
+import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
+import uk.ac.wellcome.test.utils.ExtendedPatience
+import uk.ac.wellcome.utils.JsonUtil._
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class SQSStreamTest
+    extends FunSpec
+    with Matchers
+    with Messaging
+    with Akka
+    with ScalaFutures
+    with ExtendedPatience
+    with MetricsSenderFixture {
+
+  def process(list: ConcurrentLinkedQueue[ExampleObject])(o: ExampleObject) = {
+    list.add(o)
+    Future.successful(())
+  }
+
+  it("reads messages off a queue, processes them and deletes them") {
+    withSQSStreamFixtures {
+      case (messageStream, QueuePair(queue, dlq), _) =>
+        val exampleObject1 = ExampleObject("Example value 1")
+        sendMessage(queue, exampleObject1)
+
+        val exampleObject2 = ExampleObject("Example value 2")
+        sendMessage(queue, exampleObject2)
+
+        val received = new ConcurrentLinkedQueue[ExampleObject]()
+
+        messageStream.foreach(
+          streamName = "test-stream",
+          process = process(received))
+
+        eventually {
+          received should contain theSameElementsAs List(
+            exampleObject1,
+            exampleObject2)
+
+          assertQueueEmpty(queue)
+          assertQueueEmpty(dlq)
+        }
+    }
+
+  }
+
+  it("increments *_ProcessMessage metric when successful") {
+    withSQSStreamFixtures {
+      case (messageStream, QueuePair(queue, _), metricsSender) =>
+        val exampleObject = ExampleObject("An example value")
+        sendMessage(queue, exampleObject)
+
+        val received = new ConcurrentLinkedQueue[ExampleObject]()
+        messageStream.foreach(
+          streamName = "test-stream",
+          process = process(received))
+
+        eventually {
+          verify(metricsSender, times(1)).timeAndCount(
+            equalTo("test-stream_ProcessMessage"),
+            any[() => Future[Unit]]())
+        }
+    }
+  }
+
+  it("fails gracefully when the object cannot be deserialised") {
+    withSQSStreamFixtures {
+      case (messageStream, QueuePair(queue, dlq), metricsSender) =>
+        sqsClient.sendMessage(
+          queue.url,
+          "not valid json"
+        )
+
+        val received = new ConcurrentLinkedQueue[ExampleObject]()
+
+        messageStream.foreach(
+          streamName = "test-stream",
+          process = process(received))
+
+        eventually {
+
+          verify(metricsSender, never())
+            .incrementCount(endsWith("_MessageProcessingFailure"), anyDouble())
+          received shouldBe empty
+
+          assertQueueEmpty(queue)
+          assertQueueHasSize(dlq, size = 1)
+        }
+    }
+  }
+
+  it("continues reading if processing of some messages fails") {
+    withSQSStreamFixtures {
+      case (messageStream, QueuePair(queue, dlq), _) =>
+        val exampleObject1 = ExampleObject("some value 1")
+        val exampleObject2 = ExampleObject("some value 2")
+
+        sqsClient.sendMessage(
+          queue.url,
+          "not valid json"
+        )
+
+        sendMessage(queue, exampleObject1)
+
+        sqsClient.sendMessage(
+          queue.url,
+          "another not valid json"
+        )
+
+        sendMessage(queue, exampleObject2)
+
+        val received = new ConcurrentLinkedQueue[ExampleObject]()
+        messageStream.foreach(
+          streamName = "test-stream",
+          process = process(received))
+
+        eventually {
+          received should contain theSameElementsAs List(
+            exampleObject1,
+            exampleObject2)
+
+          assertQueueEmpty(queue)
+          assertQueueHasSize(dlq, size = 2)
+        }
+    }
+  }
+
+  private def sendMessage(queue: Queue, obj: ExampleObject) =
+    sqsClient.sendMessage(queue.url, toJson(obj).get)
+
+  def withSQSStreamFixtures[R](
+    testWith: TestWith[(SQSStream[ExampleObject],
+                        QueuePair,
+                        MetricsSender),
+                       R]) = {
+
+    withActorSystem { actorSystem =>
+      withLocalSqsQueueAndDlq {
+        case queuePair @ QueuePair(queue, _) =>
+          withMockMetricSender { metricsSender =>
+            val sqsConfig = SQSConfig(
+              queueUrl = queue.url,
+              waitTime = 1 millisecond,
+              maxMessages = 1
+            )
+
+            val stream = new SQSStream[ExampleObject](
+              actorSystem = actorSystem,
+              sqsClient = asyncSqsClient,
+              sqsConfig = sqsConfig,
+              metricsSender = metricsSender)
+            testWith((stream, queuePair, metricsSender))
+          }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

Currently we have a MessageStream class, which streams message pointers from SQS and fetches the associated object from S3.

This PR pulls out the SQS streaming logic, so we can reuse it in other applications where we want to read from SQS with backpressure. It's mostly a copy-and-paste of code from MessageStream into a new class, with tests likewise copied and tweaked only slightly.

### Who is this change for?

Me, as I want to make the Sierra readers backpressure-aware.