### PR TITLE
LocalDynamoDb split for reuse

### DIFF
--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.reindex_worker
 
-import com.gu.scanamo.{DynamoFormat, Scanamo}
-import org.scalatest.{FunSpec, Matchers}
+import com.gu.scanamo.Scanamo
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.sqs.SQSMessage
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
@@ -12,8 +12,8 @@ import uk.ac.wellcome.platform.reindex_worker.models.{
   ReindexJob,
   ReindexRecord
 }
-import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
+import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDbVersioned
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.utils.JsonUtil._
@@ -32,13 +32,10 @@ class ReindexerFeatureTest
     with Eventually
     with ExtendedPatience
     with fixtures.Server
-    with LocalDynamoDb[TestRecord]
+    with LocalDynamoDbVersioned
     with SNS
     with SQS
     with ScalaFutures {
-
-  override lazy val evidence: DynamoFormat[TestRecord] =
-    DynamoFormat[TestRecord]
 
   val currentVersion = 1
   val desiredVersion = 5

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
@@ -1,16 +1,15 @@
 package uk.ac.wellcome.platform.reindex_worker.services
 
 import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException
-import com.gu.scanamo.{DynamoFormat, Scanamo}
-import org.scalatest.Assertion
+import com.gu.scanamo.Scanamo
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.reindex_worker.TestRecord
 import uk.ac.wellcome.platform.reindex_worker.models.ReindexJob
 import uk.ac.wellcome.storage.dynamo.{DynamoConfig, VersionedDao}
-import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
+import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDbVersioned
 import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
@@ -19,12 +18,9 @@ class ReindexServiceTest
     with ScalaFutures
     with Matchers
     with Akka
-    with LocalDynamoDb[TestRecord]
+    with LocalDynamoDbVersioned
     with MetricsSenderFixture
     with ExtendedPatience {
-
-  override lazy val evidence: DynamoFormat[TestRecord] =
-    DynamoFormat[TestRecord]
 
   val shardName = "shard"
   val currentVersion = 1

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -1,12 +1,11 @@
 package uk.ac.wellcome.platform.reindex_worker.services
 
-import com.gu.scanamo.{DynamoFormat, Scanamo}
+import com.gu.scanamo.Scanamo
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
-import org.scalatest.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.messaging.sns.{SNSConfig, SNSWriter}
 import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSMessage, SQSReader}
@@ -15,8 +14,8 @@ import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.reindex_worker.TestRecord
 import uk.ac.wellcome.platform.reindex_worker.models.ReindexJob
 import uk.ac.wellcome.storage.dynamo.{DynamoConfig, VersionedDao}
-import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
+import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDbVersioned
 import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.utils.JsonUtil._
 
@@ -29,14 +28,11 @@ class ReindexWorkerServiceTest
     with Matchers
     with MockitoSugar
     with Akka
-    with LocalDynamoDb[TestRecord]
+    with LocalDynamoDbVersioned
     with MetricsSenderFixture
     with SNS
     with SQS
     with ScalaFutures {
-
-  override lazy val evidence: DynamoFormat[TestRecord] =
-    DynamoFormat[TestRecord]
 
   def withReindexWorkerService(table: Table)(
     testWith: TestWith[ReindexWorkerService, Assertion]) = {

--- a/sbt_common/finatra_storage/src/main/scala/uk/ac/wellcome/finatra/storage/DynamoConfigModule.scala
+++ b/sbt_common/finatra_storage/src/main/scala/uk/ac/wellcome/finatra/storage/DynamoConfigModule.scala
@@ -14,8 +14,10 @@ object DynamoConfigModule extends TwitterModule {
   @Singleton
   @Provides
   def providesDynamoConfig(): DynamoConfig = {
+
     DynamoConfig(
       table = tableName(),
       index = if (tableIndex().isEmpty) None else Some(tableIndex()))
+
   }
 }

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
@@ -237,10 +237,10 @@ class VersionedDaoTest
                                 data: String,
                                 moreData: Int,
                                 version: Int)
-              extends Id
+              extends Identified
 
           case class PartialRecord(id: String, moreData: Int, version: Int)
-              extends Id
+              extends Identified
 
           val fullRecord = FullRecord(
             id = id,

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.storage.dynamo
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.amazonaws.services.dynamodbv2.model.{GetItemRequest, UpdateItemRequest}
+import com.amazonaws.services.dynamodbv2.model.{
+  GetItemRequest,
+  UpdateItemRequest
+}
 import com.gu.scanamo.Scanamo
 import com.gu.scanamo.syntax._
 import org.mockito.Matchers.any

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
@@ -14,7 +14,6 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import shapeless._
 import uk.ac.wellcome.models.{Id => Identified}
-import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDbVersioned
 import uk.ac.wellcome.test.fixtures._

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
@@ -1,38 +1,34 @@
 package uk.ac.wellcome.storage.dynamo
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.amazonaws.services.dynamodbv2.model.{
-  GetItemRequest,
-  UpdateItemRequest
-}
+import com.amazonaws.services.dynamodbv2.model.{GetItemRequest, UpdateItemRequest}
+import com.gu.scanamo.Scanamo
 import com.gu.scanamo.syntax._
-import com.gu.scanamo.{DynamoFormat, Scanamo}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import shapeless._
-import uk.ac.wellcome.models.Id
+import uk.ac.wellcome.models.{Id => Identified}
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
+import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDbVersioned
 import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
 case class TestVersioned(override val id: String, data: String, version: Int)
-    extends Id
+    extends Identified
 
 class VersionedDaoTest
     extends FunSpec
-    with LocalDynamoDb[TestVersioned]
+    with LocalDynamoDbVersioned
     with ScalaFutures
     with ExtendedPatience
     with MockitoSugar
     with Matchers {
-
-  override lazy val evidence = DynamoFormat[TestVersioned]
 
   def withVersionedDao[R](table: Table)(
     testWith: TestWith[VersionedDao, R]): R = {

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
@@ -29,7 +29,7 @@ trait LocalDynamoDb[T <: Id] extends Eventually with ExtendedPatience {
 
   private val accessKey = "access"
   private val secretKey = "secret"
-
+  
   def dynamoDbLocalEndpointFlags(table: Table): Map[String, String] =
     dynamoClientLocalFlags ++ Map(
       "aws.dynamo.tableName" -> table.name,

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
@@ -29,7 +29,7 @@ trait LocalDynamoDb[T <: Id] extends Eventually with ExtendedPatience {
 
   private val accessKey = "access"
   private val secretKey = "secret"
-  
+
   def dynamoDbLocalEndpointFlags(table: Table): Map[String, String] =
     dynamoClientLocalFlags ++ Map(
       "aws.dynamo.tableName" -> table.name,

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
@@ -13,9 +13,7 @@ object LocalDynamoDb {
   case class Table(name: String, index: String)
 }
 
-trait LocalDynamoDb
-    extends Eventually
-    with ExtendedPatience {
+trait LocalDynamoDb extends Eventually with ExtendedPatience {
 
   import LocalDynamoDb._
 

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDb.scala
@@ -1,32 +1,27 @@
 package uk.ac.wellcome.storage.test.fixtures
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.amazonaws.services.dynamodbv2.util.TableUtils.waitUntilActive
 import org.scalatest.concurrent.Eventually
-
-import scala.util.Random
-import uk.ac.wellcome.models.Id
-import uk.ac.wellcome.test.fixtures._
-import com.amazonaws.services.dynamodbv2.model._
-import com.gu.scanamo.DynamoFormat
 import uk.ac.wellcome.storage.dynamo.DynamoClientFactory
+import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
 import scala.collection.JavaConverters._
+import scala.util.Random
 
 object LocalDynamoDb {
   case class Table(name: String, index: String)
 }
 
-trait LocalDynamoDb[T <: Id] extends Eventually with ExtendedPatience {
+trait LocalDynamoDb
+    extends Eventually
+    with ExtendedPatience {
 
   import LocalDynamoDb._
 
   private val port = 45678
   private val dynamoDBEndPoint = "http://localhost:" + port
-
   private val regionName = "localhost"
-
   private val accessKey = "access"
   private val secretKey = "secret"
 
@@ -50,8 +45,6 @@ trait LocalDynamoDb[T <: Id] extends Eventually with ExtendedPatience {
     secretKey = secretKey
   )
 
-  implicit val evidence: DynamoFormat[T]
-
   def withLocalDynamoDbTable[R]: Fixture[Table, R] = fixture[Table, R](
     create = {
       val tableName = Random.alphanumeric.take(10).mkString
@@ -64,50 +57,7 @@ trait LocalDynamoDb[T <: Id] extends Eventually with ExtendedPatience {
     }
   )
 
-  private def createTable(table: Table): Table = {
-    dynamoDbClient.createTable(
-      new CreateTableRequest()
-        .withTableName(table.name)
-        .withKeySchema(new KeySchemaElement()
-          .withAttributeName("id")
-          .withKeyType(KeyType.HASH))
-        .withAttributeDefinitions(
-          new AttributeDefinition()
-            .withAttributeName("id")
-            .withAttributeType("S"),
-          new AttributeDefinition()
-            .withAttributeName("reindexShard")
-            .withAttributeType("S"),
-          new AttributeDefinition()
-            .withAttributeName("reindexVersion")
-            .withAttributeType("N")
-        )
-        .withProvisionedThroughput(new ProvisionedThroughput()
-          .withReadCapacityUnits(1L)
-          .withWriteCapacityUnits(1L))
-        .withGlobalSecondaryIndexes(
-          new GlobalSecondaryIndex()
-            .withIndexName(table.index)
-            .withProjection(
-              new Projection().withProjectionType(ProjectionType.ALL))
-            .withKeySchema(
-              new KeySchemaElement()
-                .withAttributeName("reindexShard")
-                .withKeyType(KeyType.HASH),
-              new KeySchemaElement()
-                .withAttributeName("reindexVersion")
-                .withKeyType(KeyType.RANGE)
-            )
-            .withProvisionedThroughput(new ProvisionedThroughput()
-              .withReadCapacityUnits(1L)
-              .withWriteCapacityUnits(1L))))
-
-    eventually {
-      waitUntilActive(dynamoDbClient, table.name)
-    }
-
-    table
-  }
+  def createTable(table: LocalDynamoDb.Table): Table
 
   private def deleteAllTables() = {
     dynamoDbClient
@@ -116,5 +66,4 @@ trait LocalDynamoDb[T <: Id] extends Eventually with ExtendedPatience {
       .asScala
       .foreach(dynamoDbClient.deleteTable)
   }
-
 }

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDbVersioned.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalDynamoDbVersioned.scala
@@ -1,0 +1,53 @@
+package uk.ac.wellcome.storage.test.fixtures
+
+import com.amazonaws.services.dynamodbv2.model._
+import com.amazonaws.services.dynamodbv2.util.TableUtils.waitUntilActive
+import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
+
+trait LocalDynamoDbVersioned extends LocalDynamoDb {
+
+  override def createTable(table: Table): Table = {
+    dynamoDbClient.createTable(
+      new CreateTableRequest()
+        .withTableName(table.name)
+        .withKeySchema(new KeySchemaElement()
+          .withAttributeName("id")
+          .withKeyType(KeyType.HASH))
+        .withAttributeDefinitions(
+          new AttributeDefinition()
+            .withAttributeName("id")
+            .withAttributeType("S"),
+          new AttributeDefinition()
+            .withAttributeName("reindexShard")
+            .withAttributeType("S"),
+          new AttributeDefinition()
+            .withAttributeName("reindexVersion")
+            .withAttributeType("N")
+        )
+        .withProvisionedThroughput(new ProvisionedThroughput()
+          .withReadCapacityUnits(1L)
+          .withWriteCapacityUnits(1L))
+        .withGlobalSecondaryIndexes(
+          new GlobalSecondaryIndex()
+            .withIndexName(table.index)
+            .withProjection(
+              new Projection().withProjectionType(ProjectionType.ALL))
+            .withKeySchema(
+              new KeySchemaElement()
+                .withAttributeName("reindexShard")
+                .withKeyType(KeyType.HASH),
+              new KeySchemaElement()
+                .withAttributeName("reindexVersion")
+                .withKeyType(KeyType.RANGE)
+            )
+            .withProvisionedThroughput(new ProvisionedThroughput()
+              .withReadCapacityUnits(1L)
+              .withWriteCapacityUnits(1L))))
+
+    eventually {
+      waitUntilActive(dynamoDbClient, table.name)
+    }
+    table
+  }
+
+}

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
@@ -11,7 +11,11 @@ import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.s3._
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
-import uk.ac.wellcome.storage.vhs.{HybridRecord, VHSConfig, VersionedHybridStore}
+import uk.ac.wellcome.storage.vhs.{
+  HybridRecord,
+  VHSConfig,
+  VersionedHybridStore
+}
 import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.test.utils.JsonTestUtil
 import uk.ac.wellcome.utils.JsonUtil._
@@ -38,9 +42,9 @@ trait LocalVersionedHybridStore
   def withTypeVHS[T <: Id, R](bucket: Bucket,
                               table: Table,
                               globalS3Prefix: String = defaultGlobalS3Prefix)(
-                               testWith: TestWith[VersionedHybridStore[T, S3TypeStore[T]], R])(
-                               implicit encoder: Encoder[T],
-                               decoder: Decoder[T]): R = {
+    testWith: TestWith[VersionedHybridStore[T, S3TypeStore[T]], R])(
+    implicit encoder: Encoder[T],
+    decoder: Decoder[T]): R = {
     val s3Config = S3Config(bucketName = bucket.name)
     val dynamoConfig = DynamoConfig(table = table.name, Some(table.index))
     val vhsConfig = VHSConfig(
@@ -64,8 +68,9 @@ trait LocalVersionedHybridStore
 
   def withStreamVHS[R](bucket: Bucket,
                        table: Table,
-                       globalS3Prefix: String = defaultGlobalS3Prefix)
-                      (testWith: TestWith[VersionedHybridStore[InputStream, S3StreamStore], R]): R = {
+                       globalS3Prefix: String = defaultGlobalS3Prefix)(
+    testWith: TestWith[VersionedHybridStore[InputStream, S3StreamStore], R])
+    : R = {
     val s3Config = S3Config(bucketName = bucket.name)
 
     val dynamoConfig =
@@ -93,7 +98,7 @@ trait LocalVersionedHybridStore
   def withStringVHS[R](bucket: Bucket,
                        table: Table,
                        globalS3Prefix: String = defaultGlobalS3Prefix)(
-                        testWith: TestWith[VersionedHybridStore[String, S3StringStore], R]): R = {
+    testWith: TestWith[VersionedHybridStore[String, S3StringStore], R]): R = {
     val s3Config = S3Config(bucketName = bucket.name)
     val dynamoConfig =
       DynamoConfig(table = table.name, index = Some(table.index))
@@ -145,4 +150,4 @@ trait LocalVersionedHybridStore
           case Right(record) => record
         }
     }
-  }
+}

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
@@ -75,8 +75,10 @@ trait LocalVersionedHybridStore
     testWith: TestWith[VersionedHybridStore[InputStream, S3StreamStore], R])
     : R = {
     val s3Config = S3Config(bucketName = bucket.name)
+
     val dynamoConfig =
       DynamoConfig(table = table.name, index = Some(table.index))
+
     val vhsConfig = VHSConfig(
       dynamoConfig = dynamoConfig,
       s3Config = s3Config,

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
@@ -11,11 +11,7 @@ import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.s3._
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
-import uk.ac.wellcome.storage.vhs.{
-  HybridRecord,
-  VHSConfig,
-  VersionedHybridStore
-}
+import uk.ac.wellcome.storage.vhs.{HybridRecord, VHSConfig, VersionedHybridStore}
 import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.test.utils.JsonTestUtil
 import uk.ac.wellcome.utils.JsonUtil._
@@ -23,15 +19,12 @@ import uk.ac.wellcome.utils.JsonUtil._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait LocalVersionedHybridStore
-    extends LocalDynamoDb[HybridRecord]
+    extends LocalDynamoDbVersioned
     with S3
     with JsonTestUtil
     with Matchers {
 
   val defaultGlobalS3Prefix = "testing"
-
-  override lazy val evidence: DynamoFormat[HybridRecord] =
-    DynamoFormat[HybridRecord]
 
   def vhsLocalFlags(bucket: Bucket,
                     table: Table,
@@ -45,9 +38,9 @@ trait LocalVersionedHybridStore
   def withTypeVHS[T <: Id, R](bucket: Bucket,
                               table: Table,
                               globalS3Prefix: String = defaultGlobalS3Prefix)(
-    testWith: TestWith[VersionedHybridStore[T, S3TypeStore[T]], R])(
-    implicit encoder: Encoder[T],
-    decoder: Decoder[T]): R = {
+                               testWith: TestWith[VersionedHybridStore[T, S3TypeStore[T]], R])(
+                               implicit encoder: Encoder[T],
+                               decoder: Decoder[T]): R = {
     val s3Config = S3Config(bucketName = bucket.name)
     val dynamoConfig = DynamoConfig(table = table.name, Some(table.index))
     val vhsConfig = VHSConfig(
@@ -100,7 +93,7 @@ trait LocalVersionedHybridStore
   def withStringVHS[R](bucket: Bucket,
                        table: Table,
                        globalS3Prefix: String = defaultGlobalS3Prefix)(
-    testWith: TestWith[VersionedHybridStore[String, S3StringStore], R]): R = {
+                        testWith: TestWith[VersionedHybridStore[String, S3StringStore], R]): R = {
     val s3Config = S3Config(bucketName = bucket.name)
     val dynamoConfig =
       DynamoConfig(table = table.name, index = Some(table.index))
@@ -152,4 +145,4 @@ trait LocalVersionedHybridStore
           case Right(record) => record
         }
     }
-}
+  }

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
@@ -71,9 +71,8 @@ trait LocalVersionedHybridStore
 
   def withStreamVHS[R](bucket: Bucket,
                        table: Table,
-                       globalS3Prefix: String = defaultGlobalS3Prefix)(
-    testWith: TestWith[VersionedHybridStore[InputStream, S3StreamStore], R])
-    : R = {
+                       globalS3Prefix: String = defaultGlobalS3Prefix)
+                      (testWith: TestWith[VersionedHybridStore[InputStream, S3StreamStore], R]): R = {
     val s3Config = S3Config(bucketName = bucket.name)
 
     val dynamoConfig =

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/ServerTest.scala
@@ -1,20 +1,15 @@
 package uk.ac.wellcome.platform.sierra_bib_merger
 
-import com.gu.scanamo.DynamoFormat
 import com.twitter.finagle.http.Status._
 import org.scalatest.FunSpec
 import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.storage.test.fixtures.LocalVersionedHybridStore
-import uk.ac.wellcome.storage.vhs.HybridRecord
 
 class ServerTest
     extends FunSpec
     with LocalVersionedHybridStore
     with fixtures.Server
     with SQS {
-
-  override lazy val evidence: DynamoFormat[HybridRecord] =
-    DynamoFormat[HybridRecord]
 
   it("shows the healthcheck message") {
     withLocalSqsQueue { queue =>

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/ServerTest.scala
@@ -1,20 +1,15 @@
 package uk.ac.wellcome.platform.sierra_item_merger
 
-import com.gu.scanamo.DynamoFormat
 import com.twitter.finagle.http.Status._
 import org.scalatest.FunSpec
 import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.storage.test.fixtures.LocalVersionedHybridStore
-import uk.ac.wellcome.storage.vhs.HybridRecord
 
 class ServerTest
     extends FunSpec
     with LocalVersionedHybridStore
     with fixtures.Server
     with SQS {
-
-  override lazy val evidence: DynamoFormat[HybridRecord] =
-    DynamoFormat[HybridRecord]
 
   it("shows the healthcheck message") {
     withLocalSqsQueue { queue =>

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/ServerTest.scala
@@ -1,20 +1,15 @@
 package uk.ac.wellcome.platform.sierra_items_to_dynamo
 
-import com.gu.scanamo.DynamoFormat
 import com.twitter.finagle.http.Status._
 import org.scalatest.FunSpec
 import uk.ac.wellcome.messaging.test.fixtures.SQS
-import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
-import uk.ac.wellcome.storage.dynamo._
-import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb
+import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDbVersioned
 
 class ServerTest
     extends FunSpec
-    with LocalDynamoDb[SierraItemRecord]
+    with LocalDynamoDbVersioned
     with SQS
     with fixtures.Server {
-
-  override lazy val evidence = DynamoFormat[SierraItemRecord]
 
   it("shows the healthcheck message") {
     withLocalDynamoDbTable { table =>

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.sierra_items_to_dynamo
 
 import java.time.Instant
 
-import com.gu.scanamo.{DynamoFormat, Scanamo}
+import com.gu.scanamo.Scanamo
 import com.gu.scanamo.syntax._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FunSpec, Matchers}
@@ -13,19 +13,16 @@ import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 import uk.ac.wellcome.storage.dynamo._
-import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb
+import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDbVersioned
 
 class SierraItemsToDynamoFeatureTest
     extends FunSpec
-    with LocalDynamoDb[SierraItemRecord]
+    with LocalDynamoDbVersioned
     with SQS
     with fixtures.Server
     with Matchers
     with Eventually
     with ExtendedPatience {
-
-  override lazy val evidence: DynamoFormat[SierraItemRecord] =
-    DynamoFormat[SierraItemRecord]
 
   it("reads items from Sierra and adds them to DynamoDB") {
     withLocalDynamoDbTable { table =>

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/DynamoInserterFixture.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/DynamoInserterFixture.scala
@@ -1,17 +1,12 @@
 package uk.ac.wellcome.platform.sierra_items_to_dynamo.fixtures
 
-import com.gu.scanamo.DynamoFormat
-import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.services.DynamoInserter
 import uk.ac.wellcome.storage.dynamo._
-import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb
+import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDbVersioned
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.test.fixtures.TestWith
 
-trait DynamoInserterFixture extends LocalDynamoDb[SierraItemRecord] {
-
-  override lazy val evidence: DynamoFormat[SierraItemRecord] =
-    DynamoFormat[SierraItemRecord]
+trait DynamoInserterFixture extends LocalDynamoDbVersioned {
 
   def withDynamoInserter[R](table: Table)(
     testWith: TestWith[DynamoInserter, R]): Unit = {

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.sierra_items_to_dynamo.services
 
 import java.time.Instant
 
-import com.gu.scanamo.{DynamoFormat, Scanamo}
+import com.gu.scanamo.Scanamo
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSMessage, SQSReader}
@@ -34,9 +34,6 @@ class SierraItemsToDynamoWorkerServiceTest
     with Akka
     with MetricsSenderFixture
     with ScalaFutures {
-
-  override lazy val evidence: DynamoFormat[SierraItemRecord] =
-    DynamoFormat[SierraItemRecord]
 
   case class ServiceFixtures(
     service: SierraItemsToDynamoWorkerService,


### PR DESCRIPTION
### What is this PR trying to achieve?
Split up the current LocalDynamoDb trait used in testing to be reusable while supporting different databases.  Principally by moving out table creation.
