### PR TITLE
Make sure we use the identifiers include consistently

### DIFF
--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayAbstractAgentV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayAbstractAgentV1.scala
@@ -26,9 +26,8 @@ case class DisplayAgentV1(
 ) extends DisplayAbstractAgentV1
 
 case object DisplayAbstractAgentV1 {
-  def apply(
-    displayableAgent: Displayable[AbstractAgent],
-    includesIdentifiers: Boolean): DisplayAbstractAgentV1 =
+  def apply(displayableAgent: Displayable[AbstractAgent],
+            includesIdentifiers: Boolean): DisplayAbstractAgentV1 =
     displayableAgent match {
       case Unidentifiable(a: Agent) =>
         DisplayAgentV1(
@@ -39,16 +38,23 @@ case object DisplayAbstractAgentV1 {
       case Identified(a: Agent, id, identifiers) =>
         DisplayAgentV1(
           id = Some(id),
-          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV1(_))) else None,
+          identifiers =
+            if (includesIdentifiers)
+              Some(identifiers.map(DisplayIdentifierV1(_)))
+            else None,
           label = a.label
         )
       case Identified(p: Person, id, identifiers) =>
         DisplayPersonV1(
           id = Some(id),
-          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV1(_))) else None,
+          identifiers =
+            if (includesIdentifiers)
+              Some(identifiers.map(DisplayIdentifierV1(_)))
+            else None,
           label = p.label,
           prefix = p.prefix,
-          numeration = p.numeration)
+          numeration = p.numeration
+        )
       case Unidentifiable(p: Person) =>
         DisplayPersonV1(
           id = None,
@@ -59,7 +65,10 @@ case object DisplayAbstractAgentV1 {
       case Identified(o: Organisation, id, identifiers) =>
         DisplayOrganisationV1(
           id = Some(id),
-          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV1(_))) else None,
+          identifiers =
+            if (includesIdentifiers)
+              Some(identifiers.map(DisplayIdentifierV1(_)))
+            else None,
           o.label)
       case Unidentifiable(o: Organisation) =>
         DisplayOrganisationV1(id = None, identifiers = None, label = o.label)

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayAbstractAgentV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayAbstractAgentV1.scala
@@ -27,7 +27,8 @@ case class DisplayAgentV1(
 
 case object DisplayAbstractAgentV1 {
   def apply(
-    displayableAgent: Displayable[AbstractAgent]): DisplayAbstractAgentV1 =
+    displayableAgent: Displayable[AbstractAgent],
+    includesIdentifiers: Boolean): DisplayAbstractAgentV1 =
     displayableAgent match {
       case Unidentifiable(a: Agent) =>
         DisplayAgentV1(
@@ -38,13 +39,13 @@ case object DisplayAbstractAgentV1 {
       case Identified(a: Agent, id, identifiers) =>
         DisplayAgentV1(
           id = Some(id),
-          identifiers = Some(identifiers.map(DisplayIdentifierV1(_))),
+          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV1(_))) else None,
           label = a.label
         )
       case Identified(p: Person, id, identifiers) =>
         DisplayPersonV1(
           id = Some(id),
-          identifiers = Some(identifiers.map(DisplayIdentifierV1(_))),
+          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV1(_))) else None,
           label = p.label,
           prefix = p.prefix,
           numeration = p.numeration)
@@ -58,7 +59,7 @@ case object DisplayAbstractAgentV1 {
       case Identified(o: Organisation, id, identifiers) =>
         DisplayOrganisationV1(
           id = Some(id),
-          identifiers = Some(identifiers.map(DisplayIdentifierV1(_))),
+          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV1(_))) else None,
           o.label)
       case Unidentifiable(o: Organisation) =>
         DisplayOrganisationV1(id = None, identifiers = None, label = o.label)

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayAbstractAgentV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayAbstractAgentV1.scala
@@ -7,7 +7,11 @@ import uk.ac.wellcome.models.work.internal._
 @ApiModel(
   value = "Agent"
 )
