### PR TITLE
Namespace message writer/reader flags

### DIFF
--- a/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
@@ -6,6 +6,6 @@
 -aws.rds.userName=${db_username}
 -aws.metrics.namespace=id-minter
 -aws.message.s3.bucketName=${message_bucket_name}
--aws.message.sns.topic.arn=${topic_arn}
+-aws.message.writer.sns.topic.arn=${topic_arn}
 -aws.message.sqs.queue.url=${queue_url}
 -aws.message.sqs.maxMessages=${sqs_max_messages}

--- a/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
@@ -7,5 +7,6 @@
 -aws.metrics.namespace=id-minter
 -aws.message.s3.bucketName=${message_bucket_name}
 -aws.message.writer.sns.topic.arn=${topic_arn}
+-aws.message.writer.s3.bucketName=${message_bucket_name}
 -aws.message.sqs.queue.url=${queue_url}
 -aws.message.sqs.maxMessages=${sqs_max_messages}

--- a/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
@@ -5,7 +5,7 @@
 -aws.rds.port=${db_port}
 -aws.rds.userName=${db_username}
 -aws.metrics.namespace=id-minter
--aws.message.s3.bucketName=${message_bucket_name}
+-aws.message.reader.s3.bucketName=${message_bucket_name}
 -aws.message.writer.sns.topic.arn=${topic_arn}
 -aws.message.writer.s3.bucketName=${message_bucket_name}
 -aws.message.sqs.queue.url=${queue_url}

--- a/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
@@ -9,4 +9,4 @@
 -aws.message.writer.sns.topic.arn=${topic_arn}
 -aws.message.writer.s3.bucketName=${message_bucket_name}
 -aws.message.reader.sqs.queue.url=${queue_url}
--aws.message.sqs.maxMessages=${sqs_max_messages}
+-aws.message.reader.sqs.maxMessages=${sqs_max_messages}

--- a/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
@@ -8,5 +8,5 @@
 -aws.message.reader.s3.bucketName=${message_bucket_name}
 -aws.message.writer.sns.topic.arn=${topic_arn}
 -aws.message.writer.s3.bucketName=${message_bucket_name}
--aws.message.sqs.queue.url=${queue_url}
+-aws.message.reader.sqs.queue.url=${queue_url}
 -aws.message.sqs.maxMessages=${sqs_max_messages}

--- a/catalogue_pipeline/ingestor/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/ingestor/src/universal/conf/application.ini.template
@@ -8,5 +8,5 @@
 -es.username=${es_username}
 -es.password=${es_password}
 -es.protocol=${es_protocol}
--aws.message.s3.bucketName=${message_bucket_name}
+-aws.message.reader.s3.bucketName=${message_bucket_name}
 -aws.message.sqs.queue.url=${ingest_queue_id}

--- a/catalogue_pipeline/ingestor/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/ingestor/src/universal/conf/application.ini.template
@@ -9,4 +9,4 @@
 -es.password=${es_password}
 -es.protocol=${es_protocol}
 -aws.message.reader.s3.bucketName=${message_bucket_name}
--aws.message.sqs.queue.url=${ingest_queue_id}
+-aws.message.reader.sqs.queue.url=${ingest_queue_id}

--- a/catalogue_pipeline/recorder/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/recorder/src/universal/conf/application.ini.template
@@ -1,4 +1,4 @@
--aws.message.sqs.queue.url=${recorder_queue_url}
+-aws.message.reader.sqs.queue.url=${recorder_queue_url}
 -aws.message.reader.s3.bucketName=${message_bucket_name}
 -aws.vhs.dynamo.tableName=${vhs_recorder_dynamo_table_name}
 -aws.vhs.s3.bucketName=${vhs_recorder_bucket_name}

--- a/catalogue_pipeline/recorder/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/recorder/src/universal/conf/application.ini.template
@@ -1,5 +1,5 @@
 -aws.message.sqs.queue.url=${recorder_queue_url}
--aws.message.s3.bucketName=${message_bucket_name}
+-aws.message.reader.s3.bucketName=${message_bucket_name}
 -aws.vhs.dynamo.tableName=${vhs_recorder_dynamo_table_name}
 -aws.vhs.s3.bucketName=${vhs_recorder_bucket_name}
 -aws.metrics.namespace=${metrics_namespace}

--- a/catalogue_pipeline/transformer/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/transformer/src/universal/conf/application.ini.template
@@ -3,4 +3,5 @@
 -aws.metrics.namespace=${metrics_namespace}
 -aws.s3.bucketName=${storage_bucket_name}
 -aws.message.writer.sns.topic.arn=${sns_arn}
+-aws.message.writer.s3.bucketName=${message_bucket_name}
 -aws.message.s3.bucketName=${message_bucket_name}

