### PR TITLE
Sending medium agnostic messaging

### DIFF
--- a/catalogue_pipeline/id_minter/docker-compose.yml
+++ b/catalogue_pipeline/id_minter/docker-compose.yml
@@ -9,10 +9,11 @@ sns:
   image: wellcome/fake-sns
   ports:
     - "9292:9292"
-sqs:
-  image: s12v/elasticmq
+localstack:
+  image: localstack/localstack
   ports:
-    - "9324:9324"
+    - "4567-4583:4567-4583"
+    - "8080:8080"
 s3:
   image: scality/s3server:mem-latest
   ports:

--- a/catalogue_pipeline/ingestor/docker-compose.yml
+++ b/catalogue_pipeline/ingestor/docker-compose.yml
@@ -1,7 +1,8 @@
-sqs:
-  image: s12v/elasticmq
+localstack:
+  image: localstack/localstack
   ports:
-    - "9324:9324"
+    - "4567-4583:4567-4583"
+    - "8080:8080"
 elasticsearch:
   image: docker.elastic.co/elasticsearch/elasticsearch:5.6.6
   ports:

--- a/catalogue_pipeline/matcher/docker-compose.yml
+++ b/catalogue_pipeline/matcher/docker-compose.yml
@@ -1,7 +1,8 @@
-sqs:
- image: s12v/elasticmq
- ports:
-   - "9324:9324"
+localstack:
+  image: localstack/localstack
+  ports:
+    - "4567-4583:4567-4583"
+    - "8080:8080"
 dynamodb:
   image: peopleperhour/dynamodb
   ports:

--- a/catalogue_pipeline/recorder/docker-compose.yml
+++ b/catalogue_pipeline/recorder/docker-compose.yml
@@ -1,7 +1,8 @@
-sqs:
- image: s12v/elasticmq
- ports:
-   - "9324:9324"
+localstack:
+  image: localstack/localstack
+  ports:
+    - "4567-4583:4567-4583"
+    - "8080:8080"
 dynamodb:
   image: peopleperhour/dynamodb
   ports:

--- a/catalogue_pipeline/transformer/docker-compose.yml
+++ b/catalogue_pipeline/transformer/docker-compose.yml
@@ -2,10 +2,12 @@ sns:
   image: wellcome/fake-sns
   ports:
     - "9292:9292"
-sqs:
-  image: s12v/elasticmq
+localstack:
+  image: localstack/localstack
   ports:
-    - "9324:9324"
+    - "4567-4583:4567-4583"
+    - "8080:8080"
+
 s3:
   image: scality/s3server:mem-latest
   ports:

--- a/data_api/snapshot_generator/docker-compose.yml
+++ b/data_api/snapshot_generator/docker-compose.yml
@@ -5,7 +5,7 @@ sns:
 sqs:
   image: s12v/elasticmq
   ports:
-    - "9324:9324"
+    - "9324:4576"
 s3:
   image: scality/s3server:mem-latest
   ports:

--- a/goobi_adapter/goobi_reader/docker-compose.yml
+++ b/goobi_adapter/goobi_reader/docker-compose.yml
@@ -2,7 +2,8 @@ s3:
   image: scality/s3server:mem-latest
   ports:
     - "33333:8000"
-sqs:
-  image: s12v/elasticmq
+localstack:
+  image: localstack/localstack
   ports:
-    - "9324:9324"
+    - "4567-4583:4567-4583"
+    - "8080:8080"

--- a/reindexer/reindex_worker/docker-compose.yml
+++ b/reindexer/reindex_worker/docker-compose.yml
@@ -2,10 +2,11 @@ sns:
   image: wellcome/fake-sns
   ports:
     - "9292:9292"
-sqs:
-  image: s12v/elasticmq
+localstack:
+  image: localstack/localstack
   ports:
-    - "9324:9324"
+    - "4567-4583:4567-4583"
+    - "8080:8080"
 dynamodb:
   image: peopleperhour/dynamodb
   ports:

--- a/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
+++ b/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
@@ -3,14 +3,15 @@ package uk.ac.wellcome.finatra.messaging
 import com.google.inject.Provides
 import com.twitter.inject.TwitterModule
 import javax.inject.Singleton
