### PR TITLE
Less is more: improve the coverage of Lambda testing in Travis while saving build jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,21 @@ jobs:
     - env: TASK=common_storage-test
     - env: TASK=common_monitoring-test
 
+    # Lambda tests.
+    #
+    # We test all the Lambdas in a single job to reduce the number of small
+    # build VMs we start.  Because most of our applications are Scala, the
+    # majority of builds for a Lambda wake up, discover they have nothing to
+    # do, and exit immediately.
+    #
+    # This includes all the tests for monitoring and shared_infra stacks.
+    #
+    # When this job runs, all the Lambdas get tested at once, but even this
+    # isn't significantly longer than a Scala test.
+    #
+    - stage: test
+      env: TASK=travis-lambda-test
+
     # Catalogue API stack
     - stage: test
       env: TASK=api-test
@@ -94,29 +109,20 @@ jobs:
     - env: TASK=id_minter-test
 
     # Data API stack
-    - env: TASK=snapshot_scheduler-test
     - env: TASK=snapshot_generator-test
 
     # Reindexer stack
     - env: TASK=reindex_worker-test
-    - env: TASK=reindex_job_creator-test
-    - env: TASK=complete_reindex-test
-    - env: TASK=reindex_shard_generator-test
 
     # Goobi adapter stack
     - env: TASK=goobi_reader-test
 
     # Sierra adapter stack
     - env: TASK=sierra_adapter_common-test
-    - env: TASK=sierra_window_generator-test
     - env: TASK=sierra_reader-test
     - env: TASK=sierra_items_to_dynamo-test
     - env: TASK=sierra_bib_merger-test
     - env: TASK=sierra_item_merger-test
-    - env: TASK=s3_demultiplexer-test
-
-    # Shared infra stack
-    - env: TASK=shared_infra-test
 
     # (not under active development)
 
@@ -126,9 +132,6 @@ jobs:
     # Loris stack
     # - env: TASK=loris-build
     # - env: TASK=cache_cleaner-build
-
-    # Monitoring stack
-    # - env: TASK=monitoring-test
 
 stages:
   - quicktest

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,21 +93,7 @@ jobs:
     # isn't significantly longer than a Scala test.
     #
     - stage: test
-      env: TRAVIS_LAMBDAS="snapshot_scheduler \
-        reindex_job_creator \
-        complete_reindex \
-        reindex_shard_generator \
-        sierra_window_generator \
-        s3_demultiplexer \
-        drain_ecs_container_instance \
-        dynamo_to_sns \
-        ecs_ec2_instance_tagger \
-        run_ecs_task \
-        gatling_to_cloudwatch \
-        notify_old_deploys \
-        post_to_slack \
-        service_deployment_status \
-        update_service_list"
+      env: TRAVIS_LAMBDAS="snapshot_scheduler reindex_job_creator complete_reindex reindex_shard_generator sierra_window_generator s3_demultiplexer drain_ecs_container_instance dynamo_to_sns ecs_ec2_instance_tagger run_ecs_task gatling_to_cloudwatch notify_old_deploys post_to_slack service_deployment_status update_service_list"
       env: TASK=travis-lambda-test
 
     # Catalogue API stack

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,21 @@ jobs:
     # isn't significantly longer than a Scala test.
     #
     - stage: test
+      env: TRAVIS_LAMBDAS = snapshot_scheduler \
+        reindex_job_creator \
+        complete_reindex \
+        reindex_shard_generator \
+        sierra_window_generator \
+        s3_demultiplexer \
+        drain_ecs_container_instance \
+        dynamo_to_sns \
+        ecs_ec2_instance_tagger \
+        run_ecs_task \
+        gatling_to_cloudwatch \
+        notify_old_deploys \
+        post_to_slack \
+        service_deployment_status \
+        update_service_list
       env: TASK=travis-lambda-test
 
     # Catalogue API stack

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,8 +93,23 @@ jobs:
     # isn't significantly longer than a Scala test.
     #
     - stage: test
