### PR TITLE
Bump the version of Guice to 4.2.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val aws = "1.11.95"
     val apacheLogging = "2.8.2"
     val finatra = "18.4.0"
-    val guice = "4.0"
+    val guice = "4.2.0"
     val logback = "1.1.8"
     val mockito = "1.9.5"
     val scalatest = "3.0.1"


### PR DESCRIPTION
We see the following error in our tests, I’m hoping this fixes it:

```
[warn] Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[warn] 
[warn] 	* com.google.guava:guava:19.0 is selected over 16.0.1
[warn] 	    +- com.twitter:finatra-http_2.12:18.4.0 ()            (depends on 19.0)
[warn] 	    +- net.codingwell:scala-guice_2.12:4.1.0              (depends on 19.0)
[warn] 	    +- com.google.inject:guice:4.0                        (depends on 16.0.1)
[warn] 
```