### PR TITLE
Less repetition in the Server test fixtures, plus a cleanup (maybe?)

### DIFF
--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/Server.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/Server.scala
@@ -1,29 +1,11 @@
 package uk.ac.wellcome.platform.api.fixtures
 
-import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.Suite
 import uk.ac.wellcome.platform.api.{Server => AppServer}
-import uk.ac.wellcome.test.fixtures.TestWith
+import uk.ac.wellcome.test.fixtures.ServerFixtures
 
-trait Server { this: Suite =>
-  def withServer[R](
-    flags: Map[String, String],
-    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer = identity
-  )(testWith: TestWith[EmbeddedHttpServer, R]) = {
+trait Server extends ServerFixtures { this: Suite =>
+  def newAppServer: () => AppServer = () => new AppServer()
 
-    val server: EmbeddedHttpServer = modifyServer(
-      new EmbeddedHttpServer(
-        new AppServer(),
-        flags = flags
-      )
-    )
-
-    server.start()
-
-    try {
-      testWith(server)
-    } finally {
-      server.close()
-    }
-  }
+  val defaultFlags: Map[String, String] = Map()
 }

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -98,7 +98,7 @@ class IdMinterFeatureTest
                 messagingLocalFlags(bucket, topic, queue)
 
             withServer(flags) { _ =>
-              sqsClient.sendMessage(queue.url, "not a json string")
+              sqsClient.sendMessage(queue.url, "Not a valid JSON string or UnidentifiedWork")
 
               val miroId = "1234"
 

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -98,7 +98,9 @@ class IdMinterFeatureTest
                 messagingLocalFlags(bucket, topic, queue)
 
             withServer(flags) { _ =>
-              sqsClient.sendMessage(queue.url, "Not a valid JSON string or UnidentifiedWork")
+              sqsClient.sendMessage(
+                queue.url,
+                "Not a valid JSON string or UnidentifiedWork")
 
               val miroId = "1234"
 

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/Server.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/Server.scala
@@ -8,5 +8,6 @@ import uk.ac.wellcome.test.fixtures.ServerFixtures
 trait Server extends ServerFixtures with CloudWatch { this: Suite =>
   def newAppServer: () => AppServer = () => new AppServer()
 
-  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
+  val defaultFlags
+    : Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/Server.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/Server.scala
@@ -1,32 +1,12 @@
 package uk.ac.wellcome.platform.idminter.fixtures
 
-import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.Suite
 import uk.ac.wellcome.monitoring.test.fixtures.CloudWatch
 import uk.ac.wellcome.platform.idminter.{Server => AppServer}
-import uk.ac.wellcome.test.fixtures.TestWith
+import uk.ac.wellcome.test.fixtures.ServerFixtures
 
-trait Server extends CloudWatch { this: Suite =>
-  def withServer[R](
-    flags: Map[String, String],
-    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer = identity
-  )(testWith: TestWith[EmbeddedHttpServer, R]) = {
+trait Server extends ServerFixtures with CloudWatch { this: Suite =>
+  def newAppServer: () => AppServer = () => new AppServer()
 
-    val server: EmbeddedHttpServer = modifyServer(
-      new EmbeddedHttpServer(
-        new AppServer(),
-        flags = Map(
-          "aws.region" -> "localhost"
-        ) ++ flags ++ cloudWatchLocalFlags
-      )
-    )
-
-    server.start()
-
-    try {
-      testWith(server)
-    } finally {
-      server.close()
-    }
-  }
+  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
@@ -33,7 +33,7 @@ class IdMinterWorkerTest
         withIdentifiersDatabase { dbConfig =>
           withLocalS3Bucket { bucket =>
             val flags =
-              sqsLocalFlags(queue) ++ messagingLocalFlags(bucket, topic, queue) ++ dbConfig.flags
+              messagingLocalFlags(bucket, topic, queue) ++ dbConfig.flags
 
             val identifiersDao = mock[IdentifiersDao]
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/Server.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/Server.scala
@@ -8,5 +8,6 @@ import uk.ac.wellcome.test.fixtures.ServerFixtures
 trait Server extends ServerFixtures with CloudWatch { this: Suite =>
   def newAppServer: () => AppServer = () => new AppServer()
 
-  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
+  val defaultFlags
+    : Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/Server.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/Server.scala
@@ -1,32 +1,12 @@
 package uk.ac.wellcome.platform.ingestor.fixtures
 
-import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.Suite
 import uk.ac.wellcome.monitoring.test.fixtures.CloudWatch
 import uk.ac.wellcome.platform.ingestor.{Server => AppServer}
-import uk.ac.wellcome.test.fixtures.TestWith
+import uk.ac.wellcome.test.fixtures.ServerFixtures
 
-trait Server extends CloudWatch { this: Suite =>
-  def withServer[R](
-    flags: Map[String, String],
-    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer = identity
-  )(testWith: TestWith[EmbeddedHttpServer, R]) = {
+trait Server extends ServerFixtures with CloudWatch { this: Suite =>
+  def newAppServer: () => AppServer = () => new AppServer()
 
-    val server: EmbeddedHttpServer = modifyServer(
-      new EmbeddedHttpServer(
-        new AppServer(),
-        flags = Map(
-          "aws.region" -> "localhost"
-        ) ++ flags ++ cloudWatchLocalFlags
-      )
-    )
-
-    server.start()
-
-    try {
-      testWith(server)
-    } finally {
-      server.close()
-    }
-  }
+  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/Server.scala
+++ b/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/Server.scala
@@ -1,32 +1,12 @@
 package uk.ac.wellcome.platform.recorder.fixtures
 
-import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.Suite
 import uk.ac.wellcome.monitoring.test.fixtures.CloudWatch
 import uk.ac.wellcome.platform.recorder.{Server => AppServer}
-import uk.ac.wellcome.test.fixtures.TestWith
+import uk.ac.wellcome.test.fixtures.ServerFixtures
 
-trait Server extends CloudWatch { this: Suite =>
-  def withServer[R](
-    flags: Map[String, String],
-    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer = identity
-  )(testWith: TestWith[EmbeddedHttpServer, R]) = {
+trait Server extends ServerFixtures with CloudWatch { this: Suite =>
+  def newAppServer: () => AppServer = () => new AppServer()
 
-    val server: EmbeddedHttpServer = modifyServer(
-      new EmbeddedHttpServer(
-        new AppServer(),
-        flags = Map(
-          "aws.region" -> "localhost"
-        ) ++ flags ++ cloudWatchLocalFlags
-      )
-    )
-
-    server.start()
-
-    try {
-      testWith(server)
-    } finally {
-      server.close()
-    }
-  }
+  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/fixtures/Server.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/fixtures/Server.scala
@@ -1,32 +1,12 @@
 package uk.ac.wellcome.platform.transformer.fixtures
 
-import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.Suite
 import uk.ac.wellcome.monitoring.test.fixtures.CloudWatch
+import uk.ac.wellcome.test.fixtures.ServerFixtures
 import uk.ac.wellcome.platform.transformer.{Server => AppServer}
-import uk.ac.wellcome.test.fixtures.TestWith
 
-trait Server extends CloudWatch { this: Suite =>
-  def withServer[R](
-    flags: Map[String, String],
-    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer = identity
-  )(testWith: TestWith[EmbeddedHttpServer, R]) = {
+trait Server extends ServerFixtures with CloudWatch { this: Suite =>
+  def newAppServer: () => AppServer = () => new AppServer()
 
-    val server: EmbeddedHttpServer = modifyServer(
-      new EmbeddedHttpServer(
-        new AppServer(),
-        flags = Map(
-          "aws.region" -> "localhost"
-        ) ++ flags ++ cloudWatchLocalFlags
-      )
-    )
-
-    server.start()
-
-    try {
-      testWith(server)
-    } finally {
-      server.close()
-    }
-  }
+  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/fixtures/Server.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/fixtures/Server.scala
@@ -8,5 +8,6 @@ import uk.ac.wellcome.platform.transformer.{Server => AppServer}
 trait Server extends ServerFixtures with CloudWatch { this: Suite =>
   def newAppServer: () => AppServer = () => new AppServer()
 
-  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
+  val defaultFlags
+    : Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/ServerFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/ServerFixtures.scala
@@ -8,10 +8,13 @@ trait ServerFixtures extends Eventually {
   def newAppServer: () => Ports
   val defaultFlags: Map[String, String]
 
-  def withServer[R](flags: Map[String, String])(testWith: TestWith[EmbeddedHttpServer, R]) = {
-    val server: EmbeddedHttpServer = new EmbeddedHttpServer(
-      newAppServer(),
-      flags = flags ++ defaultFlags
+  def withServer[R](flags: Map[String, String],
+                    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer = identity)(testWith: TestWith[EmbeddedHttpServer, R]) = {
+    val server: EmbeddedHttpServer = modifyServer(
+      new EmbeddedHttpServer(
+        newAppServer(),
+        flags = flags ++ defaultFlags
+      )
     )
 
     server.start()

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/ServerFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/ServerFixtures.scala
@@ -2,9 +2,8 @@ package uk.ac.wellcome.test.fixtures
 
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.server.Ports
-import org.scalatest.concurrent.Eventually
 
-trait ServerFixtures extends Eventually {
+trait ServerFixtures {
   def newAppServer: () => Ports
   val defaultFlags: Map[String, String]
 
@@ -22,9 +21,7 @@ trait ServerFixtures extends Eventually {
     try {
       testWith(server)
     } finally {
-      eventually {
-        server.close()
-      }
+      server.close()
     }
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/ServerFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/ServerFixtures.scala
@@ -1,0 +1,27 @@
+package uk.ac.wellcome.test.fixtures
+
+import com.twitter.finatra.http.EmbeddedHttpServer
+import com.twitter.inject.server.Ports
+import org.scalatest.concurrent.Eventually
+
+trait ServerFixtures extends Eventually {
+  def newAppServer: () => Ports
+  val defaultFlags: Map[String, String]
+
+  def withServer[R](flags: Map[String, String])(testWith: TestWith[EmbeddedHttpServer, R]) = {
+    val server: EmbeddedHttpServer = new EmbeddedHttpServer(
+      newAppServer(),
+      flags = flags ++ defaultFlags
+    )
+
+    server.start()
+
+    try {
+      testWith(server)
+    } finally {
+      eventually {
+        server.close()
+      }
+    }
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/ServerFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/ServerFixtures.scala
@@ -8,7 +8,8 @@ trait ServerFixtures {
   val defaultFlags: Map[String, String]
 
   def withServer[R](flags: Map[String, String],
-                    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer = identity)(testWith: TestWith[EmbeddedHttpServer, R]) = {
+                    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer =
+                      identity)(testWith: TestWith[EmbeddedHttpServer, R]) = {
     val server: EmbeddedHttpServer = modifyServer(
       new EmbeddedHttpServer(
         newAppServer(),

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/Server.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/Server.scala
@@ -1,32 +1,12 @@
 package uk.ac.wellcome.platform.snapshot_generator.fixtures
 
-import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.Suite
 import uk.ac.wellcome.monitoring.test.fixtures.CloudWatch
 import uk.ac.wellcome.platform.snapshot_generator.{Server => AppServer}
-import uk.ac.wellcome.test.fixtures.TestWith
+import uk.ac.wellcome.test.fixtures.ServerFixtures
 
-trait Server extends CloudWatch { this: Suite =>
-  def withServer[R](
-    flags: Map[String, String],
-    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer = identity
-  )(testWith: TestWith[EmbeddedHttpServer, R]) = {
+trait Server extends ServerFixtures with CloudWatch { this: Suite =>
+  def newAppServer: () => AppServer = () => new AppServer()
 
-    val server: EmbeddedHttpServer = modifyServer(
-      new EmbeddedHttpServer(
-        new AppServer(),
-        flags = Map(
-          "aws.region" -> "localhost"
-        ) ++ flags ++ cloudWatchLocalFlags
-      )
-    )
-
-    server.start()
-
-    try {
-      testWith(server)
-    } finally {
-      server.close()
-    }
-  }
+  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/Server.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/Server.scala
@@ -8,5 +8,6 @@ import uk.ac.wellcome.test.fixtures.ServerFixtures
 trait Server extends ServerFixtures with CloudWatch { this: Suite =>
   def newAppServer: () => AppServer = () => new AppServer()
 
-  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
+  val defaultFlags
+    : Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/fixtures/Server.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/fixtures/Server.scala
@@ -8,5 +8,6 @@ import uk.ac.wellcome.test.fixtures.ServerFixtures
 trait Server extends ServerFixtures with CloudWatch { this: Suite =>
   def newAppServer: () => AppServer = () => new AppServer()
 
-  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
+  val defaultFlags
+    : Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/fixtures/Server.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/fixtures/Server.scala
@@ -1,32 +1,12 @@
 package uk.ac.wellcome.platform.reindex_worker.fixtures
 
-import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.Suite
 import uk.ac.wellcome.monitoring.test.fixtures.CloudWatch
 import uk.ac.wellcome.platform.reindex_worker.{Server => AppServer}
-import uk.ac.wellcome.test.fixtures.TestWith
+import uk.ac.wellcome.test.fixtures.ServerFixtures
 
-trait Server extends CloudWatch { this: Suite =>
-  def withServer[R](
-    flags: Map[String, String],
-    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer = identity
-  )(testWith: TestWith[EmbeddedHttpServer, R]) = {
+trait Server extends ServerFixtures with CloudWatch { this: Suite =>
+  def newAppServer: () => AppServer = () => new AppServer()
 
-    val server: EmbeddedHttpServer = modifyServer(
-      new EmbeddedHttpServer(
-        new AppServer(),
-        flags = Map(
-          "aws.region" -> "localhost"
-        ) ++ flags ++ cloudWatchLocalFlags
-      )
-    )
-
-    server.start()
-
-    try {
-      testWith(server)
-    } finally {
-      server.close()
-    }
-  }
+  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSClientModule.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSClientModule.scala
@@ -9,8 +9,6 @@ import javax.inject.Singleton
 import uk.ac.wellcome.models.aws.AWSConfig
 
 object SQSClientModule extends TwitterModule {
-  override val modules = Seq(SQSConfigModule)
-
   val sqsEndpoint = flag[String](
     "aws.sqs.endpoint",
     "",

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -63,7 +63,8 @@ trait Messaging
   def messageReaderLocalFlags(bucket: Bucket, queue: Queue) =
     Map(
       "aws.message.s3.bucketName" -> bucket.name,
-      "aws.message.sqs.queue.url" -> queue.url
+      "aws.message.sqs.queue.url" -> queue.url,
+      "aws.message.sqs.waitTime" -> "1",
     ) ++ s3ClientLocalFlags ++ sqsLocalClientFlags
 
   def messageWriterLocalFlags(bucket: Bucket, topic: Topic) =

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -78,9 +78,7 @@ trait SQS extends Matchers {
       queue
     },
     destroy = { queue =>
-      safeCleanup(queue) { url =>
-        sqsClient.purgeQueue(new PurgeQueueRequest().withQueueUrl(queue.url))
-      }
+      sqsClient.purgeQueue(new PurgeQueueRequest().withQueueUrl(queue.url))
       sqsClient.deleteQueue(queue.url)
     }
   )

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/fixtures/Server.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/fixtures/Server.scala
@@ -8,5 +8,6 @@ import uk.ac.wellcome.test.fixtures.ServerFixtures
 trait Server extends ServerFixtures with CloudWatch { this: Suite =>
   def newAppServer: () => AppServer = () => new AppServer()
 
-  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
+  val defaultFlags
+    : Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/fixtures/Server.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/fixtures/Server.scala
@@ -1,32 +1,12 @@
 package uk.ac.wellcome.platform.sierra_bib_merger.fixtures
 
-import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.Suite
 import uk.ac.wellcome.monitoring.test.fixtures.CloudWatch
 import uk.ac.wellcome.platform.sierra_bib_merger.{Server => AppServer}
-import uk.ac.wellcome.test.fixtures.TestWith
+import uk.ac.wellcome.test.fixtures.ServerFixtures
 
-trait Server extends CloudWatch { this: Suite =>
-  def withServer[R](
-    flags: Map[String, String],
-    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer = identity
-  )(testWith: TestWith[EmbeddedHttpServer, R]) = {
+trait Server extends ServerFixtures with CloudWatch { this: Suite =>
+  def newAppServer: () => AppServer = () => new AppServer()
 
-    val server: EmbeddedHttpServer = modifyServer(
-      new EmbeddedHttpServer(
-        new AppServer(),
-        flags = Map(
-          "aws.region" -> "localhost"
-        ) ++ flags ++ cloudWatchLocalFlags
-      )
-    )
-
-    server.start()
-
-    try {
-      testWith(server)
-    } finally {
-      server.close()
-    }
-  }
+  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/fixtures/Server.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/fixtures/Server.scala
@@ -8,5 +8,6 @@ import uk.ac.wellcome.test.fixtures.ServerFixtures
 trait Server extends ServerFixtures with CloudWatch { this: Suite =>
   def newAppServer: () => AppServer = () => new AppServer()
 
-  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
+  val defaultFlags
+    : Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/fixtures/Server.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/fixtures/Server.scala
@@ -1,32 +1,12 @@
 package uk.ac.wellcome.platform.sierra_item_merger.fixtures
 
-import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.Suite
 import uk.ac.wellcome.monitoring.test.fixtures.CloudWatch
 import uk.ac.wellcome.platform.sierra_item_merger.{Server => AppServer}
-import uk.ac.wellcome.test.fixtures.TestWith
+import uk.ac.wellcome.test.fixtures.ServerFixtures
 
-trait Server extends CloudWatch { this: Suite =>
-  def withServer[R](
-    flags: Map[String, String],
-    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer = identity
-  )(testWith: TestWith[EmbeddedHttpServer, R]) = {
+trait Server extends ServerFixtures with CloudWatch { this: Suite =>
+  def newAppServer: () => AppServer = () => new AppServer()
 
-    val server: EmbeddedHttpServer = modifyServer(
-      new EmbeddedHttpServer(
-        new AppServer(),
-        flags = Map(
-          "aws.region" -> "localhost"
-        ) ++ flags ++ cloudWatchLocalFlags
-      )
-    )
-
-    server.start()
-
-    try {
-      testWith(server)
-    } finally {
-      server.close()
-    }
-  }
+  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/Server.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/Server.scala
@@ -8,5 +8,6 @@ import uk.ac.wellcome.test.fixtures.ServerFixtures
 trait Server extends ServerFixtures with CloudWatch { this: Suite =>
   def newAppServer: () => AppServer = () => new AppServer()
 
-  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
+  val defaultFlags
+    : Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/Server.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/Server.scala
@@ -1,32 +1,12 @@
 package uk.ac.wellcome.platform.sierra_items_to_dynamo.fixtures
 
-import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.Suite
 import uk.ac.wellcome.monitoring.test.fixtures.CloudWatch
-import uk.ac.wellcome.test.fixtures.TestWith
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.{Server => AppServer}
+import uk.ac.wellcome.test.fixtures.ServerFixtures
 
-trait Server extends CloudWatch { this: Suite =>
-  def withServer[R](
-    flags: Map[String, String],
-    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer = identity
-  )(testWith: TestWith[EmbeddedHttpServer, R]) = {
+trait Server extends ServerFixtures with CloudWatch { this: Suite =>
+  def newAppServer: () => AppServer = () => new AppServer()
 
-    val server: EmbeddedHttpServer = modifyServer(
-      new EmbeddedHttpServer(
-        new AppServer(),
-        flags = Map(
-          "aws.region" -> "localhost"
-        ) ++ flags ++ cloudWatchLocalFlags
-      )
-    )
-
-    server.start()
-
-    try {
-      testWith(server)
-    } finally {
-      server.close()
-    }
-  }
+  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/fixtures/Server.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/fixtures/Server.scala
@@ -1,32 +1,12 @@
 package uk.ac.wellcome.platform.sierra_reader.fixtures
 
-import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.Suite
 import uk.ac.wellcome.monitoring.test.fixtures.CloudWatch
 import uk.ac.wellcome.platform.sierra_reader.{Server => AppServer}
-import uk.ac.wellcome.test.fixtures.TestWith
+import uk.ac.wellcome.test.fixtures.ServerFixtures
 
-trait Server extends CloudWatch { this: Suite =>
-  def withServer[R](
-    flags: Map[String, String],
-    modifyServer: (EmbeddedHttpServer) => EmbeddedHttpServer = identity
-  )(testWith: TestWith[EmbeddedHttpServer, R]) = {
+trait Server extends ServerFixtures with CloudWatch { this: Suite =>
+  def newAppServer: () => AppServer = () => new AppServer()
 
-    val server: EmbeddedHttpServer = modifyServer(
-      new EmbeddedHttpServer(
-        new AppServer(),
-        flags = Map(
-          "aws.region" -> "localhost"
-        ) ++ flags ++ cloudWatchLocalFlags
-      )
-    )
-
-    server.start()
-
-    try {
-      testWith(server)
-    } finally {
-      server.close()
-    }
-  }
+  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/fixtures/Server.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/fixtures/Server.scala
@@ -8,5 +8,6 @@ import uk.ac.wellcome.test.fixtures.ServerFixtures
 trait Server extends ServerFixtures with CloudWatch { this: Suite =>
   def newAppServer: () => AppServer = () => new AppServer()
 
-  val defaultFlags: Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
+  val defaultFlags
+    : Map[String, String] = Map("aws.region" -> "localhost") ++ cloudWatchLocalFlags
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

While poking at #2039, I noticed that the test logs are spammed with messages of the form:

```
com.amazonaws.services.sqs.model.QueueDoesNotExistException: AWS.SimpleQueueService.NonExistentQueue; see the SQS docs. (Service: AmazonSQS; Status Code: 400; Error Code: AWS.SimpleQueueService.NonExistentQueue; Request ID: 00000000-0000-0000-0000-000000000000)
```

This appears in the logs of several applications.

My guess is that the server created by `withServer(flags)` is taking longer to shut down than the queue does to be deleted – so the `destroy` method in the fixture returns while the server is still running. It does a few more polls, and hits this error.

This patch moves `server.stop()` into an `eventually`, so the server should really be stopped before we clean up the local AWS resources. I still see a bunch of errors about non-existent queues, but I don’t think this makes the problem _worse_.

While I was at it, I decided to tidy up all our server fixtures, as they’re pretty repetitive – now they all benefit from this change!

### Who is this change for?

Folks who want tidy test logs.