### PR TITLE
Use streams to get SQS messages in the Sierra reader

### DIFF
--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/SierraReaderModule.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/SierraReaderModule.scala
@@ -34,9 +34,6 @@ object SierraReaderModule extends TwitterModule {
     info("Terminating Sierra Bibs to SNS worker")
 
     val system = injector.instance[ActorSystem]
-    val workerService = injector.instance[SierraReaderWorkerService]
-
-    workerService.stop()
     system.terminate()
   }
 

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -7,19 +7,22 @@ import com.amazonaws.services.s3.model.PutObjectResult
 import com.google.inject.Inject
 import com.twitter.inject.Logging
 import com.twitter.inject.annotations.Flag
-import io.circe.syntax._
 import uk.ac.wellcome.messaging.sqs._
 import uk.ac.wellcome.platform.sierra_reader.flow.SierraRecordWrapperFlow
 import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
-import uk.ac.wellcome.platform.sierra_reader.modules.{WindowManager, WindowStatus}
-import uk.ac.wellcome.platform.sierra_reader.sink.SequentialS3Sink
 import uk.ac.wellcome.sierra.{SierraSource, ThrottleRate}
 import uk.ac.wellcome.sierra_adapter.services.WindowExtractor
 import uk.ac.wellcome.storage.s3.S3Config
+import io.circe.syntax._
 import uk.ac.wellcome.utils.JsonUtil._
+import uk.ac.wellcome.platform.sierra_reader.modules.{
+  WindowManager,
+  WindowStatus
+}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import uk.ac.wellcome.platform.sierra_reader.sink.SequentialS3Sink
 
 class SierraReaderWorkerService @Inject()(
   system: ActorSystem,

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.sierra_reader.services
 
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.PutObjectResult
 import com.google.inject.Inject
@@ -20,6 +22,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class SierraReaderWorkerService @Inject()(
+  system: ActorSystem,
   sqsStream: SQSStream[String],
   windowManager: WindowManager,
   s3client: AmazonS3,
@@ -31,6 +34,10 @@ class SierraReaderWorkerService @Inject()(
   @Flag("sierra.oauthSecret") sierraOauthSecret: String,
   @Flag("sierra.fields") fields: String
 ) extends Logging {
+
+  implicit val actorSystem = system
+  implicit val materialiser = ActorMaterializer()
+  implicit val executionContext = system.dispatcher
 
   // This is the throttle rate for requests to Sierra, *not* the rate at
   // which we fetch messages from SQS.

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -250,6 +250,14 @@ class SierraReaderWorkerServiceTest
           |}
         """.stripMargin
 
+      val sqsMessage =
+        SQSMessage(
+          Some("subject"),
+          message,
+          "topic",
+          "messageType",
+          "timestamp")
+
       whenReady(fixtures.worker.processMessage(message).failed) { ex =>
         ex shouldBe a[GracefulFailureException]
       }
@@ -271,6 +279,13 @@ class SierraReaderWorkerServiceTest
           |}
         """.stripMargin
 
+      val sqsMessage =
+        SQSMessage(
+          Some("subject"),
+          message,
+          "topic",
+          "messageType",
+          "timestamp")
 
       whenReady(fixtures.worker.processMessage(message).failed) { ex =>
         ex shouldNot be(a[GracefulFailureException])

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -1,25 +1,27 @@
 package uk.ac.wellcome.platform.sierra_reader.services
 
-import org.scalatest.{FunSpec, Matchers}
-import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import uk.ac.wellcome.exceptions.GracefulFailureException
+import org.scalatest.Matchers
 import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSMessage, SQSStream}
-import uk.ac.wellcome.messaging.test.fixtures.SQS
-import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
+import uk.ac.wellcome.test.utils.ExtendedPatience
+import org.scalatest.FunSpec
+import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
+import uk.ac.wellcome.utils.JsonUtil._
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
-import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
 import uk.ac.wellcome.platform.sierra_reader.modules.WindowManager
 import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
-import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
-import uk.ac.wellcome.test.utils.ExtendedPatience
-import uk.ac.wellcome.utils.JsonUtil._
 
-import scala.collection.JavaConversions._
 import scala.concurrent.duration._
+import org.scalatest.compatible.Assertion
+import uk.ac.wellcome.messaging.test.fixtures.SQS
+import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
+import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
+
+import collection.JavaConversions._
 
 class SierraReaderWorkerServiceTest
     extends FunSpec
@@ -257,7 +259,6 @@ class SierraReaderWorkerServiceTest
           "topic",
           "messageType",
           "timestamp")
-
       whenReady(fixtures.worker.processMessage(sqsMessage).failed) { ex =>
         ex shouldBe a[GracefulFailureException]
       }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -258,7 +258,7 @@ class SierraReaderWorkerServiceTest
           "messageType",
           "timestamp")
 
-      whenReady(fixtures.worker.processMessage(message).failed) { ex =>
+      whenReady(fixtures.worker.processMessage(sqsMessage).failed) { ex =>
         ex shouldBe a[GracefulFailureException]
       }
 
@@ -287,7 +287,7 @@ class SierraReaderWorkerServiceTest
           "messageType",
           "timestamp")
 
-      whenReady(fixtures.worker.processMessage(message).failed) { ex =>
+      whenReady(fixtures.worker.processMessage(sqsMessage).failed) { ex =>
         ex shouldNot be(a[GracefulFailureException])
       }
     }


### PR DESCRIPTION
### What is this PR trying to achieve?

An attempt at #2016. My theory is that the Sierra reader is getting messages off the queue too quickly, hammering Sierra with requests, which struggles to keep out and times out all the requests. Everything hangs on the queue, then reappears at the same time. Repeat.

Using streams should cause us to process from SQS at a closer speed to Sierra.

### Who is this change for?

🔑 ⌨️ 