-sealed trait DisplayAbstractAgentV1
+sealed trait DisplayAbstractAgentV1 {
+  val id: Option[String]
+  val identifiers: Option[List[DisplayIdentifierV1]]
+  val label: String
+}
 
 @ApiModel(
   value = "Agent"

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
@@ -120,7 +120,7 @@ case object DisplayWorkV1 {
       createdDate = work.createdDate.map { DisplayPeriodV1(_) },
       creators = work.contributors.map {
         contributor: Contributor[Displayable[AbstractAgent]] =>
-          DisplayAbstractAgentV1(contributor.agent)
+          DisplayAbstractAgentV1(contributor.agent, includesIdentifiers = includes.identifiers)
       },
       subjects = work.subjects.flatMap { subject =>
         subject.concepts.map { DisplayConceptV1(_) }
@@ -142,7 +142,9 @@ case object DisplayWorkV1 {
             DisplayItemV1(_, includesIdentifiers = includes.identifiers)
           })
         else None,
-      publishers = work.publishers.map(DisplayAbstractAgentV1(_)),
+      publishers = work.publishers.map {
+        DisplayAbstractAgentV1(_, includesIdentifiers = includes.identifiers)
+      },
       publicationDate = work.publicationDate.map { DisplayPeriodV1(_) },
       placesOfPublication = work.placesOfPublication.map { DisplayPlaceV1(_) },
       language = work.language.map { DisplayLanguage(_) },

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
@@ -120,7 +120,9 @@ case object DisplayWorkV1 {
       createdDate = work.createdDate.map { DisplayPeriodV1(_) },
       creators = work.contributors.map {
         contributor: Contributor[Displayable[AbstractAgent]] =>
-          DisplayAbstractAgentV1(contributor.agent, includesIdentifiers = includes.identifiers)
+          DisplayAbstractAgentV1(
+            contributor.agent,
+            includesIdentifiers = includes.identifiers)
       },
       subjects = work.subjects.flatMap { subject =>
         subject.concepts.map { DisplayConceptV1(_) }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractAgentV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractAgentV2.scala
@@ -7,7 +7,11 @@ import uk.ac.wellcome.models.work.internal._
 @ApiModel(
   value = "Agent"
 )
-sealed trait DisplayAbstractAgentV2
+sealed trait DisplayAbstractAgentV2 {
+  val id: Option[String]
+  val identifiers: Option[List[DisplayIdentifierV2]]
+  val label: String
+}
 
 @ApiModel(
   value = "Agent"

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractAgentV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractAgentV2.scala
@@ -27,7 +27,8 @@ case class DisplayAgentV2(
 
 case object DisplayAbstractAgentV2 {
   def apply(
-    displayableAgent: Displayable[AbstractAgent]): DisplayAbstractAgentV2 =
+    displayableAgent: Displayable[AbstractAgent],
+    includesIdentifiers: Boolean): DisplayAbstractAgentV2 =
     displayableAgent match {
       case Unidentifiable(a: Agent) =>
         DisplayAgentV2(
@@ -38,13 +39,13 @@ case object DisplayAbstractAgentV2 {
       case Identified(a: Agent, id, identifiers) =>
         DisplayAgentV2(
           id = Some(id),
-          identifiers = Some(identifiers.map(DisplayIdentifierV2(_))),
+          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV2(_))) else None,
           label = a.label
         )
       case Identified(p: Person, id, identifiers) =>
         DisplayPersonV2(
           id = Some(id),
-          identifiers = Some(identifiers.map(DisplayIdentifierV2(_))),
+          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV2(_))) else None,
           label = p.label,
           prefix = p.prefix,
           numeration = p.numeration)
@@ -58,7 +59,7 @@ case object DisplayAbstractAgentV2 {
       case Identified(o: Organisation, id, identifiers) =>
         DisplayOrganisationV2(
           id = Some(id),
-          identifiers = Some(identifiers.map(DisplayIdentifierV2(_))),
+          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV2(_))) else None,
           o.label)
       case Unidentifiable(o: Organisation) =>
         DisplayOrganisationV2(id = None, identifiers = None, label = o.label)

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractAgentV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractAgentV2.scala
@@ -26,9 +26,8 @@ case class DisplayAgentV2(
 ) extends DisplayAbstractAgentV2
 
 case object DisplayAbstractAgentV2 {
-  def apply(
-    displayableAgent: Displayable[AbstractAgent],
-    includesIdentifiers: Boolean): DisplayAbstractAgentV2 =
+  def apply(displayableAgent: Displayable[AbstractAgent],
+            includesIdentifiers: Boolean): DisplayAbstractAgentV2 =
     displayableAgent match {
       case Unidentifiable(a: Agent) =>
         DisplayAgentV2(
@@ -39,16 +38,23 @@ case object DisplayAbstractAgentV2 {
       case Identified(a: Agent, id, identifiers) =>
         DisplayAgentV2(
           id = Some(id),
-          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV2(_))) else None,
+          identifiers =
+            if (includesIdentifiers)
+              Some(identifiers.map(DisplayIdentifierV2(_)))
+            else None,
           label = a.label
         )
       case Identified(p: Person, id, identifiers) =>
         DisplayPersonV2(
           id = Some(id),
-          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV2(_))) else None,
+          identifiers =
+            if (includesIdentifiers)
+              Some(identifiers.map(DisplayIdentifierV2(_)))
+            else None,
           label = p.label,
           prefix = p.prefix,
-          numeration = p.numeration)
+          numeration = p.numeration
+        )
       case Unidentifiable(p: Person) =>
         DisplayPersonV2(
           id = None,
@@ -59,7 +65,10 @@ case object DisplayAbstractAgentV2 {
       case Identified(o: Organisation, id, identifiers) =>
         DisplayOrganisationV2(
           id = Some(id),
-          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV2(_))) else None,
+          identifiers =
+            if (includesIdentifiers)
+              Some(identifiers.map(DisplayIdentifierV2(_)))
+            else None,
           o.label)
       case Unidentifiable(o: Organisation) =>
         DisplayOrganisationV2(id = None, identifiers = None, label = o.label)

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
@@ -7,7 +7,11 @@ import uk.ac.wellcome.models.work.internal._
 @ApiModel(
   value = "Concept"
 )
-sealed trait DisplayAbstractConcept
+sealed trait DisplayAbstractConcept {
+  val id: Option[String]
+  val identifiers: Option[List[DisplayIdentifierV2]]
+  val label: String
+}
 
 case object DisplayAbstractConcept {
   def apply(

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
@@ -14,9 +14,8 @@ sealed trait DisplayAbstractConcept {
 }
 
 case object DisplayAbstractConcept {
-  def apply(
-    abstractConcept: Displayable[AbstractConcept],
-    includesIdentifiers: Boolean): DisplayAbstractConcept =
+  def apply(abstractConcept: Displayable[AbstractConcept],
+            includesIdentifiers: Boolean): DisplayAbstractConcept =
     abstractConcept match {
       case Unidentifiable(concept: Concept) =>
         DisplayConcept(
@@ -27,7 +26,10 @@ case object DisplayAbstractConcept {
       case Identified(concept: Concept, id, identifiers) =>
         DisplayConcept(
           id = Some(id),
-          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV2(_))) else None,
+          identifiers =
+            if (includesIdentifiers)
+              Some(identifiers.map(DisplayIdentifierV2(_)))
+            else None,
           label = concept.label
         )
       case Unidentifiable(period: Period) =>
@@ -39,7 +41,10 @@ case object DisplayAbstractConcept {
       case Identified(period: Period, id, identifiers) =>
         DisplayPeriod(
           id = Some(id),
-          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV2(_))) else None,
+          identifiers =
+            if (includesIdentifiers)
+              Some(identifiers.map(DisplayIdentifierV2(_)))
+            else None,
           label = period.label
         )
       case Unidentifiable(place: Place) =>
@@ -51,7 +56,10 @@ case object DisplayAbstractConcept {
       case Identified(place: Place, id, identifiers) =>
         DisplayPlace(
           id = Some(id),
-          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV2(_))) else None,
+          identifiers =
+            if (includesIdentifiers)
+              Some(identifiers.map(DisplayIdentifierV2(_)))
+            else None,
           label = place.label
         )
     }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
@@ -15,7 +15,8 @@ sealed trait DisplayAbstractConcept {
 
 case object DisplayAbstractConcept {
   def apply(
-    abstractConcept: Displayable[AbstractConcept]): DisplayAbstractConcept =
+    abstractConcept: Displayable[AbstractConcept],
+    includesIdentifiers: Boolean): DisplayAbstractConcept =
     abstractConcept match {
       case Unidentifiable(concept: Concept) =>
         DisplayConcept(
@@ -26,7 +27,7 @@ case object DisplayAbstractConcept {
       case Identified(concept: Concept, id, identifiers) =>
         DisplayConcept(
           id = Some(id),
-          identifiers = Some(identifiers.map { DisplayIdentifierV2(_) }),
+          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV2(_))) else None,
           label = concept.label
         )
       case Unidentifiable(period: Period) =>
@@ -38,7 +39,7 @@ case object DisplayAbstractConcept {
       case Identified(period: Period, id, identifiers) =>
         DisplayPeriod(
           id = Some(id),
-          identifiers = Some(identifiers.map { DisplayIdentifierV2(_) }),
+          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV2(_))) else None,
           label = period.label
         )
       case Unidentifiable(place: Place) =>
@@ -50,7 +51,7 @@ case object DisplayAbstractConcept {
       case Identified(place: Place, id, identifiers) =>
         DisplayPlace(
           id = Some(id),
-          identifiers = Some(identifiers.map { DisplayIdentifierV2(_) }),
+          identifiers = if (includesIdentifiers) Some(identifiers.map(DisplayIdentifierV2(_))) else None,
           label = place.label
         )
     }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayContributor.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayContributor.scala
@@ -21,9 +21,10 @@ case class DisplayContributor(
 
 object DisplayContributor {
   def apply(
-    contributor: Contributor[Displayable[AbstractAgent]]): DisplayContributor =
+    contributor: Contributor[Displayable[AbstractAgent]],
+    includesIdentifiers: Boolean): DisplayContributor =
     DisplayContributor(
-      agent = DisplayAbstractAgentV2(contributor.agent),
+      agent = DisplayAbstractAgentV2(contributor.agent, includesIdentifiers = includesIdentifiers),
       roles = contributor.roles.map { DisplayContributionRole(_) }
     )
 }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayContributor.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayContributor.scala
@@ -20,11 +20,12 @@ case class DisplayContributor(
 )
 
 object DisplayContributor {
-  def apply(
-    contributor: Contributor[Displayable[AbstractAgent]],
-    includesIdentifiers: Boolean): DisplayContributor =
+  def apply(contributor: Contributor[Displayable[AbstractAgent]],
+            includesIdentifiers: Boolean): DisplayContributor =
     DisplayContributor(
-      agent = DisplayAbstractAgentV2(contributor.agent, includesIdentifiers = includesIdentifiers),
+      agent = DisplayAbstractAgentV2(
+        contributor.agent,
+        includesIdentifiers = includesIdentifiers),
       roles = contributor.roles.map { DisplayContributionRole(_) }
     )
 }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayGenre.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayGenre.scala
@@ -19,8 +19,8 @@ case class DisplayGenre(
   @JsonProperty("type") ontologyType: String = "Genre")
 
 object DisplayGenre {
-  def apply(genre: Genre[Displayable[AbstractConcept]]): DisplayGenre =
+  def apply(genre: Genre[Displayable[AbstractConcept]], includesIdentifiers: Boolean): DisplayGenre =
     DisplayGenre(label = genre.label, concepts = genre.concepts.map {
-      DisplayAbstractConcept(_)
+      DisplayAbstractConcept(_, includesIdentifiers = includesIdentifiers)
     }, ontologyType = genre.ontologyType)
 }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayGenre.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayGenre.scala
@@ -19,7 +19,8 @@ case class DisplayGenre(
   @JsonProperty("type") ontologyType: String = "Genre")
 
 object DisplayGenre {
-  def apply(genre: Genre[Displayable[AbstractConcept]], includesIdentifiers: Boolean): DisplayGenre =
+  def apply(genre: Genre[Displayable[AbstractConcept]],
+            includesIdentifiers: Boolean): DisplayGenre =
     DisplayGenre(label = genre.label, concepts = genre.concepts.map {
       DisplayAbstractConcept(_, includesIdentifiers = includesIdentifiers)
     }, ontologyType = genre.ontologyType)

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplaySubject.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplaySubject.scala
@@ -19,8 +19,13 @@ case class DisplaySubject(
   @JsonProperty("type") ontologyType: String = "Subject")
 
 object DisplaySubject {
-  def apply(subject: Subject[Displayable[AbstractConcept]], includesIdentifiers: Boolean): DisplaySubject =
-    DisplaySubject(label = subject.label, concepts = subject.concepts.map {
-      DisplayAbstractConcept(_, includesIdentifiers = includesIdentifiers)
-    }, ontologyType = subject.ontologyType)
+  def apply(subject: Subject[Displayable[AbstractConcept]],
+            includesIdentifiers: Boolean): DisplaySubject =
+    DisplaySubject(
+      label = subject.label,
+      concepts = subject.concepts.map {
+        DisplayAbstractConcept(_, includesIdentifiers = includesIdentifiers)
+      },
+      ontologyType = subject.ontologyType
+    )
 }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplaySubject.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplaySubject.scala
@@ -19,8 +19,8 @@ case class DisplaySubject(
   @JsonProperty("type") ontologyType: String = "Subject")
 
 object DisplaySubject {
-  def apply(subject: Subject[Displayable[AbstractConcept]]): DisplaySubject =
+  def apply(subject: Subject[Displayable[AbstractConcept]], includesIdentifiers: Boolean): DisplaySubject =
     DisplaySubject(label = subject.label, concepts = subject.concepts.map {
-      DisplayAbstractConcept(_)
+      DisplayAbstractConcept(_, includesIdentifiers = includesIdentifiers)
     }, ontologyType = subject.ontologyType)
 }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
@@ -118,7 +118,7 @@ case object DisplayWorkV2 {
       extent = work.extent,
       lettering = work.lettering,
       createdDate = work.createdDate.map { DisplayPeriod(_) },
-      contributors = work.contributors.map { DisplayContributor(_) },
+      contributors = work.contributors.map { DisplayContributor(_, includesIdentifiers = includes.identifiers) },
       subjects = work.subjects.map { DisplaySubject(_) },
       genres = work.genres.map { DisplayGenre(_) },
       identifiers =
@@ -135,7 +135,9 @@ case object DisplayWorkV2 {
             DisplayItemV2(_, includesIdentifiers = includes.identifiers)
           })
         else None,
-      publishers = work.publishers.map(DisplayAbstractAgentV2(_)),
+      publishers = work.publishers.map {
+        DisplayAbstractAgentV2(_, includesIdentifiers = includes.identifiers)
+      },
       publicationDate = work.publicationDate.map { DisplayPeriod(_) },
       placesOfPublication = work.placesOfPublication.map { DisplayPlace(_) },
       language = work.language.map { DisplayLanguage(_) },

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
@@ -119,8 +119,8 @@ case object DisplayWorkV2 {
       lettering = work.lettering,
       createdDate = work.createdDate.map { DisplayPeriod(_) },
       contributors = work.contributors.map { DisplayContributor(_, includesIdentifiers = includes.identifiers) },
-      subjects = work.subjects.map { DisplaySubject(_) },
-      genres = work.genres.map { DisplayGenre(_) },
+      subjects = work.subjects.map { DisplaySubject(_, includesIdentifiers = includes.identifiers) },
+      genres = work.genres.map { DisplayGenre(_, includesIdentifiers = includes.identifiers) },
       identifiers =
         if (includes.identifiers)
           Some(work.identifiers.map { DisplayIdentifierV2(_) })

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
@@ -118,9 +118,15 @@ case object DisplayWorkV2 {
       extent = work.extent,
       lettering = work.lettering,
       createdDate = work.createdDate.map { DisplayPeriod(_) },
-      contributors = work.contributors.map { DisplayContributor(_, includesIdentifiers = includes.identifiers) },
-      subjects = work.subjects.map { DisplaySubject(_, includesIdentifiers = includes.identifiers) },
-      genres = work.genres.map { DisplayGenre(_, includesIdentifiers = includes.identifiers) },
+      contributors = work.contributors.map {
+        DisplayContributor(_, includesIdentifiers = includes.identifiers)
+      },
+      subjects = work.subjects.map {
+        DisplaySubject(_, includesIdentifiers = includes.identifiers)
+      },
+      genres = work.genres.map {
+        DisplayGenre(_, includesIdentifiers = includes.identifiers)
+      },
       identifiers =
         if (includes.identifiers)
           Some(work.identifiers.map { DisplayIdentifierV2(_) })

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.{DisplaySerialisationTestBase, WorksIncludes}
+import uk.ac.wellcome.display.models.{
+  DisplaySerialisationTestBase,
+  WorksIncludes
+}
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.test.util.WorksUtil
@@ -110,7 +113,8 @@ class DisplayCreatorsV1SerialisationTest
         )
       )
     )
-    val displayWork = DisplayWorkV1(work, includes = WorksIncludes(identifiers = true))
+    val displayWork =
+      DisplayWorkV1(work, includes = WorksIncludes(identifiers = true))
 
     val actualJson = objectMapper.writeValueAsString(displayWork)
     val expectedJson = s"""

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
+import uk.ac.wellcome.display.models.{DisplaySerialisationTestBase, WorksIncludes}
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.test.util.WorksUtil
@@ -110,13 +110,14 @@ class DisplayCreatorsV1SerialisationTest
         )
       )
     )
-    val displayWork = DisplayWorkV1(work)
+    val displayWork = DisplayWorkV1(work, includes = WorksIncludes(identifiers = true))
 
     val actualJson = objectMapper.writeValueAsString(displayWork)
     val expectedJson = s"""
                             |{
                             |  "type": "Work",
                             |  "id": "${work.canonicalId}",
+                            |  "identifiers": [],
                             |  "title": "${work.title.get}",
                             |  "creators": [
                             |    ${identifiedOrUnidentifiable(

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -200,7 +200,8 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
       )
     )
 
-    val displayWork = DisplayWorkV1(work, includes = WorksIncludes(identifiers = true))
+    val displayWork =
+      DisplayWorkV1(work, includes = WorksIncludes(identifiers = true))
     displayWork.creators shouldBe List(
       DisplayPersonV1(
         id = None,
@@ -490,7 +491,10 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
       }
 
       it("creators") {
-        displayWork.creators.map { _.identifiers} shouldBe List(None, None, None)
+        displayWork.creators.map { _.identifiers } shouldBe List(
+          None,
+          None,
+          None)
       }
 
       it("publishers") {
@@ -498,17 +502,20 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
       }
 
       it("items") {
-        val displayWork = DisplayWorkV1(work, includes = WorksIncludes(items = true))
+        val displayWork =
+          DisplayWorkV1(work, includes = WorksIncludes(items = true))
         val item: DisplayItemV1 = displayWork.items.get.head
         item.identifiers shouldBe None
       }
     }
 
     describe("includes identifiers if WorksIncludes.identifiers is true") {
-      val displayWork = DisplayWorkV1(work, includes = WorksIncludes(identifiers = true))
+      val displayWork =
+        DisplayWorkV1(work, includes = WorksIncludes(identifiers = true))
 
       it("on the top-level Work") {
-        displayWork.identifiers shouldBe Some(List(DisplayIdentifierV1(sourceIdentifier)))
+        displayWork.identifiers shouldBe Some(
+          List(DisplayIdentifierV1(sourceIdentifier)))
       }
 
       it("creators") {
@@ -518,21 +525,24 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
           creatorAgentSourceIdentifier,
           creatorOrganisationSourceIdentifier,
           creatorPersonSourceIdentifier
-        )
-          .map { DisplayIdentifierV1(_) }
+        ).map { DisplayIdentifierV1(_) }
           .map { List(_) }
           .map { Some(_) }
         displayWork.creators.map { _.identifiers } shouldBe expectedIdentifiers
       }
 
       it("publishers") {
-        displayWork.publishers.head.identifiers shouldBe Some(List(DisplayIdentifierV1(publisherSourceIdentifier)))
+        displayWork.publishers.head.identifiers shouldBe Some(
+          List(DisplayIdentifierV1(publisherSourceIdentifier)))
       }
 
       it("items") {
-        val displayWork = DisplayWorkV1(work, includes = WorksIncludes(identifiers = true, items = true))
+        val displayWork = DisplayWorkV1(
+          work,
+          includes = WorksIncludes(identifiers = true, items = true))
         val item: DisplayItemV1 = displayWork.items.get.head
-        item.identifiers shouldBe Some(List(DisplayIdentifierV1(itemSourceIdentifier)))
+        item.identifiers shouldBe Some(
+          List(DisplayIdentifierV1(itemSourceIdentifier)))
       }
     }
   }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -402,4 +402,36 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
 
     caught.getMessage shouldBe s"IdentifiedWork ${work.canonicalId} has visible=false, cannot be converted to DisplayWork"
   }
+
+  describe("omits identifiers if WorksIncludes.identifiers is false") {
+    val work = IdentifiedWork(
+      canonicalId = "jas2rhsu",
+      title = Some("Jumping junipers in a jovial June"),
+      sourceIdentifier = sourceIdentifier,
+      identifiers = List(sourceIdentifier),
+      version = 1
+    )
+
+    val displayWork = DisplayWorkV1(work, includes = WorksIncludes())
+
+    it("on the top-level Work") {
+      displayWork.identifiers shouldBe None
+    }
+  }
+
+  describe("includes identifiers if WorksIncludes.identifiers is true") {
+    val work = IdentifiedWork(
+      canonicalId = "pt5vupg4",
+      title = Some("Pouncing pugs play in pipes"),
+      sourceIdentifier = sourceIdentifier,
+      identifiers = List(sourceIdentifier),
+      version = 1
+    )
+
+    val displayWork = DisplayWorkV1(work, includes = WorksIncludes(identifiers = true))
+
+    it("on the top-level Work") {
+      displayWork.identifiers shouldBe Some(List(DisplayIdentifierV1(sourceIdentifier)))
+    }
+  }
 }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -409,22 +409,144 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
       title = Some("Jumping junipers in a jovial June"),
       sourceIdentifier = sourceIdentifier,
       identifiers = List(sourceIdentifier),
+      contributors = List(
+        Contributor(
+          agent = Identified(
+            Agent(label = "Jazzy John"),
+            canonicalId = "j7bjw9w9",
+            identifiers = List(
+              SourceIdentifier(
+                identifierType = IdentifierType("LCNames"),
+                value = "lcnames/jazz",
+                ontologyType = "Agent"
+              )
+            )
+          ),
+          roles = List()
+        ),
+        Contributor(
+          agent = Identified(
+            Organisation(label = "Junior Journals"),
+            canonicalId = "j7bjw9w9",
+            identifiers = List(
+              SourceIdentifier(
+                identifierType = IdentifierType("LCNames"),
+                value = "lcnames/jun",
+                ontologyType = "Organisation"
+              )
+            )
+          ),
+          roles = List()
+        ),
+        Contributor(
+          agent = Identified(
+            Person(label = "Jokey Janet"),
+            canonicalId = "jgfsjf9c",
+            identifiers = List(
+              SourceIdentifier(
+                identifierType = IdentifierType("LCNames"),
+                value = "lcnames/jok",
+                ontologyType = "Person"
+              )
+            )
+          ),
+          roles = List()
+        )
+      ),
+      publishers = List(
+        Identified(
+          Agent(label = "Jenny Jupiter"),
+          canonicalId = "j4cqr6wy",
+          identifiers = List(
+            SourceIdentifier(
+              identifierType = IdentifierType("LCNames"),
+              value = "lcnames/jj",
+              ontologyType = "Agent"
+            )
+          )
+        )
+      ),
       version = 1
     )
 
     val displayWork = DisplayWorkV1(work, includes = WorksIncludes())
 
-    it("on the top-level Work") {
+    it("the top-level Work") {
       displayWork.identifiers shouldBe None
+    }
+
+    it("creators") {
+      displayWork.creators.map { _.identifiers} shouldBe List(None, None, None)
+    }
+
+    it("publishers") {
+      displayWork.publishers.head.identifiers shouldBe None
     }
   }
 
   describe("includes identifiers if WorksIncludes.identifiers is true") {
+    val publisherSourceIdentifier = SourceIdentifier(
+      identifierType = IdentifierType("LCNames"),
+      value = "lcnames/pp",
+      ontologyType = "Agent"
+    )
+
+    val creatorAgentSourceIdentifier = SourceIdentifier(
+      identifierType = IdentifierType("LCNames"),
+      value = "lcnames/pp",
+      ontologyType = "Agent"
+    )
+
+    val creatorPersonSourceIdentifier = SourceIdentifier(
+      identifierType = IdentifierType("LCNames"),
+      value = "lcnames/pri",
+      ontologyType = "Agent"
+    )
+
+    val creatorOrganisationSourceIdentifier = SourceIdentifier(
+      identifierType = IdentifierType("LCNames"),
+      value = "lcnames/pri",
+      ontologyType = "Agent"
+    )
+
     val work = IdentifiedWork(
       canonicalId = "pt5vupg4",
       title = Some("Pouncing pugs play in pipes"),
       sourceIdentifier = sourceIdentifier,
       identifiers = List(sourceIdentifier),
+      contributors = List(
+        Contributor(
+          agent = Identified(
+            Agent(label = "Purple Penelope"),
+            canonicalId = "p72ujfbe",
+            identifiers = List(creatorAgentSourceIdentifier)
+          ),
+          roles = List()
+        ),
+        Contributor(
+          agent = Identified(
+            Organisation(label = "Pretty Prints"),
+            canonicalId = "pqcmakdp",
+            identifiers = List(creatorOrganisationSourceIdentifier)
+          ),
+          roles = List()
+        ),
+        Contributor(
+          agent = Identified(
+            Person(label = "Private Paul"),
+            canonicalId = "pcynevb6",
+            identifiers = List(creatorPersonSourceIdentifier)
+          ),
+          roles = List()
+        )
+      ),
+      publishers = List(
+        Identified(
+          Agent(label = "Percy Publisher"),
+          canonicalId = "p6gxycfb",
+          identifiers = List(publisherSourceIdentifier)
+        )
+      ),
       version = 1
     )
 
@@ -432,6 +554,24 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
 
     it("on the top-level Work") {
       displayWork.identifiers shouldBe Some(List(DisplayIdentifierV1(sourceIdentifier)))
+    }
+
+    it("creators") {
+      // This is moderately verbose, but the Scala compiler got confused when
+      // I tried to combine the three map() calls into one.
+      val expectedIdentifiers = List(
+        creatorAgentSourceIdentifier,
+        creatorOrganisationSourceIdentifier,
+        creatorPersonSourceIdentifier
+      )
+        .map { DisplayIdentifierV1(_) }
+        .map { List(_) }
+        .map { Some(_) }
+      displayWork.creators.map { _.identifiers } shouldBe expectedIdentifiers
+    }
+
+    it("publishers") {
+      displayWork.publishers.head.identifiers shouldBe Some(List(DisplayIdentifierV1(publisherSourceIdentifier)))
     }
   }
 }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -466,6 +466,16 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
           )
         )
       ),
