### PR TITLE
Messaging/Storage/Monitoring Finatra independent

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/utils/JsonUtil.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/JsonUtil.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.utils
 
-import com.twitter.inject.Logging
+import grizzled.slf4j.Logging
 import io.circe.generic.extras.{AutoDerivation, Configuration}
 import io.circe.java8.time.TimeInstances
 import io.circe.parser._

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/package.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/package.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.test
 
-
 import grizzled.slf4j.Logging
 
 import scala.util.Try

--- a/common/src/test/scala/uk/ac/wellcome/test/fixtures/package.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/fixtures/package.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.test
 
-import com.twitter.inject.Logging
+
+import grizzled.slf4j.Logging
 
 import scala.util.Try
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -47,6 +47,10 @@ object Dependencies {
     "com.jakehschwartz" %% "finatra-swagger" % versions.finatra
   )
 
+  val loggingDependencies = Seq(
+    "org.clapper" %% "grizzled-slf4j" % "1.3.2"
+  )
+
   val sharedDependencies = Seq(
     "org.scalatest" %% "scalatest" % versions.scalatest % "test"
   )
@@ -99,7 +103,12 @@ object Dependencies {
   )
 
   // Internal Library dependency groups
-  val commonDependencies = testDependencies ++ injectDependencies ++ akkaDependencies ++ circeDependencies
+  val commonDependencies =
+    testDependencies ++
+      loggingDependencies ++
+      injectDependencies ++
+      akkaDependencies ++
+      circeDependencies
 
   val commonDisplayDependencies: Seq[ModuleID] = swaggerDependencies
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,7 +52,7 @@ object Dependencies {
   )
 
   val guiceDependencies = Seq(
-    "com.google.inject" % "guice" % versions.guice % "test",
+    "com.google.inject" % "guice" % versions.guice,
     "com.google.inject.extensions" % "guice-testlib" % versions.guice % "test"
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,7 +53,7 @@ object Dependencies {
 
   val guiceDependencies = Seq(
     "com.google.inject" % "guice" % versions.guice % "test",
-    "com.google.inject.extensions" % "guice-testlib" % versions.guice % "test",
+    "com.google.inject.extensions" % "guice-testlib" % versions.guice % "test"
   )
 
   val sharedDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,6 +51,11 @@ object Dependencies {
     "org.clapper" %% "grizzled-slf4j" % "1.3.2"
   )
 
+  val guiceDependencies = Seq(
+    "com.google.inject" % "guice" % versions.guice % "test",
+    "com.google.inject.extensions" % "guice-testlib" % versions.guice % "test",
+  )
+
   val sharedDependencies = Seq(
     "org.scalatest" %% "scalatest" % versions.scalatest % "test"
   )
@@ -67,11 +72,7 @@ object Dependencies {
     "com.twitter" %% "finatra-http" % versions.finatra,
     "com.twitter" %% "finatra-httpclient" % versions.finatra,
     "com.twitter" %% "finatra-jackson" % versions.finatra % "test",
-    "com.twitter" %% "finatra-jackson" % versions.finatra % "test" classifier "tests"
-  )
-
-  val injectDependencies = Seq(
-    "com.google.inject.extensions" % "guice-testlib" % versions.guice % "test",
+    "com.twitter" %% "finatra-jackson" % versions.finatra % "test" classifier "tests",
     "com.twitter" %% "inject-app" % versions.finatra % "test" classifier "tests",
     "com.twitter" %% "inject-app" % versions.finatra % "test",
     "com.twitter" %% "inject-core" % versions.finatra,
@@ -106,7 +107,7 @@ object Dependencies {
   val commonDependencies =
     testDependencies ++
       loggingDependencies ++
-      injectDependencies ++
+      guiceDependencies ++
       akkaDependencies ++
       circeDependencies
 
@@ -128,7 +129,7 @@ object Dependencies {
     "com.amazonaws" % "aws-java-sdk-s3" % versions.aws
   ) ++ dynamoDependencies
 
-  val finatraAkkaDependencies = akkaDependencies ++ injectDependencies
+  val finatraAkkaDependencies = akkaDependencies ++ finatraDependencies
 
   val commonMonitoringDependencies = Seq(
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % versions.aws

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticSearchIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticSearchIndex.scala
@@ -5,7 +5,7 @@ import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.http.index.mappings.PutMappingResponse
 import com.sksamuel.elastic4s.mappings.MappingDefinition
 import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicMapping
-import com.twitter.inject.Logging
+import grizzled.slf4j.Logging
 import org.elasticsearch.client.ResponseException
 import uk.ac.wellcome.elasticsearch.GlobalExecutionContext.context
 

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -6,7 +6,7 @@ import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.mappings.{FieldDefinition, MappingDefinition}
 import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicMapping
-import com.twitter.inject.Logging
+import grizzled.slf4j.Logging
 
 class WorksIndex @Inject()(client: HttpClient, elasticConfig: ElasticConfig)
     extends ElasticSearchIndex

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWorker.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWorker.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.messaging.message
 
 import akka.actor.ActorSystem
-import com.twitter.inject.Logging
 import io.circe.Decoder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.monitoring.MetricsSender
@@ -10,6 +9,8 @@ import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+
+import grizzled.slf4j.Logging
 
 abstract class MessageWorker[T](messageReader: MessageReader[T],
                                 actorSystem: ActorSystem,

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -6,7 +6,7 @@ import java.util.Date
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sns.AmazonSNS
 import com.google.inject.Inject
-import com.twitter.inject.Logging
+import grizzled.slf4j.Logging
 import io.circe.{Decoder, Encoder}
 import uk.ac.wellcome.messaging.sns.{SNSConfig, SNSWriter}
 import uk.ac.wellcome.storage.s3.{S3Config, S3TypeStore}

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.messaging.sns
 import com.amazonaws.services.sns.AmazonSNS
 import com.amazonaws.services.sns.model.PublishRequest
 import com.google.inject.Inject
-import com.twitter.inject.Logging
+import grizzled.slf4j.Logging
 import uk.ac.wellcome.messaging.GlobalExecutionContext.context
 
 import scala.concurrent.{blocking, Future}

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSReader.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSReader.scala
@@ -7,7 +7,7 @@ import com.amazonaws.services.sqs.model.{
   ReceiveMessageRequest
 }
 import com.google.inject.Inject
-import com.twitter.inject.Logging
+import grizzled.slf4j.Logging
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.messaging.GlobalExecutionContext.context
 import scala.collection.JavaConverters._

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
@@ -9,7 +9,7 @@ import com.amazonaws.services.sqs
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.model.Message
 import com.google.inject.Inject
-import com.twitter.inject.Logging
+import grizzled.slf4j.Logging
 import io.circe.Decoder
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.monitoring.MetricsSender

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSWorker.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSWorker.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.utils.JsonUtil.fromJson
 import uk.ac.wellcome.messaging.GlobalExecutionContext.context
 import scala.concurrent.Future
-import com.twitter.inject.Logging
+import grizzled.slf4j.Logging
 import scala.concurrent.duration._
 
 abstract class SQSWorker(sqsReader: SQSReader,

--- a/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
+++ b/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
@@ -13,7 +13,7 @@ import akka.stream.{
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model._
 import com.google.inject.Inject
-import com.twitter.inject.Logging
+import grizzled.slf4j.Logging
 import uk.ac.wellcome.monitoring.GlobalExecutionContext.context
 
 import scala.collection.JavaConverters._

--- a/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/MetricsSenderFixture.scala
+++ b/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/MetricsSenderFixture.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.monitoring.test.fixtures
 
 import akka.actor.ActorSystem
-import com.twitter.inject.Logging
+import grizzled.slf4j.Logging
 import org.mockito.Matchers.{any, anyString}
 import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/VersionedDao.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/VersionedDao.scala
@@ -7,7 +7,7 @@ import com.gu.scanamo.ops.ScanamoOps
 import com.gu.scanamo.query.{KeyEquals, UniqueKey}
 import com.gu.scanamo.syntax.{attributeExists, not, _}
 import com.gu.scanamo.{DynamoFormat, Scanamo, Table}
-import com.twitter.inject.Logging
+import grizzled.slf4j.Logging
 import uk.ac.wellcome.storage.type_classes.{
   IdGetter,
   VersionGetter,

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3Storage.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3Storage.scala
@@ -7,6 +7,8 @@ import com.amazonaws.services.s3.model.ObjectMetadata
 import com.twitter.inject.Logging
 import uk.ac.wellcome.storage.type_classes.StorageStrategy
 
+import grizzled.slf4j.Logging
+
 import scala.concurrent.{ExecutionContext, Future}
 import scala.collection.JavaConverters._
 

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3Storage.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3Storage.scala
@@ -4,7 +4,6 @@ import java.io.InputStream
 
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.ObjectMetadata
-import com.twitter.inject.Logging
 import uk.ac.wellcome.storage.type_classes.StorageStrategy
 
 import grizzled.slf4j.Logging

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StreamStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StreamStore.scala
@@ -4,7 +4,7 @@ import java.io.InputStream
 
 import com.amazonaws.services.s3.AmazonS3
 import com.google.inject.Inject
-import com.twitter.inject.Logging
+import grizzled.slf4j.Logging
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
@@ -3,6 +3,8 @@ package uk.ac.wellcome.storage.s3
 import com.amazonaws.services.s3.AmazonS3
 import com.google.inject.Inject
 import com.twitter.inject.Logging
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.storage.GlobalExecutionContext.context
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.io.Source

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StringStore.scala
@@ -2,11 +2,10 @@ package uk.ac.wellcome.storage.s3
 
 import com.amazonaws.services.s3.AmazonS3
 import com.google.inject.Inject
-import com.twitter.inject.Logging
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.storage.GlobalExecutionContext.context
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.io.Source
 
 import uk.ac.wellcome.storage.type_classes.StorageStrategyGenerator._
@@ -14,7 +13,7 @@ import uk.ac.wellcome.storage.type_classes.StorageStrategyGenerator._
 
 class S3StringStore @Inject()(
   s3Client: AmazonS3,
-)(implicit ec: ExecutionContext) extends Logging
+) extends Logging
     with S3ObjectStore[String]{
 
   override def put(bucket: String)(

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3TypeStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3TypeStore.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.storage.s3
 
 import com.amazonaws.services.s3.AmazonS3
 import com.google.inject.Inject
-import com.twitter.inject.Logging
+import grizzled.slf4j.Logging
 import io.circe.{Decoder, Encoder}
 import uk.ac.wellcome.utils.JsonUtil._
 

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/S3.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/S3.scala
@@ -75,9 +75,11 @@ trait S3 extends Logging with Eventually {
     )
 
   def getContentFromS3(bucket: Bucket, key: String): String =
-    scala.io.Source.fromInputStream(
-      s3Client.getObject(bucket.name, key).getObjectContent
-    ).mkString
+    scala.io.Source
+      .fromInputStream(
+        s3Client.getObject(bucket.name, key).getObjectContent
+      )
+      .mkString
 
   def getJsonFromS3(bucket: Bucket, key: String): Json = {
     parse(getContentFromS3(bucket, key)).right.get

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/S3.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/S3.scala
@@ -1,10 +1,9 @@
 package uk.ac.wellcome.storage.test.fixtures
 
 import com.amazonaws.services.s3.AmazonS3
-import com.twitter.inject.Logging
+import grizzled.slf4j.Logging
 import io.circe.Json
 import io.circe.parser.parse
-import org.apache.commons.io.IOUtils
 import org.scalatest.concurrent.Eventually
 import uk.ac.wellcome.storage.s3.S3ClientFactory
 import uk.ac.wellcome.test.fixtures._
@@ -75,9 +74,10 @@ trait S3 extends Logging with Eventually {
       }
     )
 
-  def getContentFromS3(bucket: Bucket, key: String): String = {
-    IOUtils.toString(s3Client.getObject(bucket.name, key).getObjectContent)
-  }
+  def getContentFromS3(bucket: Bucket, key: String): String =
+    scala.io.Source.fromInputStream(
+      s3Client.getObject(bucket.name, key).getObjectContent
+    ).mkString
 
   def getJsonFromS3(bucket: Bucket, key: String): Json = {
     parse(getContentFromS3(bucket, key)).right.get


### PR DESCRIPTION
### What is this PR trying to achieve?

Allow the extraction of Messaging/Storage/Monitoring libraries as appropriate by removing the dependency on Finatra and replacing with common interface alternatives (guice/sl4j).

### Who is this change for?

Folk who want to reduce build times, version projects with many dependencies, and contribute to the open source community.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.