### PR TITLE
Move MetricsSender config into a module, consolidate flags

### DIFF
--- a/sbt_common/finatra_monitoring/src/main/scala/uk/ac/wellcome/finatra/monitoring/MetricsConfigModule.scala
+++ b/sbt_common/finatra_monitoring/src/main/scala/uk/ac/wellcome/finatra/monitoring/MetricsConfigModule.scala
@@ -1,0 +1,33 @@
+package uk.ac.wellcome.finatra.monitoring
+
+import com.google.inject.{Provides, Singleton}
+import com.twitter.app.Flaggable
+import com.twitter.inject.TwitterModule
+import uk.ac.wellcome.monitoring.MetricsConfig
+
+import scala.concurrent.duration._
+
+object MetricsConfigModule extends TwitterModule {
+  implicit val finiteDurationFlaggable =
+    Flaggable.mandatory[FiniteDuration](config =>
+      Duration.apply(config).asInstanceOf[FiniteDuration])
+
+  val awsNamespace = flag[String](
+    "aws.metrics.namespace",
+    "",
+    "Namespace for cloudwatch metrics")
+
+  val flushInterval = flag[FiniteDuration](
+    "aws.metrics.flushInterval",
+    10 minutes,
+    "Interval within which metrics get flushed to cloudwatch. A short interval will result in an increased number of PutMetric requests."
+  )
+
+  @Singleton
+  @Provides
+  def providesMetricsConfig(): MetricsConfig =
+    MetricsConfig(
+      namespace = awsNamespace(),
+      flushInterval = flushInterval()
+    )
+}

--- a/sbt_common/finatra_monitoring/src/main/scala/uk/ac/wellcome/finatra/monitoring/MetricsSenderModule.scala
+++ b/sbt_common/finatra_monitoring/src/main/scala/uk/ac/wellcome/finatra/monitoring/MetricsSenderModule.scala
@@ -20,9 +20,8 @@ object MetricsSenderModule extends TwitterModule {
                             actorSystem: ActorSystem,
                             metricsConfig: MetricsConfig) =
     new MetricsSender(
-      namespace = metricsConfig.namespace,
-      flushInterval = metricsConfig.flushInterval,
       amazonCloudWatch = amazonCloudWatch,
-      actorSystem = actorSystem
+      actorSystem = actorSystem,
+      metricsConfig = metricsConfig
     )
 }

--- a/sbt_common/finatra_monitoring/src/main/scala/uk/ac/wellcome/finatra/monitoring/MetricsSenderModule.scala
+++ b/sbt_common/finatra_monitoring/src/main/scala/uk/ac/wellcome/finatra/monitoring/MetricsSenderModule.scala
@@ -3,38 +3,25 @@ package uk.ac.wellcome.finatra.monitoring
 import akka.actor.ActorSystem
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.google.inject.{Provides, Singleton}
-import com.twitter.app.Flaggable
 import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.finatra.akka.AkkaModule
