### PR TITLE
Move ApiVersions out of common to display

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/ContextHelper.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/ContextHelper.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.api
 
-import uk.ac.wellcome.versions.ApiVersions
+import uk.ac.wellcome.display.models.ApiVersions
 
 object ContextHelper {
   def buildContextUri(apiScheme: String,

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/ContextController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/ContextController.scala
@@ -4,7 +4,7 @@ import com.twitter.inject.annotations.Flag
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
 import javax.inject.{Inject, Singleton}
-import uk.ac.wellcome.versions.ApiVersions
+import uk.ac.wellcome.display.models.ApiVersions
 
 @Singleton
 class ContextController @Inject()(

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/DocsController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/DocsController.scala
@@ -6,7 +6,7 @@ import com.twitter.finatra.http.Controller
 import io.swagger.util.Json
 import io.swagger.models.{Info, Scheme, Swagger}
 import javax.inject.{Inject, Singleton}
-import uk.ac.wellcome.versions.ApiVersions
+import uk.ac.wellcome.display.models.ApiVersions
 
 object ApiV1Swagger extends Swagger
 object ApiV2Swagger extends Swagger

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
@@ -2,9 +2,9 @@ package uk.ac.wellcome.platform.api.controllers
 
 import com.twitter.inject.annotations.Flag
 import javax.inject.{Inject, Singleton}
+import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.platform.api.services.WorksService
-import uk.ac.wellcome.versions.ApiVersions
 
 @Singleton
 class V1WorksController @Inject()(

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
@@ -2,9 +2,9 @@ package uk.ac.wellcome.platform.api.controllers
 
 import com.twitter.inject.annotations.Flag
 import javax.inject.{Inject, Singleton}
+import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
 import uk.ac.wellcome.platform.api.services.WorksService
-import uk.ac.wellcome.versions.ApiVersions
 
 @Singleton
 class V2WorksController @Inject()(

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -5,19 +5,15 @@ import com.twitter.finatra.http.Controller
 import io.swagger.models.parameters.QueryParameter
 import io.swagger.models.properties.StringProperty
 import io.swagger.models.{Operation, Swagger}
-import uk.ac.wellcome.display.models.{DisplayWork, WorksIncludes}
+import uk.ac.wellcome.display.models.{ApiVersions, DisplayWork, WorksIncludes}
 import uk.ac.wellcome.models.Error
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
 import uk.ac.wellcome.platform.api.models.{DisplayError, DisplayResultList}
 import uk.ac.wellcome.platform.api.requests._
-import uk.ac.wellcome.platform.api.responses.{
-  ResultListResponse,
-  ResultResponse
-}
+import uk.ac.wellcome.platform.api.responses.{ResultListResponse, ResultResponse}
 import uk.ac.wellcome.platform.api.services.WorksService
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
-import uk.ac.wellcome.versions.ApiVersions
 
 import scala.collection.JavaConverters._
 import scala.reflect.runtime.universe.TypeTag

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -11,7 +11,10 @@ import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
 import uk.ac.wellcome.platform.api.models.{DisplayError, DisplayResultList}
 import uk.ac.wellcome.platform.api.requests._
-import uk.ac.wellcome.platform.api.responses.{ResultListResponse, ResultResponse}
+import uk.ac.wellcome.platform.api.responses.{
+  ResultListResponse,
+  ResultResponse
+}
 import uk.ac.wellcome.platform.api.services.WorksService
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/package.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/package.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.api.finatra
 
 import com.twitter.finagle.http.Request
-import uk.ac.wellcome.versions.ApiVersions
+import uk.ac.wellcome.display.models.ApiVersions
 
 package object exceptions {
   // Shitty workaround to the fact that ExceptionMapper.toResponse method only allows

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.api
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.twitter.finagle.http.{Response, Status}
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.versions.ApiVersions
+import uk.ac.wellcome.display.models.ApiVersions
 
 import scala.collection.JavaConverters._
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.api.works
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.apache.commons.io.IOUtils
-import uk.ac.wellcome.versions.ApiVersions
+import uk.ac.wellcome.display.models.ApiVersions
 
 class ApiContextTest extends ApiWorksTestBase {
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.api.works
 
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
-import uk.ac.wellcome.versions.ApiVersions
+import uk.ac.wellcome.display.models.ApiVersions
 
 class ApiErrorsTest extends ApiWorksTestBase {
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.api.works
 import com.sksamuel.elastic4s.Indexable
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.{ApiVersions, DisplaySerialisationTestBase}
+import uk.ac.wellcome.display.models.{
+  ApiVersions,
+  DisplaySerialisationTestBase
+}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.models.work.test.util.WorksUtil

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -3,14 +3,13 @@ package uk.ac.wellcome.platform.api.works
 import com.sksamuel.elastic4s.Indexable
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
+import uk.ac.wellcome.display.models.{ApiVersions, DisplaySerialisationTestBase}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.platform.api.Server
 import uk.ac.wellcome.test.fixtures.TestWith
 import uk.ac.wellcome.utils.JsonUtil._
-import uk.ac.wellcome.versions.ApiVersions
 
 trait ApiWorksTestBase
     extends FunSpec

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -2,14 +2,9 @@ package uk.ac.wellcome.platform.api.works.v1
 
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
-import uk.ac.wellcome.models.work.internal.{
-  DigitalLocation,
-  IdentifierSchemes,
-  License_CCBY,
-  SourceIdentifier
-}
+import uk.ac.wellcome.display.models.ApiVersions
+import uk.ac.wellcome.models.work.internal.{DigitalLocation, IdentifierSchemes, License_CCBY, SourceIdentifier}
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
-import uk.ac.wellcome.versions.ApiVersions
 
 class ApiV1WorksTest extends ApiWorksTestBase {
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -3,7 +3,12 @@ package uk.ac.wellcome.platform.api.works.v1
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.display.models.ApiVersions
-import uk.ac.wellcome.models.work.internal.{DigitalLocation, IdentifierSchemes, License_CCBY, SourceIdentifier}
+import uk.ac.wellcome.models.work.internal.{
+  DigitalLocation,
+  IdentifierSchemes,
+  License_CCBY,
+  SourceIdentifier
+}
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
 class ApiV1WorksTest extends ApiWorksTestBase {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
@@ -2,9 +2,9 @@ package uk.ac.wellcome.platform.api.works.v1
 
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
+import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
-import uk.ac.wellcome.versions.ApiVersions
 
 class ApiV1WorksTestInvisible extends ApiWorksTestBase {
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -2,14 +2,9 @@ package uk.ac.wellcome.platform.api.works.v2
 
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
-import uk.ac.wellcome.models.work.internal.{
-  DigitalLocation,
-  IdentifierSchemes,
-  License_CCBY,
-  SourceIdentifier
-}
+import uk.ac.wellcome.display.models.ApiVersions
+import uk.ac.wellcome.models.work.internal.{DigitalLocation, IdentifierSchemes, License_CCBY, SourceIdentifier}
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
-import uk.ac.wellcome.versions.ApiVersions
 
 class ApiV2WorksTest extends ApiWorksTestBase {
   def withV2Api[R] = withApiFixtures[R](ApiVersions.v2)(_)

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -3,7 +3,12 @@ package uk.ac.wellcome.platform.api.works.v2
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.display.models.ApiVersions
-import uk.ac.wellcome.models.work.internal.{DigitalLocation, IdentifierSchemes, License_CCBY, SourceIdentifier}
+import uk.ac.wellcome.models.work.internal.{
+  DigitalLocation,
+  IdentifierSchemes,
+  License_CCBY,
+  SourceIdentifier
+}
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
 class ApiV2WorksTest extends ApiWorksTestBase {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
@@ -2,9 +2,9 @@ package uk.ac.wellcome.platform.api.works.v2
 
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
+import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
-import uk.ac.wellcome.versions.ApiVersions
 
 class ApiV2WorksTestInvisible extends ApiWorksTestBase {
   def withV2Api[R] = withApiFixtures[R](ApiVersions.v2)(_)

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/models/SnapshotJob.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/models/SnapshotJob.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.snapshot_generator.models
 
-import uk.ac.wellcome.versions.ApiVersions
+import uk.ac.wellcome.display.models.ApiVersions
 
 case class SnapshotJob(publicBucketName: String,
                        publicObjectKey: String,

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
@@ -13,20 +13,12 @@ import com.twitter.inject.annotations.Flag
 import javax.inject.Inject
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
-import uk.ac.wellcome.display.models.{DisplayWork, WorksIncludes}
+import uk.ac.wellcome.display.models.{ApiVersions, DisplayWork, WorksIncludes}
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
-import uk.ac.wellcome.platform.snapshot_generator.flow.{
-  DisplayWorkToJsonStringFlow,
-  IdentifiedWorkToVisibleDisplayWork,
-  StringToGzipFlow
-}
-import uk.ac.wellcome.platform.snapshot_generator.models.{
-  CompletedSnapshotJob,
-  SnapshotJob
-}
+import uk.ac.wellcome.platform.snapshot_generator.flow.{DisplayWorkToJsonStringFlow, IdentifiedWorkToVisibleDisplayWork, StringToGzipFlow}
+import uk.ac.wellcome.platform.snapshot_generator.models.{CompletedSnapshotJob, SnapshotJob}
 import uk.ac.wellcome.platform.snapshot_generator.source.ElasticsearchWorksSource
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
-import uk.ac.wellcome.versions.ApiVersions
 
 import scala.concurrent.Future
 

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
@@ -15,8 +15,15 @@ import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
 import uk.ac.wellcome.display.models.{ApiVersions, DisplayWork, WorksIncludes}
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
-import uk.ac.wellcome.platform.snapshot_generator.flow.{DisplayWorkToJsonStringFlow, IdentifiedWorkToVisibleDisplayWork, StringToGzipFlow}
-import uk.ac.wellcome.platform.snapshot_generator.models.{CompletedSnapshotJob, SnapshotJob}
+import uk.ac.wellcome.platform.snapshot_generator.flow.{
+  DisplayWorkToJsonStringFlow,
+  IdentifiedWorkToVisibleDisplayWork,
+  StringToGzipFlow
+}
+import uk.ac.wellcome.platform.snapshot_generator.models.{
+  CompletedSnapshotJob,
+  SnapshotJob
+}
 import uk.ac.wellcome.platform.snapshot_generator.source.ElasticsearchWorksSource
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -12,10 +12,17 @@ import uk.ac.wellcome.messaging.sqs.SQSMessage
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
-import uk.ac.wellcome.models.work.internal.{IdentifiedWork, IdentifierSchemes, SourceIdentifier}
+import uk.ac.wellcome.models.work.internal.{
+  IdentifiedWork,
+  IdentifierSchemes,
+  SourceIdentifier
+}
 import uk.ac.wellcome.monitoring.test.fixtures.CloudWatch
 import uk.ac.wellcome.platform.snapshot_generator.fixtures.AkkaS3
-import uk.ac.wellcome.platform.snapshot_generator.models.{CompletedSnapshotJob, SnapshotJob}
+import uk.ac.wellcome.platform.snapshot_generator.models.{
+  CompletedSnapshotJob,
+  SnapshotJob
+}
 import uk.ac.wellcome.platform.snapshot_generator.test.utils.GzipUtils
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -6,29 +6,22 @@ import com.amazonaws.services.s3.model.GetObjectRequest
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.messaging.sqs.SQSMessage
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
-import uk.ac.wellcome.models.work.internal.{
-  IdentifiedWork,
-  IdentifierSchemes,
-  SourceIdentifier
-}
+import uk.ac.wellcome.models.work.internal.{IdentifiedWork, IdentifierSchemes, SourceIdentifier}
 import uk.ac.wellcome.monitoring.test.fixtures.CloudWatch
 import uk.ac.wellcome.platform.snapshot_generator.fixtures.AkkaS3
-import uk.ac.wellcome.platform.snapshot_generator.models.{
-  CompletedSnapshotJob,
-  SnapshotJob
-}
+import uk.ac.wellcome.platform.snapshot_generator.models.{CompletedSnapshotJob, SnapshotJob}
 import uk.ac.wellcome.platform.snapshot_generator.test.utils.GzipUtils
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.test.utils.{ExtendedPatience, JsonTestUtil}
 import uk.ac.wellcome.utils.JsonUtil._
-import uk.ac.wellcome.versions.ApiVersions
 
 class SnapshotGeneratorFeatureTest
     extends FunSpec

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -19,7 +19,10 @@ import uk.ac.wellcome.models.work.internal.IdentifierSchemes.sierraSystemNumber
 import uk.ac.wellcome.models.work.internal.{IdentifiedWork, SourceIdentifier}
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.platform.snapshot_generator.fixtures.AkkaS3
-import uk.ac.wellcome.platform.snapshot_generator.models.{CompletedSnapshotJob, SnapshotJob}
+import uk.ac.wellcome.platform.snapshot_generator.models.{
+  CompletedSnapshotJob,
+  SnapshotJob
+}
 import uk.ac.wellcome.platform.snapshot_generator.test.utils.GzipUtils
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -13,22 +13,18 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
-import uk.ac.wellcome.display.models.AllWorksIncludes
+import uk.ac.wellcome.display.models.{AllWorksIncludes, ApiVersions}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.internal.IdentifierSchemes.sierraSystemNumber
 import uk.ac.wellcome.models.work.internal.{IdentifiedWork, SourceIdentifier}
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.platform.snapshot_generator.fixtures.AkkaS3
-import uk.ac.wellcome.platform.snapshot_generator.models.{
-  CompletedSnapshotJob,
-  SnapshotJob
-}
+import uk.ac.wellcome.platform.snapshot_generator.models.{CompletedSnapshotJob, SnapshotJob}
 import uk.ac.wellcome.platform.snapshot_generator.test.utils.GzipUtils
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 import uk.ac.wellcome.test.utils.ExtendedPatience
-import uk.ac.wellcome.versions.ApiVersions
 
 import scala.util.Random
 

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/ApiVersions.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/ApiVersions.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.versions
+package uk.ac.wellcome.display.models
 
 import io.circe.{Decoder, Encoder}
 


### PR DESCRIPTION
### What is this PR trying to achieve?

Reduce dependencies on common

### Who is this change for?

📈 