+      items = List(
+        IdentifiedItem(
+          canonicalId = "jtbaang9",
+          sourceIdentifier = SourceIdentifier(
+            identifierType = IdentifierType("MiroImageNumber"),
+            value = "miro/i0001",
+            ontologyType = "Item"
+          )
+        )
+      ),
       version = 1
     )
 
@@ -481,6 +491,12 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
 
     it("publishers") {
       displayWork.publishers.head.identifiers shouldBe None
+    }
+
+    it("items") {
+      val displayWork = DisplayWorkV1(work, includes = WorksIncludes(items = true))
+      val item: DisplayItemV1 = displayWork.items.get.head
+      item.identifiers shouldBe None
     }
   }
 
@@ -507,6 +523,12 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
       identifierType = IdentifierType("LCNames"),
       value = "lcnames/pri",
       ontologyType = "Agent"
+    )
+
+    val itemSourceIdentifier = SourceIdentifier(
+      identifierType = IdentifierType("MiroImageNumber"),
+      value = "miro/p0001",
+      ontologyType = "Item"
     )
 
     val work = IdentifiedWork(
@@ -547,6 +569,13 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
           identifiers = List(publisherSourceIdentifier)
         )
       ),
+      items = List(
+        IdentifiedItem(
+          canonicalId = "pwaazubr",
+          sourceIdentifier = itemSourceIdentifier,
+          identifiers = List(itemSourceIdentifier)
+        )
+      ),
       version = 1
     )
 
