### PR TITLE
Share AWS builder methods between client modules and fixtures; take another step away from Finatra

### DIFF
--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/modules/AkkaS3ClientModule.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/modules/AkkaS3ClientModule.scala
@@ -42,25 +42,34 @@ object AkkaS3ClientModule extends TwitterModule {
   @Singleton
   @Provides
   def providesAkkaS3Client(awsConfig: AWSConfig,
-                           actorSystem: ActorSystem): S3Client = {
+                           actorSystem: ActorSystem): S3Client =
+    buildAkkaS3Client(
+      awsConfig = awsConfig,
+      actorSystem = actorSystem,
+      endpoint = endpoint(),
+      accessKey = accessKey(),
+      secretKey = secretKey()
+    )
+
+  def buildAkkaS3Client(awsConfig: AWSConfig, actorSystem: ActorSystem, endpoint: String, accessKey: String, secretKey: String): S3Client = {
     val regionProvider =
       new AwsRegionProvider {
         def getRegion: String = awsConfig.region
       }
 
-    val credentialsProvider = if (endpoint().isEmpty) {
+    val credentialsProvider = if (endpoint.isEmpty) {
       DefaultAWSCredentialsProviderChain.getInstance()
     } else {
       new AWSStaticCredentialsProvider(
-        new BasicAWSCredentials(accessKey(), secretKey())
+        new BasicAWSCredentials(accessKey, secretKey)
       )
     }
 
     val actorMaterializer = ActorMaterializer()(actorSystem)
-    val endpointUrl = if (endpoint().isEmpty) {
+    val endpointUrl = if (endpoint.isEmpty) {
       None
     } else {
-      Some(endpoint())
+      Some(endpoint)
     }
 
     val settings = akkaS3Settings(

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/modules/AkkaS3ClientModule.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/modules/AkkaS3ClientModule.scala
@@ -51,7 +51,11 @@ object AkkaS3ClientModule extends TwitterModule {
       secretKey = secretKey()
     )
 
-  def buildAkkaS3Client(awsConfig: AWSConfig, actorSystem: ActorSystem, endpoint: String, accessKey: String, secretKey: String): S3Client = {
+  def buildAkkaS3Client(awsConfig: AWSConfig,
+                        actorSystem: ActorSystem,
+                        endpoint: String,
+                        accessKey: String,
+                        secretKey: String): S3Client = {
     val regionProvider =
       new AwsRegionProvider {
         def getRegion: String = awsConfig.region

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/finatra/modules/ElasticClientModule.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/finatra/modules/ElasticClientModule.scala
@@ -37,11 +37,20 @@ object ElasticClientModule extends TwitterModule {
   @Provides
   def provideElasticClient(): HttpClient = {
     info(s"Building clientUri for ${host()}:${port()}")
+    buildElasticClient(
+      host = host(),
+      port = port(),
+      protocol = protocol(),
+      username = username(),
+      password = password()
+    )
+  }
 
+  def buildElasticClient(host: String, port: Int, protocol: String, username: String, password: String): HttpClient = {
     val restClient = RestClient
-      .builder(new HttpHost(host(), port(), protocol()))
+      .builder(new HttpHost(host, port, protocol))
       .setHttpClientConfigCallback(
-        new ElasticCredentials(username(), password()))
+        new ElasticCredentials(username, password))
       // Needed for the snapshot_generator.
       // TODO Make this a flag
       .setMaxRetryTimeoutMillis(2000)

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/finatra/modules/ElasticClientModule.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/finatra/modules/ElasticClientModule.scala
@@ -46,11 +46,14 @@ object ElasticClientModule extends TwitterModule {
     )
   }
 
-  def buildElasticClient(host: String, port: Int, protocol: String, username: String, password: String): HttpClient = {
+  def buildElasticClient(host: String,
+                         port: Int,
+                         protocol: String,
+                         username: String,
+                         password: String): HttpClient = {
     val restClient = RestClient
       .builder(new HttpHost(host, port, protocol))
-      .setHttpClientConfigCallback(
-        new ElasticCredentials(username, password))
+      .setHttpClientConfigCallback(new ElasticCredentials(username, password))
       // Needed for the snapshot_generator.
       // TODO Make this a flag
       .setMaxRetryTimeoutMillis(2000)

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -2,12 +2,10 @@ package uk.ac.wellcome.elasticsearch.test.fixtures
 
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.HttpClient
-import org.apache.http.HttpHost
-import org.elasticsearch.client.RestClient
 import org.elasticsearch.index.VersionType
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{Matchers, Suite}
-import uk.ac.wellcome.elasticsearch.finatra.modules.ElasticCredentials
+import uk.ac.wellcome.elasticsearch.finatra.modules.ElasticClientModule
 import uk.ac.wellcome.elasticsearch.{ElasticSearchIndex, WorksIndex}
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.test.fixtures.TestWith
@@ -25,26 +23,27 @@ trait ElasticsearchFixtures
     with JsonTestUtil { this: Suite =>
 
   private val esHost = "localhost"
-  private val esPort = "9200"
+  private val esPort = 9200
   private val esName = "wellcome"
 
   def esLocalFlags(indexNameV1: String,
                    indexNameV2: String,
                    itemType: String) = Map(
     "es.host" -> esHost,
-    "es.port" -> esPort,
+    "es.port" -> esPort.toString,
     "es.name" -> esName,
     "es.index.v1" -> indexNameV1,
     "es.index.v2" -> indexNameV2,
     "es.type" -> itemType
   )
 
-  val restClient: RestClient = RestClient
-    .builder(new HttpHost("localhost", 9200, "http"))
-    .setHttpClientConfigCallback(new ElasticCredentials("elastic", "changeme"))
-    .build()
-
-  val elasticClient: HttpClient = HttpClient.fromRestClient(restClient)
+  val elasticClient: HttpClient = ElasticClientModule.buildElasticClient(
+    host = esHost,
+    port = esPort,
+    protocol = "http",
+    username = "elastic",
+    password = "changeme"
+  )
 
   // Elasticsearch takes a while to start up so check that it actually started before running tests
   eventually {

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSClientModule.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSClientModule.scala
@@ -22,19 +22,26 @@ object SNSClientModule extends TwitterModule {
 
   @Singleton
   @Provides
-  def providesSNSClient(awsConfig: AWSConfig): AmazonSNS = {
-    val standardSnsClient = AmazonSNSClientBuilder.standard
-    if (snsEndpoint().isEmpty)
-      standardSnsClient
+  def providesSNSClient(awsConfig: AWSConfig): AmazonSNS =
+    buildSNSClient(
+      awsConfig = awsConfig,
+      endpoint = snsEndpoint(),
+      accessKey = accessKey(),
+      secretKey = secretKey()
+    )
+
+  def buildSNSClient(awsConfig: AWSConfig, endpoint: String, accessKey: String, secretKey: String): AmazonSNS = {
+    val standardClient = AmazonSNSClientBuilder.standard
+    if (endpoint.isEmpty)
+      standardClient
         .withRegion(awsConfig.region)
         .build()
     else
-      standardSnsClient
-        .withCredentials(
-          new AWSStaticCredentialsProvider(
-            new BasicAWSCredentials(accessKey(), secretKey())))
+      standardClient
+        .withCredentials(new AWSStaticCredentialsProvider(
+          new BasicAWSCredentials(accessKey, secretKey)))
         .withEndpointConfiguration(
-          new EndpointConfiguration(snsEndpoint(), awsConfig.region))
+          new EndpointConfiguration(endpoint, awsConfig.region))
         .build()
   }
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSClientModule.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSClientModule.scala
@@ -30,7 +30,10 @@ object SNSClientModule extends TwitterModule {
       secretKey = secretKey()
     )
 
-  def buildSNSClient(awsConfig: AWSConfig, endpoint: String, accessKey: String, secretKey: String): AmazonSNS = {
+  def buildSNSClient(awsConfig: AWSConfig,
+                     endpoint: String,
+                     accessKey: String,
+                     secretKey: String): AmazonSNS = {
     val standardClient = AmazonSNSClientBuilder.standard
     if (endpoint.isEmpty)
       standardClient
@@ -38,8 +41,9 @@ object SNSClientModule extends TwitterModule {
         .build()
     else
       standardClient
-        .withCredentials(new AWSStaticCredentialsProvider(
-          new BasicAWSCredentials(accessKey, secretKey)))
+        .withCredentials(
+          new AWSStaticCredentialsProvider(
+            new BasicAWSCredentials(accessKey, secretKey)))
         .withEndpointConfiguration(
           new EndpointConfiguration(endpoint, awsConfig.region))
         .build()

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSClientModule.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSClientModule.scala
@@ -25,36 +25,51 @@ object SQSClientModule extends TwitterModule {
 
   @Singleton
   @Provides
-  def providesSQSClient(awsConfig: AWSConfig): AmazonSQS = {
-    val sqsClientBuilder = AmazonSQSClientBuilder.standard
-    if (sqsEndpoint().isEmpty)
-      sqsClientBuilder
+  def providesSQSClient(awsConfig: AWSConfig): AmazonSQS =
+    buildSQSClient(
+      awsConfig = awsConfig,
+      endpoint = sqsEndpoint(),
+      accessKey = accessKey(),
+      secretKey = secretKey()
+    )
+
+  def buildSQSClient(awsConfig: AWSConfig, endpoint: String, accessKey: String, secretKey: String): AmazonSQS = {
+    val standardClient = AmazonSQSClientBuilder.standard
+    if (endpoint.isEmpty)
+      standardClient
         .withRegion(awsConfig.region)
         .build()
     else
-      sqsClientBuilder
-        .withEndpointConfiguration(
-          new EndpointConfiguration(sqsEndpoint(), awsConfig.region))
+      standardClient
         .withCredentials(new AWSStaticCredentialsProvider(
-          new BasicAWSCredentials(accessKey(), secretKey())))
+          new BasicAWSCredentials(accessKey, secretKey)))
+        .withEndpointConfiguration(
+          new EndpointConfiguration(endpoint, awsConfig.region))
         .build()
   }
 
   @Singleton
   @Provides
-  def providesSQSAsyncClient(awsConfig: AWSConfig): AmazonSQSAsync = {
-    val sqsClientBuilder = AmazonSQSAsyncClientBuilder.standard
-    if (sqsEndpoint().isEmpty)
-      sqsClientBuilder
+  def providesSQSAsyncClient(awsConfig: AWSConfig): AmazonSQSAsync =
+    buildSQSAsyncClient(
+      awsConfig = awsConfig,
+      endpoint = sqsEndpoint(),
+      accessKey = accessKey(),
+      secretKey = secretKey()
+    )
+
+  def buildSQSAsyncClient(awsConfig: AWSConfig, endpoint: String, accessKey: String, secretKey: String): AmazonSQSAsync = {
+    val standardClient = AmazonSQSAsyncClientBuilder.standard
+    if (endpoint.isEmpty)
+      standardClient
         .withRegion(awsConfig.region)
         .build()
     else
-      sqsClientBuilder
-        .withEndpointConfiguration(
-          new EndpointConfiguration(sqsEndpoint(), awsConfig.region))
+      standardClient
         .withCredentials(new AWSStaticCredentialsProvider(
-          new BasicAWSCredentials(accessKey(), secretKey())))
+          new BasicAWSCredentials(accessKey, secretKey)))
+        .withEndpointConfiguration(
+          new EndpointConfiguration(endpoint, awsConfig.region))
         .build()
   }
-
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSClientModule.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSClientModule.scala
@@ -33,7 +33,10 @@ object SQSClientModule extends TwitterModule {
       secretKey = secretKey()
     )
 
-  def buildSQSClient(awsConfig: AWSConfig, endpoint: String, accessKey: String, secretKey: String): AmazonSQS = {
+  def buildSQSClient(awsConfig: AWSConfig,
+                     endpoint: String,
+                     accessKey: String,
+                     secretKey: String): AmazonSQS = {
     val standardClient = AmazonSQSClientBuilder.standard
     if (endpoint.isEmpty)
       standardClient
@@ -41,8 +44,9 @@ object SQSClientModule extends TwitterModule {
         .build()
     else
       standardClient
-        .withCredentials(new AWSStaticCredentialsProvider(
-          new BasicAWSCredentials(accessKey, secretKey)))
+        .withCredentials(
+          new AWSStaticCredentialsProvider(
+            new BasicAWSCredentials(accessKey, secretKey)))
         .withEndpointConfiguration(
           new EndpointConfiguration(endpoint, awsConfig.region))
         .build()
@@ -58,7 +62,10 @@ object SQSClientModule extends TwitterModule {
       secretKey = secretKey()
     )
 
-  def buildSQSAsyncClient(awsConfig: AWSConfig, endpoint: String, accessKey: String, secretKey: String): AmazonSQSAsync = {
+  def buildSQSAsyncClient(awsConfig: AWSConfig,
+                          endpoint: String,
+                          accessKey: String,
+                          secretKey: String): AmazonSQSAsync = {
     val standardClient = AmazonSQSAsyncClientBuilder.standard
     if (endpoint.isEmpty)
       standardClient
@@ -66,8 +73,9 @@ object SQSClientModule extends TwitterModule {
         .build()
     else
       standardClient
-        .withCredentials(new AWSStaticCredentialsProvider(
-          new BasicAWSCredentials(accessKey, secretKey)))
+        .withCredentials(
+          new AWSStaticCredentialsProvider(
+            new BasicAWSCredentials(accessKey, secretKey)))
         .withEndpointConfiguration(
           new EndpointConfiguration(endpoint, awsConfig.region))
         .build()

--- a/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/CloudWatchClientModule.scala
+++ b/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/CloudWatchClientModule.scala
@@ -1,10 +1,7 @@
 package uk.ac.wellcome.monitoring
 
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.cloudwatch.{
-  AmazonCloudWatch,
-  AmazonCloudWatchClientBuilder
-}
+import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
 import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.finatra.modules.AWSConfigModule
@@ -20,16 +17,22 @@ object CloudWatchClientModule extends TwitterModule {
 
   @Provides
   @Singleton
-  def providesAmazonCloudWatch(awsConfig: AWSConfig): AmazonCloudWatch = {
+  def providesAmazonCloudWatch(awsConfig: AWSConfig): AmazonCloudWatch =
+    buildCloudWatchClient(
+      awsConfig = awsConfig,
+      endpoint = endpoint()
+    )
+
+  def buildCloudWatchClient(awsConfig: AWSConfig, endpoint: String): AmazonCloudWatch = {
     val standardClient = AmazonCloudWatchClientBuilder.standard
-    if (endpoint().isEmpty)
+    if (endpoint.isEmpty)
       standardClient
         .withRegion(awsConfig.region)
         .build()
     else
       standardClient
         .withEndpointConfiguration(
-          new EndpointConfiguration(endpoint(), awsConfig.region))
+          new EndpointConfiguration(endpoint, awsConfig.region))
         .build()
   }
 }

--- a/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/CloudWatchClientModule.scala
+++ b/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/CloudWatchClientModule.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.monitoring
 
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
+import com.amazonaws.services.cloudwatch.{
+  AmazonCloudWatch,
+  AmazonCloudWatchClientBuilder
+}
 import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.finatra.modules.AWSConfigModule
@@ -23,7 +26,8 @@ object CloudWatchClientModule extends TwitterModule {
       endpoint = endpoint()
     )
 
-  def buildCloudWatchClient(awsConfig: AWSConfig, endpoint: String): AmazonCloudWatch = {
+  def buildCloudWatchClient(awsConfig: AWSConfig,
+                            endpoint: String): AmazonCloudWatch = {
     val standardClient = AmazonCloudWatchClientBuilder.standard
     if (endpoint.isEmpty)
       standardClient

--- a/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/CloudWatch.scala
+++ b/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/CloudWatch.scala
@@ -1,11 +1,8 @@
 package uk.ac.wellcome.monitoring.test.fixtures
 
-import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.cloudwatch.{
-  AmazonCloudWatch,
-  AmazonCloudWatchClientBuilder
-}
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import uk.ac.wellcome.models.aws.AWSConfig
+import uk.ac.wellcome.monitoring.CloudWatchClientModule
 
 import scala.concurrent.duration._
 
@@ -17,22 +14,13 @@ trait CloudWatch {
 
   protected val flushInterval: FiniteDuration = 1 second
 
-  private val accessKey: String = "accessKey1"
-  private val secretKey: String = "verySecretKey1"
-
   def cloudWatchLocalFlags =
     Map(
       "aws.cloudWatch.endpoint" -> localCloudWatchEndpointUrl
     )
 
-  private val credentials = new AWSStaticCredentialsProvider(
-    new BasicAWSCredentials(accessKey, secretKey))
-
-  val cloudWatchClient: AmazonCloudWatch = AmazonCloudWatchClientBuilder
-    .standard()
-    .withCredentials(credentials)
-    .withEndpointConfiguration(
-      new EndpointConfiguration(localCloudWatchEndpointUrl, regionName))
-    .build()
-
+  val cloudWatchClient: AmazonCloudWatch = CloudWatchClientModule.buildCloudWatchClient(
+    awsConfig = AWSConfig(region = regionName),
+    endpoint = localCloudWatchEndpointUrl
+  )
 }

--- a/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/CloudWatch.scala
+++ b/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/CloudWatch.scala
@@ -19,8 +19,9 @@ trait CloudWatch {
       "aws.cloudWatch.endpoint" -> localCloudWatchEndpointUrl
     )
 
-  val cloudWatchClient: AmazonCloudWatch = CloudWatchClientModule.buildCloudWatchClient(
-    awsConfig = AWSConfig(region = regionName),
-    endpoint = localCloudWatchEndpointUrl
-  )
+  val cloudWatchClient: AmazonCloudWatch =
+    CloudWatchClientModule.buildCloudWatchClient(
+      awsConfig = AWSConfig(region = regionName),
+      endpoint = localCloudWatchEndpointUrl
+    )
 }

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoClientModule.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoClientModule.scala
@@ -32,7 +32,10 @@ object DynamoClientModule extends TwitterModule {
       secretKey = secretKey()
     )
 
-  def buildDynamoClient(awsConfig: AWSConfig, endpoint: String, accessKey: String, secretKey: String): AmazonDynamoDB = {
+  def buildDynamoClient(awsConfig: AWSConfig,
+                        endpoint: String,
+                        accessKey: String,
+                        secretKey: String): AmazonDynamoDB = {
     val standardClient = AmazonDynamoDBClientBuilder.standard
     if (endpoint.isEmpty)
       standardClient
@@ -40,8 +43,9 @@ object DynamoClientModule extends TwitterModule {
         .build()
     else
       standardClient
-        .withCredentials(new AWSStaticCredentialsProvider(
-          new BasicAWSCredentials(accessKey, secretKey)))
+        .withCredentials(
+          new AWSStaticCredentialsProvider(
+            new BasicAWSCredentials(accessKey, secretKey)))
         .withEndpointConfiguration(
           new EndpointConfiguration(endpoint, awsConfig.region))
         .build()

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoClientModule.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoClientModule.scala
@@ -24,19 +24,26 @@ object DynamoClientModule extends TwitterModule {
 
   @Singleton
   @Provides
-  def providesDynamoClient(awsConfig: AWSConfig): AmazonDynamoDB = {
+  def providesDynamoClient(awsConfig: AWSConfig): AmazonDynamoDB =
+    buildDynamoClient(
+      awsConfig = awsConfig,
+      endpoint = dynamoDbEndpoint(),
+      accessKey = accessKey(),
+      secretKey = secretKey()
+    )
+
+  def buildDynamoClient(awsConfig: AWSConfig, endpoint: String, accessKey: String, secretKey: String): AmazonDynamoDB = {
     val standardClient = AmazonDynamoDBClientBuilder.standard
-    if (dynamoDbEndpoint().isEmpty)
+    if (endpoint.isEmpty)
       standardClient
         .withRegion(awsConfig.region)
         .build()
     else
       standardClient
-        .withCredentials(
-          new AWSStaticCredentialsProvider(
-            new BasicAWSCredentials(accessKey(), secretKey())))
+        .withCredentials(new AWSStaticCredentialsProvider(
+          new BasicAWSCredentials(accessKey, secretKey)))
         .withEndpointConfiguration(
-          new EndpointConfiguration(dynamoDbEndpoint(), awsConfig.region))
+          new EndpointConfiguration(endpoint, awsConfig.region))
         .build()
   }
 }

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3ClientModule.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3ClientModule.scala
@@ -29,7 +29,10 @@ object S3ClientModule extends TwitterModule {
       secretKey = secretKey()
     )
 
-  def buildS3Client(awsConfig: AWSConfig, endpoint: String, accessKey: String, secretKey: String): AmazonS3 = {
+  def buildS3Client(awsConfig: AWSConfig,
+                    endpoint: String,
+                    accessKey: String,
+                    secretKey: String): AmazonS3 = {
     val standardClient = AmazonS3ClientBuilder.standard
     if (endpoint.isEmpty)
       standardClient

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3ClientModule.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3ClientModule.scala
@@ -21,19 +21,27 @@ object S3ClientModule extends TwitterModule {
 
   @Singleton
   @Provides
-  def providesS3Client(awsConfig: AWSConfig): AmazonS3 = {
+  def providesS3Client(awsConfig: AWSConfig): AmazonS3 =
+    buildS3Client(
+      awsConfig = awsConfig,
+      endpoint = endpoint(),
+      accessKey = accessKey(),
+      secretKey = secretKey()
+    )
+
+  def buildS3Client(awsConfig: AWSConfig, endpoint: String, accessKey: String, secretKey: String): AmazonS3 = {
     val standardClient = AmazonS3ClientBuilder.standard
-    if (endpoint().isEmpty)
+    if (endpoint.isEmpty)
       standardClient
         .withRegion(awsConfig.region)
         .build()
     else
       standardClient
         .withCredentials(new AWSStaticCredentialsProvider(
-          new BasicAWSCredentials(accessKey(), secretKey())))
+          new BasicAWSCredentials(accessKey, secretKey)))
         .withPathStyleAccessEnabled(true)
         .withEndpointConfiguration(
-          new EndpointConfiguration(endpoint(), awsConfig.region))
+          new EndpointConfiguration(endpoint, awsConfig.region))
         .build()
   }
 

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/S3.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/S3.scala
@@ -1,14 +1,13 @@
 package uk.ac.wellcome.storage.test.fixtures
 
-import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.services.s3.AmazonS3
 import com.twitter.inject.Logging
 import io.circe.Json
 import io.circe.parser.parse
 import org.apache.commons.io.IOUtils
-import org.scalatest.Matchers
 import org.scalatest.concurrent.Eventually
+import uk.ac.wellcome.models.aws.AWSConfig
+import uk.ac.wellcome.storage.s3.S3ClientModule
 import uk.ac.wellcome.test.fixtures._
 
 import scala.collection.JavaConversions._
@@ -44,19 +43,15 @@ trait S3 extends Logging with Eventually {
     "aws.s3.endpoint" -> localS3EndpointUrl,
     "aws.s3.accessKey" -> accessKey,
     "aws.s3.secretKey" -> secretKey,
-    "aws.region" -> "localhost"
+    "aws.region" -> regionName
   )
 
-  private val credentials = new AWSStaticCredentialsProvider(
-    new BasicAWSCredentials(accessKey, secretKey))
-
-  val s3Client: AmazonS3 = AmazonS3ClientBuilder
-    .standard()
-    .withPathStyleAccessEnabled(true)
-    .withCredentials(credentials)
-    .withEndpointConfiguration(
-      new EndpointConfiguration(localS3EndpointUrl, regionName))
-    .build()
+  val s3Client: AmazonS3 = S3ClientModule.buildS3Client(
+    awsConfig = AWSConfig(region = regionName),
+    endpoint = localS3EndpointUrl,
+    accessKey = accessKey,
+    secretKey = secretKey
+  )
 
   def withLocalS3Bucket[R] =
     fixture[Bucket, R](


### PR DESCRIPTION
### What is this PR trying to achieve?

All of our AWS client modules now have a `builds()` and a `provides()` method, the former of which can be reused in fixtures for consistent behaviour and configuration.

This means we simplify our fixture code, and take one more step away from relying on Finatra everywhere.

### Who is this change for?

🌐 🌏 