### PR TITLE
Update Finatra to 18.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,12 +74,12 @@ env:
     #
     - PYTHONUNBUFFERED=x
 
-jobs:
+matrix:
   include:
 #    - stage: quicktest
 #      env: TASK=travis-format
 #    - env: TASK=travistooling-test
-#
+
 #    - stage: sbt-common-test
 
     # Lambda tests.
@@ -114,8 +114,8 @@ jobs:
 #        - TASK=travis-lambda-test
 
     # Catalogue API stack
-    - stage: test
-      env: TASK=common-test
+#    - stage: test
+    - env: TASK=common-test
     - env: TASK=internal_model-test
     - env: TASK=display-test
     - env: TASK=elasticsearch-test
@@ -158,10 +158,10 @@ jobs:
     # - env: TASK=loris-build
     # - env: TASK=cache_cleaner-build
 
-stages:
-  - quicktest
+#stages:
+#  - quicktest
 #  - sbt-common-test
-  - test
+#  - test
 
 # This has a Slack API token for posting messages about build failures to
 # our team channel.  It was created by following the "Setup Instructions" at

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,13 @@ cache:
     - catalogue_pipeline/transformer/target
     - catalogue_pipeline/recorder/target
 
-    - common/target
-
     - data_api/snapshot_generator/target
 
     - goobi_adapter/goobi_reader/target
 
     - reindexer/reindex_worker/target
 
+    - sbt_common/common/target
     - sbt_common/display/target
     - sbt_common/elasticsearch/target
     - sbt_common/finatra_akka/target
@@ -74,13 +73,20 @@ env:
     #
     - PYTHONUNBUFFERED=x
 
-matrix:
+jobs:
   include:
-#    - stage: quicktest
-#      env: TASK=travis-format
-#    - env: TASK=travistooling-test
+    - stage: quicktest
+      env: TASK=travis-format
+    - env: TASK=travistooling-test
 
-#    - stage: sbt-common-test
+    - stage: sbt-common-test
+      env: TASK=common-test
+    - env: TASK=elasticsearch-test
+    - env: TASK=messaging-test
+    - env: TASK=storage-test
+    - env: TASK=monitoring-test
+    - env: TASK=internal_model-test
+    - env: TASK=display-test
 
     # Lambda tests.
     #
@@ -94,35 +100,28 @@ matrix:
     # When this job runs, all the Lambdas get tested at once, but even this
     # isn't significantly longer than a Scala test.
     #
-#    - stage: test
-#      env:
-#        - TRAVIS_LAMBDAS="snapshot_scheduler \
-#          reindex_job_creator \
-#          complete_reindex \
-#          reindex_shard_generator \
-#          sierra_window_generator \
-#          s3_demultiplexer \
-#          drain_ecs_container_instance \
-#          dynamo_to_sns \
-#          ecs_ec2_instance_tagger \
-#          run_ecs_task \
-#          gatling_to_cloudwatch \
-#          notify_old_deploys \
-#          post_to_slack \
-#          service_deployment_status \
-#          update_service_list"
-#        - TASK=travis-lambda-test
+    - stage: test
+      env:
+        - TRAVIS_LAMBDAS="snapshot_scheduler \
+          reindex_job_creator \
+          complete_reindex \
+          reindex_shard_generator \
+          sierra_window_generator \
+          s3_demultiplexer \
+          drain_ecs_container_instance \
+          dynamo_to_sns \
+          ecs_ec2_instance_tagger \
+          run_ecs_task \
+          gatling_to_cloudwatch \
+          notify_old_deploys \
+          post_to_slack \
+          service_deployment_status \
+          update_service_list"
+        - TASK=travis-lambda-test
 
     # Catalogue API stack
