### PR TITLE
Bump the version of Akka to 2.5.9

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   lazy val versions = new {
-    val akka = "2.4.17"
+    val akka = "2.5.9"
     val akkaStreamAlpakkaS3 = "0.17"
     val aws = "1.11.95"
     val apacheLogging = "2.8.2"


### PR DESCRIPTION
This should fix one of the version conflicts described in #2093, namely:

```
[warn] Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[warn]
[warn] 	* com.typesafe.akka:akka-stream_2.12:2.5.9 is selected over 2.4.17
[warn] 	    +- com.lightbend.akka:akka-stream-alpakka-sqs_2.12:0.17 () (depends on 2.5.9)
[warn] 	    +- uk.ac.wellcome:finatra_akka_2.12:0.1-SNAPSHOT      (depends on 2.4.17)
[warn] 	    +- uk.ac.wellcome:common_2.12:0.1-SNAPSHOT            (depends on 2.4.17)
[warn]
[warn] 	* com.typesafe.akka:akka-actor_2.12:2.5.9 is selected over 2.4.17
[info] Resolving uk.ac.wellcome#common_2.12;0.1-SNAPSHOT ...
[warn] 	    +- com.typesafe.akka:akka-stream_2.12:2.5.9 ()        (depends on 2.5.9)
[warn] 	    +- com.typesafe.akka:akka-stream_2.12:2.4.17 ()       (depends on 2.4.17)
[warn] 	    +- com.typesafe.akka:akka-agent_2.12:2.4.17 ()        (depends on 2.4.17)
[warn] 	    +- uk.ac.wellcome:finatra_akka_2.12:0.1-SNAPSHOT      (depends on 2.4.17)
[warn] 	    +- uk.ac.wellcome:common_2.12:0.1-SNAPSHOT            (depends on 2.4.17)
[warn]
```

We’re already running with Akka 2.5.9, but this should stop sbt yelling about it.