-      env: TRAVIS_LAMBDAS="snapshot_scheduler reindex_job_creator complete_reindex reindex_shard_generator sierra_window_generator s3_demultiplexer drain_ecs_container_instance dynamo_to_sns ecs_ec2_instance_tagger run_ecs_task gatling_to_cloudwatch notify_old_deploys post_to_slack service_deployment_status update_service_list"
-      env: TASK=travis-lambda-test
+      env:
+        - TRAVIS_LAMBDAS="snapshot_scheduler \
+          reindex_job_creator \
+          complete_reindex \
+          reindex_shard_generator \
+          sierra_window_generator \
+          s3_demultiplexer \
+          drain_ecs_container_instance \
+          dynamo_to_sns \
+          ecs_ec2_instance_tagger \
+          run_ecs_task \
+          gatling_to_cloudwatch \
+          notify_old_deploys \
+          post_to_slack \
+          service_deployment_status \
+          update_service_list"
+        - TASK=travis-lambda-test
 
     # Catalogue API stack
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ jobs:
     # isn't significantly longer than a Scala test.
     #
     - stage: test
-      env: TRAVIS_LAMBDAS = snapshot_scheduler \
+      env: TRAVIS_LAMBDAS="snapshot_scheduler \
         reindex_job_creator \
         complete_reindex \
         reindex_shard_generator \
@@ -107,7 +107,7 @@ jobs:
         notify_old_deploys \
         post_to_slack \
         service_deployment_status \
-        update_service_list
+        update_service_list"
       env: TASK=travis-lambda-test
 
     # Catalogue API stack

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ sbt-common-publish:
 
 
 travis-lambda-test:
-	$(foreach task,$(TRAVIS_LAMBDAS),TASK=$(task)-test python run_travis_task.py;)
+	python run_travis_lambdas.py test
 
 travis-lambda-publish:
-	$(foreach task,$(TRAVIS_LAMBDAS),TASK=$(task)-publish python run_travis_task.py;)
+	python run_travis_lambdas.py publish
 
 
 travistooling-test:

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ sbt-common-publish:
 
 
 travis-lambda-test:
-	$(foreach task,$(TRAVIS_LAMBDAS),python run_travis_task.py $(task)-test;)
+	$(foreach task,$(TRAVIS_LAMBDAS),TASK=$(task)-test python run_travis_task.py;)
 
 travis-lambda-publish:
-	$(foreach task,$(TRAVIS_LAMBDAS),python run_travis_task.py $(task)-publish;)
+	$(foreach task,$(TRAVIS_LAMBDAS),TASK=$(task)-publish python run_travis_task.py;)
 
 
 travistooling-test:

--- a/Makefile
+++ b/Makefile
@@ -25,23 +25,21 @@ sbt-common-publish:
 	echo "Nothing to do!"
 
 
-travis-lambda-test: snapshot_scheduler-test \
-					reindex_job_creator-test \
-					complete_reindex-test \
-					reindex_shard_generator-test \
-					sierra_window_generator-test \
-					s3_demultiplexer-test \
-					shared_infra-test \
-					monitoring-test
+TRAVIS_LAMBDAS = snapshot_scheduler-test \
+				reindex_job_creator-test \
+				complete_reindex-test \
+				reindex_shard_generator-test \
+				sierra_window_generator-test \
+				s3_demultiplexer-test \
+				shared_infra-test \
+				monitoring-test
 
-travis-lambda-publish: snapshot_scheduler-publish \
-					reindex_job_creator-publish \
-					complete_reindex-publish \
-					reindex_shard_generator-publish \
-					sierra_window_generator-publish \
-					s3_demultiplexer-publish \
-					shared_infra-publish \
-					monitoring-publish
+
+travis-lambda-test:
+	$(foreach task,$(TRAVIS_LAMBDAS),python run_travis_task.py $(task)-test;)
+
+travis-lambda-publish:
+	$(foreach task,$(TRAVIS_LAMBDAS),python run_travis_task.py $(task)-publish;)
 
 
 travistooling-test:

--- a/Makefile
+++ b/Makefile
@@ -25,16 +25,6 @@ sbt-common-publish:
 	echo "Nothing to do!"
 
 
-TRAVIS_LAMBDAS = snapshot_scheduler-test \
-				reindex_job_creator-test \
-				complete_reindex-test \
-				reindex_shard_generator-test \
-				sierra_window_generator-test \
-				s3_demultiplexer-test \
-				shared_infra-test \
-				monitoring-test
-
-
 travis-lambda-test:
 	$(foreach task,$(TRAVIS_LAMBDAS),python run_travis_task.py $(task)-test;)
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,25 @@ sbt-common-publish:
 	echo "Nothing to do!"
 
 