-import uk.ac.wellcome.messaging.message.MessageReaderConfig
+import uk.ac.wellcome.messaging.message.{MessageReaderConfig, MessageWriterConfig}
+import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.sqs.SQSConfig
 import uk.ac.wellcome.storage.s3.S3Config
 
 import scala.concurrent.duration._
 
 object MessageConfigModule extends TwitterModule {
-  
+
   private val writerTopicArn = flag[String](
     "aws.message.writer.sns.topic.arn",
     "",
@@ -40,6 +41,16 @@ object MessageConfigModule extends TwitterModule {
       "aws.message.reader.sqs.maxMessages",
       10,
       "Maximum number of SQS messages to return")
+
+
+  @Singleton
+  @Provides
+  def providesMessageWriterConfig(): MessageWriterConfig = {
+    val snsConfig = SNSConfig(topicArn = writerTopicArn())
+    val s3Config = S3Config(bucketName = writerBucketName())
+
+    MessageWriterConfig(snsConfig = snsConfig, s3Config = s3Config)
+  }
 
   @Singleton
   @Provides

--- a/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
+++ b/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
@@ -3,11 +3,7 @@ package uk.ac.wellcome.finatra.messaging
 import com.google.inject.Provides
 import com.twitter.inject.TwitterModule
 import javax.inject.Singleton
-import uk.ac.wellcome.messaging.message.{
-  MessageReaderConfig,
-  MessageWriterConfig
-}
-import uk.ac.wellcome.messaging.sns.SNSConfig
+import uk.ac.wellcome.messaging.message.MessageReaderConfig
 import uk.ac.wellcome.messaging.sqs.SQSConfig
 import uk.ac.wellcome.storage.s3.S3Config
 
@@ -43,15 +39,6 @@ object MessageConfigModule extends TwitterModule {
       "aws.message.reader.sqs.maxMessages",
       10,
       "Maximum number of SQS messages to return")
-
-  @Singleton
-  @Provides
-  def providesMessageWriterConfig(): MessageWriterConfig = {
-    val snsConfig = SNSConfig(topicArn = writerTopicArn())
-    val s3Config = S3Config(bucketName = writerBucketName())
-
-    MessageWriterConfig(snsConfig = snsConfig, s3Config = s3Config)
-  }
 
   @Singleton
   @Provides

--- a/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
+++ b/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.finatra.messaging
 import com.google.inject.Provides
 import com.twitter.inject.TwitterModule
 import javax.inject.Singleton
-import uk.ac.wellcome.messaging.message.{MessageReaderConfig, MessageWriterConfig}
+import uk.ac.wellcome.messaging.message.{
+  MessageReaderConfig,
+  MessageWriterConfig
+}
 import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.sqs.SQSConfig
 import uk.ac.wellcome.storage.s3.S3Config
@@ -41,7 +44,6 @@ object MessageConfigModule extends TwitterModule {
       "aws.message.reader.sqs.maxMessages",
       10,
       "Maximum number of SQS messages to return")
-
 
   @Singleton
   @Provides

--- a/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
+++ b/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
@@ -10,6 +10,7 @@ import uk.ac.wellcome.storage.s3.S3Config
 import scala.concurrent.duration._
 
 object MessageConfigModule extends TwitterModule {
+  
   private val writerTopicArn = flag[String](
     "aws.message.writer.sns.topic.arn",
     "",

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageRetriever.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageRetriever.scala
@@ -10,7 +10,8 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait MessageRetriever[T] {
   def retrieve(notification: NotificationMessage)(
-    implicit decoderT: Decoder[T], ec: ExecutionContext
+    implicit decoderT: Decoder[T],
+    ec: ExecutionContext
   ): Future[T]
 }
 
@@ -18,21 +19,24 @@ class S3TypeMessageRetriever[T] @Inject()(s3TypeStore: S3TypeStore[T])(
   implicit decoderP: Decoder[MessagePointer]
 ) extends MessageRetriever[T] {
   def retrieve(notification: NotificationMessage)(
-    implicit decoderT: Decoder[T], ec: ExecutionContext
-  ): Future[T] = for {
-    messagePointer <- Future.fromTry(
-      fromJson[MessagePointer](notification.Message))
-    deserialisedObject <- s3TypeStore.get(messagePointer.src)
-  } yield deserialisedObject
+    implicit decoderT: Decoder[T],
+    ec: ExecutionContext
+  ): Future[T] =
+    for {
+      messagePointer <- Future.fromTry(
+        fromJson[MessagePointer](notification.Message))
+      deserialisedObject <- s3TypeStore.get(messagePointer.src)
+    } yield deserialisedObject
 }
 
-class TypeMessageRetriever[T] @Inject()()
-  extends MessageRetriever[T] {
+class TypeMessageRetriever[T] @Inject()() extends MessageRetriever[T] {
   def retrieve(notification: NotificationMessage)(
-    implicit decoderT: Decoder[T], ec: ExecutionContext
-  ): Future[T] = for {
-    deserialisedObject <- Future.fromTry(
-      fromJson[T](notification.Message)
-    )
-  } yield deserialisedObject
+    implicit decoderT: Decoder[T],
+    ec: ExecutionContext
+  ): Future[T] =
+    for {
+      deserialisedObject <- Future.fromTry(
+        fromJson[T](notification.Message)
+      )
+    } yield deserialisedObject
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageRetriever.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageRetriever.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.messaging.message
 
+import com.google.inject.Inject
 import io.circe.Decoder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.storage.s3.S3TypeStore
@@ -8,23 +9,30 @@ import uk.ac.wellcome.utils.JsonUtil.fromJson
 import scala.concurrent.{ExecutionContext, Future}
 
 trait MessageRetriever[T] {
-  def retrieve(notification: NotificationMessage)(implicit decoderT: Decoder[T],
-                                                  decoderN: Decoder[NotificationMessage], ec: ExecutionContext): Future[T]
+  def retrieve(notification: NotificationMessage)(
+    implicit decoderT: Decoder[T], ec: ExecutionContext
+  ): Future[T]
 }
 
-class S3TypeMessageRetriever[T](s3TypeStore: S3TypeStore[T])(implicit decoderP: Decoder[MessagePointer]) extends MessageRetriever[T] {
-  def retrieve(notification: NotificationMessage)(implicit decoderT: Decoder[T],
-                                                  decoderN: Decoder[NotificationMessage], ec: ExecutionContext): Future[T] = for {
+class S3TypeMessageRetriever[T] @Inject()(s3TypeStore: S3TypeStore[T])(
+  implicit decoderP: Decoder[MessagePointer]
+) extends MessageRetriever[T] {
+  def retrieve(notification: NotificationMessage)(
+    implicit decoderT: Decoder[T], ec: ExecutionContext
+  ): Future[T] = for {
     messagePointer <- Future.fromTry(
       fromJson[MessagePointer](notification.Message))
     deserialisedObject <- s3TypeStore.get(messagePointer.src)
   } yield deserialisedObject
 }
 
-class TypeMessageRetriever[T](s3TypeStore: S3TypeStore[T]) extends MessageRetriever[T] {
-  def retrieve(notification: NotificationMessage)(implicit decoderT: Decoder[T],
-                                                  decoderN: Decoder[NotificationMessage], ec: ExecutionContext): Future[T] = for {
+class TypeMessageRetriever[T] @Inject()()
+  extends MessageRetriever[T] {
+  def retrieve(notification: NotificationMessage)(
+    implicit decoderT: Decoder[T], ec: ExecutionContext
+  ): Future[T] = for {
     deserialisedObject <- Future.fromTry(
-      fromJson[T](notification.Message))
+      fromJson[T](notification.Message)
+    )
   } yield deserialisedObject
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageRetriever.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageRetriever.scala
@@ -1,0 +1,30 @@
+package uk.ac.wellcome.messaging.message
+
+import io.circe.Decoder
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.storage.s3.S3TypeStore
+import uk.ac.wellcome.utils.JsonUtil.fromJson
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MessageRetriever[T] {
+  def retrieve(notification: NotificationMessage)(implicit decoderT: Decoder[T],
+                                                  decoderN: Decoder[NotificationMessage], ec: ExecutionContext): Future[T]
+}
+
+class S3TypeMessageRetriever[T](s3TypeStore: S3TypeStore[T])(implicit decoderP: Decoder[MessagePointer]) extends MessageRetriever[T] {
+  def retrieve(notification: NotificationMessage)(implicit decoderT: Decoder[T],
+                                                  decoderN: Decoder[NotificationMessage], ec: ExecutionContext): Future[T] = for {
+    messagePointer <- Future.fromTry(
+      fromJson[MessagePointer](notification.Message))
+    deserialisedObject <- s3TypeStore.get(messagePointer.src)
+  } yield deserialisedObject
+}
+
+class TypeMessageRetriever[T](s3TypeStore: S3TypeStore[T]) extends MessageRetriever[T] {
+  def retrieve(notification: NotificationMessage)(implicit decoderT: Decoder[T],
+                                                  decoderN: Decoder[NotificationMessage], ec: ExecutionContext): Future[T] = for {
+    deserialisedObject <- Future.fromTry(
+      fromJson[T](notification.Message))
+  } yield deserialisedObject
+}

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageSender.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageSender.scala
@@ -1,0 +1,35 @@
+package uk.ac.wellcome.messaging.message
+
+import io.circe.Encoder
+import uk.ac.wellcome.messaging.sns.{PublishAttempt, SNSWriter}
+import uk.ac.wellcome.storage.s3.S3TypeStore
+import uk.ac.wellcome.utils.JsonUtil.toJson
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MessageSender[T] {
+  def send(message: T, subject: String)(
+    implicit encoder: Encoder[T], ec: ExecutionContext
+  ): Future[PublishAttempt]
+}
+
+class S3TypeMessageSender[T](sns: SNSWriter, s3TypeStore: S3TypeStore[T])(
+  implicit encoderM: Encoder[MessagePointer]
+) extends MessageSender[T] {
+  def send(message: T, subject: String)(
+    implicit encoderT: Encoder[T], ec: ExecutionContext
+  ): Future[PublishAttempt] = for {
+    location <- s3TypeStore.put(message, subject)
+    pointer <- Future.fromTry(toJson(MessagePointer(location)))
+    publishAttempt <- sns.writeMessage(pointer, subject)
+  } yield publishAttempt
+}
+
+class TypeMessageSender[T](sns: SNSWriter) extends MessageSender[T] {
+  def send(message: T, subject: String)(
+    implicit encoder: Encoder[T], ec: ExecutionContext
+  ): Future[PublishAttempt] = for {
+    jsonMessage <- Future.fromTry(toJson(message))
+    publishAttempt <- sns.writeMessage(jsonMessage, subject)
+  } yield publishAttempt
+}

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageSender.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageSender.scala
@@ -9,7 +9,8 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait MessageSender[T] {
   def send(message: T, subject: String)(
-    implicit encoder: Encoder[T], ec: ExecutionContext
+    implicit encoder: Encoder[T],
+    ec: ExecutionContext
   ): Future[PublishAttempt]
 }
 
@@ -17,19 +18,23 @@ class S3TypeMessageSender[T](sns: SNSWriter, s3TypeStore: S3TypeStore[T])(
   implicit encoderM: Encoder[MessagePointer]
 ) extends MessageSender[T] {
   def send(message: T, subject: String)(
-    implicit encoderT: Encoder[T], ec: ExecutionContext
-  ): Future[PublishAttempt] = for {
-    location <- s3TypeStore.put(message, subject)
-    pointer <- Future.fromTry(toJson(MessagePointer(location)))
-    publishAttempt <- sns.writeMessage(pointer, subject)
-  } yield publishAttempt
+    implicit encoderT: Encoder[T],
+    ec: ExecutionContext
+  ): Future[PublishAttempt] =
+    for {
+      location <- s3TypeStore.put(message, subject)
+      pointer <- Future.fromTry(toJson(MessagePointer(location)))
+      publishAttempt <- sns.writeMessage(pointer, subject)
+    } yield publishAttempt
 }
 
 class TypeMessageSender[T](sns: SNSWriter) extends MessageSender[T] {
   def send(message: T, subject: String)(
-    implicit encoder: Encoder[T], ec: ExecutionContext
-  ): Future[PublishAttempt] = for {
-    jsonMessage <- Future.fromTry(toJson(message))
-    publishAttempt <- sns.writeMessage(jsonMessage, subject)
-  } yield publishAttempt
+    implicit encoder: Encoder[T],
+    ec: ExecutionContext
+  ): Future[PublishAttempt] =
+    for {
+      jsonMessage <- Future.fromTry(toJson(message))
+      publishAttempt <- sns.writeMessage(jsonMessage, subject)
+    } yield publishAttempt
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -1,48 +1,28 @@
 package uk.ac.wellcome.messaging.message
 
-import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.sns.AmazonSNS
 import com.google.inject.Inject
 import com.twitter.inject.Logging
-import io.circe.{Decoder, Encoder}
-import uk.ac.wellcome.messaging.sns.{SNSConfig, SNSWriter}
-import uk.ac.wellcome.storage.s3.{KeyPrefixGenerator, S3Config, S3TypeStore}
 import uk.ac.wellcome.messaging.GlobalExecutionContext.context
+import io.circe.Encoder
+import uk.ac.wellcome.messaging.sns.SNSWriter
+
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.Future
 
-case class MessageWriterConfig(
-  snsConfig: SNSConfig,
-  s3Config: S3Config
-)
 
-class MessageWriter[T] @Inject()(
-  messageConfig: MessageWriterConfig,
-  snsClient: AmazonSNS,
-  s3Client: AmazonS3,
-  keyPrefixGenerator: KeyPrefixGenerator[T]
-)(implicit encoder: Encoder[T], decoder: Decoder[T])
-    extends Logging {
+class MessageWriter[T, S <: MessageSender[T]] @Inject()(
+  snsWriter: SNSWriter,
+  messageSender: S
+) extends Logging {
 
-  private val sns = new SNSWriter(
-    snsClient = snsClient,
-    snsConfig = messageConfig.snsConfig
-  )
-
-  private val s3 = new S3TypeStore[T](
-    s3Client = s3Client
-  )
-
-  def write(message: T, subject: String): Future[Unit] = {
+  def write(message: T, subject: String)(
+    implicit encoder: Encoder[T]): Future[Unit] = {
     for {
-      location <- s3.put(messageConfig.s3Config.bucketName)(
-        message,
-        keyPrefixGenerator.generate(message))
-      pointer <- Future.fromTry(toJson(MessagePointer(location)))
-      publishAttempt <- sns.writeMessage(pointer, subject)
+      publishAttempt <- messageSender.send(message, subject)
       _ = info(publishAttempt)
     } yield ()
 
   }
 }
+

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -11,9 +11,9 @@ import uk.ac.wellcome.utils.JsonUtil._
 import scala.concurrent.Future
 
 case class MessageWriterConfig(
-                                snsConfig: SNSConfig,
-                                s3Config: S3Config
-                              )
+  snsConfig: SNSConfig,
+  s3Config: S3Config
+)
 
 class MessageWriter[T, S <: MessageSender[T]] @Inject()(
   snsWriter: SNSWriter,

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -4,11 +4,16 @@ import com.google.inject.Inject
 import com.twitter.inject.Logging
 import uk.ac.wellcome.messaging.GlobalExecutionContext.context
 import io.circe.Encoder
-import uk.ac.wellcome.messaging.sns.SNSWriter
-
+import uk.ac.wellcome.messaging.sns.{SNSConfig, SNSWriter}
+import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.Future
+
+case class MessageWriterConfig(
+                                snsConfig: SNSConfig,
+                                s3Config: S3Config
+                              )
 
 class MessageWriter[T, S <: MessageSender[T]] @Inject()(
   snsWriter: SNSWriter,

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -10,7 +10,6 @@ import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.Future
 
-
 class MessageWriter[T, S <: MessageSender[T]] @Inject()(
   snsWriter: SNSWriter,
   messageSender: S
@@ -25,4 +24,3 @@ class MessageWriter[T, S <: MessageSender[T]] @Inject()(
 
   }
 }
-

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageRetrieverTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageRetrieverTest.scala
@@ -1,0 +1,83 @@
+package uk.ac.wellcome.messaging.message
+
+import org.scalatest.{Assertion, FunSpec, Matchers}
+import org.scalatest.concurrent.ScalaFutures
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.messaging.test.fixtures.Messaging
+import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
+import uk.ac.wellcome.storage.s3.{S3Config, S3ObjectLocation}
+import uk.ac.wellcome.storage.test.fixtures.S3
+import uk.ac.wellcome.test.fixtures.Akka
+import uk.ac.wellcome.test.utils.ExtendedPatience
+
+import scala.util.Random
+import scala.concurrent.ExecutionContext.Implicits.global
+import uk.ac.wellcome.utils.JsonUtil._
+
+class MessageRetrieverTest
+  extends FunSpec
+    with Matchers
+    with Messaging
+    with Akka
+    with ScalaFutures
+    with ExtendedPatience
+    with S3
+    with MetricsSenderFixture {
+
+  describe("with S3TypeMessageRetriever") {
+    it("retrieves messages") {
+      withLocalS3Bucket { bucket =>
+        withS3TypeStore[ExampleObject, Assertion](s3Client, S3Config(bucket.name)) { typeStore =>
+          withS3TypeMessageRetriever[ExampleObject, Assertion](typeStore) { retriever =>
+
+            val exampleObject = ExampleObject(Random.nextString(15))
+
+            val s3Location = S3ObjectLocation(
+              bucket = bucket.name,
+              key = Random.nextString(5)
+            )
+
+            put(exampleObject, s3Location)
+
+            val messagePointer = MessagePointer(s3Location)
+
+            val notificationMessage = NotificationMessage(
+              MessageId = Random.nextString(5),
+              TopicArn = Random.nextString(5),
+              Subject = Random.nextString(5),
+              Message = toJson(messagePointer).get
+            )
+
+            val retrieval = retriever.retrieve(notificationMessage)
+
+            whenReady(retrieval) { result =>
+              result shouldBe exampleObject
+            }
+          }
+        }
+      }
+    }
+  }
+
+  describe("with TypeMessageRetriever") {
+    it("retrieves messages") {
+      withTypeMessageRetriever[ExampleObject, Assertion]() { retriever =>
+
+        val exampleObject = ExampleObject(Random.nextString(15))
+
+        val notificationMessage = NotificationMessage(
+          MessageId = Random.nextString(5),
+          TopicArn = Random.nextString(5),
+          Subject = Random.nextString(5),
+          Message = toJson(exampleObject).get
+        )
+
+        val retrieval = retriever.retrieve(notificationMessage)
+
+        whenReady(retrieval) { result =>
+          result shouldBe exampleObject
+        }
+      }
+    }
+  }
+}

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageRetrieverTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageRetrieverTest.scala
@@ -15,7 +15,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import uk.ac.wellcome.utils.JsonUtil._
 
 class MessageRetrieverTest
-  extends FunSpec
+    extends FunSpec
     with Matchers
     with Messaging
     with Akka
@@ -27,32 +27,34 @@ class MessageRetrieverTest
   describe("with S3TypeMessageRetriever") {
     it("retrieves messages") {
       withLocalS3Bucket { bucket =>
-        withS3TypeStore[ExampleObject, Assertion](s3Client, S3Config(bucket.name)) { typeStore =>
-          withS3TypeMessageRetriever[ExampleObject, Assertion](typeStore) { retriever =>
+        withS3TypeStore[ExampleObject, Assertion](
+          s3Client,
+          S3Config(bucket.name)) { typeStore =>
+          withS3TypeMessageRetriever[ExampleObject, Assertion](typeStore) {
+            retriever =>
+              val exampleObject = ExampleObject(Random.nextString(15))
 
-            val exampleObject = ExampleObject(Random.nextString(15))
+              val s3Location = S3ObjectLocation(
+                bucket = bucket.name,
+                key = Random.nextString(5)
+              )
 
-            val s3Location = S3ObjectLocation(
-              bucket = bucket.name,
-              key = Random.nextString(5)
-            )
+              put(exampleObject, s3Location)
 
-            put(exampleObject, s3Location)
+              val messagePointer = MessagePointer(s3Location)
 
-            val messagePointer = MessagePointer(s3Location)
+              val notificationMessage = NotificationMessage(
+                MessageId = Random.nextString(5),
+                TopicArn = Random.nextString(5),
+                Subject = Random.nextString(5),
+                Message = toJson(messagePointer).get
+              )
 
-            val notificationMessage = NotificationMessage(
-              MessageId = Random.nextString(5),
-              TopicArn = Random.nextString(5),
-              Subject = Random.nextString(5),
-              Message = toJson(messagePointer).get
-            )
+              val retrieval = retriever.retrieve(notificationMessage)
 
-            val retrieval = retriever.retrieve(notificationMessage)
-
-            whenReady(retrieval) { result =>
-              result shouldBe exampleObject
-            }
+              whenReady(retrieval) { result =>
+                result shouldBe exampleObject
+              }
           }
         }
       }
@@ -62,7 +64,6 @@ class MessageRetrieverTest
   describe("with TypeMessageRetriever") {
     it("retrieves messages") {
       withTypeMessageRetriever[ExampleObject, Assertion]() { retriever =>
-
         val exampleObject = ExampleObject(Random.nextString(15))
 
         val notificationMessage = NotificationMessage(

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageSenderTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageSenderTest.scala
@@ -1,12 +1,18 @@
 package uk.ac.wellcome.messaging.message
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 import org.scalatest.concurrent.ScalaFutures
-import uk.ac.wellcome.messaging.test.fixtures.Messaging
+import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS}
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
+import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.test.fixtures.Akka
 import uk.ac.wellcome.test.utils.ExtendedPatience
+
+import scala.util.Random
+import uk.ac.wellcome.utils.JsonUtil._
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class MessageSenderTest
   extends FunSpec
@@ -16,18 +22,66 @@ class MessageSenderTest
     with ScalaFutures
     with ExtendedPatience
     with S3
+    with SNS
     with MetricsSenderFixture {
 
 
   describe("with S3TypeMessageSender") {
-    it("retrieves messages") {
+    it("sends messages") {
+      withLocalS3Bucket { bucket =>
+        withLocalSnsTopic { topic =>
+          withSNSWriter(snsClient, topic) { snsWriter =>
+            withS3TypeStore[ExampleObject, Assertion](s3Client, S3Config(bucketName = bucket.name)) { s3TypeStore =>
+              withS3TypeMessageSender[ExampleObject, Assertion](snsWriter, s3TypeStore) { messageSender =>
+                val subject = Random.nextString(10)
 
+                val exampleObject = ExampleObject(Random.nextString(15))
+
+                val attempt = messageSender.send(exampleObject, subject)
+
+                whenReady(attempt) { _ =>
+                  val messages = listMessagesReceivedFromSNS(topic)
+
+                  messages.length shouldBe 1
+                  messages.head.subject shouldBe subject
+
+                  val actualMessage = get[ExampleObject](messages.head)
+                  
+                  exampleObject shouldBe actualMessage
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 
   describe("with TypeMessageSender") {
-    it("retrieves messages") {
+    it("sends messages") {
+      withLocalSnsTopic { topic =>
+        withSNSWriter(snsClient, topic) { snsWriter =>
+          withTypeMessageSender[ExampleObject, Assertion](snsWriter) { messageSender =>
+            val subject = Random.nextString(10)
 
+            val exampleObject = ExampleObject(Random.nextString(15))
+
+            val attempt = messageSender.send(exampleObject, subject)
+
+            whenReady(attempt) { _ =>
+              val messages = listMessagesReceivedFromSNS(topic)
+
+              messages.length shouldBe 1
+              messages.head.subject shouldBe subject
+
+              val actualMessage = fromJson[ExampleObject](messages.head.message).get
+
+              exampleObject shouldBe actualMessage
+            }
+          }
+        }
+      }
     }
   }
 }
+

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageSenderTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageSenderTest.scala
@@ -15,7 +15,7 @@ import uk.ac.wellcome.utils.JsonUtil._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class MessageSenderTest
-  extends FunSpec
+    extends FunSpec
     with Matchers
     with Messaging
     with Akka
@@ -25,14 +25,17 @@ class MessageSenderTest
     with SNS
     with MetricsSenderFixture {
 
-
   describe("with S3TypeMessageSender") {
     it("sends messages") {
       withLocalS3Bucket { bucket =>
         withLocalSnsTopic { topic =>
           withSNSWriter(snsClient, topic) { snsWriter =>
-            withS3TypeStore[ExampleObject, Assertion](s3Client, S3Config(bucketName = bucket.name)) { s3TypeStore =>
-              withS3TypeMessageSender[ExampleObject, Assertion](snsWriter, s3TypeStore) { messageSender =>
+            withS3TypeStore[ExampleObject, Assertion](
+              s3Client,
+              S3Config(bucketName = bucket.name)) { s3TypeStore =>
+              withS3TypeMessageSender[ExampleObject, Assertion](
+                snsWriter,
+                s3TypeStore) { messageSender =>
                 val subject = Random.nextString(10)
 
                 val exampleObject = ExampleObject(Random.nextString(15))
@@ -46,7 +49,7 @@ class MessageSenderTest
                   messages.head.subject shouldBe subject
 
                   val actualMessage = get[ExampleObject](messages.head)
-                  
+
                   exampleObject shouldBe actualMessage
                 }
               }
@@ -61,27 +64,28 @@ class MessageSenderTest
     it("sends messages") {
       withLocalSnsTopic { topic =>
         withSNSWriter(snsClient, topic) { snsWriter =>
-          withTypeMessageSender[ExampleObject, Assertion](snsWriter) { messageSender =>
-            val subject = Random.nextString(10)
+          withTypeMessageSender[ExampleObject, Assertion](snsWriter) {
+            messageSender =>
+              val subject = Random.nextString(10)
 
-            val exampleObject = ExampleObject(Random.nextString(15))
+              val exampleObject = ExampleObject(Random.nextString(15))
 
-            val attempt = messageSender.send(exampleObject, subject)
+              val attempt = messageSender.send(exampleObject, subject)
 
-            whenReady(attempt) { _ =>
-              val messages = listMessagesReceivedFromSNS(topic)
+              whenReady(attempt) { _ =>
+                val messages = listMessagesReceivedFromSNS(topic)
 
-              messages.length shouldBe 1
-              messages.head.subject shouldBe subject
+                messages.length shouldBe 1
+                messages.head.subject shouldBe subject
 
-              val actualMessage = fromJson[ExampleObject](messages.head.message).get
+                val actualMessage =
+                  fromJson[ExampleObject](messages.head.message).get
 
-              exampleObject shouldBe actualMessage
-            }
+                exampleObject shouldBe actualMessage
+              }
           }
         }
       }
     }
   }
 }
-

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageSenderTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageSenderTest.scala
@@ -1,0 +1,33 @@
+package uk.ac.wellcome.messaging.message
+
+import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.concurrent.ScalaFutures
+import uk.ac.wellcome.messaging.test.fixtures.Messaging
+import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
+import uk.ac.wellcome.storage.test.fixtures.S3
+import uk.ac.wellcome.test.fixtures.Akka
+import uk.ac.wellcome.test.utils.ExtendedPatience
+
+class MessageSenderTest
+  extends FunSpec
+    with Matchers
+    with Messaging
+    with Akka
+    with ScalaFutures
+    with ExtendedPatience
+    with S3
+    with MetricsSenderFixture {
+
+
+  describe("with S3TypeMessageSender") {
+    it("retrieves messages") {
+
+    }
+  }
+
+  describe("with TypeMessageSender") {
+    it("retrieves messages") {
+
+    }
+  }
+}

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
@@ -9,11 +9,9 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.Messaging
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
-import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
-import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
-import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
+import uk.ac.wellcome.test.fixtures.Akka
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.utils.JsonUtil._
 
@@ -67,6 +65,7 @@ class MessageStreamTest
         sendMessage(bucket, queue, exampleObject)
 
         val received = new ConcurrentLinkedQueue[ExampleObject]()
+
         messageStream.foreach(
           streamName = "test-stream",
           process = process(received))
@@ -184,32 +183,6 @@ class MessageStreamTest
           assertQueueEmpty(queue)
           assertQueueHasSize(dlq, size = 2)
         }
-    }
-  }
-
-  def withMessageStreamFixtures[R](
-    testWith: TestWith[(Bucket,
-                        MessageStream[ExampleObject],
-                        QueuePair,
-                        MetricsSender),
-                       R]) = {
-
-    withActorSystem { actorSystem =>
-      withLocalS3Bucket { bucket =>
-        withLocalSqsQueueAndDlq {
-          case queuePair @ QueuePair(queue, _) =>
-            withMockMetricSender { metricsSender =>
-              withMessageStream[ExampleObject, R](
-                actorSystem,
-                bucket,
-                queue,
-                metricsSender) { stream =>
-                testWith((bucket, stream, queuePair, metricsSender))
-              }
-
-            }
-        }
-      }
     }
   }
 }

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessagingIntegrationTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessagingIntegrationTest.scala
@@ -28,7 +28,7 @@ class MessagingIntegrationTest
   }
 
   private def withLocalStackMessageWriter[R](
-    testWith: TestWith[(ExampleMessageWorker, MessageWriter[ExampleObject]),
+    testWith: TestWith[(ExampleMessageWorker, MessageWriter[ExampleObject, S3TypeMessageSender[ExampleObject]]),
                        R]) = {
     withExampleObjectMessageWorkerFixtures {
       case (metricsSender, queue, bucket, worker) =>

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessagingIntegrationTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessagingIntegrationTest.scala
@@ -1,13 +1,18 @@
 package uk.ac.wellcome.messaging.message
 
+import java.util.concurrent.ConcurrentLinkedQueue
+
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.test.fixtures.Messaging
+import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
+import scala.concurrent.Future
+
 class MessagingIntegrationTest
-    extends FunSpec
+  extends FunSpec
     with Matchers
     with Messaging
     with Eventually
@@ -16,7 +21,33 @@ class MessagingIntegrationTest
   val message = ExampleObject("A message sent in the MessagingIntegrationTest")
   val subject = "message-integration-test-subject"
 
-  it("sends and receives messages") {
+  def process(list: ConcurrentLinkedQueue[ExampleObject])(o: ExampleObject) = {
+    list.add(o)
+    Future.successful(())
+  }
+
+  it("sends and receives messages via writer/stream") {
+    withLocalStackMessageStream {
+      case (messageStream, messageWriter, queuePair) =>
+        messageWriter.write(message = message, subject = subject)
+
+        val received = new ConcurrentLinkedQueue[ExampleObject]()
+
+        messageStream.foreach(
+          streamName = "test-stream",
+          process = process(received))
+
+        eventually {
+          received should contain theSameElementsAs List(
+            message)
+
+          assertQueueEmpty(queuePair.queue)
+          assertQueueEmpty(queuePair.dlq)
+        }
+    }
+  }
+
+  it("sends and receives messages via writer/worker") {
     withLocalStackMessageWriter {
       case (worker, messageWriter) =>
         messageWriter.write(message = message, subject = subject)
@@ -27,9 +58,25 @@ class MessagingIntegrationTest
     }
   }
 
+
+  private def withLocalStackMessageStream[R](
+                                              testWith: TestWith[(MessageStream[ExampleObject], MessageWriter[ExampleObject, S3TypeMessageSender[ExampleObject]], QueuePair), R]) = {
+
+    withMessageStreamFixtures {
+      case (bucket, messageStream, QueuePair(queue, dlq), _) =>
+        withLocalStackSnsTopic { topic =>
+          withLocalStackSubscription(queue, topic) { _ =>
+            withMessageWriter(bucket, topic, localStackSnsClient) {
+              messageWriter =>
+                testWith((messageStream, messageWriter, QueuePair(queue,dlq)))
+            }
+          }
+        }
+    }
+  }
+
   private def withLocalStackMessageWriter[R](
-    testWith: TestWith[(ExampleMessageWorker, MessageWriter[ExampleObject, S3TypeMessageSender[ExampleObject]]),
-                       R]) = {
+                                              testWith: TestWith[(ExampleMessageWorker, MessageWriter[ExampleObject, S3TypeMessageSender[ExampleObject]]), R]) = {
     withExampleObjectMessageWorkerFixtures {
       case (metricsSender, queue, bucket, worker) =>
         withLocalStackSnsTopic { topic =>

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessagingIntegrationTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessagingIntegrationTest.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.test.utils.ExtendedPatience
 import scala.concurrent.Future
 
 class MessagingIntegrationTest
-  extends FunSpec
+    extends FunSpec
     with Matchers
     with Messaging
     with Eventually
@@ -38,8 +38,7 @@ class MessagingIntegrationTest
           process = process(received))
 
         eventually {
-          received should contain theSameElementsAs List(
-            message)
+          received should contain theSameElementsAs List(message)
 
           assertQueueEmpty(queuePair.queue)
           assertQueueEmpty(queuePair.dlq)
@@ -58,9 +57,12 @@ class MessagingIntegrationTest
     }
   }
 
-
   private def withLocalStackMessageStream[R](
-                                              testWith: TestWith[(MessageStream[ExampleObject], MessageWriter[ExampleObject, S3TypeMessageSender[ExampleObject]], QueuePair), R]) = {
+    testWith: TestWith[
+      (MessageStream[ExampleObject],
+       MessageWriter[ExampleObject, S3TypeMessageSender[ExampleObject]],
+       QueuePair),
+      R]) = {
 
     withMessageStreamFixtures {
       case (bucket, messageStream, QueuePair(queue, dlq), _) =>
@@ -68,7 +70,7 @@ class MessagingIntegrationTest
           withLocalStackSubscription(queue, topic) { _ =>
             withMessageWriter(bucket, topic, localStackSnsClient) {
               messageWriter =>
-                testWith((messageStream, messageWriter, QueuePair(queue,dlq)))
+                testWith((messageStream, messageWriter, QueuePair(queue, dlq)))
             }
           }
         }
@@ -76,7 +78,10 @@ class MessagingIntegrationTest
   }
 
   private def withLocalStackMessageWriter[R](
-                                              testWith: TestWith[(ExampleMessageWorker, MessageWriter[ExampleObject, S3TypeMessageSender[ExampleObject]]), R]) = {
+    testWith: TestWith[
+      (ExampleMessageWorker,
+       MessageWriter[ExampleObject, S3TypeMessageSender[ExampleObject]]),
+      R]) = {
     withExampleObjectMessageWorkerFixtures {
       case (metricsSender, queue, bucket, worker) =>
         withLocalStackSnsTopic { topic =>

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -2,11 +2,7 @@ package uk.ac.wellcome.messaging.test.fixtures
 
 import akka.actor.ActorSystem
 import com.amazonaws.services.sns.AmazonSNS
-import com.amazonaws.services.sns.model.{
-  SubscribeRequest,
-  SubscribeResult,
-  UnsubscribeRequest
-}
+import com.amazonaws.services.sns.model.{SubscribeRequest, SubscribeResult, UnsubscribeRequest}
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
 import org.scalatest.Matchers
@@ -17,15 +13,14 @@ import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
-import uk.ac.wellcome.storage.s3.{
-  KeyPrefixGenerator,
-  S3Config,
-  S3ObjectLocation
-}
+import uk.ac.wellcome.storage.s3._
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.utils.JsonUtil._
+
+import uk.ac.wellcome.messaging.sns.SNSWriter
+
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -155,19 +150,19 @@ trait Messaging
   def withMessageWriter[R](bucket: Bucket,
                            topic: Topic,
                            writerSnsClient: AmazonSNS = snsClient)(
-    testWith: TestWith[MessageWriter[ExampleObject], R]) = {
+    testWith: TestWith[MessageWriter[ExampleObject, S3TypeMessageSender[ExampleObject]], R]) = {
+
     val s3Config = S3Config(bucketName = bucket.name)
     val snsConfig = SNSConfig(topicArn = topic.arn)
-    val messageConfig = MessageWriterConfig(
-      s3Config = s3Config,
-      snsConfig = snsConfig
-    )
+    val snsWriter = new SNSWriter(snsClient, snsConfig)
+    val s3StringStore = new S3StringStore(s3Client, s3Config)
+    val s3TypeStore = new S3TypeStore[ExampleObject](s3StringStore)
 
-    val messageWriter = new MessageWriter[ExampleObject](
-      messageConfig = messageConfig,
-      snsClient = writerSnsClient,
-      s3Client = s3Client,
-      keyPrefixGenerator = keyPrefixGenerator
+    val messageSender = new S3TypeMessageSender[ExampleObject](snsWriter, s3TypeStore)
+
+    val messageWriter = new MessageWriter[ExampleObject, S3TypeMessageSender[ExampleObject]](
+      snsWriter = snsWriter,
+      messageSender = messageSender
     )
 
     testWith(messageWriter)
@@ -230,17 +225,19 @@ trait Messaging
       waitTime = 1 millisecond,
       maxMessages = 1)
 
-    val messageConfig = MessageReaderConfig(
-      sqsConfig = sqsConfig,
-      s3Config = s3Config
-    )
+    val s3StringStore = new S3StringStore(s3Client, s3Config)
+
+    val s3TypeStore = new S3TypeStore[T](s3StringStore)
+
+    val messageRetriever = new S3TypeMessageRetriever[T](s3TypeStore)
 
     val stream = new MessageStream[T](
       actorSystem,
       asyncSqsClient,
-      s3Client,
-      messageConfig,
+      sqsConfig,
+      messageRetriever,
       metricsSender)
+
     testWith(stream)
   }
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -77,7 +77,8 @@ trait SQS extends Matchers {
       queue
     },
     destroy = { queue =>
-      localStackSqsClient.purgeQueue(new PurgeQueueRequest().withQueueUrl(queue.url))
+      localStackSqsClient.purgeQueue(
+        new PurgeQueueRequest().withQueueUrl(queue.url))
       localStackSqsClient.deleteQueue(queue.url)
     }
   )

--- a/sierra_adapter/sierra_bib_merger/docker-compose.yml
+++ b/sierra_adapter/sierra_bib_merger/docker-compose.yml
@@ -1,7 +1,8 @@
-sqs:
- image: s12v/elasticmq
- ports:
-   - "9324:9324"
+localstack:
+  image: localstack/localstack
+  ports:
+    - "4567-4583:4567-4583"
+    - "8080:8080"
 dynamodb:
   image: peopleperhour/dynamodb
   ports:

--- a/sierra_adapter/sierra_item_merger/docker-compose.yml
+++ b/sierra_adapter/sierra_item_merger/docker-compose.yml
@@ -1,7 +1,8 @@
-sqs:
- image: s12v/elasticmq
- ports:
-   - "9324:9324"
+localstack:
+  image: localstack/localstack
+  ports:
+    - "4567-4583:4567-4583"
+    - "8080:8080"
 dynamodb:
   image: peopleperhour/dynamodb
   ports:

--- a/sierra_adapter/sierra_items_to_dynamo/docker-compose.yml
+++ b/sierra_adapter/sierra_items_to_dynamo/docker-compose.yml
@@ -2,7 +2,8 @@ dynamodb:
   image: peopleperhour/dynamodb
   ports:
     - "45678:8000"
-sqs:
-  image: s12v/elasticmq
+localstack:
+  image: localstack/localstack
   ports:
-    - "9324:9324"
+    - "4567-4583:4567-4583"
+    - "8080:8080"

--- a/sierra_adapter/sierra_reader/docker-compose.yml
+++ b/sierra_adapter/sierra_reader/docker-compose.yml
@@ -2,10 +2,10 @@ s3:
   image: scality/s3server:mem-latest
   ports:
     - "33333:8000"
-sqs:
-  image: s12v/elasticmq
+localstack:
+  image: localstack/localstack
   ports:
-    - "9324:9324"
+    - "4567-4583:4567-4583"
 wiremock:
   image: rodolpheche/wiremock
   ports:


### PR DESCRIPTION
### What is this PR trying to achieve?

We need to be able to send messages that are too large for SNS/SQS and also account for the case where we know the messages are small enough to send without S3.

Creates a `MessageRetriever` and `MessageSender` trait, with `MessageStream` and `MessageWriter` accepting those as constructor params respectively.

The implementer can write their own retrieval and sending logic.

This PR implements:
-  `TypeMessageSender`: Send strongly typed objects using SNS only.
- `TypeMessageRetriever`: Send strongly typed objects using SNS and S3, for when your objects are too large to send.
- `S3TypeMessageSender`: Gets strongly typed objects using SQS only.
- `S3TypeMessageRetriever` : Gets strongly typed objects using SQS and S3, for when your objects are too large to retrieve.

### Who is this change for?

📹 🐕 