--- a/catalogue_pipeline/transformer/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/transformer/src/universal/conf/application.ini.template
@@ -4,4 +4,4 @@
 -aws.s3.bucketName=${storage_bucket_name}
 -aws.message.writer.sns.topic.arn=${sns_arn}
 -aws.message.writer.s3.bucketName=${message_bucket_name}
--aws.message.s3.bucketName=${message_bucket_name}
+-aws.message.reader.s3.bucketName=${message_bucket_name}

--- a/catalogue_pipeline/transformer/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/transformer/src/universal/conf/application.ini.template
@@ -2,5 +2,5 @@
 -aws.sqs.queue.url=${transformer_queue_id}
 -aws.metrics.namespace=${metrics_namespace}
 -aws.s3.bucketName=${storage_bucket_name}
--aws.message.sns.topic.arn=${sns_arn}
+-aws.message.writer.sns.topic.arn=${sns_arn}
 -aws.message.s3.bucketName=${message_bucket_name}

--- a/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
+++ b/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
@@ -18,6 +18,11 @@ object MessageConfigModule extends TwitterModule {
     "aws.message.writer.sns.topic.arn",
     "",
     "ARN of the SNS topic where new message pointers are sent")
+  private val writerBucketName =
+    flag[String](
+      "aws.message.writer.s3.bucketName",
+      "",
+      "Name of the S3 bucket where new message bodies are written")
 
   private val bucketName =
     flag[String](
@@ -41,7 +46,7 @@ object MessageConfigModule extends TwitterModule {
   @Provides
   def providesMessageWriterConfig(): MessageWriterConfig = {
     val snsConfig = SNSConfig(topicArn = writerTopicArn())
-    val s3Config = S3Config(bucketName = bucketName())
+    val s3Config = S3Config(bucketName = writerBucketName())
 
     MessageWriterConfig(snsConfig = snsConfig, s3Config = s3Config)
   }

--- a/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
+++ b/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
@@ -29,9 +29,11 @@ object MessageConfigModule extends TwitterModule {
       "aws.message.reader.s3.bucketName",
       "",
       "Name of the S3 bucket where message bodies are read from")
-
-  private val queueUrl =
-    flag[String]("aws.message.sqs.queue.url", "", "URL of the SQS Queue")
+  private val readerQueueUrl =
+    flag[String](
+      "aws.message.reader.sqs.queue.url",
+      "",
+      "URL of the SQS Queue to read messages from")
   val waitTime = flag(
     "aws.message.sqs.waitTime",
     20,
@@ -54,7 +56,9 @@ object MessageConfigModule extends TwitterModule {
   @Singleton
   @Provides
   def providesMessageReaderConfig(): MessageReaderConfig = {
-    val sqsConfig = SQSConfig(queueUrl(), waitTime() seconds, maxMessages())
+    val sqsConfig = SQSConfig(
+      queueUrl = readerQueueUrl(),
+      waitTime() seconds, maxMessages())
     val s3Config = S3Config(bucketName = readerBucketName())
 
     MessageReaderConfig(sqsConfig = sqsConfig, s3Config = s3Config)

--- a/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
+++ b/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
@@ -14,10 +14,10 @@ import uk.ac.wellcome.storage.s3.S3Config
 import scala.concurrent.duration._
 
 object MessageConfigModule extends TwitterModule {
-  private val topicArn = flag[String](
-    "aws.message.sns.topic.arn",
+  private val writerTopicArn = flag[String](
+    "aws.message.writer.sns.topic.arn",
     "",
-    "ARN of the SNS topic used for messaging")
+    "ARN of the SNS topic where new message pointers are sent")
 
   private val bucketName =
     flag[String](
@@ -40,7 +40,7 @@ object MessageConfigModule extends TwitterModule {
   @Singleton
   @Provides
   def providesMessageWriterConfig(): MessageWriterConfig = {
-    val snsConfig = SNSConfig(topicArn = topicArn())
+    val snsConfig = SNSConfig(topicArn = writerTopicArn())
     val s3Config = S3Config(bucketName = bucketName())
 
     MessageWriterConfig(snsConfig = snsConfig, s3Config = s3Config)

--- a/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
+++ b/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
@@ -24,11 +24,11 @@ object MessageConfigModule extends TwitterModule {
       "",
       "Name of the S3 bucket where new message bodies are written")
 
-  private val bucketName =
+  private val readerBucketName =
     flag[String](
-      "aws.message.s3.bucketName",
+      "aws.message.reader.s3.bucketName",
       "",
-      "Name of the S3 bucket holding messaging pointers")
+      "Name of the S3 bucket where message bodies are read from")
 
   private val queueUrl =
     flag[String]("aws.message.sqs.queue.url", "", "URL of the SQS Queue")
@@ -55,7 +55,7 @@ object MessageConfigModule extends TwitterModule {
   @Provides
   def providesMessageReaderConfig(): MessageReaderConfig = {
     val sqsConfig = SQSConfig(queueUrl(), waitTime() seconds, maxMessages())
-    val s3Config = S3Config(bucketName = bucketName())
+    val s3Config = S3Config(bucketName = readerBucketName())
 
     MessageReaderConfig(sqsConfig = sqsConfig, s3Config = s3Config)
   }

--- a/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
+++ b/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
@@ -34,8 +34,8 @@ object MessageConfigModule extends TwitterModule {
       "aws.message.reader.sqs.queue.url",
       "",
       "URL of the SQS Queue to read messages from")
-  val waitTime = flag(
-    "aws.message.sqs.waitTime",
+  private val readerWaitTime = flag(
+    "aws.message.reader.sqs.waitTime",
     20,
     "Time to wait (in seconds) for a message to arrive on the queue before returning")
   val maxMessages =
@@ -58,7 +58,8 @@ object MessageConfigModule extends TwitterModule {
   def providesMessageReaderConfig(): MessageReaderConfig = {
     val sqsConfig = SQSConfig(
       queueUrl = readerQueueUrl(),
-      waitTime() seconds, maxMessages())
+      waitTime = readerWaitTime() seconds,
+      maxMessages())
     val s3Config = S3Config(bucketName = readerBucketName())
 
     MessageReaderConfig(sqsConfig = sqsConfig, s3Config = s3Config)

--- a/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
+++ b/sbt_common/finatra-messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
@@ -38,9 +38,9 @@ object MessageConfigModule extends TwitterModule {
     "aws.message.reader.sqs.waitTime",
     20,
     "Time to wait (in seconds) for a message to arrive on the queue before returning")
-  val maxMessages =
+  private val readerMaxMessages =
     flag(
-      "aws.message.sqs.maxMessages",
+      "aws.message.reader.sqs.maxMessages",
       10,
       "Maximum number of SQS messages to return")
 
@@ -59,7 +59,8 @@ object MessageConfigModule extends TwitterModule {
     val sqsConfig = SQSConfig(
       queueUrl = readerQueueUrl(),
       waitTime = readerWaitTime() seconds,
-      maxMessages())
+      maxMessages = readerMaxMessages()
+    )
     val s3Config = S3Config(bucketName = readerBucketName())
 
     MessageReaderConfig(sqsConfig = sqsConfig, s3Config = s3Config)

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -63,7 +63,7 @@ trait Messaging
   def messageReaderLocalFlags(bucket: Bucket, queue: Queue) =
     Map(
       "aws.message.reader.s3.bucketName" -> bucket.name,
-      "aws.message.sqs.queue.url" -> queue.url,
+      "aws.message.reader.sqs.queue.url" -> queue.url,
       "aws.message.sqs.waitTime" -> "1",
     ) ++ s3ClientLocalFlags ++ sqsLocalClientFlags
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -69,7 +69,7 @@ trait Messaging
 
   def messageWriterLocalFlags(bucket: Bucket, topic: Topic) =
     Map(
-      "aws.message.sns.topic.arn" -> topic.arn,
+      "aws.message.writer.sns.topic.arn" -> topic.arn,
       "aws.message.s3.bucketName" -> bucket.name
     ) ++ s3ClientLocalFlags ++ snsLocalClientFlags
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -62,7 +62,7 @@ trait Messaging
 
   def messageReaderLocalFlags(bucket: Bucket, queue: Queue) =
     Map(
-      "aws.message.s3.bucketName" -> bucket.name,
+      "aws.message.reader.s3.bucketName" -> bucket.name,
       "aws.message.sqs.queue.url" -> queue.url,
       "aws.message.sqs.waitTime" -> "1",
     ) ++ s3ClientLocalFlags ++ sqsLocalClientFlags

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -70,7 +70,7 @@ trait Messaging
   def messageWriterLocalFlags(bucket: Bucket, topic: Topic) =
     Map(
       "aws.message.writer.sns.topic.arn" -> topic.arn,
-      "aws.message.s3.bucketName" -> bucket.name
+      "aws.message.writer.s3.bucketName" -> bucket.name
     ) ++ s3ClientLocalFlags ++ snsLocalClientFlags
 
   case class ExampleObject(name: String)

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -64,7 +64,7 @@ trait Messaging
     Map(
       "aws.message.reader.s3.bucketName" -> bucket.name,
       "aws.message.reader.sqs.queue.url" -> queue.url,
-      "aws.message.sqs.waitTime" -> "1",
+      "aws.message.reader.sqs.waitTime" -> "1",
     ) ++ s3ClientLocalFlags ++ sqsLocalClientFlags
 
   def messageWriterLocalFlags(bucket: Bucket, topic: Topic) =


### PR DESCRIPTION
A minor annoyance – the fact that reader/writer use the same bucket is an implementation detail, but absolutely not guaranteed or required. Namespacing the flags makes it clearer which application uses what, and gets rid of this assumption.