@@ -572,6 +601,12 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
 
     it("publishers") {
       displayWork.publishers.head.identifiers shouldBe Some(List(DisplayIdentifierV1(publisherSourceIdentifier)))
+    }
+
+    it("items") {
+      val displayWork = DisplayWorkV1(work, includes = WorksIncludes(identifiers = true, items = true))
+      val item: DisplayItemV1 = displayWork.items.get.head
+      item.identifiers shouldBe Some(List(DisplayIdentifierV1(itemSourceIdentifier)))
     }
   }
 }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -200,7 +200,7 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
       )
     )
 
-    val displayWork = DisplayWorkV1(work)
+    val displayWork = DisplayWorkV1(work, includes = WorksIncludes(identifiers = true))
     displayWork.creators shouldBe List(
       DisplayPersonV1(
         id = None,

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
@@ -71,7 +71,7 @@ class DisplayAbstractConceptSerialisationTest
     )
 
     assertObjectMapsToJson(
-      DisplayAbstractConcept(concept),
+      DisplayAbstractConcept(concept, includesIdentifiers = true),
       expectedJson = s"""
          |  {
          |    "id": "${concept.canonicalId}",
@@ -90,7 +90,7 @@ class DisplayAbstractConceptSerialisationTest
         Unidentifiable(Concept("conceptLabel")),
         Unidentifiable(Place("placeLabel")),
         Unidentifiable(Period("periodLabel"))
-      ).map(DisplayAbstractConcept(_)),
+      ).map(DisplayAbstractConcept(_, includesIdentifiers = false)),
       expectedJson = s"""
           | [
           |    {

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
@@ -105,7 +105,8 @@ class DisplayConceptTest extends FunSpec with Matchers {
     concept: Displayable[AbstractConcept],
     expectedDisplayConcept: DisplayAbstractConcept
   ) = {
-    val displayConcept = DisplayAbstractConcept(concept, includesIdentifiers = true)
+    val displayConcept =
+      DisplayAbstractConcept(concept, includesIdentifiers = true)
     displayConcept shouldBe expectedDisplayConcept
   }
 }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
@@ -105,7 +105,7 @@ class DisplayConceptTest extends FunSpec with Matchers {
     concept: Displayable[AbstractConcept],
     expectedDisplayConcept: DisplayAbstractConcept
   ) = {
-    val displayConcept = DisplayAbstractConcept(concept)
+    val displayConcept = DisplayAbstractConcept(concept, includesIdentifiers = true)
     displayConcept shouldBe expectedDisplayConcept
   }
 }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
@@ -30,7 +30,7 @@ class DisplayGenreV2SerialisationTest
     )
 
     assertObjectMapsToJson(
-      DisplayGenre(genre),
+      DisplayGenre(genre, includesIdentifiers = true),
       expectedJson = s"""
          |  {
          |    "label" : "${genre.label}",

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
@@ -30,7 +30,7 @@ class DisplaySubjectV2SerialisationTest
     )
 
     assertObjectMapsToJson(
-      DisplaySubject(subject),
+      DisplaySubject(subject, includesIdentifiers = true),
       expectedJson = s"""
          |  {
          |    "label" : "${subject.label}",

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
@@ -272,7 +272,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
       version = 1
     )
 
-    val displayWork = DisplayWorkV2(work)
+    val displayWork = DisplayWorkV2(work, includes = WorksIncludes(identifiers = true))
 
     displayWork.contributors shouldBe List(
       DisplayContributor(

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
@@ -419,6 +419,18 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
           )
         )
       ),
+      genres = List(
+        Genre(
+          label = "Black, Brown and Blue",
+          concepts = List(
+            Identified(
+              Concept("Colours"),
+              canonicalId = "chzwu4ea",
+              identifiers = List(conceptSourceIdentifier)
+            )
+          )
+        )
+      ),
       version = 1
     )
 
