### PR TITLE
Use fixed version of sqs-autoscaling for all services

### DIFF
--- a/catalogue_pipeline/terraform/service_id_minter.tf
+++ b/catalogue_pipeline/terraform/service_id_minter.tf
@@ -1,5 +1,5 @@
 module "id_minter" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v7.0.1"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
   name   = "id_minter"
 
   source_queue_name  = "${module.id_minter_queue.name}"

--- a/catalogue_pipeline/terraform/service_ingestor.tf
+++ b/catalogue_pipeline/terraform/service_ingestor.tf
@@ -8,7 +8,7 @@ data "template_file" "es_cluster_host_ingestor" {
 }
 
 module "ingestor" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v7.0.1"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
   name   = "ingestor"
 
   source_queue_name  = "${module.es_ingest_queue.name}"

--- a/catalogue_pipeline/terraform/service_matcher.tf
+++ b/catalogue_pipeline/terraform/service_matcher.tf
@@ -1,5 +1,5 @@
 module "matcher" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v7.0.1"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
   name   = "matcher"
 
   source_queue_name  = "${module.matcher_queue.name}"

--- a/catalogue_pipeline/terraform/service_recorder.tf
+++ b/catalogue_pipeline/terraform/service_recorder.tf
@@ -1,5 +1,5 @@
 module "recorder" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v7.0.1"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
   name   = "recorder"
 
   source_queue_name  = "${module.recorder_queue.name}"

--- a/catalogue_pipeline/terraform/service_transformer.tf
+++ b/catalogue_pipeline/terraform/service_transformer.tf
@@ -1,5 +1,5 @@
 module "transformer" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v7.0.1"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
   name   = "transformer"
 
   memory = "2560"

--- a/sierra_adapter/terraform/items_to_dynamo/services.tf
+++ b/sierra_adapter/terraform/items_to_dynamo/services.tf
@@ -3,7 +3,7 @@ data "aws_ecs_cluster" "cluster" {
 }
 
 module "sierra_to_dynamo_service" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v7.0.1"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
   name   = "sierra_items_to_dynamo"
 
   source_queue_name  = "${module.demultiplexer_queue.name}"

--- a/sierra_adapter/terraform/merger/services.tf
+++ b/sierra_adapter/terraform/merger/services.tf
@@ -7,7 +7,7 @@ data "aws_ecs_cluster" "cluster" {
 }
 
 module "sierra_merger_service" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v7.0.1"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
   name   = "sierra_${local.resource_type_singular}_merger"
 
   source_queue_name  = "${module.updates_queue.name}"

--- a/sierra_adapter/terraform/sierra_reader/service.tf
+++ b/sierra_adapter/terraform/sierra_reader/service.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "sierra_reader_service" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v7.0.1"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
   name   = "${local.service_name}"
 
   source_queue_name  = "${module.windows_queue.name}"


### PR DESCRIPTION
### What is this PR trying to achieve?
Use the same version sqs-autoscaling-service as the one for snapshot generator, where issues in sqs scaling up and down have been fixed
