### PR TITLE
Exclude Jupyter notebooks and .git files from Travis tests

### DIFF
--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -43,7 +43,15 @@ def does_file_affect_build_task(path, task):
         raise CheckedByTravisFormat()
 
     # These extensions and paths never have an effect on tests.
-    if path.endswith(('.in', '.md', '.png', '.graffle', '.tf', 'Makefile')):
+    if path.endswith((
+        '.in',
+        '.ipynb',
+        '.md',
+        '.png',
+        '.graffle',
+        '.tf',
+        'Makefile'
+    )) or os.path.basename(path).startswith('.git'):
         raise IgnoredFileFormat()
 
     # These paths never have an effect on tests.

--- a/travistooling/tests/test_decisionmaker.py
+++ b/travistooling/tests/test_decisionmaker.py
@@ -41,6 +41,9 @@ from travistooling.decisions import (
     ('monitoring/Makefile', 'travistooling-test', IgnoredFileFormat, False),
     ('formatting.Makefile', 'travistooling-test', IgnoredFileFormat, False),
     ('my_lambda/requirements.in', 'my_lambda-test', IgnoredFileFormat, False),
+    ('data_science/data/.gitkeep', 'ingestor-test', IgnoredFileFormat, False),
+    ('data_science/.gitignore', 'ingestor-test', IgnoredFileFormat, False),
+    ('data_science/experiments.ipynb', 'ingestor-test', IgnoredFileFormat, False),
 
     # Terraform files are significant, but only in the travis-format task
     ('s3.tf', 'elasticdump-test', IgnoredFileFormat, False),


### PR DESCRIPTION
### What is this PR trying to achieve?

Now that Harrison is committing stuff (see #2075), yay, we want to avoid PRs burning unnecessary amounts of time on Travis – Jupyter notebooks, `.gitkeep` and `.gitignore` files have no effect on our Scala tests, and can be safely ignored.

This modifies travistooling to make that change.

### Who is this change for?

🖲 🔨 