### PR TITLE
The caller of this function already wraps it in eventually { ... }

### DIFF
--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -145,14 +145,12 @@ class IdMinterFeatureTest
     // TODO Write this test using dead letter queues once https://github.com/adamw/elasticmq/issues/69 is closed
     Thread.sleep(2000)
 
-    eventually {
-      sqsClient
-        .getQueueAttributes(
-          queue.url,
-          List("ApproximateNumberOfMessagesNotVisible").asJava
-        )
-        .getAttributes
-        .get("ApproximateNumberOfMessagesNotVisible") shouldBe "1"
-    }
+    sqsClient
+      .getQueueAttributes(
+        queue.url,
+        List("ApproximateNumberOfMessagesNotVisible").asJava
+      )
+      .getAttributes
+      .get("ApproximateNumberOfMessagesNotVisible") shouldBe "1"
   }
 }


### PR DESCRIPTION
Tiny cleanup spotted while looking at #2039. No idea if it’ll make a difference to reliability.