@@ -447,6 +459,10 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
       it("subjects") {
         val concepts = displayWork.subjects.head.concepts
         concepts.map { _.identifiers } shouldBe List(None, None, None)
+      }
+
+      it("genres") {
+        displayWork.genres.head.concepts.head.identifiers shouldBe None
       }
     }
 
@@ -495,6 +511,10 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
 
         val concepts = displayWork.subjects.head.concepts
         concepts.map { _.identifiers } shouldBe expectedIdentifiers
+      }
+
+      it("genres") {
+        displayWork.genres.head.concepts.head.identifiers shouldBe Some(List(DisplayIdentifierV2(conceptSourceIdentifier)))
       }
     }
   }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
@@ -334,6 +334,24 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
       ontologyType = "Item"
     )
 
+    val conceptSourceIdentifier = SourceIdentifier(
+      identifierType = IdentifierType("LCSH"),
+      value = "lcsh/bonds",
+      ontologyType = "Concept"
+    )
+
+    val periodSourceIdentifier = SourceIdentifier(
+      identifierType = IdentifierType("LCSH"),
+      value = "lcsh/before",
+      ontologyType = "Concept"
+    )
+
+    val placeSourceIdentifier = SourceIdentifier(
+      identifierType = IdentifierType("LCSH"),
+      value = "lcsh/bul",
+      ontologyType = "Concept"
+    )
+
     val work = IdentifiedWork(
       canonicalId = "bmzwdx3t",
       title = Some("Bizarre bees bounce below a basketball"),
@@ -379,6 +397,28 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
           identifiers = List(itemSourceIdentifier)
         )
       ),
