### PR TITLE
Only display the Git branch in an ECR push if it's "interesting"

### DIFF
--- a/monitoring/deployment_tracking/notify_pushes/src/notify_pushes.py
+++ b/monitoring/deployment_tracking/notify_pushes/src/notify_pushes.py
@@ -34,11 +34,12 @@ def main(event, context):
         username = 'ecr-pushes'
         icon_emoji = 'ecr'
 
-    lines = [
-        message,
-        f'Git branch: {git_branch} ({commit_id})',
-        f'Commit message: {commit_msg!r}',
-    ]
+    lines = [message]
+
+    if (git_branch != 'HEAD') and (commit_id != 'HEAD'):
+        lines.apppend(f'Git branch: {git_branch} ({commit_id})')
+
+    lines.append(f'Commit message: {commit_msg!r}')
 
     slack_data = {
         'username': username,


### PR DESCRIPTION
This just tidies up the ECR notifications in Slack slightly. Before/after:

![screen shot 2018-05-18 at 11 01 46](https://user-images.githubusercontent.com/301220/40230426-5abcd314-5a8f-11e8-8bf5-59025b5b9bbf.png)

Makes it slightly cleaner. This is already deployed.