-import uk.ac.wellcome.monitoring.MetricsSender
-
-import scala.concurrent.duration._
+import uk.ac.wellcome.monitoring.{MetricsConfig, MetricsSender}
 
 object MetricsSenderModule extends TwitterModule {
-  override val modules = Seq(AkkaModule, CloudWatchClientModule)
-
-  implicit val finoteDurationFlaggable =
-    Flaggable.mandatory[FiniteDuration](config =>
-      Duration.apply(config).asInstanceOf[FiniteDuration])
-
-  val awsNamespace = flag[String](
-    "aws.metrics.namespace",
-    "",
-    "Namespace for cloudwatch metrics")
-
-  val flushInterval = flag[FiniteDuration](
-    "aws.metrics.flushInterval",
-    10 minutes,
-    "Interval within which metrics get flushed to cloudwatch. A short interval will result in an increased number of PutMetric requests."
+  override val modules = Seq(
+    AkkaModule,
+    CloudWatchClientModule,
+    MetricsConfigModule
   )
 
   @Provides
   @Singleton
   def providesMetricsSender(amazonCloudWatch: AmazonCloudWatch,
-                            actorSystem: ActorSystem) =
+                            actorSystem: ActorSystem,
+                            metricsConfig: MetricsConfig) =
     new MetricsSender(
-      namespace = awsNamespace(),
-      flushInterval = flushInterval(),
+      namespace = metricsConfig.namespace,
+      flushInterval = metricsConfig.flushInterval,
       amazonCloudWatch = amazonCloudWatch,
       actorSystem = actorSystem
     )

--- a/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsConfig.scala
+++ b/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsConfig.scala
@@ -1,0 +1,8 @@
+package uk.ac.wellcome.monitoring
+
+import scala.concurrent.duration.FiniteDuration
+
+case class MetricsConfig(
+  namespace: String,
+  flushInterval: FiniteDuration
+)

--- a/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
+++ b/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
@@ -4,7 +4,12 @@ import java.util.Date
 
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source, SourceQueueWithComplete}
-import akka.stream.{ActorMaterializer, OverflowStrategy, QueueOfferResult, ThrottleMode}
+import akka.stream.{
+  ActorMaterializer,
+  OverflowStrategy,
+  QueueOfferResult,
+  ThrottleMode
+}
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model._
 import com.google.inject.Inject