+      subjects = List(
+        Subject(
+          label = "Beryllium-Boron Bonding",
+          concepts = List(
+            Identified(
+              Concept("Bonding"),
+              canonicalId = "b5qsqkyh",
+              identifiers = List(conceptSourceIdentifier)
+            ),
+            Identified(
+              Period("Before"),
+              canonicalId = "bwn894hk",
+              identifiers = List(periodSourceIdentifier)
+            ),
+            Identified(
+              Place("Bulgaria"),
+              canonicalId = "bf42vqst",
+              identifiers = List(placeSourceIdentifier)
+            )
+          )
+        )
+      ),
       version = 1
     )
 
@@ -402,6 +442,11 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
         val displayWork = DisplayWorkV2(work, includes = WorksIncludes(items = true))
         val item: DisplayItemV2 = displayWork.items.get.head
         item.identifiers shouldBe None
+      }
+
+      it("subjects") {
+        val concepts = displayWork.subjects.head.concepts
+        concepts.map { _.identifiers } shouldBe List(None, None, None)
       }
     }
 
@@ -436,6 +481,20 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
         val displayWork = DisplayWorkV2(work, includes = WorksIncludes(identifiers = true, items = true))
         val item: DisplayItemV2 = displayWork.items.get.head
         item.identifiers shouldBe Some(List(DisplayIdentifierV2(itemSourceIdentifier)))
