### PR TITLE
Split out concept identifiers as a separate object

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConceptIdentifier.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConceptIdentifier.scala
@@ -3,6 +3,22 @@ package uk.ac.wellcome.transformer.transformers.sierra
 import uk.ac.wellcome.models.work.internal.{IdentifierSchemes, SourceIdentifier}
 import uk.ac.wellcome.transformer.source.{MarcSubfield, VarField}
 
+// Implements logic for finding a source identifier for varFields with
+// MARC tag 648, 650, 651 and 655.  These are the fields we use for genre
+// and subject.
+//
+// The rules for these identifiers is moderately fiddly:
+//
+//   - Look in indicator 2.  Values 0 to 6 have hard-coded meanings.
+//   - If indicator 2 is 7, look in subfield $2 instead.
+//
+// The rules are the same for all four MARC tags, hence the shared object.
+//
+// https://www.loc.gov/marc/bibliographic/bd648.html
+// https://www.loc.gov/marc/bibliographic/bd650.html
+// https://www.loc.gov/marc/bibliographic/bd651.html
+// https://www.loc.gov/marc/bibliographic/bd655.html
+//
 object SierraConceptIdentifier {
 
   def maybeFindIdentifier(

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConceptIdentifier.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConceptIdentifier.scala
@@ -1,0 +1,35 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+import uk.ac.wellcome.models.work.internal.{IdentifierSchemes, SourceIdentifier}
+import uk.ac.wellcome.transformer.source.{MarcSubfield, VarField}
+
+object SierraConceptIdentifier {
+
+  def maybeFindIdentifier(
+    varField: VarField,
+    identifierSubfield: MarcSubfield,
+    ontologyType: String): Option[SourceIdentifier] = {
+
+    // The mapping from indicator 2 to the identifier scheme is provided
+    // by the MARC spec.
+    // https://www.loc.gov/marc/bibliographic/bd655.html
+    val maybeIdentifierScheme = varField.indicator2 match {
+      case None => None
+      case Some("0") =>
+        Some(IdentifierSchemes.libraryOfCongressSubjectHeadings)
+      case Some("2") => Some(IdentifierSchemes.medicalSubjectHeadings)
+      case Some(scheme) =>
+        throw new RuntimeException(s"Unrecognised identifier scheme: $scheme")
+    }
+
+    maybeIdentifierScheme match {
+      case None => None
+      case Some(identifierScheme) =>
+        Some(SourceIdentifier(
+          identifierScheme = identifierScheme,
+          value = identifierSubfield.content,
+          ontologyType = ontologyType
+        ))
+    }
+  }
+}

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConceptIdentifier.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConceptIdentifier.scala
@@ -1,6 +1,9 @@
 package uk.ac.wellcome.transformer.transformers.sierra
 
-import uk.ac.wellcome.models.work.internal.{IdentifierSchemes, SourceIdentifier}
+import uk.ac.wellcome.models.work.internal.{
+  IdentifierSchemes,
+  SourceIdentifier
+}
 import uk.ac.wellcome.transformer.source.{MarcSubfield, VarField}
 
 // Implements logic for finding a source identifier for varFields with
@@ -21,10 +24,9 @@ import uk.ac.wellcome.transformer.source.{MarcSubfield, VarField}
 //
 object SierraConceptIdentifier {
 
-  def maybeFindIdentifier(
-    varField: VarField,
-    identifierSubfield: MarcSubfield,
-    ontologyType: String): Option[SourceIdentifier] = {
+  def maybeFindIdentifier(varField: VarField,
+                          identifierSubfield: MarcSubfield,
+                          ontologyType: String): Option[SourceIdentifier] = {
 
     // The mapping from indicator 2 to the identifier scheme is provided
     // by the MARC spec.
@@ -35,17 +37,19 @@ object SierraConceptIdentifier {
         Some(IdentifierSchemes.libraryOfCongressSubjectHeadings)
       case Some("2") => Some(IdentifierSchemes.medicalSubjectHeadings)
       case Some(scheme) =>
-        throw new RuntimeException(s"Unrecognised identifier scheme: $scheme (${varField.subfields})")
+        throw new RuntimeException(
+          s"Unrecognised identifier scheme: $scheme (${varField.subfields})")
     }
 
     maybeIdentifierScheme match {
       case None => None
       case Some(identifierScheme) =>
-        Some(SourceIdentifier(
-          identifierScheme = identifierScheme,
-          value = identifierSubfield.content,
-          ontologyType = ontologyType
-        ))
+        Some(
+          SourceIdentifier(
+            identifierScheme = identifierScheme,
+            value = identifierSubfield.content,
+            ontologyType = ontologyType
+          ))
     }
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConceptIdentifier.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConceptIdentifier.scala
@@ -19,7 +19,7 @@ object SierraConceptIdentifier {
         Some(IdentifierSchemes.libraryOfCongressSubjectHeadings)
       case Some("2") => Some(IdentifierSchemes.medicalSubjectHeadings)
       case Some(scheme) =>
-        throw new RuntimeException(s"Unrecognised identifier scheme: $scheme")
+        throw new RuntimeException(s"Unrecognised identifier scheme: $scheme (${varField.subfields})")
     }
 
     maybeIdentifierScheme match {

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -42,12 +42,6 @@ trait SierraConcepts extends MarcUtils {
     }
   }
 
-  protected def maybeFindIdentifier(
-    varField: VarField,
-    identifierSubfield: MarcSubfield): Some[SourceIdentifier] = {
-
-  }
-
   // If there's exactly one subfield $0 on the VarField, add an identifier
   // if possible.
   private def maybeAddIdentifier[T <: AbstractConcept](

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConcepts.scala
@@ -42,40 +42,32 @@ trait SierraConcepts extends MarcUtils {
     }
   }
 
+  protected def maybeFindIdentifier(
+    varField: VarField,
+    identifierSubfield: MarcSubfield): Some[SourceIdentifier] = {
+
+  }
+
   // If there's exactly one subfield $0 on the VarField, add an identifier
   // if possible.
   private def maybeAddIdentifier[T <: AbstractConcept](
     concept: T,
     varField: VarField,
     identifierSubfield: MarcSubfield): MaybeDisplayable[T] = {
+    val maybeSourceIdentifier = SierraConceptIdentifier.maybeFindIdentifier(
+      varField = varField,
+      identifierSubfield = identifierSubfield,
+      ontologyType = concept.ontologyType
+    )
 
-    // The mapping from indicator 2 to the identifier scheme is provided
-    // by the MARC spec.
-    // https://www.loc.gov/marc/bibliographic/bd655.html
-    val maybeIdentifierScheme = varField.indicator2 match {
-      case None => None
-      case Some("0") =>
-        Some(IdentifierSchemes.libraryOfCongressSubjectHeadings)
-      case Some("2") => Some(IdentifierSchemes.medicalSubjectHeadings)
-      case Some(scheme) =>
-        throw new RuntimeException(s"Unrecognised identifier scheme: $scheme")
-    }
-
-    maybeIdentifierScheme match {
+    maybeSourceIdentifier match {
       case None => Unidentifiable(agent = concept)
-      case Some(identifierScheme) => {
-        val sourceIdentifier = SourceIdentifier(
-          identifierScheme = identifierScheme,
-          value = identifierSubfield.content,
-          ontologyType = concept.ontologyType
-        )
-
+      case Some(sourceIdentifier) =>
         Identifiable(
           agent = concept,
           sourceIdentifier = sourceIdentifier,
           identifiers = List(sourceIdentifier)
         )
-      }
     }
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConceptIdentifierTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConceptIdentifierTest.scala
@@ -1,0 +1,105 @@
+package uk.ac.wellcome.transformer.transformers.sierra
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.transformer.source.{
+  MarcSubfield,
+  SierraBibData,
+  VarField
+}
+
+class SierraConceptIdentifierTest extends FunSpec with Matchers {
+
+  it("finds an LCSH identifier") {
+    val varField = baseVarField.copy(indicator2 = Some("0"))
+    val identifierSubfield = MarcSubfield(tag = "0", content = "lcsh/123")
+
+    val expectedSourceIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.libraryOfCongressSubjectHeadings,
+      value = "lcsh/123",
+      ontologyType = ontologyType
+    )
+
+    val actualSourceIdentifier = SierraConceptIdentifier.maybeFindIdentifier(
+      varField = varField,
+      identifierSubfield = identifierSubfield,
+      ontologyType = ontologyType
+    ).get
+
+    actualSourceIdentifier shouldBe expectedSourceIdentifier
+  }
+
+  it("finds a MESH identifier") {
+    val varField = baseVarField.copy(indicator2 = Some("2"))
+    val identifierSubfield = MarcSubfield(tag = "0", content = "mesh/456")
+
+    val expectedSourceIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.medicalSubjectHeadings,
+      value = "mesh/456",
+      ontologyType = ontologyType
+    )
+
+    val actualSourceIdentifier = SierraConceptIdentifier.maybeFindIdentifier(
+      varField = varField,
+      identifierSubfield = identifierSubfield,
+      ontologyType = ontologyType
+    ).get
+
+    actualSourceIdentifier shouldBe expectedSourceIdentifier
+  }
+
+  it("returns None if indicator 2 is empty") {
+    val varField = baseVarField.copy(indicator2 = None)
+    val identifierSubfield = MarcSubfield(tag = "0", content = "lcsh/789")
+
+    SierraConceptIdentifier.maybeFindIdentifier(
+      varField = varField,
+      identifierSubfield = identifierSubfield,
+      ontologyType = ontologyType
+    ) shouldBe None
+  }
+
+  it("throws an exception if it sees an unrecognised identifier scheme") {
+    val varField = baseVarField.copy(indicator2 = Some("8"))
+    val identifierSubfield = MarcSubfield(tag = "0", content = "u/xxx")
+
+    val caught = intercept[RuntimeException] {
+      SierraConceptIdentifier.maybeFindIdentifier(
+        varField = varField,
+        identifierSubfield = identifierSubfield,
+        ontologyType = ontologyType
+      )
+    }
+
+    caught.getMessage shouldEqual "Unrecognised identifier scheme: 8"
+  }
+
+  it("passes through the ontology type") {
+    val varField = baseVarField.copy(indicator2 = Some("2"))
+    val identifierSubfield = MarcSubfield(tag = "0", content = "mesh/456")
+
+    val expectedSourceIdentifier = SourceIdentifier(
+      identifierScheme = IdentifierSchemes.medicalSubjectHeadings,
+      value = "mesh/456",
+      ontologyType = "Item"
+    )
+
+    val actualSourceIdentifier = SierraConceptIdentifier.maybeFindIdentifier(
+      varField = varField,
+      identifierSubfield = identifierSubfield,
+      ontologyType = "Item
+    ).get
+
+    actualSourceIdentifier shouldBe expectedSourceIdentifier
+  }
+
+  val ontologyType = "Concept"
+
+  val baseVarField = VarField(
+    fieldTag = "p",
+    marcTag = "655",
+    indicator1 = "",
+    indicator2 = "",
+    subfields = List()
+  )
+}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConceptIdentifierTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConceptIdentifierTest.scala
@@ -87,7 +87,7 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
     val actualSourceIdentifier = SierraConceptIdentifier.maybeFindIdentifier(
       varField = varField,
       identifierSubfield = identifierSubfield,
-      ontologyType = "Item
+      ontologyType = "Item"
     ).get
 
     actualSourceIdentifier shouldBe expectedSourceIdentifier

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConceptIdentifierTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConceptIdentifierTest.scala
@@ -20,11 +20,13 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
       ontologyType = ontologyType
     )
 
-    val actualSourceIdentifier = SierraConceptIdentifier.maybeFindIdentifier(
-      varField = varField,
-      identifierSubfield = identifierSubfield,
-      ontologyType = ontologyType
-    ).get
+    val actualSourceIdentifier = SierraConceptIdentifier
+      .maybeFindIdentifier(
+        varField = varField,
+        identifierSubfield = identifierSubfield,
+        ontologyType = ontologyType
+      )
+      .get
 
     actualSourceIdentifier shouldBe expectedSourceIdentifier
   }
@@ -39,11 +41,13 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
       ontologyType = ontologyType
     )
 
-    val actualSourceIdentifier = SierraConceptIdentifier.maybeFindIdentifier(
-      varField = varField,
-      identifierSubfield = identifierSubfield,
-      ontologyType = ontologyType
-    ).get
+    val actualSourceIdentifier = SierraConceptIdentifier
+      .maybeFindIdentifier(
+        varField = varField,
+        identifierSubfield = identifierSubfield,
+        ontologyType = ontologyType
+      )
+      .get
 
     actualSourceIdentifier shouldBe expectedSourceIdentifier
   }
@@ -87,11 +91,13 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
       ontologyType = "Item"
     )
 