@@ -16,10 +21,9 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
-class MetricsSender @Inject()(
-  amazonCloudWatch: AmazonCloudWatch,
-  actorSystem: ActorSystem,
-  metricsConfig: MetricsConfig)
+class MetricsSender @Inject()(amazonCloudWatch: AmazonCloudWatch,
+                              actorSystem: ActorSystem,
+                              metricsConfig: MetricsConfig)
     extends Logging {
   implicit val system = actorSystem
   implicit val materialiser = ActorMaterializer()
@@ -36,8 +40,9 @@ class MetricsSender @Inject()(
       // Group the MetricDatum objects into lists of at max 20 items.
       // Send smaller chunks if not appearing within 10 seconds
       .viaMat(
-        Flow[MetricDatum].groupedWithin(metricDataListMaxSize, metricsConfig.flushInterval))(
-        Keep.left)
+        Flow[MetricDatum].groupedWithin(
+          metricDataListMaxSize,
+          metricsConfig.flushInterval))(Keep.left)
       // Make sure we don't exceed aws rate limit
       .throttle(
         maxPutMetricDataRequestsPerSecond,

--- a/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/MetricsSenderTest.scala
+++ b/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/MetricsSenderTest.scala
@@ -9,7 +9,7 @@ import org.mockito.ArgumentCaptor
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.monitoring.MetricsSender
+import uk.ac.wellcome.monitoring.{MetricsConfig, MetricsSender}
 import uk.ac.wellcome.test.fixtures.Akka
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.monitoring.GlobalExecutionContext.context
@@ -33,8 +33,15 @@ class MetricsSenderTest
     it("records the time and count of a successful future") {
       withActorSystem { actorSystem =>
         val amazonCloudWatch = mock[AmazonCloudWatch]
-        val metricsSender =
-          new MetricsSender("test", 1 second, amazonCloudWatch, actorSystem)
+        val metricsConfig = MetricsConfig(
+          namespace = "test",
+          flushInterval = 1 second
+        )
+        val metricsSender = new MetricsSender(
+          amazonCloudWatch = amazonCloudWatch,
+          actorSystem = actorSystem,
+          metricsConfig = metricsConfig
+        )
         val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
         val expectedResult = "foo"
@@ -67,8 +74,15 @@ class MetricsSenderTest
     it("records the time and count of a failed future") {
       withActorSystem { actorSystem =>
         val amazonCloudWatch = mock[AmazonCloudWatch]
-        val metricsSender =
-          new MetricsSender("test", 1 second, amazonCloudWatch, actorSystem)
+        val metricsConfig = MetricsConfig(
+          namespace = "test",
+          flushInterval = 1 second
+        )
+        val metricsSender = new MetricsSender(
+          amazonCloudWatch = amazonCloudWatch,
+          actorSystem = actorSystem,
+          metricsConfig = metricsConfig
+        )
         val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
         val timedFunction = () => Future { throw new RuntimeException() }
@@ -99,8 +113,15 @@ class MetricsSenderTest
     it("groups 20 MetricDatum into one PutMetricDataRequest") {
       withActorSystem { actorSystem =>
         val amazonCloudWatch = mock[AmazonCloudWatch]
-        val metricsSender =
-          new MetricsSender("test", 1 second, amazonCloudWatch, actorSystem)
+        val metricsConfig = MetricsConfig(
+          namespace = "test",
+          flushInterval = 1 second
+        )
+        val metricsSender = new MetricsSender(
+          amazonCloudWatch = amazonCloudWatch,
+          actorSystem = actorSystem,
+          metricsConfig = metricsConfig
+        )
         val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
         val emptyFunction = () => Future.successful(())
@@ -126,8 +147,15 @@ class MetricsSenderTest
     it("takes at least one second to make 150 PutMetricData requests") {
       withActorSystem { actorSystem =>
         val amazonCloudWatch = mock[AmazonCloudWatch]
-        val metricsSender =
-          new MetricsSender("test", 2 second, amazonCloudWatch, actorSystem)
+        val metricsConfig = MetricsConfig(
+          namespace = "test",
+          flushInterval = 2 seconds
+        )
+        val metricsSender = new MetricsSender(
+          amazonCloudWatch = amazonCloudWatch,
+          actorSystem = actorSystem,
+          metricsConfig = metricsConfig
+        )
         val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
         val expectedDuration = (1 second).toMillis
@@ -164,12 +192,15 @@ class MetricsSenderTest
     it("calls putMetricData with the correct value") {
       withActorSystem { actorSystem =>
         val amazonCloudWatch = mock[AmazonCloudWatch]
-        val metricsSender =
-          new MetricsSender(
-            "test",
-            100 millisecond,
-            amazonCloudWatch,
-            actorSystem)
+        val metricsConfig = MetricsConfig(
+          namespace = "test",
+          flushInterval = 100 milliseconds
+        )
+        val metricsSender = new MetricsSender(
+          amazonCloudWatch = amazonCloudWatch,
+          actorSystem = actorSystem,
+          metricsConfig = metricsConfig
+        )
         val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
         val expectedValue = 3.0F
@@ -190,12 +221,15 @@ class MetricsSenderTest
     it("calls putMetricData with the correct value") {
       withActorSystem { actorSystem =>
         val amazonCloudWatch = mock[AmazonCloudWatch]
-        val metricsSender =
-          new MetricsSender(
-            "test",
-            100 milliseconds,
-            amazonCloudWatch,
-            actorSystem)
+        val metricsConfig = MetricsConfig(
+          namespace = "test",
+          flushInterval = 100 milliseconds
+        )
+        val metricsSender = new MetricsSender(
+          amazonCloudWatch = amazonCloudWatch,
+          actorSystem = actorSystem,
+          metricsConfig = metricsConfig
+        )
         val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
         val expectedValue = 5 millis

--- a/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/MetricsSenderFixture.scala
+++ b/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/MetricsSenderFixture.scala
@@ -7,7 +7,7 @@ import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.mockito.MockitoSugar
-import uk.ac.wellcome.monitoring.MetricsSender
+import uk.ac.wellcome.monitoring.{MetricsConfig, MetricsSender}
 import uk.ac.wellcome.test.fixtures._
 
 import scala.concurrent.Future
@@ -21,10 +21,12 @@ trait MetricsSenderFixture
   def withMetricsSender[R](actorSystem: ActorSystem) =
     fixture[MetricsSender, R](
       create = new MetricsSender(
-        namespace = awsNamespace,
-        flushInterval = flushInterval,
         amazonCloudWatch = cloudWatchClient,
-        actorSystem = actorSystem
+        actorSystem = actorSystem,
+        metricsConfig = MetricsConfig(
+          namespace = awsNamespace,
+          flushInterval = flushInterval
+        )
       )
     )
 


### PR DESCRIPTION
Same as #2091, but for the monitoring package. Pushes out another use of annotation.Flag.