-#    - stage: test
-    - env: TASK=common-test
-    - env: TASK=internal_model-test
-    - env: TASK=display-test
-    - env: TASK=elasticsearch-test
-    - env: TASK=messaging-test
-    - env: TASK=storage-test
-    - env: TASK=monitoring-test
-    - env: TASK=api-test
+    - stage: test
+      env: TASK=api-test
     # (not under active development)
     # - env: TASK=api_docs-build
 
@@ -158,10 +157,10 @@ matrix:
     # - env: TASK=loris-build
     # - env: TASK=cache_cleaner-build
 
-#stages:
-#  - quicktest
-#  - sbt-common-test
-#  - test
+stages:
+  - quicktest
+  - sbt-common-test
+  - test
 
 # This has a Slack API token for posting messages about build failures to
 # our team channel.  It was created by following the "Setup Instructions" at

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,14 @@ cache:
     - catalogue_pipeline/transformer/target
     - catalogue_pipeline/recorder/target
 
+    - common/target
+
     - data_api/snapshot_generator/target
 
     - goobi_adapter/goobi_reader/target
 
     - reindexer/reindex_worker/target
 
-    - sbt_common/common/target
     - sbt_common/display/target
     - sbt_common/elasticsearch/target
     - sbt_common/finatra_akka/target
@@ -75,18 +76,11 @@ env:
 
 jobs:
   include:
-    - stage: quicktest
-      env: TASK=travis-format
-    - env: TASK=travistooling-test
-
-    - stage: sbt-common-test
-      env: TASK=common-test
-    - env: TASK=elasticsearch-test
-    - env: TASK=messaging-test
-    - env: TASK=storage-test
-    - env: TASK=monitoring-test
-    - env: TASK=internal_model-test
-    - env: TASK=display-test
+#    - stage: quicktest
+#      env: TASK=travis-format
+#    - env: TASK=travistooling-test
+#
+#    - stage: sbt-common-test
 
     # Lambda tests.
     #
@@ -100,28 +94,35 @@ jobs:
     # When this job runs, all the Lambdas get tested at once, but even this
     # isn't significantly longer than a Scala test.
     #
-    - stage: test
-      env:
-        - TRAVIS_LAMBDAS="snapshot_scheduler \
-          reindex_job_creator \
-          complete_reindex \
-          reindex_shard_generator \
-          sierra_window_generator \
-          s3_demultiplexer \
-          drain_ecs_container_instance \
-          dynamo_to_sns \
-          ecs_ec2_instance_tagger \
-          run_ecs_task \
-          gatling_to_cloudwatch \
-          notify_old_deploys \
-          post_to_slack \
-          service_deployment_status \
-          update_service_list"
-        - TASK=travis-lambda-test
+#    - stage: test
+#      env:
+#        - TRAVIS_LAMBDAS="snapshot_scheduler \
+#          reindex_job_creator \
+#          complete_reindex \
+#          reindex_shard_generator \
+#          sierra_window_generator \
+#          s3_demultiplexer \
+#          drain_ecs_container_instance \
+#          dynamo_to_sns \
+#          ecs_ec2_instance_tagger \
+#          run_ecs_task \
+#          gatling_to_cloudwatch \
+#          notify_old_deploys \
+#          post_to_slack \
+#          service_deployment_status \
+#          update_service_list"
+#        - TASK=travis-lambda-test
 
     # Catalogue API stack
     - stage: test
-      env: TASK=api-test
+      env: TASK=common-test
+    - env: TASK=internal_model-test
+    - env: TASK=display-test
+    - env: TASK=elasticsearch-test
+    - env: TASK=messaging-test
+    - env: TASK=storage-test
+    - env: TASK=monitoring-test
+    - env: TASK=api-test
     # (not under active development)
     # - env: TASK=api_docs-build
 
@@ -159,7 +160,7 @@ jobs:
 
 stages:
   - quicktest