+travis-lambda-test: snapshot_scheduler-test \
+					reindex_job_creator-test \
+					complete_reindex-test \
+					reindex_shard_generator-test \
+					sierra_window_generator-test \
+					s3_demultiplexer-test \
+					shared_infra-test \
+					monitoring-test
+
+travis-lambda-publish: snapshot_scheduler-publish \
+					reindex_job_creator-publish \
+					complete_reindex-publish \
+					reindex_shard_generator-publish \
+					sierra_window_generator-publish \
+					s3_demultiplexer-publish \
+					shared_infra-publish \
+					monitoring-publish
+
+
 travistooling-test:
 	$(ROOT)/docker_run.py -- \
 		--volume $(ROOT):/data \

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -19,17 +19,3 @@ $(val $(call stack_setup))
 include $(ROOT)/monitoring/deployment_tracking/Makefile
 include $(ROOT)/monitoring/ecs_dashboard/Makefile
 include $(ROOT)/monitoring/load_test/Makefile
-
-
-monitoring-test: gatling_to_cloudwatch-test \
-				 notify_old_deploys-test \
-				 post_to_slack-test \
-				 service_deployment_status-test \
-				 update_service_list-test
-
-monitoring-publish:	gatling_to_cloudwatch-publish \
-					gatling-publish \
-					notify_old_deploys-publish \
-					post_to_slack-publish \
-					service_deployment_status-publish \
-					update_service_list-publish

--- a/run_travis_lambdas.py
+++ b/run_travis_lambdas.py
@@ -24,7 +24,10 @@ if __name__ == '__main__':
         try:
             subprocess.check_call(
                 ['python', 'run_travis_task.py'],
-                env={'TASK': '%s-%s' % (lambda_name, verb)}
+                env={
+                    'TASK': '%s-%s' % (lambda_name, verb),
+                    'TRAVIS_EVENT_TYPE': os.environ['TRAVIS_EVENT_TYPE'],
+                }
             )
         except subprocess.CalledProcessError:
             outcome = 'FAILED'

--- a/run_travis_lambdas.py
+++ b/run_travis_lambdas.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8
+"""
+Usage: run_travis_lambdas.py (test|publish)
+"""
+
+import os
+import subprocess
+import sys
+
+
+if __name__ == '__main__':
+    try:
+        verb = sys.argv[1]
+        assert verb in ('test', 'publish')
+    except (AssertionError, IndexError):
+        sys.exit(__doc__.strip())
+
+    results = {}
+
+    for lambda_name in os.environ['TRAVIS_LAMBDAS'].split():
+        print('===  Starting Lambda task for %s ===' % lambda_name)
+
+        try:
+            subprocess.check_call(
+                ['python', 'run_travis_task.py'],
+                env={'TASK': '%s-%s' % (lambda_name, verb)}
+            )
+        except subprocess.CalledProcessError:
+            outcome = 'FAILED'
+        else:
+            outcome = 'OK'
+
+        results[lambda_name] = outcome
+
+        print(
+            '=== Completed Lambda task for %s [%s] ===' %
+            (lambda_name, outcome)
+        )
+
+    print('')
+    print('=== SUMMARY ===')
+    for (name, outcome) in sorted(results.items()):
+        print('%s %s' % (name.ljust(30), outcome))
+
+    if set(results.values()) == 'OK':
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/run_travis_lambdas.py
+++ b/run_travis_lambdas.py
@@ -21,14 +21,11 @@ if __name__ == '__main__':
     for lambda_name in os.environ['TRAVIS_LAMBDAS'].split():
         print('===  Starting Lambda task for %s ===' % lambda_name)
 
+        env = os.environ.copy()
+        env['TASK'] = '%s-%s' % (lambda_name, verb)
+
         try:
-            subprocess.check_call(
-                ['python', 'run_travis_task.py'],
-                env={
-                    'TASK': '%s-%s' % (lambda_name, verb),
-                    'TRAVIS_EVENT_TYPE': os.environ['TRAVIS_EVENT_TYPE'],
-                }
-            )
+            subprocess.check_call(['python', 'run_travis_task.py'], env=env)
         except subprocess.CalledProcessError:
             outcome = 'FAILED'
         else:

