### PR TITLE
Drop unrecognised identifiers in Sierra concepts/genres, don't throw an error

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConceptIdentifier.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConceptIdentifier.scala
@@ -27,18 +27,22 @@ object SierraConceptIdentifier {
   def maybeFindIdentifier(varField: VarField,
                           identifierSubfield: MarcSubfield,
                           ontologyType: String): Option[SourceIdentifier] = {
-
-    // The mapping from indicator 2 to the identifier scheme is provided
-    // by the MARC spec.
-    // https://www.loc.gov/marc/bibliographic/bd655.html
     val maybeIdentifierScheme = varField.indicator2 match {
       case None => None
+
+      // These mappings are provided by the MARC spec.
+      // https://www.loc.gov/marc/bibliographic/bd655.html
       case Some("0") =>
         Some(IdentifierSchemes.libraryOfCongressSubjectHeadings)
       case Some("2") => Some(IdentifierSchemes.medicalSubjectHeadings)
-      case Some(scheme) =>
-        throw new RuntimeException(
-          s"Unrecognised identifier scheme: $scheme (${varField.subfields})")
+      case Some("4") => None
+
+      // For now we omit the other schemes as they're fairly unusual in
+      // our collections.  If ind2 = "7", then we need to look in another
+      // subfield to find the identifier scheme.  For now, we just highlight
+      // LCSH and MESH, and drop everything else.
+      // TODO: Revisit this properly.
+      case Some(scheme) => None
     }
 
     maybeIdentifierScheme match {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConceptIdentifierTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConceptIdentifierTest.scala
@@ -48,6 +48,17 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
     actualSourceIdentifier shouldBe expectedSourceIdentifier
   }
 
+  it("finds a no-ID identifier if indicator 2 = 4") {
+    val varField = baseVarField.copy(indicator2 = Some("4"))
+    val identifierSubfield = MarcSubfield(tag = "0", content = "noid/000")
+
+    SierraConceptIdentifier.maybeFindIdentifier(
+      varField = varField,
+      identifierSubfield = identifierSubfield,
+      ontologyType = ontologyType
+    ) shouldBe None
+  }
+
   it("returns None if indicator 2 is empty") {
     val varField = baseVarField.copy(indicator2 = None)
     val identifierSubfield = MarcSubfield(tag = "0", content = "lcsh/789")
@@ -59,22 +70,18 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
     ) shouldBe None
   }
 
-  it("throws an exception if it sees an unrecognised identifier scheme") {
+  it("returns None if it sees an unrecognised identifier scheme") {
     val identifierSubfield = MarcSubfield(tag = "0", content = "u/xxx")
     val varField = baseVarField.copy(
       indicator2 = Some("8"),
       subfields = List(identifierSubfield)
     )
 
-    val caught = intercept[RuntimeException] {
-      SierraConceptIdentifier.maybeFindIdentifier(
-        varField = varField,
-        identifierSubfield = identifierSubfield,
-        ontologyType = ontologyType
-      )
-    }
-
-    caught.getMessage shouldEqual s"Unrecognised identifier scheme: ${varField.indicator2.get} (${varField.subfields})"
+    SierraConceptIdentifier.maybeFindIdentifier(
+      varField = varField,
+      identifierSubfield = identifierSubfield,
+      ontologyType = ontologyType
+    ) shouldBe None
   }
 
   it("passes through the ontology type") {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraGenresTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraGenresTest.scala
@@ -240,31 +240,6 @@ class SierraGenresTest extends FunSpec with Matchers {
     expectedSourceIdentifiers shouldBe actualSourceIdentifiers
   }
 
-  it(s"throws an error if it sees an unrecognised identifier scheme") {
-    val bibData = SierraBibData(
-      id = "b7816189",
-      title = Some("Under the universal umbrella"),
-      varFields = List(
-        VarField(
-          fieldTag = "p",
-          marcTag = "655",
-          indicator1 = "",
-          indicator2 = "7",
-          subfields = List(
-            MarcSubfield(tag = "a", content = "absence"),
-            MarcSubfield(tag = "0", content = "u/xxx")
-          )
-        )
-      )
-    )
-
-    val caught = intercept[RuntimeException] {
-      transformer.getGenres(bibData)
-    }
-
-    caught.getMessage shouldEqual s"Unrecognised identifier scheme: 7 (${bibData.varFields.head.subfields})"
-  }
-
   it(s"throws an error if it sees too many subfield $$0 instances") {
     val bibData = SierraBibData(
       id = "b0918723",

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraSubjectsTest.scala
@@ -287,31 +287,6 @@ class SierraSubjectsTest extends FunSpec with Matchers {
     expectedSourceIdentifiers shouldBe actualSourceIdentifiers
   }
 
-  it(s"throws an error if it sees an unrecognised identifier scheme") {
-    val bibData = SierraBibData(
-      id = "b1987161",
-      title = Some("Under the universal umbrella"),
-      varFields = List(
-        VarField(
-          fieldTag = "p",
-          marcTag = "650",
-          indicator1 = "",
-          indicator2 = "7",
-          subfields = List(
-            MarcSubfield(tag = "a", content = "absence"),
-            MarcSubfield(tag = "0", content = "u/xxx")
-          )
-        )
-      )
-    )
-
-    val caught = intercept[RuntimeException] {
-      transformer.getSubjects(bibData)
-    }
-
-    caught.getMessage shouldEqual s"Unrecognised identifier scheme: 7 (${bibData.varFields.head.subfields})"
-  }
-
   it(s"throws an error if it sees too many subfield $$0 instances") {
     val bibData = SierraBibData(
       id = "b9171786",


### PR DESCRIPTION
### What is this PR trying to achieve?

For #2030. Previously we'd throw a RuntimeError if we saw an identifier we didn't recognise. Useful for finding the gaps in the code, but now we want them to be silently dropped rather than block transformation.

### Who is this change for?

⚫️ 🖲 