-  - sbt-common-test
+#  - sbt-common-test
   - test
 
 # This has a Slack API token for posting messages about build failures to

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/DocsController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/DocsController.scala
@@ -17,7 +17,6 @@ class DocsController @Inject()(
   @Flag("api.prefix") apiPrefix: String,
   @Flag("api.host") apiHost: String
 ) extends Controller {
-
   prefix(apiPrefix) {
     setupSwaggerEndpoint(ApiVersions.v1, ApiV1Swagger)
     setupSwaggerEndpoint(ApiVersions.v2, ApiV2Swagger)
@@ -49,7 +48,10 @@ class DocsController @Inject()(
         .title("Catalogue"))
     swagger.scheme(scheme)
     swagger.host(apiHost)
-    swagger.basePath(s"$apiPrefix/$apiVersion")
+    // Had to remove the basePath because of this "improvement"
+    // https://github.com/jakehschwartz/finatra-swagger/pull/27
+    // all paths now are including the prefix which means they
+    // are relative to the host, not to the basePath
     swagger.produces("application/json")
     swagger.produces("application/ld+json")
   }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -91,24 +91,7 @@ class ApiSwaggerTest extends FunSpec with Matchers with fixtures.Server {
       .toString shouldBe "\"#/definitions/Work\""
   }
 
-  // Because the Swagger should be the same on every request, we cache
-  // requests for the Swagger to save the time cost of starting a new
-  // server for every test/request.
-  //
-  var cachedResponses = Map[String, JsonNode]()
-
   def readTree(path: String): JsonNode = {
-    cachedResponses.get(path) match {
-      case Some(node) => node
-      case None => {
-        val newTree = readTreeFromServer(path)
-        cachedResponses += (path -> newTree)
-        newTree
-      }
-    }
-  }
-
-  def readTreeFromServer(path: String): JsonNode = {
     val flags = Map(
       "api.host" -> "test.host",
       "api.scheme" -> "http",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -11,37 +11,36 @@ class ApiSwaggerTest extends FunSpec with Matchers with fixtures.Server {
 
   it("returns a valid JSON response for all api versions") {
     ApiVersions.values.toList.foreach { version: ApiVersions.Value =>
-      val tree = readTree(s"/test/${version.toString}/swagger.json")
+      val tree = readTree(s"/catalogue/${version.toString}/swagger.json")
 
       tree.at("/host").toString should be("\"test.host\"")
       tree.at("/schemes").toString should be("[\"http\"]")
       tree.at("/info/version").toString should be(s""""${version.toString}"""")
-      tree.at("/basePath").toString should be(
-        s""""/test/${version.toString}"""")
+      tree.at("/basePath").toString should be("")
     }
   }
 
   it("includes the DisplayError model all api versions") {
     ApiVersions.values.toList.foreach { version: ApiVersions.Value =>
-      val tree = readTree(s"/test/${version.toString}/swagger.json")
+      val tree = readTree(s"/catalogue/${version.toString}/swagger.json")
       tree.at("/definitions/Error/type").toString should be("\"object\"")
     }
   }
 
   it("shows only the endpoints for the specified version") {
     ApiVersions.values.toList.foreach { version: ApiVersions.Value =>
-      val tree = readTree(s"/test/${version.toString}/swagger.json")
+      val tree = readTree(s"/catalogue/${version.toString}/swagger.json")
       tree.at("/paths").isObject shouldBe true
       tree
         .at("/paths")
         .fieldNames
         .asScala
-        .toList should contain only ("/works", "/works/{id}")
+        .toList should contain only (s"/catalogue/${version.toString}/works", s"/catalogue/${version.toString}/works/{id}")
     }
   }
 
   it("shows the correct Work model for v1") {
-    val tree = readTree(s"/test/${ApiVersions.v1.toString}/swagger.json")
+    val tree = readTree(s"/catalogue/${ApiVersions.v1.toString}/swagger.json")
     tree.at("/definitions/Work").isObject shouldBe true
     tree
       .at("/definitions/Work/properties/creators/type")
@@ -49,7 +48,7 @@ class ApiSwaggerTest extends FunSpec with Matchers with fixtures.Server {
   }
 
   it("shows the correct Work model for v2") {
-    val tree = readTree(s"/test/${ApiVersions.v2.toString}/swagger.json")
+    val tree = readTree(s"/catalogue/${ApiVersions.v2.toString}/swagger.json")
     tree.at("/definitions/Work").isObject shouldBe true
     tree
       .at("/definitions/Work/properties/contributors/type")
@@ -57,7 +56,7 @@ class ApiSwaggerTest extends FunSpec with Matchers with fixtures.Server {
   }
 
   it("shows the correct Subject model for v2") {
-    val tree = readTree(s"/test/${ApiVersions.v2.toString}/swagger.json")
+    val tree = readTree(s"/catalogue/${ApiVersions.v2.toString}/swagger.json")
     tree.at("/definitions/Subject").isObject shouldBe true
     tree
       .at("/definitions/Subject/properties/concepts/type")
@@ -68,7 +67,7 @@ class ApiSwaggerTest extends FunSpec with Matchers with fixtures.Server {
   }
 
   it("shows the correct Genre model for v2") {
-    val tree = readTree(s"/test/${ApiVersions.v2.toString}/swagger.json")
+    val tree = readTree(s"/catalogue/${ApiVersions.v2.toString}/swagger.json")
     tree.at("/definitions/Genre").isObject shouldBe true
     tree
       .at("/definitions/Genre/properties/concepts/type")
@@ -79,13 +78,13 @@ class ApiSwaggerTest extends FunSpec with Matchers with fixtures.Server {
   }
 
   it("doesn't show DisplayWork in the definitions") {
-    val tree = readTree(s"/test/${ApiVersions.v2.toString}/swagger.json")
+    val tree = readTree(s"/catalogue/${ApiVersions.v2.toString}/swagger.json")
     tree.at("/definitions").fieldNames.asScala.toList shouldNot contain(
       "DisplayWork")
   }
 
   it("shows Work as the items type in ResultList") {
-    val tree = readTree(s"/test/${ApiVersions.v2.toString}/swagger.json")
+    val tree = readTree(s"/catalogue/${ApiVersions.v2.toString}/swagger.json")
     tree
       .at(s"/definitions/ResultList/properties/results/items/$$ref")
       .toString shouldBe "\"#/definitions/Work\""
@@ -95,7 +94,7 @@ class ApiSwaggerTest extends FunSpec with Matchers with fixtures.Server {
     val flags = Map(
       "api.host" -> "test.host",
       "api.scheme" -> "http",
-      "api.name" -> "test",
+      "api.name" -> "catalogue",
       "es.index.v1" -> "v1",
       "es.index.v2" -> "v2"
     )

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
@@ -40,7 +40,7 @@ class IdMinterWorkerTest
             withModifiedServer(
               flags,
               modifyServer = (server: EmbeddedHttpServer) => {
-                server.bind[IdentifiersDao](identifiersDao)
+                server.bind[IdentifiersDao].toInstance(identifiersDao)
               }) { _ =>
               val database = dbConfig.database
               val table = dbConfig.table

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,21 +67,9 @@ object Dependencies {
 
   val finatraDependencies = Seq(
     "ch.qos.logback" % "logback-classic" % versions.logback,
-    "com.twitter" %% "finatra-http" % versions.finatra % "test" classifier "tests",
-    "com.twitter" %% "finatra-http" % versions.finatra % "test",
     "com.twitter" %% "finatra-http" % versions.finatra,
     "com.twitter" %% "finatra-httpclient" % versions.finatra,
-    "com.twitter" %% "finatra-jackson" % versions.finatra % "test",
-    "com.twitter" %% "finatra-jackson" % versions.finatra % "test" classifier "tests",
-    "com.twitter" %% "inject-app" % versions.finatra % "test" classifier "tests",
-    "com.twitter" %% "inject-app" % versions.finatra % "test",
-    "com.twitter" %% "inject-core" % versions.finatra,
-    "com.twitter" %% "inject-core" % versions.finatra % "test",
-    "com.twitter" %% "inject-core" % versions.finatra % "test" classifier "tests",
-    "com.twitter" %% "inject-modules" % versions.finatra % "test",
-    "com.twitter" %% "inject-modules" % versions.finatra % "test" classifier "tests",
-    "com.twitter" %% "inject-server" % versions.finatra % "test" classifier "tests",
-    "com.twitter" %% "inject-server" % versions.finatra % "test"
+    "com.twitter" %% "inject-core" % versions.finatra
   )
 
   val elasticsearchDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val akkaStreamAlpakkaS3 = "0.17"
     val aws = "1.11.95"
     val apacheLogging = "2.8.2"
-    val finatra = "2.10.0"
+    val finatra = "18.5.0"
     val guice = "4.0"
     val logback = "1.1.8"
     val mockito = "1.9.5"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,9 +67,19 @@ object Dependencies {
 
   val finatraDependencies = Seq(
     "ch.qos.logback" % "logback-classic" % versions.logback,
+    "com.twitter" %% "finatra-http" % versions.finatra % "test" classifier "tests",
     "com.twitter" %% "finatra-http" % versions.finatra,
     "com.twitter" %% "finatra-httpclient" % versions.finatra,
-    "com.twitter" %% "inject-core" % versions.finatra
+    "com.twitter" %% "finatra-jackson" % versions.finatra % "test",
+    "com.twitter" %% "finatra-jackson" % versions.finatra % "test" classifier "tests",
+    "com.twitter" %% "inject-app" % versions.finatra % "test" classifier "tests",
+    "com.twitter" %% "inject-app" % versions.finatra % "test",
+    "com.twitter" %% "inject-core" % versions.finatra,
+    "com.twitter" %% "inject-core" % versions.finatra % "test" classifier "tests",
+    "com.twitter" %% "inject-modules" % versions.finatra % "test",
+    "com.twitter" %% "inject-modules" % versions.finatra % "test" classifier "tests",
+    "com.twitter" %% "inject-server" % versions.finatra % "test" classifier "tests",
+    "com.twitter" %% "inject-server" % versions.finatra % "test"
   )
 
   val elasticsearchDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val akkaStreamAlpakkaS3 = "0.17"
     val aws = "1.11.95"
     val apacheLogging = "2.8.2"
-    val finatra = "18.5.0"
+    val finatra = "18.4.0"
     val guice = "4.0"
     val logback = "1.1.8"
     val mockito = "1.9.5"

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/modules/DisplayJacksonModule.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/modules/DisplayJacksonModule.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.display.modules
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.twitter.finatra.json.modules.FinatraJacksonModule
-import com.twitter.finatra.json.utils.CamelCasePropertyNamingStrategy
 import uk.ac.wellcome.display.models.WorksIncludesDeserializerModule
 
 object DisplayJacksonModule extends FinatraJacksonModule {
-  override val propertyNamingStrategy = CamelCasePropertyNamingStrategy
+  override val propertyNamingStrategy = PropertyNamingStrategy.LOWER_CAMEL_CASE
   override val additionalJacksonModules = Seq(
     new WorksIncludesDeserializerModule
   )


### PR DESCRIPTION
Couple of comments:
* Couldn't migrate to finatra 18.5.0 because finatra-swagger brings in jackson-databind 9.2 which is incompatible with the jackson-scala-module that it brings in. We could work around that with exclusions or upgrading the jackson-scala-module in our dependencies, but that means polluting our dependencies file
* finatra-swagger now always adds the full path relative to the host, not the prefix thanks to [this "improvement"](https://github.com/jakehschwartz/finatra-swagger/pull/27), so had to remove the basePath to keep a valid swagger.json. 
* Other changes are mostly minor around deprecated methods and so on