--- a/run_travis_lambdas.py
+++ b/run_travis_lambdas.py
@@ -18,7 +18,9 @@ if __name__ == '__main__':
 
     results = {}
 
-    for lambda_name in os.environ['TRAVIS_LAMBDAS'].split():
+    names = os.environ['TRAVIS_LAMBDAS'].replace('\\\n', ' ').split()
+
+    for lambda_name in names:
         print('===  Starting Lambda task for %s ===' % lambda_name)
 
         env = os.environ.copy()

--- a/run_travis_lambdas.py
+++ b/run_travis_lambdas.py
@@ -18,7 +18,11 @@ if __name__ == '__main__':
 
     results = {}
 
-    names = os.environ['TRAVIS_LAMBDAS'].replace('\\\n', ' ').split()
+    names = [
+        n
+        for n in os.environ['TRAVIS_LAMBDAS'].split()
+        if n != '\\'
+    ]
 
     for lambda_name in names:
         print('===  Starting Lambda task for %s ===' % lambda_name)
@@ -45,7 +49,7 @@ if __name__ == '__main__':
     for (name, outcome) in sorted(results.items()):
         print('%s %s' % (name.ljust(30), outcome))
 
-    if set(results.values()) == 'OK':
+    if set(results.values()) == set(['OK']):
         sys.exit(0)
     else:
         sys.exit(1)

--- a/shared_infra/Makefile
+++ b/shared_infra/Makefile
@@ -17,14 +17,3 @@ TF_PATH     = $(STACK_ROOT)
 TF_IS_PUBLIC_FACING = false
 
 $(val $(call stack_setup))
-
-
-shared_infra-test:	drain_ecs_container_instance-test \
-					dynamo_to_sns-test \
-					ecs_ec2_instance_tagger-test \
-					run_ecs_task-test
-
-shared_infra-publish:	drain_ecs_container_instance-publish \
-						dynamo_to_sns-publish \
-						ecs_ec2_instance_tagger-publish \
-						run_ecs_task-publish

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -71,20 +71,17 @@ def does_file_affect_build_task(path, task):
     # For example, the ``catalogue_api/api`` directory only contains code
     # for the api Scala app, so changes in this directory cannot affect
     # any other task.
-    #
-    for project in PROJECTS:
-        project_path = os.path.relpath(project.exclusive_path, start=ROOT)
-        if path.startswith(project_path):
-            if (
-                project.type == 'python_lambda' and
-                task in ('travis-lambda-test', 'travis-lambda-publish')
-            ):
-                raise ExclusivelyAffectsThisTask()
+    exclusive_directories = {
+        os.path.relpath(t.exclusive_path, start=ROOT): t.name for t in PROJECTS
+    }
 
-            if task.startswith(project.name):
+    for dir_name, task_prefix in exclusive_directories.items():
+        if path.startswith(dir_name):
+            if task.startswith(task_prefix):
                 raise ExclusivelyAffectsThisTask()
             else:
-                raise ExclusivelyAffectsAnotherTask(project.name)
+                raise ExclusivelyAffectsAnotherTask(task_prefix)
+
 
     # We have a couple of sbt common libs and files scattered around the
     # repository; changes to any of these don't affect non-sbt applications.

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -71,16 +71,20 @@ def does_file_affect_build_task(path, task):
     # For example, the ``catalogue_api/api`` directory only contains code
     # for the api Scala app, so changes in this directory cannot affect
     # any other task.
-    exclusive_directories = {
-        os.path.relpath(t.exclusive_path, start=ROOT): t.name for t in PROJECTS
-    }
+    #
+    for project in PROJECTS:
+        project_path = os.path.relpath(project.exclusive_path, start=ROOT)
+        if path.startswith(project_path):
+            if (
+                project.type == 'python_lambda' and
+                task in ('travis-lambda-test', 'travis-lambda-publish')
+            ):
+                raise ExclusivelyAffectsThisTask()
 
-    for dir_name, task_prefix in exclusive_directories.items():
-        if path.startswith(dir_name):
-            if task.startswith(task_prefix):
+            if task.startswith(project.name):
                 raise ExclusivelyAffectsThisTask()
             else:
