### PR TITLE
Pass the VHS record ID to KeyPrefixGenerator.generate

### DIFF
--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/models/JsonKeyPrefixGenerator.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/models/JsonKeyPrefixGenerator.scala
@@ -4,7 +4,7 @@ import io.circe.Json
 import uk.ac.wellcome.storage.s3.KeyPrefixGenerator
 
 class JsonKeyPrefixGenerator extends KeyPrefixGenerator[Json] {
-  override def generate(obj: Json): String = {
+  override def generate(id: String, obj: Json): String = {
     obj.hashCode().toString
   }
 }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/finatra/modules/IdentifiedWorkModule.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/finatra/modules/IdentifiedWorkModule.scala
@@ -29,7 +29,7 @@ object IdentifiedWorkModule extends TwitterModule {
 
 class IdentifiedWorkKeyPrefixGenerator
     extends KeyPrefixGenerator[IdentifiedWork] {
-  override def generate(obj: IdentifiedWork): String = {
+  override def generate(id: String, obj: IdentifiedWork): String = {
     obj.sourceIdentifier.value.reverse.slice(0, 2)
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/modules/UnidentifiedWorkModule.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/modules/UnidentifiedWorkModule.scala
@@ -30,7 +30,7 @@ object UnidentifiedWorkModule extends TwitterModule {
 
 class UnidentifiedWorkKeyPrefixGenerator
     extends KeyPrefixGenerator[UnidentifiedWork] {
-  override def generate(obj: UnidentifiedWork): String = {
+  override def generate(id: String, obj: UnidentifiedWork): String = {
     obj.sourceIdentifier.value.reverse.slice(0, 2)
   }
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -38,7 +38,7 @@ class MessageWriter[T] @Inject()(
     for {
       location <- s3.put(messageConfig.s3Config.bucketName)(
         message,
-        keyPrefixGenerator.generate(message))
+        keyPrefixGenerator.generate(id = "", obj = message))
       pointer <- Future.fromTry(toJson(MessagePointer(location)))
       publishAttempt <- sns.writeMessage(pointer, subject)
       _ = info(publishAttempt)

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -101,7 +101,7 @@ trait Messaging
 
   val keyPrefixGenerator: KeyPrefixGenerator[ExampleObject] =
     new KeyPrefixGenerator[ExampleObject] {
-      override def generate(obj: ExampleObject): String = "/"
+      override def generate(id: String, obj: ExampleObject): String = "/"
     }
 
   def withExampleObjectMessageReader[R](bucket: Bucket, queue: Queue)(

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/KeyPrefixGenerator.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/KeyPrefixGenerator.scala
@@ -22,7 +22,7 @@ import uk.ac.wellcome.models.Sourced
 // and use it on all instances, even when T is a subclass of Sourced.
 
 trait KeyPrefixGenerator[-T] {
-  def generate(obj: T): String
+  def generate(id: String, obj: T): String
 }
 
 // To spread objects evenly in our S3 bucket, we take the last two
@@ -35,7 +35,7 @@ trait KeyPrefixGenerator[-T] {
 //      e.g. b0001 and b0002 are separated by nine shards.
 
 class SourcedKeyPrefixGenerator @Inject() extends KeyPrefixGenerator[Sourced] {
-  override def generate(obj: Sourced): String = {
+  override def generate(id: String, obj: Sourced): String = {
     val s3Shard = obj.sourceId.reverse.slice(0, 2)
 
     s"${obj.sourceName}/${s3Shard}/${obj.sourceId}"

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
@@ -103,7 +103,7 @@ class VersionedHybridStore[T, S <: S3ObjectStore[T]] @Inject()(
 
     val futureUri = s3ObjectStore.put(vhsConfig.s3Config.bucketName)(
       t,
-      keyPrefixGenerator.generate(t))
+      keyPrefixGenerator.generate(id = id, obj = t))
 
     futureUri.flatMap {
       case S3ObjectLocation(_, key) => versionedDao.updateRecord(f(key))

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/SourcedKeyPrefixGeneratorTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/s3/SourcedKeyPrefixGeneratorTest.scala
@@ -12,7 +12,10 @@ class SourcedKeyPrefixGeneratorTest extends FunSpec with Matchers {
     }
 
     val sourcedKeyPrefixGenerator = new SourcedKeyPrefixGenerator()
-    val prefix = sourcedKeyPrefixGenerator.generate(sourced)
+    val prefix = sourcedKeyPrefixGenerator.generate(
+      id = sourced.sourceId,
+      obj = sourced
+    )
 
     prefix shouldBe "sourceName/43/1234"
   }

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
@@ -56,7 +56,7 @@ trait LocalVersionedHybridStore
       vhsConfig = vhsConfig,
       s3ObjectStore = s3ObjectStore,
       keyPrefixGenerator = new KeyPrefixGenerator[T] {
-        override def generate(obj: T): String = "/"
+        override def generate(id: String, obj: T): String = "/"
       },
       dynamoDbClient = dynamoDbClient
     )
@@ -82,7 +82,7 @@ trait LocalVersionedHybridStore
       vhsConfig = vhsConfig,
       s3ObjectStore = s3ObjectStore,
       keyPrefixGenerator = new KeyPrefixGenerator[InputStream] {
-        override def generate(obj: InputStream): String = "/"
+        override def generate(id: String, obj: InputStream): String = "/"
       },
       dynamoDbClient = dynamoDbClient
     )
@@ -107,7 +107,7 @@ trait LocalVersionedHybridStore
       vhsConfig = vhsConfig,
       s3ObjectStore = s3ObjectStore,
       keyPrefixGenerator = new KeyPrefixGenerator[String] {
-        override def generate(obj: String): String = "/"
+        override def generate(id: String, obj: String): String = "/"
       },
       dynamoDbClient = dynamoDbClient
     )

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -31,7 +31,7 @@ class SierraItemMergerUpdaterServiceTest
 
   val keyPrefixGenerator: KeyPrefixGenerator[Sourced] =
     new KeyPrefixGenerator[Sourced] {
-      override def generate(obj: Sourced): String = "/"
+      override def generate(id: String, obj: Sourced): String = "/"
     }
 
   def withSierraUpdaterService(


### PR DESCRIPTION
### What is this PR trying to achieve?

Include the ID when generating the key prefix. This is required for work on the Goobi reader – because we're passing around streams of data, we can’t inspect the object to be stored to get an ID.

### Who is this change for?

🎹 🤴 