### PR TITLE
Changes to the display library don't trigger builds for (some) pipeline applications

### DIFF
--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -90,7 +90,7 @@ def does_file_affect_build_task(path, task):
     # for the api Scala app, so changes in this directory cannot affect
     # any other task.
     exclusive_directories = {
-        os.path.relpath(t.exclusive_path, start=ROOT): t.name for t in PROJECTS
+        proj.exclusive_path: proj.name for proj in PROJECTS
     }
 
     for dir_name, task_prefix in exclusive_directories.items():

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -104,7 +104,6 @@ def does_file_affect_build_task(path, task):
     # repository; changes to any of these don't affect non-sbt applications.
     if path.startswith((
         'sierra_adapter/common',
-        'common/',
         'project/',
         'build.sbt',
         'sbt_common/'

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -14,6 +14,7 @@ import os
 
 from travistooling.decisions import (
     ChangesToTestsDontGetPublished,
+    ChangeToUnusedLibrary,
     CheckedByTravisFormat,
     CheckedByTravisLambda,
     ExclusivelyAffectsAnotherTask,
@@ -99,6 +100,27 @@ def does_file_affect_build_task(path, task):
                 raise ExclusivelyAffectsThisTask()
             else:
                 raise ExclusivelyAffectsAnotherTask(task_prefix)
+
+    # We have a library containing display models in sbt_common/display.
+    #
+    # Not every application uses these display models -- in particular,
+    # all our pipeline applications.  So a change to the display models
+    # can be safely ignored here.  Specifically, applications in the
+    # following stacks:
+    #
+    #   - catalogue_pipeline
+    #   - goobi_adapter
+    #   - sierra_adapter
+    #
+    if path.startswith('sbt_common/display'):
+        for project in PROJECTS:
+            if task.startswith(project.name) and (project.type == 'sbt_app'):
+                if project.exclusive_path.startswith((
+                    'catalogue_pipeline/',
+                    'goobi_adapter/',
+                    'sierra_adapter/',
+                )):
+                    raise ChangeToUnusedLibrary('display')
 
     # We have a couple of sbt common libs and files scattered around the
     # repository; changes to any of these don't affect non-sbt applications.

--- a/travistooling/decisions.py
+++ b/travistooling/decisions.py
@@ -65,3 +65,11 @@ class ScalaChangeAndNotScalaApp(InsignificantFile):
 
 class ChangesToTestsDontGetPublished(InsignificantFile):
     message = "Changes to test files don't need to be published"
+
+
+class ChangeToUnusedLibrary(InsignificantFile):
+    def __init__(self, library):
+        self.message = (
+            "Changes to the %s library don't affect this task" % library
+        )
+        super(ChangeToUnusedLibrary, self).__init__()

--- a/travistooling/parse_makefiles.py
+++ b/travistooling/parse_makefiles.py
@@ -3,6 +3,8 @@
 import collections
 import os
 
+from travistooling.git_utils import ROOT
+
 Project = collections.namedtuple('Project', ['name', 'type', 'exclusive_path'])
 
 
@@ -46,8 +48,11 @@ def _get_projects_from_makefile(root, path):
             )
 
         for t in targets:
+            exclusive_path = os.path.relpath(
+                os.path.join(root, t), start=ROOT
+            )
             yield Project(
                 name=t,
                 type=project_type,
-                exclusive_path=os.path.join(root, t)
+                exclusive_path=exclusive_path
             )

--- a/travistooling/tests/test_decisionmaker.py
+++ b/travistooling/tests/test_decisionmaker.py
@@ -8,6 +8,7 @@ from travistooling.decisionmaker import (
 )
 from travistooling.decisions import (
     ChangesToTestsDontGetPublished,
+    ChangeToUnusedLibrary,
     CheckedByTravisFormat,
     CheckedByTravisLambda,
     ExclusivelyAffectsAnotherTask,
@@ -69,10 +70,15 @@ from travistooling.decisions import (
     ('sierra_adapter/common/main.scala', 's3_demultiplexer-test', ScalaChangeAndNotScalaApp, False),
     ('sierra_adapter/common/main.scala', 'sierra_window_generator-test', ScalaChangeAndNotScalaApp, False),
     ('sierra_adapter/common/main.scala', 'travistooling-test', ScalaChangeAndNotScalaApp, False),
-    ('sbt_common/display/model.scala', 'id_minter-test', ScalaChangeAndIsScalaApp, True),
+    ('sbt_common/elasticsearch/model.scala', 'id_minter-test', ScalaChangeAndIsScalaApp, True),
     ('sbt_common/display/model.scala', 'loris-publish', ScalaChangeAndNotScalaApp, False),
     ('sbt_common/display/model.scala', 'travis-lambda-test', ScalaChangeAndNotScalaApp, False),
-    ('sbt_common/display/model.scala', 'sierra_adapter-publish', UnrecognisedFile, True),
+
+    # Changes to the display models don't affect all of the stacks
+    ('sbt_common/display/model.scala', 'id_minter-test', ChangeToUnusedLibrary, False),
+    ('sbt_common/display/model.scala', 'goobi_reader-test', ChangeToUnusedLibrary, False),
+    ('sbt_common/display/model.scala', 'sierra_reader-test', ChangeToUnusedLibrary, False),
+    ('sbt_common/display/model.scala', 'api-test', ScalaChangeAndIsScalaApp, True),
 
     # Changes to Scala test files trigger a -test Scala task, but not
     # a -publish task.

--- a/travistooling/tests/test_git_utils.py
+++ b/travistooling/tests/test_git_utils.py
@@ -22,8 +22,16 @@ def test_known_change_diff():
     #
     try:
         git('fetch', 'origin', '--unshallow')
-    except SystemExit:
-        pass
+    except SystemExit as err:  # pragma: no cover
+
+        # When running tests locally, you normally have a full checkout,
+        # so the command above is an error, and fails with:
+        #
+        #     fatal: --unshallow on a complete repository does not make sense
+        #
+        # In that case, we check we're seeing the expected exit code,
+        # but we don't need to run this branch in the tests.
+        assert err.value.code == 128
 
     assert get_changed_paths('1228fc9^', '1228fc9') == set([
         'travistooling/decisionmaker.py',

--- a/travistooling/tests/test_git_utils.py
+++ b/travistooling/tests/test_git_utils.py
@@ -20,7 +20,10 @@ def test_known_change_diff():
     #
     # See https://docs.travis-ci.com/user/customizing-the-build#Git-Clone-Depth
     #
-    git('fetch', 'origin', '--unshallow')
+    try:
+        git('fetch', 'origin', '--unshallow')
+    except SystemExit:
+        pass
 
     assert get_changed_paths('1228fc9^', '1228fc9') == set([
         'travistooling/decisionmaker.py',

--- a/travistooling/tests/test_travis_utils.py
+++ b/travistooling/tests/test_travis_utils.py
@@ -10,7 +10,7 @@ from travistooling import travis_utils
 
 
 @pytest.fixture
-def cleanup_secrets():
+def cleanup_secrets():  # pragma: no cover
     yield
     subprocess.check_call(['rm', '-rf', 'secrets'])
 
@@ -40,7 +40,11 @@ def test_travis_branch_name_on_pr():
         assert travis_utils.branch_name() == 'feature-branch'
 
 
-def test_unpack_secrets(cleanup_secrets):
+@pytest.mark.skipif(
+    os.environ['encrypted_83630750896a_key'] == '',
+    reason='Encrypted env vars are not available'
+)
+def test_unpack_secrets(cleanup_secrets):  # pragma: no cover
     travis_utils.unpack_secrets()
     assert os.path.exists('secrets/id_rsa')
 


### PR DESCRIPTION
### What is this PR trying to achieve?

If the only changes are to a display library, and we're testing an application that has no public-facing bits (i.e. catalogue pipeline, Goobi and Sierra adapters), we can shortcut running the tests.

This is in anticipation of some changes to the display models following #2134, when I modify DisplayIdentifier to match our new model.

### Who is this change for?

🏈 🎫 