+      }
+
+      it("subjects") {
+        val expectedIdentifiers = List(
+          conceptSourceIdentifier,
+          periodSourceIdentifier,
+          placeSourceIdentifier
+        )
+          .map { DisplayIdentifierV2(_) }
+          .map { List(_) }
+          .map { Some(_) }
+
+        val concepts = displayWork.subjects.head.concepts
+        concepts.map { _.identifiers } shouldBe expectedIdentifiers
       }
     }
   }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
@@ -272,7 +272,8 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
       version = 1
     )
 
-    val displayWork = DisplayWorkV2(work, includes = WorksIncludes(identifiers = true))
+    val displayWork =
+      DisplayWorkV2(work, includes = WorksIncludes(identifiers = true))
 
     displayWork.contributors shouldBe List(
       DisplayContributor(
@@ -442,7 +443,8 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
       }
 
       it("contributors") {
-        val agents: List[DisplayAbstractAgentV2] = displayWork.contributors.map { _.agent }
+        val agents: List[DisplayAbstractAgentV2] =
+          displayWork.contributors.map { _.agent }
         agents.map { _.identifiers } shouldBe List(None, None, None)
       }
 
@@ -451,7 +453,8 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
       }
 
       it("items") {
-        val displayWork = DisplayWorkV2(work, includes = WorksIncludes(items = true))
+        val displayWork =
+          DisplayWorkV2(work, includes = WorksIncludes(items = true))
         val item: DisplayItemV2 = displayWork.items.get.head
         item.identifiers shouldBe None
       }
