### PR TITLE
Split S3ObjectStore into a StringStore and a TypedObjectStore

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/SQSMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/SQSMessageReceiver.scala
@@ -16,7 +16,7 @@ import uk.ac.wellcome.models.transformable.{
 }
 import uk.ac.wellcome.models.work.internal.UnidentifiedWork
 import uk.ac.wellcome.monitoring.MetricsSender
-import uk.ac.wellcome.storage.s3.{S3Config, S3ObjectStore}
+import uk.ac.wellcome.storage.s3.{S3Config, S3TypedObjectStore}
 import uk.ac.wellcome.storage.vhs.HybridRecord
 import uk.ac.wellcome.platform.transformer.transformers.{
   CalmTransformableTransformer,
@@ -68,13 +68,13 @@ class SQSMessageReceiver @Inject()(
   ) = {
     sourceMetadata.sourceName match {
       case "miro" =>
-        S3ObjectStore.get[MiroTransformable](s3Client, s3Config.bucketName)(
+        S3TypedObjectStore.get[MiroTransformable](s3Client, s3Config.bucketName)(
           hybridRecord.s3key)
       case "calm" =>
-        S3ObjectStore.get[CalmTransformable](s3Client, s3Config.bucketName)(
+        S3TypedObjectStore.get[CalmTransformable](s3Client, s3Config.bucketName)(
           hybridRecord.s3key)
       case "sierra" =>
-        S3ObjectStore.get[SierraTransformable](s3Client, s3Config.bucketName)(
+        S3TypedObjectStore.get[SierraTransformable](s3Client, s3Config.bucketName)(
           hybridRecord.s3key)
     }
   }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/SQSMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/SQSMessageReceiver.scala
@@ -68,14 +68,17 @@ class SQSMessageReceiver @Inject()(
   ) = {
     sourceMetadata.sourceName match {
       case "miro" =>
-        S3TypedObjectStore.get[MiroTransformable](s3Client, s3Config.bucketName)(
-          hybridRecord.s3key)
+        S3TypedObjectStore.get[MiroTransformable](
+          s3Client,
+          s3Config.bucketName)(hybridRecord.s3key)
       case "calm" =>
-        S3TypedObjectStore.get[CalmTransformable](s3Client, s3Config.bucketName)(
-          hybridRecord.s3key)
+        S3TypedObjectStore.get[CalmTransformable](
+          s3Client,
+          s3Config.bucketName)(hybridRecord.s3key)
       case "sierra" =>
-        S3TypedObjectStore.get[SierraTransformable](s3Client, s3Config.bucketName)(
-          hybridRecord.s3key)
+        S3TypedObjectStore.get[SierraTransformable](
+          s3Client,
+          s3Config.bucketName)(hybridRecord.s3key)
     }
   }
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/SQSMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/SQSMessageReceiver.scala
@@ -16,7 +16,12 @@ import uk.ac.wellcome.models.transformable.{
 }
 import uk.ac.wellcome.models.work.internal.UnidentifiedWork
 import uk.ac.wellcome.monitoring.MetricsSender
-import uk.ac.wellcome.storage.s3.{S3Config, S3ObjectLocation, S3StringStore, S3TypedObjectStore}
+import uk.ac.wellcome.storage.s3.{
+  S3Config,
+  S3ObjectLocation,
+  S3StringStore,
+  S3TypedObjectStore
+}
 import uk.ac.wellcome.storage.vhs.HybridRecord
 import uk.ac.wellcome.platform.transformer.transformers.{
   CalmTransformableTransformer,
@@ -67,9 +72,12 @@ class SQSMessageReceiver @Inject()(
     )
   }
 
-  val miroTransformableStore = new S3TypedObjectStore[MiroTransformable](s3StringStore)
-  val calmTransformableStore = new S3TypedObjectStore[CalmTransformable](s3StringStore)
-  val sierraTransformableStore = new S3TypedObjectStore[SierraTransformable](s3StringStore)
+  val miroTransformableStore =
+    new S3TypedObjectStore[MiroTransformable](s3StringStore)
+  val calmTransformableStore =
+    new S3TypedObjectStore[CalmTransformable](s3StringStore)
+  val sierraTransformableStore =
+    new S3TypedObjectStore[SierraTransformable](s3StringStore)
 
   private def getTransformable(
     hybridRecord: HybridRecord,

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/SQSMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/SQSMessageReceiver.scala
@@ -16,7 +16,7 @@ import uk.ac.wellcome.models.transformable.{
 }
 import uk.ac.wellcome.models.work.internal.UnidentifiedWork
 import uk.ac.wellcome.monitoring.MetricsSender
-import uk.ac.wellcome.storage.s3.{S3Config, S3TypedObjectStore}
+import uk.ac.wellcome.storage.s3.{S3Config, S3ObjectLocation, S3StringStore, S3TypedObjectStore}
 import uk.ac.wellcome.storage.vhs.HybridRecord
 import uk.ac.wellcome.platform.transformer.transformers.{
   CalmTransformableTransformer,
@@ -35,6 +35,11 @@ class SQSMessageReceiver @Inject()(
   s3Config: S3Config,
   metricsSender: MetricsSender)
     extends Logging {
+
+  val s3StringStore = new S3StringStore(
+    s3Client = s3Client,
+    s3Config = s3Config
+  )
 
   def receiveMessage(message: SQSMessage): Future[Unit] = {
     debug(s"Starting to process message $message")
@@ -62,23 +67,23 @@ class SQSMessageReceiver @Inject()(
     )
   }
 
+  val miroTransformableStore = new S3TypedObjectStore[MiroTransformable](s3StringStore)
+  val calmTransformableStore = new S3TypedObjectStore[CalmTransformable](s3StringStore)
+  val sierraTransformableStore = new S3TypedObjectStore[SierraTransformable](s3StringStore)
+
   private def getTransformable(
     hybridRecord: HybridRecord,
     sourceMetadata: SourceMetadata
   ) = {
+    val s3ObjectLocation = S3ObjectLocation(
+      bucket = s3Config.bucketName,
+      key = hybridRecord.s3key
+    )
+
     sourceMetadata.sourceName match {
-      case "miro" =>
-        S3TypedObjectStore.get[MiroTransformable](
-          s3Client,
-          s3Config.bucketName)(hybridRecord.s3key)
-      case "calm" =>
-        S3TypedObjectStore.get[CalmTransformable](
-          s3Client,
-          s3Config.bucketName)(hybridRecord.s3key)
-      case "sierra" =>
-        S3TypedObjectStore.get[SierraTransformable](
-          s3Client,
-          s3Config.bucketName)(hybridRecord.s3key)
+      case "miro" => miroTransformableStore.get(s3ObjectLocation)
+      case "calm" => calmTransformableStore.get(s3ObjectLocation)
+      case "sierra" => sierraTransformableStore.get(s3ObjectLocation)
     }
   }
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/SQSMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/SQSMessageReceiver.scala
@@ -20,7 +20,7 @@ import uk.ac.wellcome.storage.s3.{
   S3Config,
   S3ObjectLocation,
   S3StringStore,
-  S3TypedObjectStore
+  S3TypeStore
 }
 import uk.ac.wellcome.storage.vhs.HybridRecord
 import uk.ac.wellcome.platform.transformer.transformers.{
@@ -73,11 +73,11 @@ class SQSMessageReceiver @Inject()(
   }
 
   val miroTransformableStore =
-    new S3TypedObjectStore[MiroTransformable](s3StringStore)
+    new S3TypeStore[MiroTransformable](s3StringStore)
   val calmTransformableStore =
-    new S3TypedObjectStore[CalmTransformable](s3StringStore)
+    new S3TypeStore[CalmTransformable](s3StringStore)
   val sierraTransformableStore =
-    new S3TypedObjectStore[SierraTransformable](s3StringStore)
+    new S3TypeStore[SierraTransformable](s3StringStore)
 
   private def getTransformable(
     hybridRecord: HybridRecord,

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageReader.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageReader.scala
@@ -8,7 +8,7 @@ import com.google.inject.Inject
 import io.circe.Decoder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSReader}
-import uk.ac.wellcome.storage.s3.{S3Config, S3TypedObjectStore}
+import uk.ac.wellcome.storage.s3.{S3Config, S3StringStore, S3TypedObjectStore}
 
 import scala.concurrent.Future
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -22,9 +22,13 @@ class MessageReader[T] @Inject()(
 ) {
   val sqsReader = new SQSReader(sqsClient, messageReaderConfig.sqsConfig)
 
-  val s3TypedObjectStore = new S3TypedObjectStore[T](
+  val s3StringStore = new S3StringStore(
     s3Client = s3Client,
     s3Config = messageReaderConfig.s3Config
+  )
+
+  val s3TypedObjectStore = new S3TypedObjectStore[T](
+    stringStore = s3StringStore
   )
 
   def readAndDelete(process: T => Future[Unit])(

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageReader.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageReader.scala
@@ -8,7 +8,7 @@ import com.google.inject.Inject
 import io.circe.Decoder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSReader}
-import uk.ac.wellcome.storage.s3.{S3Config, S3ObjectStore}
+import uk.ac.wellcome.storage.s3.{S3Config, S3TypedObjectStore}
 
 import scala.concurrent.Future
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -22,7 +22,7 @@ class MessageReader[T] @Inject()(
 ) {
   val sqsReader = new SQSReader(sqsClient, messageReaderConfig.sqsConfig)
 
-  val s3ObjectStore = new S3ObjectStore[T](
+  val s3TypedObjectStore = new S3TypedObjectStore[T](
     s3Client = s3Client,
     s3Config = messageReaderConfig.s3Config
   )
@@ -52,7 +52,7 @@ class MessageReader[T] @Inject()(
     for {
       messagePointer <- Future.fromTry[MessagePointer](
         deserialisedMessagePointerAttempt)
-      deserialisedObject <- s3ObjectStore.get(messagePointer.src)
+      deserialisedObject <- s3TypedObjectStore.get(messagePointer.src)
     } yield deserialisedObject
   }
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageReader.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageReader.scala
@@ -8,7 +8,7 @@ import com.google.inject.Inject
 import io.circe.Decoder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSReader}
-import uk.ac.wellcome.storage.s3.{S3Config, S3StringStore, S3TypedObjectStore}
+import uk.ac.wellcome.storage.s3.{S3Config, S3StringStore, S3TypeStore}
 
 import scala.concurrent.Future
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -27,7 +27,7 @@ class MessageReader[T] @Inject()(
     s3Config = messageReaderConfig.s3Config
   )
 
-  val s3TypedObjectStore = new S3TypedObjectStore[T](
+  val s3TypeStore = new S3TypeStore[T](
     stringStore = s3StringStore
   )
 
@@ -56,7 +56,7 @@ class MessageReader[T] @Inject()(
     for {
       messagePointer <- Future.fromTry[MessagePointer](
         deserialisedMessagePointerAttempt)
-      deserialisedObject <- s3TypedObjectStore.get(messagePointer.src)
+      deserialisedObject <- s3TypeStore.get(messagePointer.src)
     } yield deserialisedObject
   }
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageStream.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageStream.scala
@@ -9,7 +9,7 @@ import io.circe.Decoder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.monitoring.MetricsSender
-import uk.ac.wellcome.storage.s3.S3ObjectStore
+import uk.ac.wellcome.storage.s3.S3TypedObjectStore
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil.{fromJson, _}
 
@@ -21,7 +21,7 @@ class MessageStream[T] @Inject()(actorSystem: ActorSystem,
                                  messageReaderConfig: MessageReaderConfig,
                                  metricsSender: MetricsSender) {
 
-  private val s3ObjectStore = new S3ObjectStore[T](
+  private val s3TypedObjectStore = new S3TypedObjectStore[T](
     s3Client = s3Client,
     s3Config = messageReaderConfig.s3Config
   )
@@ -49,7 +49,7 @@ class MessageStream[T] @Inject()(actorSystem: ActorSystem,
     for {
       messagePointer <- Future.fromTry(
         fromJson[MessagePointer](notification.Message))
-      deserialisedObject <- s3ObjectStore.get(messagePointer.src)
+      deserialisedObject <- s3TypedObjectStore.get(messagePointer.src)
       _ <- process(deserialisedObject)
     } yield ()
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageStream.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageStream.scala
@@ -9,7 +9,7 @@ import io.circe.Decoder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.monitoring.MetricsSender
-import uk.ac.wellcome.storage.s3.{S3StringStore, S3TypedObjectStore}
+import uk.ac.wellcome.storage.s3.{S3StringStore, S3TypeStore}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil.{fromJson, _}
 
@@ -26,7 +26,7 @@ class MessageStream[T] @Inject()(actorSystem: ActorSystem,
     s3Config = messageReaderConfig.s3Config
   )
 
-  private val s3TypedObjectStore = new S3TypedObjectStore[T](
+  private val s3TypeStore = new S3TypeStore[T](
     stringStore = s3StringStore
   )
 
@@ -53,7 +53,7 @@ class MessageStream[T] @Inject()(actorSystem: ActorSystem,
     for {
       messagePointer <- Future.fromTry(
         fromJson[MessagePointer](notification.Message))
-      deserialisedObject <- s3TypedObjectStore.get(messagePointer.src)
+      deserialisedObject <- s3TypeStore.get(messagePointer.src)
       _ <- process(deserialisedObject)
     } yield ()
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageStream.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageStream.scala
@@ -9,7 +9,7 @@ import io.circe.Decoder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.monitoring.MetricsSender
-import uk.ac.wellcome.storage.s3.S3TypedObjectStore
+import uk.ac.wellcome.storage.s3.{S3StringStore, S3TypedObjectStore}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil.{fromJson, _}
 
@@ -21,9 +21,13 @@ class MessageStream[T] @Inject()(actorSystem: ActorSystem,
                                  messageReaderConfig: MessageReaderConfig,
                                  metricsSender: MetricsSender) {
 
-  private val s3TypedObjectStore = new S3TypedObjectStore[T](
+  private val s3StringStore = new S3StringStore(
     s3Client = s3Client,
     s3Config = messageReaderConfig.s3Config
+  )
+
+  private val s3TypedObjectStore = new S3TypedObjectStore[T](
+    stringStore = s3StringStore
   )
 
   private val sqsStream = new SQSStream[NotificationMessage](

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.storage.s3.{
   KeyPrefixGenerator,
   S3Config,
   S3StringStore,
-  S3TypedObjectStore
+  S3TypeStore
 }
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil._
@@ -39,7 +39,7 @@ class MessageWriter[T] @Inject()(
     s3Config = messageConfig.s3Config
   )
 
-  private val s3 = new S3TypedObjectStore[T](
+  private val s3 = new S3TypeStore[T](
     stringStore = s3StringStore
   )
 

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -9,6 +9,7 @@ import uk.ac.wellcome.messaging.sns.{SNSConfig, SNSWriter}
 import uk.ac.wellcome.storage.s3.{
   KeyPrefixGenerator,
   S3Config,
+  S3StringStore,
   S3TypedObjectStore
 }
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -33,9 +34,13 @@ class MessageWriter[T] @Inject()(
     snsConfig = messageConfig.snsConfig
   )
 
-  private val s3 = new S3TypedObjectStore[T](
+  private val s3StringStore = new S3StringStore(
     s3Client = s3Client,
     s3Config = messageConfig.s3Config
+  )
+
+  private val s3 = new S3TypedObjectStore[T](
+    stringStore = s3StringStore
   )
 
   def write(message: T, subject: String)(

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -6,7 +6,7 @@ import com.google.inject.Inject
 import com.twitter.inject.Logging
 import io.circe.Encoder
 import uk.ac.wellcome.messaging.sns.{SNSConfig, SNSWriter}
-import uk.ac.wellcome.storage.s3.{KeyPrefixGenerator, S3Config, S3ObjectStore}
+import uk.ac.wellcome.storage.s3.{KeyPrefixGenerator, S3Config, S3TypedObjectStore}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil._
 
@@ -29,7 +29,7 @@ class MessageWriter[T] @Inject()(
     snsConfig = messageConfig.snsConfig
   )
 
-  private val s3 = new S3ObjectStore[T](
+  private val s3 = new S3TypedObjectStore[T](
     s3Client = s3Client,
     s3Config = messageConfig.s3Config
   )

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -6,7 +6,11 @@ import com.google.inject.Inject
 import com.twitter.inject.Logging
 import io.circe.Encoder
 import uk.ac.wellcome.messaging.sns.{SNSConfig, SNSWriter}
-import uk.ac.wellcome.storage.s3.{KeyPrefixGenerator, S3Config, S3TypedObjectStore}
+import uk.ac.wellcome.storage.s3.{
+  KeyPrefixGenerator,
+  S3Config,
+  S3TypedObjectStore
+}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil._
 

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/KeyPrefixGenerator.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/KeyPrefixGenerator.scala
@@ -16,11 +16,10 @@ import uk.ac.wellcome.models.Sourced
 //
 //      KeyPrefixGenerator[SierraTransformable] < KeyPrefixGenerator[Sourced]
 //
-// In S3TypedObjectStore, we need a KeyPrefixGenerator[T], where T is usually
-// some subclass of Sourced (this is the way we use it, not a strict
-// requirement).  This contravariance allows us to define a single
-// KeyPrefixGenerator[Sourced] and use it on all instances, even when T is a
-// subclass of Sourced.
+// In S3TypeStore, we need a KeyPrefixGenerator[T], where T is usually some
+// subclass of Sourced (this is the way we use it, not a strict requirement).
+// This contravariance allows us to define a single KeyPrefixGenerator[Sourced]
+// and use it on all instances, even when T is a subclass of Sourced.
 
 trait KeyPrefixGenerator[-T] {
   def generate(obj: T): String

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/KeyPrefixGenerator.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/KeyPrefixGenerator.scala
@@ -16,10 +16,11 @@ import uk.ac.wellcome.models.Sourced
 //
 //      KeyPrefixGenerator[SierraTransformable] < KeyPrefixGenerator[Sourced]
 //
-// In S3ObjectStore, we need a KeyPrefixGenerator[T], where T is usually some
-// subclass of Sourced (this is the way we use it, not a strict requirement).
-// This contravariance allows us to define a single KeyPrefixGenerator[Sourced]
-// and use it on all instances, even though T is some subclass of Sourced.
+// In S3TypedObjectStore, we need a KeyPrefixGenerator[T], where T is usually
+// some subclass of Sourced (this is the way we use it, not a strict
+// requirement).  This contravariance allows us to define a single
+// KeyPrefixGenerator[Sourced] and use it on all instances, even when T is a
+// subclass of Sourced.
 
 trait KeyPrefixGenerator[-T] {
   def generate(obj: T): String

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3Store.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3Store.scala
@@ -1,9 +1,0 @@
-package uk.ac.wellcome.storage.s3
-
-import scala.concurrent.Future
-
-abstract trait S3Store[T] {
-  def put(t: T, keyPrefix: String): Future[S3ObjectLocation]
-
-  def get(s3ObjectLocation: S3ObjectLocation): Future[T]
-}

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3Store.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3Store.scala
@@ -1,0 +1,9 @@
+package uk.ac.wellcome.storage.s3
+
+import scala.concurrent.Future
+
+abstract trait S3Store[T] {
+  def put(t: T, keyPrefix: String): Future[S3ObjectLocation]
+
+  def get(s3ObjectLocation: S3ObjectLocation): Future[T]
+}

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
@@ -12,8 +12,8 @@ import scala.util.hashing.MurmurHash3
 class S3StringStore @Inject()(
   s3Client: AmazonS3,
   s3Config: S3Config
-) extends Logging {
-  def put(content: String, keyPrefix: String)(): Future[S3ObjectLocation] = {
+) extends Logging with S3Store[String] {
+  def put(content: String, keyPrefix: String): Future[S3ObjectLocation] = {
     S3StringStore.put(s3Client, s3Config.bucketName)(keyPrefix)(content)
   }
 

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
@@ -1,0 +1,68 @@
+package uk.ac.wellcome.storage.s3
+
+import com.amazonaws.services.s3.AmazonS3
+import com.google.inject.Inject
+import com.twitter.inject.Logging
+import uk.ac.wellcome.utils.GlobalExecutionContext.context
+
+import scala.concurrent.Future
+import scala.io.Source
+import scala.util.hashing.MurmurHash3
+
+class S3StringStore @Inject()(
+  s3Client: AmazonS3,
+  s3Config: S3Config
+) extends Logging {
+  def put(content: String, keyPrefix: String)(): Future[S3ObjectLocation] = {
+    S3StringStore.put(s3Client, s3Config.bucketName)(keyPrefix)(content)
+  }
+
+  def get(s3ObjectLocation: S3ObjectLocation): Future[String] = {
+    val bucket = s3ObjectLocation.bucket
+    val key = s3ObjectLocation.key
+
+    if (bucket != s3Config.bucketName) {
+      debug(
+        s"Bucket name in S3ObjectLocation ($bucket) does not match configured bucket (${s3Config.bucketName})")
+    }
+
+    S3StringStore.get(s3Client, bucket)(key)
+  }
+}
+
+object S3StringStore extends Logging {
+  def put(s3Client: AmazonS3, bucketName: String)(keyPrefix: String)(content: String): Future[S3ObjectLocation] = {
+    val contentHash = MurmurHash3.stringHash(content, MurmurHash3.stringSeed)
+
+    // Ensure that keyPrefix here is normalised for concatenating with contentHash
+    val prefix = keyPrefix
+      .stripPrefix("/")
+      .stripSuffix("/")
+
+    val key = s"$prefix/$contentHash.json"
+
+    info(s"Attempting to PUT object to s3://$bucketName/$key")
+    val putObject = Future {
+      s3Client.putObject(bucketName, key, content)
+    }
+
+    putObject.map { _ =>
+      info(s"Successfully PUT object to s3://$bucketName/$key")
+      S3ObjectLocation(bucketName, key)
+    }
+  }
+
+  def get(s3Client: AmazonS3, bucketName: String)(key: String): Future[String] = {
+    info(s"Attempting to GET object from s3://$bucketName/$key")
+
+    val getObject = Future {
+      val s3Object = s3Client.getObject(bucketName, key)
+      Source.fromInputStream(s3Object.getObjectContent).mkString
+    }
+
+    getObject.map { s3ObjectContent =>
+      info(s"Successful GET object from s3://$bucketName/$key")
+      s3ObjectContent
+    }
+  }
+}

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
@@ -42,20 +42,20 @@ object S3StringStore extends Logging {
 
     val key = s"$prefix/$contentHash.json"
 
-    info(s"Attempting to PUT object to s3://$bucketName/$key")
+    info(s"Attempt: PUT object to s3://$bucketName/$key")
     val putObject = Future {
       s3Client.putObject(bucketName, key, content)
     }
 
     putObject.map { _ =>
-      info(s"Successfully PUT object to s3://$bucketName/$key")
+      info(s"Success: PUT object to s3://$bucketName/$key")
       S3ObjectLocation(bucketName, key)
     }
   }
 
   def get(s3Client: AmazonS3, bucketName: String)(
     key: String): Future[String] = {
-    info(s"Attempting to GET object from s3://$bucketName/$key")
+    info(s"Attempt: GET object from s3://$bucketName/$key")
 
     val getObject = Future {
       val s3Object = s3Client.getObject(bucketName, key)
@@ -63,7 +63,7 @@ object S3StringStore extends Logging {
     }
 
     getObject.map { s3ObjectContent =>
-      info(s"Successful GET object from s3://$bucketName/$key")
+      info(s"Success: GET object from s3://$bucketName/$key")
       s3ObjectContent
     }
   }

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
@@ -12,8 +12,7 @@ import scala.util.hashing.MurmurHash3
 class S3StringStore @Inject()(
   s3Client: AmazonS3,
   s3Config: S3Config
-) extends Logging
-    with S3Store[String] {
+) extends Logging {
   def put(content: String, keyPrefix: String): Future[S3ObjectLocation] =
     S3StringStore.put(s3Client, s3Config.bucketName)(keyPrefix)(content)
 

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
@@ -12,7 +12,8 @@ import scala.util.hashing.MurmurHash3
 class S3StringStore @Inject()(
   s3Client: AmazonS3,
   s3Config: S3Config
-) extends Logging with S3Store[String] {
+) extends Logging
+    with S3Store[String] {
   def put(content: String, keyPrefix: String): Future[S3ObjectLocation] = {
     S3StringStore.put(s3Client, s3Config.bucketName)(keyPrefix)(content)
   }

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
@@ -31,7 +31,8 @@ class S3StringStore @Inject()(
 }
 
 object S3StringStore extends Logging {
-  def put(s3Client: AmazonS3, bucketName: String)(keyPrefix: String)(content: String): Future[S3ObjectLocation] = {
+  def put(s3Client: AmazonS3, bucketName: String)(keyPrefix: String)(
+    content: String): Future[S3ObjectLocation] = {
     val contentHash = MurmurHash3.stringHash(content, MurmurHash3.stringSeed)
 
     // Ensure that keyPrefix here is normalised for concatenating with contentHash
@@ -52,7 +53,8 @@ object S3StringStore extends Logging {
     }
   }
 
-  def get(s3Client: AmazonS3, bucketName: String)(key: String): Future[String] = {
+  def get(s3Client: AmazonS3, bucketName: String)(
+    key: String): Future[String] = {
     info(s"Attempting to GET object from s3://$bucketName/$key")
 
     val getObject = Future {

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
@@ -14,9 +14,8 @@ class S3StringStore @Inject()(
   s3Config: S3Config
 ) extends Logging
     with S3Store[String] {
-  def put(content: String, keyPrefix: String): Future[S3ObjectLocation] = {
+  def put(content: String, keyPrefix: String): Future[S3ObjectLocation] =
     S3StringStore.put(s3Client, s3Config.bucketName)(keyPrefix)(content)
-  }
 
   def get(s3ObjectLocation: S3ObjectLocation): Future[String] = {
     val bucket = s3ObjectLocation.bucket

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3TypeStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3TypeStore.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.Future
 
-class S3TypedObjectStore[T] @Inject()(
+class S3TypeStore[T] @Inject()(
   stringStore: S3StringStore
 ) extends Logging {
 

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStore.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.storage.s3
 
-import com.amazonaws.services.s3.AmazonS3
 import com.google.inject.Inject
 import com.twitter.inject.Logging
 import io.circe.{Decoder, Encoder}
@@ -10,14 +9,8 @@ import uk.ac.wellcome.utils.JsonUtil._
 import scala.concurrent.Future
 
 class S3TypedObjectStore[T] @Inject()(
-  s3Client: AmazonS3,
-  s3Config: S3Config
+  stringStore: S3StringStore
 ) extends Logging {
-
-  val stringStore = new S3StringStore(
-    s3Client = s3Client,
-    s3Config = s3Config
-  )
 
   def put(sourcedObject: T, keyPrefix: String)(
     implicit encoder: Encoder[T]): Future[S3ObjectLocation] =

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStore.scala
@@ -12,8 +12,7 @@ import scala.concurrent.Future
 class S3TypedObjectStore[T] @Inject()(
   s3Client: AmazonS3,
   s3Config: S3Config
-) extends Logging
-    with S3Store[T] {
+) extends Logging {
 
   val stringStore = new S3StringStore(
     s3Client = s3Client,

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStore.scala
@@ -11,14 +11,14 @@ import scala.concurrent.Future
 import scala.io.Source
 import scala.util.hashing.MurmurHash3
 
-class S3ObjectStore[T] @Inject()(
+class S3TypedObjectStore[T] @Inject()(
   s3Client: AmazonS3,
   s3Config: S3Config
 ) extends Logging {
   def put(sourcedObject: T, keyPrefix: String)(
     implicit encoder: Encoder[T]): Future[S3ObjectLocation] = {
 
-    S3ObjectStore.put[T](s3Client, s3Config.bucketName)(keyPrefix)(
+    S3TypedObjectStore.put[T](s3Client, s3Config.bucketName)(keyPrefix)(
       sourcedObject)
   }
 
@@ -32,11 +32,11 @@ class S3ObjectStore[T] @Inject()(
         s"Bucket name in S3ObjectLocation ($bucket) does not match configured bucket (${s3Config.bucketName})")
     }
 
-    S3ObjectStore.get[T](s3Client, bucket)(key)
+    S3TypedObjectStore.get[T](s3Client, bucket)(key)
   }
 }
 
-object S3ObjectStore extends Logging {
+object S3TypedObjectStore extends Logging {
   def put[T](s3Client: AmazonS3, bucketName: String)(keyPrefix: String)(
     sourcedObject: T)(implicit encoder: Encoder[T]): Future[S3ObjectLocation] =
     Future.fromTry(JsonUtil.toJson(sourcedObject)).map { content =>

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStore.scala
@@ -4,72 +4,30 @@ import com.amazonaws.services.s3.AmazonS3
 import com.google.inject.Inject
 import com.twitter.inject.Logging
 import io.circe.{Decoder, Encoder}
-import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
+import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.Future
-import scala.io.Source
-import scala.util.hashing.MurmurHash3
 
 class S3TypedObjectStore[T] @Inject()(
   s3Client: AmazonS3,
   s3Config: S3Config
 ) extends Logging {
-  def put(sourcedObject: T, keyPrefix: String)(
-    implicit encoder: Encoder[T]): Future[S3ObjectLocation] = {
 
-    S3TypedObjectStore.put[T](s3Client, s3Config.bucketName)(keyPrefix)(
-      sourcedObject)
-  }
+  val stringStore = new S3StringStore(
+    s3Client = s3Client,
+    s3Config = s3Config
+  )
+
+  def put(sourcedObject: T, keyPrefix: String)(
+    implicit encoder: Encoder[T]): Future[S3ObjectLocation] =
+    Future.fromTry(toJson(sourcedObject)).flatMap { content =>
+      stringStore.put(content = content, keyPrefix = keyPrefix)
+    }
 
   def get(s3ObjectLocation: S3ObjectLocation)(
-    implicit decoder: Decoder[T]): Future[T] = {
-    val bucket = s3ObjectLocation.bucket
-    val key = s3ObjectLocation.key
-
-    if (bucket != s3Config.bucketName) {
-      debug(
-        s"Bucket name in S3ObjectLocation ($bucket) does not match configured bucket (${s3Config.bucketName})")
+    implicit decoder: Decoder[T]): Future[T] =
+    stringStore.get(s3ObjectLocation = s3ObjectLocation).flatMap { content =>
+      Future.fromTry(fromJson[T](content))
     }
-
-    S3TypedObjectStore.get[T](s3Client, bucket)(key)
-  }
-}
-
-object S3TypedObjectStore extends Logging {
-  def put[T](s3Client: AmazonS3, bucketName: String)(keyPrefix: String)(
-    sourcedObject: T)(implicit encoder: Encoder[T]): Future[S3ObjectLocation] =
-    Future.fromTry(JsonUtil.toJson(sourcedObject)).map { content =>
-      val contentHash = MurmurHash3.stringHash(content, MurmurHash3.stringSeed)
-
-      // Ensure that keyPrefix here is normalised for concatenating with contentHash
-      val prefix = keyPrefix
-        .stripPrefix("/")
-        .stripSuffix("/")
-
-      val key = s"$prefix/$contentHash.json"
-
-      info(s"Attempting to PUT object to s3://$bucketName/$key")
-      s3Client.putObject(bucketName, key, content)
-      info(s"Successfully PUT object to s3://$bucketName/$key")
-
-      S3ObjectLocation(bucketName, key)
-    }
-
-  def get[T](s3Client: AmazonS3, bucketName: String)(key: String)(
-    implicit decoder: Decoder[T]): Future[T] = {
-
-    info(s"Attempting to GET object from s3://$bucketName/$key")
-
-    val getObject = Future {
-      val s3Object = s3Client.getObject(bucketName, key)
-      Source.fromInputStream(s3Object.getObjectContent).mkString
-    }
-
-    getObject.flatMap(s3ObjectContent => {
-      info(s"Successful GET object from s3://$bucketName/$key")
-
-      Future.fromTry(JsonUtil.fromJson[T](s3ObjectContent))
-    })
-  }
 }

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStore.scala
@@ -12,7 +12,7 @@ import scala.concurrent.Future
 class S3TypedObjectStore[T] @Inject()(
   s3Client: AmazonS3,
   s3Config: S3Config
-) extends Logging {
+) extends Logging with S3Store[T] {
 
   val stringStore = new S3StringStore(
     s3Client = s3Client,

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStore.scala
@@ -12,7 +12,8 @@ import scala.concurrent.Future
 class S3TypedObjectStore[T] @Inject()(
   s3Client: AmazonS3,
   s3Config: S3Config
-) extends Logging with S3Store[T] {
+) extends Logging
+    with S3Store[T] {
 
   val stringStore = new S3StringStore(
     s3Client = s3Client,

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
@@ -10,6 +10,7 @@ import uk.ac.wellcome.storage.dynamo.{UpdateExpressionGenerator, VersionedDao}
 import uk.ac.wellcome.storage.s3.{
   KeyPrefixGenerator,
   S3ObjectLocation,
+  S3StringStore,
   S3TypedObjectStore
 }
 import uk.ac.wellcome.storage.type_classes.{
@@ -29,9 +30,13 @@ class VersionedHybridStore[T <: Id] @Inject()(
   dynamoDbClient: AmazonDynamoDB
 ) {
 
-  val sourcedObjectStore = new S3TypedObjectStore[T](
+  private val s3StringStore = new S3StringStore(
     s3Client = s3Client,
     s3Config = vhsConfig.s3Config
+  )
+
+  val sourcedObjectStore = new S3TypedObjectStore[T](
+    stringStore = s3StringStore
   )
 
   val versionedDao = new VersionedDao(

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.storage.s3.{
   KeyPrefixGenerator,
   S3ObjectLocation,
   S3StringStore,
-  S3TypedObjectStore
+  S3TypeStore
 }
 import uk.ac.wellcome.storage.type_classes.{
   HybridRecordEnricher,
@@ -35,7 +35,7 @@ class VersionedHybridStore[T <: Id] @Inject()(
     s3Config = vhsConfig.s3Config
   )
 
-  val sourcedObjectStore = new S3TypedObjectStore[T](
+  val sourcedObjectStore = new S3TypeStore[T](
     stringStore = s3StringStore
   )
 

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.storage.dynamo.{UpdateExpressionGenerator, VersionedDao}
 import uk.ac.wellcome.storage.s3.{
   KeyPrefixGenerator,
   S3ObjectLocation,
-  S3ObjectStore
+  S3TypedObjectStore
 }
 import uk.ac.wellcome.storage.type_classes.{
   HybridRecordEnricher,
@@ -29,7 +29,7 @@ class VersionedHybridStore[T <: Id] @Inject()(
   dynamoDbClient: AmazonDynamoDB
 ) {
 
-  val sourcedObjectStore = new S3ObjectStore[T](
+  val sourcedObjectStore = new S3TypedObjectStore[T](
     s3Client = s3Client,
     s3Config = vhsConfig.s3Config
   )

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3StringStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3StringStoreTest.scala
@@ -25,7 +25,8 @@ class S3StringStoreTest
       withS3StringObjectStore(bucket) { stringStore =>
         val prefix = "foo"
 
-        val writtenToS3 = stringStore.put(content = content, keyPrefix = prefix)
+        val writtenToS3 =
+          stringStore.put(content = content, keyPrefix = prefix)
 
         whenReady(writtenToS3) { actualKey =>
           val expectedKey = s"$prefix/$expectedHash.json"
@@ -45,7 +46,8 @@ class S3StringStoreTest
       withS3StringObjectStore(bucket) { stringStore =>
         val prefix = "/foo"
 
-        val writtenToS3 = stringStore.put(content = content, keyPrefix = prefix)
+        val writtenToS3 =
+          stringStore.put(content = content, keyPrefix = prefix)
 
         whenReady(writtenToS3) { actualKey =>
           val expectedUri =
@@ -61,7 +63,8 @@ class S3StringStoreTest
       withS3StringObjectStore(bucket) { stringStore =>
         val prefix = "foo/"
 
-        val writtenToS3 = stringStore.put(content = content, keyPrefix = prefix)
+        val writtenToS3 =
+          stringStore.put(content = content, keyPrefix = prefix)
 
         whenReady(writtenToS3) { actualKey =>
           val expectedUri =
@@ -77,7 +80,8 @@ class S3StringStoreTest
       withS3StringObjectStore(bucket) { stringStore =>
         val prefix = "foo"
 
-        val writtenToS3 = stringStore.put(content = content, keyPrefix = prefix)
+        val writtenToS3 =
+          stringStore.put(content = content, keyPrefix = prefix)
 
         whenReady(writtenToS3.flatMap(stringStore.get)) { actualContent =>
           actualContent shouldBe content
@@ -103,7 +107,8 @@ class S3StringStoreTest
     }
   }
 
-  private def withS3StringObjectStore(bucket: Bucket)(testWith: TestWith[S3StringStore, Assertion]) = {
+  private def withS3StringObjectStore(bucket: Bucket)(
+    testWith: TestWith[S3StringStore, Assertion]) = {
     val stringStore = new S3StringStore(
       s3Client = s3Client,
       s3Config = S3Config(bucketName = bucket.name)

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3StringStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3StringStoreTest.scala
@@ -20,7 +20,7 @@ class S3StringStoreTest
   val content = "Some content!"
   val expectedHash = "1227282840"
 
-  it("stores a versioned object with path id/version/hash") {
+  it("stores a string with path id/version/hash") {
     withLocalS3Bucket { bucket =>
       withS3StringObjectStore(bucket) { stringStore =>
         val prefix = "foo"
@@ -75,7 +75,7 @@ class S3StringStoreTest
     }
   }
 
-  it("retrieves a versioned object from s3") {
+  it("retrieves a string from s3") {
     withLocalS3Bucket { bucket =>
       withS3StringObjectStore(bucket) { stringStore =>
         val prefix = "foo"
@@ -90,7 +90,7 @@ class S3StringStoreTest
     }
   }
 
-  it("throws an exception when retrieving a missing object") {
+  it("throws an exception when retrieving a missing key") {
     withLocalS3Bucket { bucket =>
       withS3StringObjectStore(bucket) { stringStore =>
         whenReady(

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3StringStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3StringStoreTest.scala
@@ -1,0 +1,114 @@
+package uk.ac.wellcome.storage.s3
+
+import com.amazonaws.services.s3.model.AmazonS3Exception
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{Assertion, FunSpec, Matchers}
+import uk.ac.wellcome.storage.test.fixtures.S3
+import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
+import uk.ac.wellcome.test.fixtures.TestWith
+import uk.ac.wellcome.test.utils.ExtendedPatience
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class S3StringStoreTest
+    extends FunSpec
+    with S3
+    with Matchers
+    with ScalaFutures
+    with ExtendedPatience {
+
+  val content = "Some content!"
+  val expectedHash = "1227282840"
+
+  it("stores a versioned object with path id/version/hash") {
+    withLocalS3Bucket { bucket =>
+      withS3StringObjectStore(bucket) { stringStore =>
+        val prefix = "foo"
+
+        val writtenToS3 = stringStore.put(content = content, keyPrefix = prefix)
+
+        whenReady(writtenToS3) { actualKey =>
+          val expectedKey = s"$prefix/$expectedHash.json"
+          val expectedUri = S3ObjectLocation(bucket.name, expectedKey)
+
+          actualKey shouldBe expectedUri
+
+          val contentFromS3 = getContentFromS3(bucket, expectedKey)
+          contentFromS3 shouldBe content
+        }
+      }
+    }
+  }
+
+  it("removes leading slashes from prefixes") {
+    withLocalS3Bucket { bucket =>
+      withS3StringObjectStore(bucket) { stringStore =>
+        val prefix = "/foo"
+
+        val writtenToS3 = stringStore.put(content = content, keyPrefix = prefix)
+
+        whenReady(writtenToS3) { actualKey =>
+          val expectedUri =
+            S3ObjectLocation(bucket.name, s"foo/$expectedHash.json")
+          actualKey shouldBe expectedUri
+        }
+      }
+    }
+  }
+
+  it("removes trailing slashes from prefixes") {
+    withLocalS3Bucket { bucket =>
+      withS3StringObjectStore(bucket) { stringStore =>
+        val prefix = "foo/"
+
+        val writtenToS3 = stringStore.put(content = content, keyPrefix = prefix)
+
+        whenReady(writtenToS3) { actualKey =>
+          val expectedUri =
+            S3ObjectLocation(bucket.name, s"foo/$expectedHash.json")
+          actualKey shouldBe expectedUri
+        }
+      }
+    }
+  }
+
+  it("retrieves a versioned object from s3") {
+    withLocalS3Bucket { bucket =>
+      withS3StringObjectStore(bucket) { stringStore =>
+        val prefix = "foo"
+
+        val writtenToS3 = stringStore.put(content = content, keyPrefix = prefix)
+
+        whenReady(writtenToS3.flatMap(stringStore.get)) { actualContent =>
+          actualContent shouldBe content
+        }
+      }
+    }
+  }
+
+  it("throws an exception when retrieving a missing object") {
+    withLocalS3Bucket { bucket =>
+      withS3StringObjectStore(bucket) { stringStore =>
+        whenReady(
+          stringStore
+            .get(S3ObjectLocation(bucket.name, "not/a/real/object"))
+            .failed) { exception =>
+          exception shouldBe a[AmazonS3Exception]
+          exception
+            .asInstanceOf[AmazonS3Exception]
+            .getErrorCode shouldBe "NoSuchKey"
+
+        }
+      }
+    }
+  }
+
+  private def withS3StringObjectStore(bucket: Bucket)(testWith: TestWith[S3StringStore, Assertion]) = {
+    val stringStore = new S3StringStore(
+      s3Client = s3Client,
+      s3Config = S3Config(bucketName = bucket.name)
+    )
+
+    testWith(stringStore)
+  }
+}

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3TypeStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3TypeStoreTest.scala
@@ -14,7 +14,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 case class TestObject(content: String)
 
-class S3TypedObjectStoreTest
+class S3TypeStoreTest
     extends FunSpec
     with S3
     with Matchers
@@ -27,7 +27,7 @@ class S3TypedObjectStoreTest
 
   it("stores a versioned object with path id/version/hash") {
     withLocalS3Bucket { bucket =>
-      withS3TypedObjectStore(bucket) { objectStore =>
+      withS3TypeStore(bucket) { objectStore =>
         val content = "Some content!"
         val prefix = "foo"
 
@@ -56,7 +56,7 @@ class S3TypedObjectStoreTest
 
   it("removes leading slashes from prefixes") {
     withLocalS3Bucket { bucket =>
-      withS3TypedObjectStore(bucket) { objectStore =>
+      withS3TypeStore(bucket) { objectStore =>
         val prefix = "/foo"
 
         val testObject = TestObject(content = content)
@@ -73,7 +73,7 @@ class S3TypedObjectStoreTest
 
   it("removes trailing slashes from prefixes") {
     withLocalS3Bucket { bucket =>
-      withS3TypedObjectStore(bucket) { objectStore =>
+      withS3TypeStore(bucket) { objectStore =>
         val prefix = "foo/"
 
         val testObject = TestObject(content = content)
@@ -90,7 +90,7 @@ class S3TypedObjectStoreTest
 
   it("retrieves a versioned object from s3") {
     withLocalS3Bucket { bucket =>
-      withS3TypedObjectStore(bucket) { objectStore =>
+      withS3TypeStore(bucket) { objectStore =>
         val prefix = "foo"
 
         val testObject = TestObject(content = content)
@@ -106,7 +106,7 @@ class S3TypedObjectStoreTest
 
   it("throws an exception when retrieving a missing object") {
     withLocalS3Bucket { bucket =>
-      withS3TypedObjectStore(bucket) { objectStore =>
+      withS3TypeStore(bucket) { objectStore =>
         whenReady(
           objectStore
             .get(S3ObjectLocation(bucket.name, "not/a/real/object"))
@@ -121,17 +121,17 @@ class S3TypedObjectStoreTest
     }
   }
 
-  private def withS3TypedObjectStore(bucket: Bucket)(
-    testWith: TestWith[S3TypedObjectStore[TestObject], Assertion]) = {
+  private def withS3TypeStore(bucket: Bucket)(
+    testWith: TestWith[S3TypeStore[TestObject], Assertion]) = {
     val s3StringStore = new S3StringStore(
       s3Client = s3Client,
       s3Config = S3Config(bucketName = bucket.name)
     )
 
-    val s3TypedObjectStore = new S3TypedObjectStore[TestObject](
+    val s3TypeStore = new S3TypeStore[TestObject](
       stringStore = s3StringStore
     )
 
-    testWith(s3TypedObjectStore)
+    testWith(s3TypeStore)
   }
 }

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStoreTest.scala
@@ -121,7 +121,8 @@ class S3TypedObjectStoreTest
     }
   }
 
-  private def withS3TypedObjectStore(bucket: Bucket)(testWith: TestWith[S3TypedObjectStore[TestObject], Assertion]) = {
+  private def withS3TypedObjectStore(bucket: Bucket)(
+    testWith: TestWith[S3TypedObjectStore[TestObject], Assertion]) = {
     val objectStore = new S3TypedObjectStore[TestObject](
       s3Client = s3Client,
       s3Config = S3Config(bucketName = bucket.name)

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStoreTest.scala
@@ -123,11 +123,15 @@ class S3TypedObjectStoreTest
 
   private def withS3TypedObjectStore(bucket: Bucket)(
     testWith: TestWith[S3TypedObjectStore[TestObject], Assertion]) = {
-    val objectStore = new S3TypedObjectStore[TestObject](
+    val s3StringStore = new S3StringStore(
       s3Client = s3Client,
       s3Config = S3Config(bucketName = bucket.name)
     )
 
-    testWith(objectStore)
+    val s3TypedObjectStore = new S3TypedObjectStore[TestObject](
+      stringStore = s3StringStore
+    )
+
+    testWith(s3TypedObjectStore)
   }
 }

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStoreTest.scala
@@ -22,6 +22,9 @@ class S3TypedObjectStoreTest
     with ScalaFutures
     with ExtendedPatience {
 
+  val content = "Some content!"
+  val expectedHash = "1770874231"
+
   it("stores a versioned object with path id/version/hash") {
     withLocalS3Bucket { bucket =>
       withS3TypedObjectStore(bucket) { objectStore =>
@@ -34,7 +37,6 @@ class S3TypedObjectStoreTest
 
         whenReady(writtenToS3) { actualKey =>
           val expectedJson = JsonUtil.toJson(testObject).get
-          val expectedHash = "1770874231"
 
           val expectedKey = s"$prefix/$expectedHash.json"
           val expectedUri = S3ObjectLocation(bucket.name, expectedKey)
@@ -55,15 +57,12 @@ class S3TypedObjectStoreTest
   it("removes leading slashes from prefixes") {
     withLocalS3Bucket { bucket =>
       withS3TypedObjectStore(bucket) { objectStore =>
-        val content = "Some content!"
         val prefix = "/foo"
 
         val testObject = TestObject(content = content)
         val writtenToS3 = objectStore.put(testObject, prefix)
 
         whenReady(writtenToS3) { actualKey =>
-          val expectedHash = "1770874231"
-
           val expectedUri =
             S3ObjectLocation(bucket.name, s"foo/$expectedHash.json")
           actualKey shouldBe expectedUri
@@ -75,15 +74,12 @@ class S3TypedObjectStoreTest
   it("removes trailing slashes from prefixes") {
     withLocalS3Bucket { bucket =>
       withS3TypedObjectStore(bucket) { objectStore =>
-        val content = "Some content!"
         val prefix = "foo/"
 
         val testObject = TestObject(content = content)
         val writtenToS3 = objectStore.put(testObject, prefix)
 
         whenReady(writtenToS3) { actualKey =>
-          val expectedHash = "1770874231"
-
           val expectedUri =
             S3ObjectLocation(bucket.name, s"foo/$expectedHash.json")
           actualKey shouldBe expectedUri
@@ -95,7 +91,6 @@ class S3TypedObjectStoreTest
   it("retrieves a versioned object from s3") {
     withLocalS3Bucket { bucket =>
       withS3TypedObjectStore(bucket) { objectStore =>
-        val content = "Some content!"
         val prefix = "foo"
 
         val testObject = TestObject(content = content)

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStoreTest.scala
@@ -12,7 +12,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 case class TestObject(content: String)
 
-class S3ObjectStoreTest
+class S3TypedObjectStoreTest
     extends FunSpec
     with S3
     with Matchers
@@ -25,7 +25,7 @@ class S3ObjectStoreTest
       val content = "Some content!"
       val prefix = "foo"
 
-      val objectStore = new S3ObjectStore[TestObject](
+      val objectStore = new S3TypedObjectStore[TestObject](
         s3Client,
         S3Config(bucketName = bucket.name)
       )
@@ -58,7 +58,7 @@ class S3ObjectStoreTest
       val content = "Some content!"
       val prefix = "/foo"
 
-      val objectStore = new S3ObjectStore[TestObject](
+      val objectStore = new S3TypedObjectStore[TestObject](
         s3Client,
         S3Config(bucketName = bucket.name)
       )
@@ -81,7 +81,7 @@ class S3ObjectStoreTest
       val content = "Some content!"
       val prefix = "foo/"
 
-      val objectStore = new S3ObjectStore[TestObject](
+      val objectStore = new S3TypedObjectStore[TestObject](
         s3Client,
         S3Config(bucketName = bucket.name)
       )
@@ -104,7 +104,7 @@ class S3ObjectStoreTest
       val content = "Some content!"
       val prefix = "foo"
 
-      val objectStore = new S3ObjectStore[TestObject](
+      val objectStore = new S3TypedObjectStore[TestObject](
         s3Client,
         S3Config(bucketName = bucket.name)
       )
@@ -121,7 +121,7 @@ class S3ObjectStoreTest
 
   it("throws an exception when retrieving a missing object") {
     withLocalS3Bucket { bucket =>
-      val objectStore = new S3ObjectStore[TestObject](
+      val objectStore = new S3TypedObjectStore[TestObject](
         s3Client,
         S3Config(bucketName = bucket.name)
       )

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStoreTest.scala
@@ -2,8 +2,10 @@ package uk.ac.wellcome.storage.s3
 
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.storage.test.fixtures.S3
+import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
+import uk.ac.wellcome.test.fixtures.TestWith
 import uk.ac.wellcome.test.utils.{ExtendedPatience, JsonTestUtil}
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.utils.JsonUtil._
@@ -22,120 +24,114 @@ class S3TypedObjectStoreTest
 
   it("stores a versioned object with path id/version/hash") {
     withLocalS3Bucket { bucket =>
-      val content = "Some content!"
-      val prefix = "foo"
+      withS3TypedObjectStore(bucket) { objectStore =>
+        val content = "Some content!"
+        val prefix = "foo"
 
-      val objectStore = new S3TypedObjectStore[TestObject](
-        s3Client,
-        S3Config(bucketName = bucket.name)
-      )
+        val testObject = TestObject(content = content)
 
-      val testObject = TestObject(content = content)
+        val writtenToS3 = objectStore.put(testObject, prefix)
 
-      val writtenToS3 = objectStore.put(testObject, prefix)
+        whenReady(writtenToS3) { actualKey =>
+          val expectedJson = JsonUtil.toJson(testObject).get
+          val expectedHash = "1770874231"
 
-      whenReady(writtenToS3) { actualKey =>
-        val expectedJson = JsonUtil.toJson(testObject).get
-        val expectedHash = "1770874231"
+          val expectedKey = s"$prefix/$expectedHash.json"
+          val expectedUri = S3ObjectLocation(bucket.name, expectedKey)
 
-        val expectedKey = s"$prefix/$expectedHash.json"
-        val expectedUri = S3ObjectLocation(bucket.name, expectedKey)
+          actualKey shouldBe expectedUri
 
-        actualKey shouldBe expectedUri
+          val jsonFromS3 = getJsonFromS3(
+            bucket,
+            expectedKey
+          ).noSpaces
 
-        val jsonFromS3 = getJsonFromS3(
-          bucket,
-          expectedKey
-        ).noSpaces
-
-        assertJsonStringsAreEqual(jsonFromS3, expectedJson)
+          assertJsonStringsAreEqual(jsonFromS3, expectedJson)
+        }
       }
     }
   }
 
   it("removes leading slashes from prefixes") {
     withLocalS3Bucket { bucket =>
-      val content = "Some content!"
-      val prefix = "/foo"
+      withS3TypedObjectStore(bucket) { objectStore =>
+        val content = "Some content!"
+        val prefix = "/foo"
 
-      val objectStore = new S3TypedObjectStore[TestObject](
-        s3Client,
-        S3Config(bucketName = bucket.name)
-      )
+        val testObject = TestObject(content = content)
+        val writtenToS3 = objectStore.put(testObject, prefix)
 
-      val testObject = TestObject(content = content)
-      val writtenToS3 = objectStore.put(testObject, prefix)
+        whenReady(writtenToS3) { actualKey =>
+          val expectedHash = "1770874231"
 
-      whenReady(writtenToS3) { actualKey =>
-        val expectedHash = "1770874231"
-
-        val expectedUri =
-          S3ObjectLocation(bucket.name, s"foo/$expectedHash.json")
-        actualKey shouldBe expectedUri
+          val expectedUri =
+            S3ObjectLocation(bucket.name, s"foo/$expectedHash.json")
+          actualKey shouldBe expectedUri
+        }
       }
     }
   }
 
   it("removes trailing slashes from prefixes") {
     withLocalS3Bucket { bucket =>
-      val content = "Some content!"
-      val prefix = "foo/"
+      withS3TypedObjectStore(bucket) { objectStore =>
+        val content = "Some content!"
+        val prefix = "foo/"
 
-      val objectStore = new S3TypedObjectStore[TestObject](
-        s3Client,
-        S3Config(bucketName = bucket.name)
-      )
+        val testObject = TestObject(content = content)
+        val writtenToS3 = objectStore.put(testObject, prefix)
 
-      val testObject = TestObject(content = content)
-      val writtenToS3 = objectStore.put(testObject, prefix)
+        whenReady(writtenToS3) { actualKey =>
+          val expectedHash = "1770874231"
 
-      whenReady(writtenToS3) { actualKey =>
-        val expectedHash = "1770874231"
-
-        val expectedUri =
-          S3ObjectLocation(bucket.name, s"foo/$expectedHash.json")
-        actualKey shouldBe expectedUri
+          val expectedUri =
+            S3ObjectLocation(bucket.name, s"foo/$expectedHash.json")
+          actualKey shouldBe expectedUri
+        }
       }
     }
   }
 
   it("retrieves a versioned object from s3") {
     withLocalS3Bucket { bucket =>
-      val content = "Some content!"
-      val prefix = "foo"
+      withS3TypedObjectStore(bucket) { objectStore =>
+        val content = "Some content!"
+        val prefix = "foo"
 
-      val objectStore = new S3TypedObjectStore[TestObject](
-        s3Client,
-        S3Config(bucketName = bucket.name)
-      )
+        val testObject = TestObject(content = content)
 
-      val testObject = TestObject(content = content)
+        val writtenToS3 = objectStore.put(testObject, prefix)
 
-      val writtenToS3 = objectStore.put(testObject, prefix)
-
-      whenReady(writtenToS3.flatMap(objectStore.get)) { actualTestObject =>
-        actualTestObject shouldBe testObject
+        whenReady(writtenToS3.flatMap(objectStore.get)) { actualTestObject =>
+          actualTestObject shouldBe testObject
+        }
       }
     }
   }
 
   it("throws an exception when retrieving a missing object") {
     withLocalS3Bucket { bucket =>
-      val objectStore = new S3TypedObjectStore[TestObject](
-        s3Client,
-        S3Config(bucketName = bucket.name)
-      )
+      withS3TypedObjectStore(bucket) { objectStore =>
+        whenReady(
+          objectStore
+            .get(S3ObjectLocation(bucket.name, "not/a/real/object"))
+            .failed) { exception =>
+          exception shouldBe a[AmazonS3Exception]
+          exception
+            .asInstanceOf[AmazonS3Exception]
+            .getErrorCode shouldBe "NoSuchKey"
 
-      whenReady(
-        objectStore
-          .get(S3ObjectLocation(bucket.name, "not/a/real/object"))
-          .failed) { exception =>
-        exception shouldBe a[AmazonS3Exception]
-        exception
-          .asInstanceOf[AmazonS3Exception]
-          .getErrorCode shouldBe "NoSuchKey"
-
+        }
       }
     }
+  }
+
+  private def withS3TypedObjectStore(bucket: Bucket)(testWith: TestWith[S3TypedObjectStore[TestObject], Assertion]) = {
+    val objectStore = new S3TypedObjectStore[TestObject](
+      s3Client,
+      S3Config(bucketName = bucket.name)
+    )
+
+    testWith(objectStore)
   }
 }

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3TypedObjectStoreTest.scala
@@ -128,8 +128,8 @@ class S3TypedObjectStoreTest
 
   private def withS3TypedObjectStore(bucket: Bucket)(testWith: TestWith[S3TypedObjectStore[TestObject], Assertion]) = {
     val objectStore = new S3TypedObjectStore[TestObject](
-      s3Client,
-      S3Config(bucketName = bucket.name)
+      s3Client = s3Client,
+      s3Config = S3Config(bucketName = bucket.name)
     )
 
     testWith(objectStore)


### PR DESCRIPTION
### What is this PR trying to achieve?

To allow us to store raw strings in S3 while keeping the following behaviours:

* Keys based on the hash of the object contents
* Consistent logging
* Managed key prefixes

We have a new class S3StringStore, which just stores raw strings, and then S3ObjectStore becomes S3TypedObjectStore, and just handles serialisation/deserialisation.

### Who is this change for?

♐️ 🍶 