### PR TITLE
[RFC] Merged work identifier is one of the original source identifiers

### DIFF
--- a/docs/rfcs/merger_matcher/README.md
+++ b/docs/rfcs/merger_matcher/README.md
@@ -65,7 +65,7 @@ This implies storing each work that is sees, along to the group of nodes it belo
 The group that each work belongs to should have an indentifier that is deterministic on the identifiers of the nodes that compose it.
 The group identifiers should be never exposed outside the matcher.
 
-Similalry, the matcher needs to be able to break connections if a link from one node to another is removes.
+Similarly, the matcher needs to be able to break connections if a link from one work to another is removed.
 This mean storing, for each work, the list of works directly referenced.
 
 ## Database schema
@@ -177,23 +177,15 @@ We receive an update to B telling us it now has edges B→A and B→D.
         F         | -     | ABCDEF
 
 4.  The output JSON is:
-    ```[json]
+```[json]
+{
+  "work-groups":[
     {
-    "work-groups":[
-        {
-            "identifiers":
-                [
-                    "A",
-                    "B",
-                    "C",
-                    "D",
-                    "E",
-                    "F"
-                ]
-        }
-    ]
+      "identifiers": [ "A", "B", "C", "D", "E", "F" ]
     }
-    ```
+  ]
+}
+```
 
 ## Example 2
 
@@ -248,7 +240,8 @@ This results in an eventually consistent graph, which is as good as we can
 guarantee.
 
 3. Eventually the output JSON is:
-    ```[json]
+
+```[json]
 {
   "work-groups": [
     {
@@ -256,7 +249,7 @@ guarantee.
     }
   ]
 }
-    ```
+```
 
 ## Example 3
 
@@ -298,7 +291,8 @@ In this example A, B and C are connected into a component called ABC. We receive
             C         | _     | C
 
 7.  The output JSON is:
-    ```[json]
+
+```[json]
 {
   "work-groups": [
     {
@@ -309,4 +303,4 @@ In this example A, B and C are connected into a component called ABC. We receive
     }
   ]
 }
-    ```
+```


### PR DESCRIPTION
This is putting in writing some things that we have discussed.
I think that not creating a new sourceIdentifier for the merged work actually makes our life easier:
* The matcher is truly a matcher, it has no mixed redirection logic
* The matcher needs to store each work with its links and the group it currently belongs to, but it doesn't need to store groups that used to exist and have been broken down.
* This means the matcher table can be entirely recreated with a full reindex. It can be safely deleted.
* The matcher ouput is just made by lists of work identifiers that represent how the works group together