-                raise ExclusivelyAffectsAnotherTask(task_prefix)
+                raise ExclusivelyAffectsAnotherTask(project.name)
 
     # We have a couple of sbt common libs and files scattered around the
     # repository; changes to any of these don't affect non-sbt applications.
@@ -91,7 +95,7 @@ def does_file_affect_build_task(path, task):
         'build.sbt',
         'sbt_common/'
     )):
-        if task == 'travistooling-test':
+        if (task in 'travistooling-test') or task.startswith('travis-lambda'):
             raise ScalaChangeAndNotScalaApp()
 
         for project in PROJECTS:

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -15,6 +15,7 @@ import os
 from travistooling.decisions import (
     ChangesToTestsDontGetPublished,
     CheckedByTravisFormat,
+    CheckedByTravisLambda,
     ExclusivelyAffectsAnotherTask,
     ExclusivelyAffectsThisTask,
     IgnoredFileFormat,
@@ -41,6 +42,14 @@ def does_file_affect_build_task(path, task):
         path.endswith(('.scala', '.tf', '.py', '.json', '.ttl'))
     ):
         raise CheckedByTravisFormat()
+
+    # And a quick catch-all of file types that might signify a change for
+    # travis-lambda-{test, publish}
+    if (
+        task.startswith('travis-lambda-') and
+        path.endswith(('requirements.txt', '.py'))
+    ):
+        raise CheckedByTravisLambda()
 
     # These extensions and paths never have an effect on tests.
     if path.endswith(('.in', '.md', '.png', '.graffle', '.tf', 'Makefile')):

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -60,6 +60,7 @@ def does_file_affect_build_task(path, task):
         'LICENSE',
         '.travis.yml',
         'run_travis_task.py',
+        'run_travis_lambdas.py',
     ] or path.startswith(('misc/', 'ontologies/', 'data_science/scripts/')):
         raise IgnoredPath()
 

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -92,7 +92,6 @@ def does_file_affect_build_task(path, task):
             else:
                 raise ExclusivelyAffectsAnotherTask(task_prefix)
 
