### PR TITLE
Add a Shapeless type class for migrating between case classes

### DIFF
--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/type_classes/Migration.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/type_classes/Migration.scala
@@ -3,6 +3,31 @@ package uk.ac.wellcome.storage.type_classes
 import shapeless.ops.hlist.{Align, Intersection}
 import shapeless.{HList, LabelledGeneric}
 
+// This is based on code from "The Type Astronaut's Guide to Shapeless",
+// as downloaded on 23 May 2018.
+//
+// The code in question comes from § 6.3 "Case study: case class migrations".
+//
+// The purpose of Migration is to allow you to move between case classes.
+// For example, suppose I had the following case classes:
+//
+//      case class Shapes(squares: Int, rectangles: Int, circles: Int)
+//      case class Roundshapes(circles: Int)
+//
+// This allows us to migrate an instance of "Shapes" to "Roundshapes".
+//
+//      val shapes = Shapes(squares = 1, rectangles = 2, circles = 3)
+//      val roundShapes = shapes.migrateTo[Roundshapes]
+//        ~> Roundshapes(circles = 3)
+//
+// You can migrate from `Source` to `Target` if the fields in `Target` are
+// a subset of the fields of `Source`.
+//
+// To pick up the `.migrateTo` method, import this object as follows:
+//
+//      import uk.ac.wellcome.storage.type_classes.Migration._
+//
+
 trait Migration[Source, Target] {
   def apply(src: Source): Target
 }
@@ -13,6 +38,12 @@ object Migration {
       migration.apply(src)
   }
 
