### PR TITLE
Remove the Versioned trait

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/Versioned.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Versioned.scala
@@ -1,5 +1,0 @@
-package uk.ac.wellcome.models
-
-trait Versioned {
-  val version: Int
-}

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import uk.ac.wellcome.messaging.sqs.SQSMessage
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
-import uk.ac.wellcome.models.{Id, Versioned}
+import uk.ac.wellcome.models.Id
 import uk.ac.wellcome.platform.reindex_worker.models.{
   CompletedReindexJob,
   ReindexJob,
@@ -24,8 +24,7 @@ case class TestRecord(
   version: Int,
   reindexShard: String,
   reindexVersion: Int
-) extends Versioned
-    with Id
+) extends Id
 
 class ReindexerFeatureTest
     extends FunSpec

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraItemRecord.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraItemRecord.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.models.transformable.sierra
 
 import java.time.Instant
 
-import uk.ac.wellcome.models.{Id, Versioned}
+import uk.ac.wellcome.models.Id
 
 case class SierraItemRecord(
   id: String,
@@ -11,8 +11,7 @@ case class SierraItemRecord(
   bibIds: List[String],
   unlinkedBibIds: List[String] = List(),
   version: Int = 0
-) extends Versioned
-    with Id
+) extends Id
 
 object SierraItemRecord {
   def apply(id: String,

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -1,9 +1,7 @@
 package uk.ac.wellcome.models.work.internal
 
-import uk.ac.wellcome.models.Versioned
-
 /** A representation of a work in our ontology */
-trait Work extends Versioned {
+trait Work {
   val title: Option[String]
   val sourceIdentifier: SourceIdentifier
   val version: Int

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/HybridRecord.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/HybridRecord.scala
@@ -1,10 +1,9 @@
 package uk.ac.wellcome.storage.vhs
 
-import uk.ac.wellcome.models.{Id, Versioned}
+import uk.ac.wellcome.models.Id
 
 case class HybridRecord(
   id: String,
   version: Int,
   s3key: String
-) extends Versioned
-    with Id
+) extends Id

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
@@ -21,9 +21,7 @@ import uk.ac.wellcome.test.utils.ExtendedPatience
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-case class TestVersioned(override val id: String,
-                         data: String,
-                         version: Int)
+case class TestVersioned(override val id: String, data: String, version: Int)
     extends Id
 
 class VersionedDaoTest

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
@@ -13,7 +13,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import shapeless._
-import uk.ac.wellcome.models.{Id, Versioned}
+import uk.ac.wellcome.models.Id
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.test.fixtures._
@@ -23,9 +23,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 case class TestVersioned(override val id: String,
                          data: String,
-                         override val version: Int)
-    extends Versioned
-    with Id
+                         version: Int)
+    extends Id
 
 class VersionedDaoTest
     extends FunSpec
@@ -239,12 +238,10 @@ class VersionedDaoTest
                                 data: String,
                                 moreData: Int,
                                 version: Int)
-              extends Versioned
-              with Id
+              extends Id
 
           case class PartialRecord(id: String, moreData: Int, version: Int)
-              extends Versioned
-              with Id
+              extends Id
 
           val fullRecord = FullRecord(
             id = id,

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
@@ -18,9 +18,7 @@ object LocalDynamoDb {
   case class Table(name: String, index: String)
 }
 
-trait LocalDynamoDb[T <: Id]
-    extends Eventually
-    with ExtendedPatience {
+trait LocalDynamoDb[T <: Id] extends Eventually with ExtendedPatience {
 
   import LocalDynamoDb._
 

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.dynamodbv2.util.TableUtils.waitUntilActive
 import org.scalatest.concurrent.Eventually
 
 import scala.util.Random
-import uk.ac.wellcome.models.{Id, Versioned}
+import uk.ac.wellcome.models.Id
 import uk.ac.wellcome.test.fixtures._
 import com.amazonaws.services.dynamodbv2.model._
 import com.gu.scanamo.DynamoFormat
@@ -18,7 +18,7 @@ object LocalDynamoDb {
   case class Table(name: String, index: String)
 }
 
-trait LocalDynamoDb[T <: Versioned with Id]
+trait LocalDynamoDb[T <: Id]
     extends Eventually
     with ExtendedPatience {
 


### PR DESCRIPTION
### What is this PR trying to achieve?

Another snip from sbt-common.

The only place we were checking this bound was in LocalDynamoDB. I think this means we don’t need it, so I’ve removed it to see what happens.

### Who is this change for?

🇻🇪 🚦 