### PR TITLE
Increase redrive attempts for items_to_dynamo

### DIFF
--- a/sierra_adapter/terraform/items_to_dynamo/queues.tf
+++ b/sierra_adapter/terraform/items_to_dynamo/queues.tf
@@ -8,5 +8,4 @@ module "demultiplexer_queue" {
   alarm_topic_arn = "${var.dlq_alarm_arn}"
 
   max_receive_count = 10
-
 }

--- a/sierra_adapter/terraform/items_to_dynamo/queues.tf
+++ b/sierra_adapter/terraform/items_to_dynamo/queues.tf
@@ -6,4 +6,7 @@ module "demultiplexer_queue" {
   topic_names = ["${var.demultiplexer_topic_name}"]
 
   alarm_topic_arn = "${var.dlq_alarm_arn}"
+
+  max_receive_count = 10
+
 }


### PR DESCRIPTION
### What is this PR trying to achieve?
Errors in items_to_dynamo seem to be due mostly to throughput exceeded or conditional check failures. Increasing the number of times messages are resent before ending in the dlq should help