+  // Type parameters:
+  //
+  // -  We are migrating from `Source` to `Target`, both case classes.
+  // -  `SRepr` and `TRepr` are HList representations of `Source` and `Target`.
+  // -  `Unaligned` is an intermedate HList used during the migration.
+  //
   implicit def genericMigration[Source, Target, SRepr <: HList, TRepr <: HList, Unaligned <: HList](
     implicit
     sourceGen: LabelledGeneric.Aux[Source, SRepr],
@@ -20,7 +51,17 @@ object Migration {
     intersection: Intersection.Aux[SRepr, TRepr, Unaligned],
     align: Align[Unaligned, TRepr]
   ): Migration[Source, Target] = new Migration[Source, Target] {
-    def apply(src: Source): Target =
-      targetGen.from(align.apply(intersection.apply(sourceGen.to(src))))
+    def apply(src: Source): Target = {
+      val sourceHList: SRepr = sourceGen.to(src)
+
+      // This gets the key-value pairs whose keys are in both `Source` and
+      // `Target`, but they may not be in the correct order.
+      val commonFields: Unaligned = intersection.apply(sourceHList)
+
+      // This reorders the HList fields to be in the same order as `Target`.
+      val targetHList: TRepr = align.apply(commonFields)
+
+      targetGen.from(targetHList)
+    }
   }
 }

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/type_classes/Migration.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/type_classes/Migration.scala
@@ -35,7 +35,8 @@ trait Migration[Source, Target] {
 
 object Migration {
   implicit class MigrationOps[Source](src: Source) {
-    def migrateTo[Target](implicit migration: Migration[Source, Target]): Target =
+    def migrateTo[Target](
+      implicit migration: Migration[Source, Target]): Target =
       migration.apply(src)
   }
 
@@ -45,9 +46,12 @@ object Migration {
   // -  `SRepr` and `TRepr` are HList representations of `Source` and `Target`.
   // -  `Unaligned` is an intermedate HList used during the migration.
   //
-  implicit def genericMigration[Source, Target, SRepr <: HList, TRepr <: HList, Unaligned <: HList](
-    implicit
-    sourceGen: LabelledGeneric.Aux[Source, SRepr],
+  implicit def genericMigration[Source,
+                                Target,
+                                SRepr <: HList,
+                                TRepr <: HList,
+                                Unaligned <: HList](
+    implicit sourceGen: LabelledGeneric.Aux[Source, SRepr],
     targetGen: LabelledGeneric.Aux[Target, TRepr],
     intersection: Intersection.Aux[SRepr, TRepr, Unaligned],
     align: Align[Unaligned, TRepr]

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/type_classes/Migration.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/type_classes/Migration.scala
@@ -7,6 +7,7 @@ import shapeless.{HList, LabelledGeneric}
 // as downloaded on 23 May 2018.
 //
 // The code in question comes from § 6.3 "Case study: case class migrations".
+// (It omits § 6.3.4 "Adding new fields", as we don't currently need that.)
 //
 // The purpose of Migration is to allow you to move between case classes.
 // For example, suppose I had the following case classes:

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/type_classes/Migration.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/type_classes/Migration.scala
@@ -1,0 +1,26 @@
+package uk.ac.wellcome.storage.type_classes
+
+import shapeless.ops.hlist.{Align, Intersection}
+import shapeless.{HList, LabelledGeneric}
+
+trait Migration[Source, Target] {
+  def apply(src: Source): Target
+}
+
+object Migration {
+  implicit class MigrationOps[Source](src: Source) {
+    def migrateTo[Target](implicit migration: Migration[Source, Target]): Target =
+      migration.apply(src)
+  }
+
+  implicit def genericMigration[Source, Target, SRepr <: HList, TRepr <: HList, Unaligned <: HList](
+    implicit
+    sourceGen: LabelledGeneric.Aux[Source, SRepr],
+    targetGen: LabelledGeneric.Aux[Target, TRepr],
+    intersection: Intersection.Aux[SRepr, TRepr, Unaligned],
+    align: Align[Unaligned, TRepr]
+  ): Migration[Source, Target] = new Migration[Source, Target] {
+    def apply(src: Source): Target =
+      targetGen.from(align.apply(intersection.apply(sourceGen.to(src))))
+  }
+}

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/type_classes/MigrationTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/type_classes/MigrationTest.scala
@@ -1,0 +1,28 @@
+package uk.ac.wellcome.storage.type_classes
+
+import org.scalatest.{FunSpec, Matchers}
+import Migration._
+
+class MigrationTest extends FunSpec with Matchers {
+
+  case class Alphabet(a: String, b: String, c: String, d: String, e: String)
+
+  val alphabet = Alphabet(a = "apple", b = "banana", c = "coconut", d = "dandelion", e = "egg")
+
+  it("gets the intersection of two case classes") {
+    case class Vowels(a: String, e: String)
+    alphabet.migrateTo[Vowels] shouldBe Vowels(
+      a = alphabet.a,
+      e = alphabet.e
+    )
+  }
+
+  it("finds case class fields in the wrong order") {
+    case class Consonants(d: String, c: String, b: String)
+    alphabet.migrateTo[Consonants] shouldBe Consonants(
+      d = alphabet.d,
+      c = alphabet.c,
+      b = alphabet.b
+    )
+  }
+}

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/type_classes/MigrationTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/type_classes/MigrationTest.scala
@@ -7,7 +7,12 @@ class MigrationTest extends FunSpec with Matchers {
 
   case class Alphabet(a: String, b: String, c: String, d: String, e: String)
 
-  val alphabet = Alphabet(a = "apple", b = "banana", c = "coconut", d = "dandelion", e = "egg")
+  val alphabet = Alphabet(
+    a = "apple",
+    b = "banana",
+    c = "coconut",
+    d = "dandelion",
+    e = "egg")
 
   it("gets the intersection of two case classes") {
     case class Vowels(a: String, e: String)


### PR DESCRIPTION
### What is this PR trying to achieve?

Allow us to extract subsets of fields from a case class.

### Who is this change for?

In the VHS, we write an HList formed from _(HybridRecord + CustomMetadata)_ as a single row in DynamoDB, where _CustomMetadata_ is a user-defined case class.

When we retrieve the row, we want to separate them back into individual case classes. This patch contains some Shapeless logic to do that.

---

Because the Shapeless type classes are among the most complicated code in the platform, I’d like a review from **all three devs** that this code is correct, and they understand what it’s doing.