-    val actualSourceIdentifier = SierraConceptIdentifier.maybeFindIdentifier(
-      varField = varField,
-      identifierSubfield = identifierSubfield,
-      ontologyType = "Item"
-    ).get
+    val actualSourceIdentifier = SierraConceptIdentifier
+      .maybeFindIdentifier(
+        varField = varField,
+        identifierSubfield = identifierSubfield,
+        ontologyType = "Item"
+      )
+      .get
 
     actualSourceIdentifier shouldBe expectedSourceIdentifier
   }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConceptIdentifierTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/transformer/transformers/sierra/SierraConceptIdentifierTest.scala
@@ -60,8 +60,11 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
   }
 
   it("throws an exception if it sees an unrecognised identifier scheme") {
-    val varField = baseVarField.copy(indicator2 = Some("8"))
     val identifierSubfield = MarcSubfield(tag = "0", content = "u/xxx")
+    val varField = baseVarField.copy(
+      indicator2 = Some("8"),
+      subfields = List(identifierSubfield)
+    )
 
     val caught = intercept[RuntimeException] {
       SierraConceptIdentifier.maybeFindIdentifier(
@@ -71,7 +74,7 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
       )
     }
 
-    caught.getMessage shouldEqual "Unrecognised identifier scheme: 8"
+    caught.getMessage shouldEqual s"Unrecognised identifier scheme: ${varField.indicator2.get} (${varField.subfields})"
   }
 
   it("passes through the ontology type") {


### PR DESCRIPTION
### What is this PR trying to achieve?

The logic for identifiers on concepts is about to get even more complicated, as I need to start looking at ind2=7 and then subfield $2.

Rather than test it through the lenses of Genres/Subject, I'm putting it in its own object with dedicated tests.

This PR just rearranges the existing logic; adding new logic will come separately.

### Who is this change for?

🆔 