-
     # We have a couple of sbt common libs and files scattered around the
     # repository; changes to any of these don't affect non-sbt applications.
     if path.startswith((

--- a/travistooling/decisions.py
+++ b/travistooling/decisions.py
@@ -51,6 +51,10 @@ class CheckedByTravisFormat(SignificantFile):
     message = 'File format is checked by the travis-format task'
 
 
+class CheckedByTravisLambda(SignificantFile):
+    message = 'File format is chekced by the travis-lambda task'
+
+
 class ScalaChangeAndIsScalaApp(SignificantFile):
     message = 'Changes to Scala common libs affect Scala apps'
 

--- a/travistooling/decisions.py
+++ b/travistooling/decisions.py
@@ -52,7 +52,7 @@ class CheckedByTravisFormat(SignificantFile):
 
 
 class CheckedByTravisLambda(SignificantFile):
-    message = 'File format is chekced by the travis-lambda task'
+    message = 'File format is checked by the travis-lambda task'
 
 
 class ScalaChangeAndIsScalaApp(SignificantFile):

--- a/travistooling/tests/test_decisionmaker.py
+++ b/travistooling/tests/test_decisionmaker.py
@@ -9,6 +9,7 @@ from travistooling.decisionmaker import (
 from travistooling.decisions import (
     ChangesToTestsDontGetPublished,
     CheckedByTravisFormat,
+    CheckedByTravisLambda,
     ExclusivelyAffectsAnotherTask,
     ExclusivelyAffectsThisTask,
     IgnoredFileFormat,
@@ -83,8 +84,8 @@ from travistooling.decisions import (
     ('reindex_job_creator/.coveragerc', 'reindex_shard_generator-publish', ChangesToTestsDontGetPublished, False),
 
     # Changes to Lambdas trigger the travis-lambda-test task.
-    ('reindexer/reindex_job_creator/src/reindex_job_creator.py', 'travis-lambda-test', ExclusivelyAffectsThisTask, True),
-    ('reindexer/reindex_job_creator/src/reindex_job_creator.py', 'travis-lambda-publish', ExclusivelyAffectsThisTask, True),
+    ('reindexer/reindex_job_creator/src/reindex_job_creator.py', 'travis-lambda-test', CheckedByTravisLambda, True),
+    ('reindexer/reindex_job_creator/src/reindex_job_creator.py', 'travis-lambda-publish', CheckedByTravisLambda, True),
 
     # Changes to travistooling only trigger the travistooling tests
     ('travistooling/decisionmaker.py', 'travistooling-test', ExclusivelyAffectsThisTask, True),

--- a/travistooling/tests/test_decisionmaker.py
+++ b/travistooling/tests/test_decisionmaker.py
@@ -67,6 +67,7 @@ from travistooling.decisions import (
     ('sierra_adapter/common/main.scala', 'travistooling-test', ScalaChangeAndNotScalaApp, False),
     ('sbt_common/display/model.scala', 'id_minter-test', ScalaChangeAndIsScalaApp, True),
     ('sbt_common/display/model.scala', 'loris-publish', ScalaChangeAndNotScalaApp, False),
+    ('sbt_common/display/model.scala', 'travis-lambda-test', ScalaChangeAndNotScalaApp, False),
     ('sbt_common/display/model.scala', 'sierra_adapter-publish', UnrecognisedFile, True),
 
     # Changes to Scala test files trigger a -test Scala task, but not
@@ -80,6 +81,10 @@ from travistooling.decisions import (
     ('lambda_conftest.py', 'post_to_slack-publish', ChangesToTestsDontGetPublished, False),
     ('shared_conftest.py', 'reindex_shard_generator-publish', ChangesToTestsDontGetPublished, False),
     ('reindex_job_creator/.coveragerc', 'reindex_shard_generator-publish', ChangesToTestsDontGetPublished, False),
+
+    # Changes to Lambdas trigger the travis-lambda-test task.
+    ('reindexer/reindex_job_creator/src/reindex_job_creator.py', 'travis-lambda-test', ExclusivelyAffectsThisTask, True),
+    ('reindexer/reindex_job_creator/src/reindex_job_creator.py', 'travis-lambda-publish', ExclusivelyAffectsThisTask, True),
 
     # Changes to travistooling only trigger the travistooling tests
     ('travistooling/decisionmaker.py', 'travistooling-test', ExclusivelyAffectsThisTask, True),

--- a/travistooling/tests/test_travis_utils.py
+++ b/travistooling/tests/test_travis_utils.py
@@ -1,11 +1,18 @@
 # -*- encoding: utf-8
 
 import os
+import subprocess
 from unittest import mock
 
 import pytest
 
 from travistooling import travis_utils
+
+
+@pytest.fixture
+def cleanup_secrets():
+    yield
+    subprocess.check_call(['rm', '-rf', 'secrets'])
 
 
 def test_not_in_travis_is_an_error():
@@ -33,7 +40,7 @@ def test_travis_branch_name_on_pr():
         assert travis_utils.branch_name() == 'feature-branch'
 
 
-def test_unpack_secrets():
+def test_unpack_secrets(cleanup_secrets):
     travis_utils.unpack_secrets()
     assert os.path.exists('secrets/id_rsa')
 

--- a/travistooling/travis_utils.py
+++ b/travistooling/travis_utils.py
@@ -25,6 +25,9 @@ def unpack_secrets():  # pragma: no cover
 
     This unencrypts the credentials, and copies them into place.
     """
+    if os.path.exists('secrets'):
+        return
+
     print('*** Loading secrets for Travis')
 
     # Unencrypted the encrypted ZIP file.


### PR DESCRIPTION
### What is this PR trying to achieve?

Currently we spend 7 build VMs per Travis run on Lambdas – even though we primarily write in Scala. That means we spend a significant amount of time starting build VMs that immediately exit.

This patch puts all our Lambda testing on a single VM, so if a patch only contains Scala changes we save having to boot **six VMs**. Additional niceties:

* Within the travis-lambda-test task, each Lambda is still considered separately. If we’ve changed one Lambda, we should only test that Lambda, not the whole set.
* We get rid of the shared_infra-test task, which was all-or-nothing.
* The monitoring Lambdas are being tested in Travis again.
* Now Lambda dependencies are pinned (see #2063), publishes should be truly deterministic, so we won't have unnecessary deployment churn.

I'm still fine-tuning the details, but I think this is nearly ready.

### Who is this change for?

🏷 Ⓜ️ 