@@ -467,10 +470,12 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
     }
 
     describe("includes identifiers if WorksIncludes.identifiers is true") {
-      val displayWork = DisplayWorkV2(work, includes = WorksIncludes(identifiers = true))
+      val displayWork =
+        DisplayWorkV2(work, includes = WorksIncludes(identifiers = true))
 
       it("on the top-level Work") {
-        displayWork.identifiers shouldBe Some(List(DisplayIdentifierV2(sourceIdentifier)))
+        displayWork.identifiers shouldBe Some(
+          List(DisplayIdentifierV2(sourceIdentifier)))
       }
 
       it("contributors") {
@@ -480,23 +485,27 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
           contributorAgentSourceIdentifier,
           contributorOrganisationSourceIdentifier,
           contributorPersonSourceIdentifier
-        )
-          .map { DisplayIdentifierV2(_) }
+        ).map { DisplayIdentifierV2(_) }
           .map { List(_) }
           .map { Some(_) }
 
-        val agents: List[DisplayAbstractAgentV2] = displayWork.contributors.map { _.agent }
+        val agents: List[DisplayAbstractAgentV2] =
+          displayWork.contributors.map { _.agent }
         agents.map { _.identifiers } shouldBe expectedIdentifiers
       }
 
       it("publishers") {
-        displayWork.publishers.head.identifiers shouldBe Some(List(DisplayIdentifierV2(publisherSourceIdentifier)))
+        displayWork.publishers.head.identifiers shouldBe Some(
+          List(DisplayIdentifierV2(publisherSourceIdentifier)))
       }
 
       it("items") {
-        val displayWork = DisplayWorkV2(work, includes = WorksIncludes(identifiers = true, items = true))
+        val displayWork = DisplayWorkV2(
+          work,
+          includes = WorksIncludes(identifiers = true, items = true))
         val item: DisplayItemV2 = displayWork.items.get.head
-        item.identifiers shouldBe Some(List(DisplayIdentifierV2(itemSourceIdentifier)))
+        item.identifiers shouldBe Some(
+          List(DisplayIdentifierV2(itemSourceIdentifier)))
       }
 
       it("subjects") {
@@ -504,8 +513,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
           conceptSourceIdentifier,
           periodSourceIdentifier,
           placeSourceIdentifier
-        )
-          .map { DisplayIdentifierV2(_) }
+        ).map { DisplayIdentifierV2(_) }
           .map { List(_) }
           .map { Some(_) }
 
@@ -514,7 +522,8 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
       }
 
       it("genres") {
-        displayWork.genres.head.concepts.head.identifiers shouldBe Some(List(DisplayIdentifierV2(conceptSourceIdentifier)))
+        displayWork.genres.head.concepts.head.identifiers shouldBe Some(
+          List(DisplayIdentifierV2(conceptSourceIdentifier)))
       }
     }
   }


### PR DESCRIPTION
While working on #2140, I noticed that we use DisplayIdentifier in a bunch of places – but we don’t always wrap it in the "identifiers" include. This means you get identifiers where you aren’t expecting them!

This patch updates our models to use the identifiers include consistently.

Notes:

* A way to enforce this going forward would be to generate lots of works, a la the WorksIndex test, and check the string `"identifiers":` doesn't appear in the JSON serialisation.
* It might be nice to have Identified/Unidentified wrappers for the display models.

I haven’t done either of these because (1) it’s late and (2) this patch works, we can do those later.