### PR TITLE
Simplify the identifier-schemes reference data

### DIFF
--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -373,7 +373,7 @@ class ApiV1WorksTest extends ApiWorksTestBase {
     withApiFixtures(ApiVersions.v1) {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
         val identifier1 = SourceIdentifier(
-          identifierType = IdentifierType("MiroImageNumber"),
+          identifierType = IdentifierType("miro-image-number"),
           ontologyType = "Work",
           value = "Test1234"
         )
@@ -384,7 +384,7 @@ class ApiV1WorksTest extends ApiWorksTestBase {
         )
 
         val identifier2 = SourceIdentifier(
-          identifierType = IdentifierType("MiroImageNumber"),
+          identifierType = IdentifierType("miro-image-number"),
           ontologyType = "Work",
           value = "DTest5678"
         )
@@ -439,7 +439,7 @@ class ApiV1WorksTest extends ApiWorksTestBase {
     withApiFixtures(ApiVersions.v1) {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
         val srcIdentifier = SourceIdentifier(
-          identifierType = IdentifierType("MiroImageNumber"),
+          identifierType = IdentifierType("miro-image-number"),
           ontologyType = "Work",
           value = "Test1234"
         )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -394,7 +394,7 @@ class ApiV2WorksTest extends ApiWorksTestBase {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
         val identifier1 = SourceIdentifier(
-          identifierType = IdentifierType("MiroImageNumber"),
+          identifierType = IdentifierType("miro-image-number"),
           ontologyType = "Work",
           value = "Test1234"
         )
@@ -405,7 +405,7 @@ class ApiV2WorksTest extends ApiWorksTestBase {
         )
 
         val identifier2 = SourceIdentifier(
-          identifierType = IdentifierType("MiroImageNumber"),
+          identifierType = IdentifierType("miro-image-number"),
           ontologyType = "Work",
           value = "DTest5678"
         )
@@ -460,7 +460,7 @@ class ApiV2WorksTest extends ApiWorksTestBase {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
         val srcIdentifier = SourceIdentifier(
-          identifierType = IdentifierType("MiroImageNumber"),
+          identifierType = IdentifierType("miro-image-number"),
           ontologyType = "Work",
           value = "Test1234"
         )

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -46,7 +46,7 @@ class IdMinterFeatureTest
 
               val identifier =
                 SourceIdentifier(
-                  identifierType = IdentifierType("MiroImageNumber"),
+                  identifierType = IdentifierType("miro-image-number"),
                   "Work",
                   miroID)
 
@@ -106,7 +106,7 @@ class IdMinterFeatureTest
 
               val identifier =
                 SourceIdentifier(
-                  identifierType = IdentifierType("MiroImageNumber"),
+                  identifierType = IdentifierType("miro-image-number"),
                   "Work",
                   miroId)
 

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -44,13 +44,13 @@ class IdentifiersDaoTest
         val identifier = Identifier(
           CanonicalId = "A turtle turns to try to taste",
           SourceId = "A tangerine",
-          SourceSystem = IdentifierType("MiroImageNumber").id,
+          SourceSystem = IdentifierType("miro-image-number").id,
           OntologyType = "t-t-t-turtles"
         )
         fixtures.identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
 
         val sourceIdentifier = SourceIdentifier(
-          identifierType = IdentifierType("MiroImageNumber"),
+          identifierType = IdentifierType("miro-image-number"),
           identifier.OntologyType,
           value = identifier.SourceId
         )
@@ -69,14 +69,14 @@ class IdentifiersDaoTest
         val identifier = Identifier(
           CanonicalId = "A turtle turns to try to taste",
           SourceId = "A tangerine",
-          SourceSystem = IdentifierType("MiroImageNumber").id,
+          SourceSystem = IdentifierType("miro-image-number").id,
           OntologyType = "t-t-t-turtles"
         )
 
         fixtures.identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
 
         val sourceIdentifier = SourceIdentifier(
-          identifierType = IdentifierType("MiroImageNumber"),
+          identifierType = IdentifierType("miro-image-number"),
           identifier.OntologyType,
           value = "not_an_existing_value"
         )
@@ -98,7 +98,7 @@ class IdentifiersDaoTest
         val identifier = Identifier(
           CanonicalId = "A provision of porpoises",
           OntologyType = "Work",
-          SourceSystem = IdentifierType("MiroImageNumber").id,
+          SourceSystem = IdentifierType("miro-image-number").id,
           SourceId = "A picture of pangolins"
         )
         fixtures.identifiersDao.saveIdentifier(identifier)
@@ -108,7 +108,7 @@ class IdentifiersDaoTest
             .where
             .eq(
               fixtures.identifiersTable.i.SourceSystem,
-              IdentifierType("MiroImageNumber").id)
+              IdentifierType("miro-image-number").id)
             .and
             .eq(
               fixtures.identifiersTable.i.CanonicalId,

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -42,7 +42,7 @@ class IdEmbedderTests
 
   it("sets the canonicalId given by the IdentifierGenerator on the work") {
     val identifier = SourceIdentifier(
-      identifierType = IdentifierType("MiroImageNumber"),
+      identifierType = IdentifierType("miro-image-number"),
       ontologyType = "Work",
       value = "1234"
     )
@@ -87,13 +87,13 @@ class IdEmbedderTests
 
   it("mints identifiers for creators in work") {
     val workIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("MiroImageNumber"),
+      identifierType = IdentifierType("miro-image-number"),
       ontologyType = "Work",
       value = "1234"
     )
 
     val creatorIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCNames"),
+      identifierType = IdentifierType("lc-names"),
       ontologyType = "Person",
       value = "1234"
     )
@@ -162,7 +162,7 @@ class IdEmbedderTests
 
   it("returns a failed future if the call to IdentifierGenerator fails") {
     val identifier = SourceIdentifier(
-      identifierType = IdentifierType("MiroImageNumber"),
+      identifierType = IdentifierType("miro-image-number"),
       ontologyType = "Work",
       value = "1234"
     )
@@ -194,7 +194,7 @@ class IdEmbedderTests
 
   it("adds canonicalIds to all items") {
     val identifier = SourceIdentifier(
-      identifierType = IdentifierType("MiroImageNumber"),
+      identifierType = IdentifierType("miro-image-number"),
       ontologyType = "Item",
       value = "1234"
     )
@@ -206,7 +206,7 @@ class IdEmbedderTests
 
     val originalItem2 = UnidentifiedItem(
       sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("MiroImageNumber"),
+        identifierType = IdentifierType("miro-image-number"),
         ontologyType = "Item",
         value = "1235"
       ),
@@ -333,7 +333,7 @@ class IdEmbedderTests
 
       val ontologyType = "false capitals"
       val sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("MiroImageNumber"),
+        identifierType = IdentifierType("miro-image-number"),
         ontologyType = ontologyType,
         "sydney"
       )
@@ -393,7 +393,7 @@ class IdEmbedderTests
       val ontologyType = "fictional cities"
 
       val sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("MiroImageNumber"),
+        identifierType = IdentifierType("miro-image-number"),
         ontologyType = ontologyType,
         "king's landing"
       )

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -74,7 +74,7 @@ class IdentifierGeneratorTest
           .namedValues(
             fixtures.identifiersTable.column.CanonicalId -> "5678",
             fixtures.identifiersTable.column.SourceSystem -> IdentifierType(
-              "MiroImageNumber").id,
+              "miro-image-number").id,
             fixtures.identifiersTable.column.SourceId -> "1234",
             fixtures.identifiersTable.column.OntologyType -> "Work"
           )
@@ -82,7 +82,7 @@ class IdentifierGeneratorTest
 
       val triedId = fixtures.identifierGenerator.retrieveOrGenerateCanonicalId(
         SourceIdentifier(
-          identifierType = IdentifierType("MiroImageNumber"),
+          identifierType = IdentifierType("miro-image-number"),
           "Work",
           "1234")
       )
@@ -97,7 +97,7 @@ class IdentifierGeneratorTest
 
       val triedId = fixtures.identifierGenerator.retrieveOrGenerateCanonicalId(
         SourceIdentifier(
-          identifierType = IdentifierType("MiroImageNumber"),
+          identifierType = IdentifierType("miro-image-number"),
           "Work",
           "1234")
       )
@@ -121,7 +121,7 @@ class IdentifierGeneratorTest
       maybeIdentifier shouldBe defined
       maybeIdentifier.get shouldBe Identifier(
         CanonicalId = id,
-        SourceSystem = IdentifierType("MiroImageNumber").id,
+        SourceSystem = IdentifierType("miro-image-number").id,
         SourceId = "1234"
       )
     }
@@ -133,7 +133,7 @@ class IdentifierGeneratorTest
     withActorSystem { actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>
         val sourceIdentifier = SourceIdentifier(
-          identifierType = IdentifierType("MiroImageNumber"),
+          identifierType = IdentifierType("miro-image-number"),
           "Work",
           value = "1234"
         )
@@ -172,7 +172,7 @@ class IdentifierGeneratorTest
 
       val triedId = fixtures.identifierGenerator.retrieveOrGenerateCanonicalId(
         SourceIdentifier(
-          identifierType = IdentifierType("MiroImageNumber"),
+          identifierType = IdentifierType("miro-image-number"),
           ontologyType,
           miroId)
       )
@@ -193,7 +193,7 @@ class IdentifierGeneratorTest
       maybeIdentifier shouldBe defined
       maybeIdentifier.get shouldBe Identifier(
         CanonicalId = id,
-        SourceSystem = IdentifierType("MiroImageNumber").id,
+        SourceSystem = IdentifierType("miro-image-number").id,
         SourceId = miroId,
         OntologyType = ontologyType
       )

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -39,8 +39,8 @@ class IngestorWorkerService @Inject()(
   // * Sierra works are indexed only in the v2 index.
   // * Works from any other source are not expected so they are discarded.
   private def decideTargetIndices(work: IdentifiedWork): List[String] = {
-    val miroIdentifier = IdentifierType("MiroImageNumber")
-    val sierraIdentifier = IdentifierType("SierraSystemNumber")
+    val miroIdentifier = IdentifierType("miro-image-number")
+    val sierraIdentifier = IdentifierType("sierra-system-number")
     work.sourceIdentifier.identifierType.id match {
       case miroIdentifier.id =>
         List(

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -34,7 +34,7 @@ class IngestorFeatureTest
     "reads a miro identified work from the queue and ingests it in the v1 and v2 index") {
     val sourceIdentifier =
       SourceIdentifier(
-        identifierType = IdentifierType("MiroImageNumber"),
+        identifierType = IdentifierType("miro-image-number"),
         "Item",
         "5678")
 
@@ -68,7 +68,7 @@ class IngestorFeatureTest
     "reads a sierra identified work from the queue and ingests it in the v2 index only") {
     val sourceIdentifier =
       SourceIdentifier(
-        identifierType = IdentifierType("SierraSystemNumber"),
+        identifierType = IdentifierType("sierra-system-number"),
         "Item",
         "5678")
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -40,7 +40,7 @@ class IngestorWorkerServiceTest
 
   it("inserts an Miro identified Work into v1 and v2 indices") {
     val miroSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("MiroImageNumber"),
+      identifierType = IdentifierType("miro-image-number"),
       ontologyType = "Work",
       value = "M000765"
     )
@@ -68,7 +68,7 @@ class IngestorWorkerServiceTest
 
   it("inserts an Sierra identified Work only into the v2 index") {
     val sierraSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("SierraSystemNumber"),
+      identifierType = IdentifierType("sierra-system-number"),
       ontologyType = "Work",
       value = "b1027467"
     )
@@ -96,7 +96,7 @@ class IngestorWorkerServiceTest
 
   it("fails inserting a non sierra or miro identified work") {
     val calmSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("CALMAltRefNo"),
+      identifierType = IdentifierType("calm-altref-no"),
       ontologyType = "Work",
       value = "MS/237"
     )
@@ -110,7 +110,7 @@ class IngestorWorkerServiceTest
 
           whenReady(future.failed) { ex =>
             ex shouldBe a[GracefulFailureException]
-            ex.getMessage shouldBe s"Cannot ingest work with identifierType: ${IdentifierType("CALMAltRefNo")}"
+            ex.getMessage shouldBe s"Cannot ingest work with identifierType: ${IdentifierType("calm-altref-no")}"
           }
         }
       }
@@ -136,7 +136,7 @@ class IngestorWorkerServiceTest
         )
 
         val miroSourceIdentifier = SourceIdentifier(
-          identifierType = IdentifierType("MiroImageNumber"),
+          identifierType = IdentifierType("miro-image-number"),
           ontologyType = "Work",
           value = "B000675"
         )

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -34,7 +34,7 @@ class MatcherFeatureTest
           withLocalDynamoDbTable { table =>
             withMatcherServer(queue, storageBucket, topic, table) { _ =>
               val identifier = SourceIdentifier(
-                identifierType = IdentifierType("SierraSystemNumber"),
+                identifierType = IdentifierType("sierra-system-number"),
                 "Work",
                 "id")
 

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -123,7 +123,7 @@ trait MatcherFixtures
 
   def aSierraSourceIdentifier(id: String) =
     SourceIdentifier(
-      identifierType = IdentifierType("SierraSystemNumber"),
+      identifierType = IdentifierType("sierra-system-number"),
       "Work",
       id)
 

--- a/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
+++ b/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
@@ -30,7 +30,7 @@ class RecorderFeatureTest
     val title = "Not from Guildford after all"
 
     val sourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("MiroImageNumber"),
+      identifierType = IdentifierType("miro-image-number"),
       value = "V0237865",
       ontologyType = "Work"
     )

--- a/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -37,7 +37,7 @@ class RecorderWorkerServiceTest
   val title = "Whose umbrella did I find?"
 
   val sourceIdentifier = SourceIdentifier(
-    identifierType = IdentifierType("MiroImageNumber"),
+    identifierType = IdentifierType("miro-image-number"),
     value = "U8634924",
     ontologyType = "Work"
   )

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/CalmTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/CalmTransformableTransformer.scala
@@ -24,14 +24,14 @@ class CalmTransformableTransformer
             UnidentifiedWork(
               title = Some("placeholder title"),
               sourceIdentifier = SourceIdentifier(
-                identifierType = IdentifierType("CALMAltRefNo"),
+                identifierType = IdentifierType("calm-altref-no"),
                 ontologyType = "Work",
                 value = "value"
               ),
               version = version,
               identifiers = List(
                 SourceIdentifier(
-                  identifierType = IdentifierType("CALMAltRefNo"),
+                  identifierType = IdentifierType("calm-altref-no"),
                   ontologyType = "Work",
                   value = "value"
                 ))

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
@@ -25,7 +25,7 @@ class MiroTransformableTransformer
         UnidentifiedWork(
           title = Some(title),
           sourceIdentifier = SourceIdentifier(
-            identifierType = IdentifierType("MiroImageNumber"),
+            identifierType = IdentifierType("miro-image-number"),
             ontologyType = "Work",
             value = miroTransformable.sourceId),
           version = version,
@@ -152,7 +152,7 @@ class MiroTransformableTransformer
                              miroId: String): List[SourceIdentifier] = {
     val miroIDList = List(
       SourceIdentifier(
-        identifierType = IdentifierType("MiroImageNumber"),
+        identifierType = IdentifierType("miro-image-number"),
         ontologyType = "Work",
         value = miroId)
     )
@@ -185,7 +185,7 @@ class MiroTransformableTransformer
           case Some(s) =>
             s.map { id =>
               SourceIdentifier(
-                identifierType = IdentifierType("SierraSystemNumber"),
+                identifierType = IdentifierType("sierra-system-number"),
                 ontologyType = "Work",
                 value = s"b$id")
             }
@@ -208,7 +208,7 @@ class MiroTransformableTransformer
         .collect {
           case (Some(label), Some(value)) =>
             SourceIdentifier(
-              identifierType = IdentifierType("MiroLibraryReference"),
+              identifierType = IdentifierType("miro-library-reference"),
               ontologyType = "Work",
               value = s"$label $value"
             )
@@ -231,12 +231,12 @@ class MiroTransformableTransformer
     List(
       UnidentifiedItem(
         sourceIdentifier = SourceIdentifier(
-          identifierType = IdentifierType("MiroImageNumber"),
+          identifierType = IdentifierType("miro-image-number"),
           "Item",
           miroId),
         identifiers = List(
           SourceIdentifier(
-            identifierType = IdentifierType("MiroImageNumber"),
+            identifierType = IdentifierType("miro-image-number"),
             "Item",
             miroId)
         ),

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
@@ -47,7 +47,7 @@ class SierraTransformableTransformer
             internal.UnidentifiedWork(
               title = getTitle(sierraBibData),
               sourceIdentifier = SourceIdentifier(
-                identifierType = IdentifierType("SierraSystemNumber"),
+                identifierType = IdentifierType("sierra-system-number"),
                 ontologyType = "Work",
                 value = addCheckDigit(
                   sierraBibData.id,

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConceptIdentifier.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConceptIdentifier.scala
@@ -29,8 +29,8 @@ object SierraConceptIdentifier {
 
       // These mappings are provided by the MARC spec.
       // https://www.loc.gov/marc/bibliographic/bd655.html
-      case Some("0") => Some(IdentifierType("LCSH"))
-      case Some("2") => Some(IdentifierType("MESHId"))
+      case Some("0") => Some(IdentifierType("lcsh"))
+      case Some("2") => Some(IdentifierType("mesh"))
       case Some("4") => None
 
       // For now we omit the other schemes as they're fairly unusual in

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributors.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributors.scala
@@ -160,7 +160,7 @@ trait SierraContributors extends MarcUtils {
       case Nil => Unidentifiable(agent)
       case Seq(code) => {
         val sourceIdentifier = SourceIdentifier(
-          identifierType = IdentifierType("LCNames"),
+          identifierType = IdentifierType("lc-names"),
           value = code,
           ontologyType = ontologyType
         )

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraIdentifiers.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraIdentifiers.scala
@@ -18,7 +18,7 @@ trait SierraIdentifiers extends SierraCheckDigits {
   def getIdentifiers(bibData: SierraBibData): List[SourceIdentifier] =
     List(
       SourceIdentifier(
-        identifierType = IdentifierType("SierraSystemNumber"),
+        identifierType = IdentifierType("sierra-system-number"),
         ontologyType = "Work",
         value = addCheckDigit(
           bibData.id,
@@ -26,7 +26,7 @@ trait SierraIdentifiers extends SierraCheckDigits {
         )
       ),
       SourceIdentifier(
-        identifierType = IdentifierType("SierraIdentifier"),
+        identifierType = IdentifierType("sierra-identifier"),
         ontologyType = "Work",
         value = bibData.id
       )

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
@@ -35,7 +35,7 @@ trait SierraItems extends Logging with SierraCheckDigits with SierraLocation {
     info(s"Attempting to transform ${sierraItemData.id}")
     internal.UnidentifiedItem(
       sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("SierraSystemNumber"),
+        identifierType = IdentifierType("sierra-system-number"),
         ontologyType = "Item",
         value = addCheckDigit(
           sierraItemData.id,
@@ -44,7 +44,7 @@ trait SierraItems extends Logging with SierraCheckDigits with SierraLocation {
       ),
       identifiers = List(
         SourceIdentifier(
-          identifierType = IdentifierType("SierraSystemNumber"),
+          identifierType = IdentifierType("sierra-system-number"),
           ontologyType = "Item",
           value = addCheckDigit(
             sierraItemData.id,
@@ -52,7 +52,7 @@ trait SierraItems extends Logging with SierraCheckDigits with SierraLocation {
           )
         ),
         SourceIdentifier(
-          identifierType = IdentifierType("SierraIdentifier"),
+          identifierType = IdentifierType("sierra-identifier"),
           ontologyType = "Item",
           value = sierraItemData.id
         )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/CalmTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/CalmTransformerFeatureTest.scala
@@ -66,7 +66,7 @@ class CalmTransformerFeatureTest
                 snsMessages.size should be >= 1
 
                 val sourceIdentifier = SourceIdentifier(
-                  identifierType = IdentifierType("CALMAltRefNo"),
+                  identifierType = IdentifierType("calm-altref-no"),
                   ontologyType = "Work",
                   value = "value"
                 )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/SierraTransformerFeatureTest.scala
@@ -68,13 +68,13 @@ class SierraTransformerFeatureTest
                 snsMessages.size should be >= 1
 
                 val sourceIdentifier = SourceIdentifier(
-                  identifierType = IdentifierType("SierraSystemNumber"),
+                  identifierType = IdentifierType("sierra-system-number"),
                   ontologyType = "Work",
                   value = "b10010014"
                 )
 
                 val sierraIdentifier = SourceIdentifier(
-                  identifierType = IdentifierType("SierraIdentifier"),
+                  identifierType = IdentifierType("sierra-identifier"),
                   ontologyType = "Work",
                   value = id
                 )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/SQSMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/SQSMessageReceiverTest.scala
@@ -49,7 +49,7 @@ class SQSMessageReceiverTest
 
   val sourceIdentifier =
     SourceIdentifier(
-      identifierType = IdentifierType("CALMAltRefNo"),
+      identifierType = IdentifierType("calm-altref-no"),
       ontologyType = "Work",
       value = "value")
 
@@ -149,12 +149,12 @@ class SQSMessageReceiverTest
             val future = recordReceiver.receiveMessage(sierraMessage)
 
             val sourceIdentifier = SourceIdentifier(
-              identifierType = IdentifierType("SierraSystemNumber"),
+              identifierType = IdentifierType("sierra-system-number"),
               ontologyType = "Work",
               value = "b50050059"
             )
             val sierraIdentifier = SourceIdentifier(
-              identifierType = IdentifierType("SierraIdentifier"),
+              identifierType = IdentifierType("sierra-identifier"),
               ontologyType = "Work",
               value = id
             )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
@@ -17,7 +17,7 @@ class MiroTransformableTransformerTest
     )
     work.identifiers shouldBe List(
       SourceIdentifier(
-        identifierType = IdentifierType("MiroImageNumber"),
+        identifierType = IdentifierType("miro-image-number"),
         "Work",
         MiroID))
   }
@@ -238,11 +238,11 @@ class MiroTransformableTransformerTest
     )
     work.identifiers shouldBe List(
       SourceIdentifier(
-        identifierType = IdentifierType("MiroImageNumber"),
+        identifierType = IdentifierType("miro-image-number"),
         "Work",
         miroID),
       SourceIdentifier(
-        identifierType = IdentifierType("SierraSystemNumber"),
+        identifierType = IdentifierType("sierra-system-number"),
         "Work",
         expectedSierraNumber)
     )
@@ -261,13 +261,13 @@ class MiroTransformableTransformerTest
     )
     val miroIDList = List(
       SourceIdentifier(
-        identifierType = IdentifierType("MiroImageNumber"),
+        identifierType = IdentifierType("miro-image-number"),
         "Work",
         "V0175278")
     )
     val libraryRefList = expectedValues.map {
       SourceIdentifier(
-        identifierType = IdentifierType("MiroLibraryReference"),
+        identifierType = IdentifierType("miro-library-reference"),
         "Work",
         _)
     }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -56,12 +56,12 @@ class SierraTransformableTransformerTest
 
     val sourceIdentifier1 =
       SourceIdentifier(
-        identifierType = IdentifierType("SierraSystemNumber"),
+        identifierType = IdentifierType("sierra-system-number"),
         ontologyType = "Item",
         "i51515155")
     val sourceIdentifier2 =
       SourceIdentifier(
-        identifierType = IdentifierType("SierraSystemNumber"),
+        identifierType = IdentifierType("sierra-system-number"),
         ontologyType = "Item",
         "i52525259")
 
@@ -114,12 +114,12 @@ class SierraTransformableTransformerTest
     work.items should have size 1
     val expectedSourceIdentifiers = List(
       SourceIdentifier(
-        identifierType = IdentifierType("SierraSystemNumber"),
+        identifierType = IdentifierType("sierra-system-number"),
         ontologyType = "Item",
         value = "i63636360"
       ),
       SourceIdentifier(
-        identifierType = IdentifierType("SierraIdentifier"),
+        identifierType = IdentifierType("sierra-identifier"),
         ontologyType = "Item",
         value = itemId
       )
@@ -246,12 +246,12 @@ class SierraTransformableTransformerTest
     transformedSierraRecord.isSuccess shouldBe true
 
     val sourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("SierraSystemNumber"),
+      identifierType = IdentifierType("sierra-system-number"),
       ontologyType = "Work",
       value = "b06060602"
     )
     val sierraIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("SierraIdentifier"),
+      identifierType = IdentifierType("sierra-identifier"),
       ontologyType = "Work",
       value = id
     )
@@ -294,12 +294,12 @@ class SierraTransformableTransformerTest
     transformedSierraRecord.isSuccess shouldBe true
 
     val sourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("SierraSystemNumber"),
+      identifierType = IdentifierType("sierra-system-number"),
       ontologyType = "Work",
       value = "b17898717"
     )
     val sierraIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("SierraIdentifier"),
+      identifierType = IdentifierType("sierra-identifier"),
       ontologyType = "Work",
       value = id
     )
@@ -338,12 +338,12 @@ class SierraTransformableTransformerTest
     transformedSierraRecord.isSuccess shouldBe true
 
     val sourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("SierraSystemNumber"),
+      identifierType = IdentifierType("sierra-system-number"),
       ontologyType = "Work",
       value = "b00010005"
     )
     val sierraIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("SierraIdentifier"),
+      identifierType = IdentifierType("sierra-identifier"),
       ontologyType = "Work",
       value = id
     )
@@ -558,7 +558,7 @@ class SierraTransformableTransformerTest
     transformedSierraRecord.isSuccess shouldBe true
 
     val expectedSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("SierraSystemNumber"),
+      identifierType = IdentifierType("sierra-system-number"),
       ontologyType = "Work",
       value = "b90000092"
     )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConceptIdentifierTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConceptIdentifierTest.scala
@@ -11,7 +11,7 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
     val identifierSubfield = MarcSubfield(tag = "0", content = "lcsh/123")
 
     val expectedSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCSH"),
+      identifierType = IdentifierType("lcsh"),
       value = "lcsh/123",
       ontologyType = ontologyType
     )
@@ -32,7 +32,7 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
     val identifierSubfield = MarcSubfield(tag = "0", content = "mesh/456")
 
     val expectedSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("MESHId"),
+      identifierType = IdentifierType("mesh"),
       value = "mesh/456",
       ontologyType = ontologyType
     )
@@ -89,7 +89,7 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
     val identifierSubfield = MarcSubfield(tag = "0", content = "mesh/456")
 
     val expectedSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("MESHId"),
+      identifierType = IdentifierType("mesh"),
       value = "mesh/456",
       ontologyType = "Item"
     )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributorsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributorsTest.scala
@@ -346,7 +346,7 @@ class SierraContributorsTest extends FunSpec with Matchers {
       )
 
       val sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("LCNames"),
+        identifierType = IdentifierType("lc-names"),
         ontologyType = "Person",
         value = lcshCode
       )
@@ -393,7 +393,7 @@ class SierraContributorsTest extends FunSpec with Matchers {
       )
 
       val sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("LCNames"),
+        identifierType = IdentifierType("lc-names"),
         ontologyType = "Person",
         value = lcshCodeCanonical
       )
@@ -570,7 +570,7 @@ class SierraContributorsTest extends FunSpec with Matchers {
       )
 
       val sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("LCNames"),
+        identifierType = IdentifierType("lc-names"),
         ontologyType = "Organisation",
         value = lcshCode
       )
@@ -612,7 +612,7 @@ class SierraContributorsTest extends FunSpec with Matchers {
       )
 
       val sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("LCNames"),
+        identifierType = IdentifierType("lc-names"),
         ontologyType = "Organisation",
         value = lcshCodeCanonical
       )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraGenresTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraGenresTest.scala
@@ -218,12 +218,12 @@ class SierraGenresTest extends FunSpec with Matchers {
 
     val expectedSourceIdentifiers = List(
       SourceIdentifier(
-        identifierType = IdentifierType("LCSH"),
+        identifierType = IdentifierType("lcsh"),
         value = "lcsh/123",
         ontologyType = "Concept"
       ),
       SourceIdentifier(
-        identifierType = IdentifierType("MESHId"),
+        identifierType = IdentifierType("mesh"),
         value = "mesh/456",
         ontologyType = "Concept"
       )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraIdentifiersTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraIdentifiersTest.scala
@@ -12,12 +12,12 @@ class SierraIdentifiersTest extends FunSpec with Matchers with SierraData {
       bibDataId = "1782863",
       expectedIdentifiers = List(
         SourceIdentifier(
-          identifierType = IdentifierType("SierraSystemNumber"),
+          identifierType = IdentifierType("sierra-system-number"),
           ontologyType = "Work",
           value = "b17828636"
         ),
         SourceIdentifier(
-          identifierType = IdentifierType("SierraIdentifier"),
+          identifierType = IdentifierType("sierra-identifier"),
           ontologyType = "Work",
           value = "1782863"
         )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
@@ -97,12 +97,12 @@ class SierraItemsTest extends FunSpec with Matchers with SierraData {
       val item = SierraItemData(id = "4000004", deleted = false)
 
       val sourceIdentifier1 = SourceIdentifier(
-        identifierType = IdentifierType("SierraSystemNumber"),
+        identifierType = IdentifierType("sierra-system-number"),
         ontologyType = "Item",
         value = "i40000047"
       )
       val sourceIdentifier2 = SourceIdentifier(
-        identifierType = IdentifierType("SierraIdentifier"),
+        identifierType = IdentifierType("sierra-identifier"),
         ontologyType = "Item",
         value = "4000004"
       )
@@ -116,7 +116,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraData {
       val item = SierraItemData(id = "5000005", deleted = false)
 
       val sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("SierraSystemNumber"),
+        identifierType = IdentifierType("sierra-system-number"),
         ontologyType = "Item",
         value = "i50000056"
       )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraSubjectsTest.scala
@@ -265,12 +265,12 @@ class SierraSubjectsTest extends FunSpec with Matchers {
 
     val expectedSourceIdentifiers = List(
       SourceIdentifier(
-        identifierType = IdentifierType("LCSH"),
+        identifierType = IdentifierType("lcsh"),
         value = "lcsh/123",
         ontologyType = "Concept"
       ),
       SourceIdentifier(
-        identifierType = IdentifierType("MESHId"),
+        identifierType = IdentifierType("mesh"),
         value = "mesh/456",
         ontologyType = "Concept"
       )

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -58,7 +58,7 @@ class SnapshotGeneratorFeatureTest
             canonicalId = s"rbfhv6b4$version",
             title = Some("Rumblings from a rambunctious rodent"),
             sourceIdentifier = SourceIdentifier(
-              identifierType = IdentifierType("MiroImageNumber"),
+              identifierType = IdentifierType("miro-image-number"),
               ontologyType = "work",
               value = "R0060400"
             ),

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -254,7 +254,7 @@ class SnapshotServiceTest
         val invalidWork = IdentifiedWork(
           canonicalId = "invalidwork",
           sourceIdentifier = SourceIdentifier(
-            identifierType = IdentifierType("SierraSystemNumber"),
+            identifierType = IdentifierType("sierra-system-number"),
             ontologyType = "Work",
             value = "123"),
           version = 1,

--- a/ontologies/Reference data/identifier-schemes.csv
+++ b/ontologies/Reference data/identifier-schemes.csv
@@ -1,16 +1,16 @@
-MiroImageNumber,miro-image-number,Miro image number
-MiroLibraryReference,miro-library-reference,Miro library reference
-WellcomeLibraryVideodiskNumber,wellcome-library-videodisk-number,Wellcome library videodisk number
-SierraSystemNumber,sierra-system-number,Sierra system number
-SierraIdentifier,sierra-identifier,Sierra identifier
-CALMRefNo,calm-ref-no,CALM ref no
-CALMAltRefNo,calm-altref-no,CALM alter no
-LCGMGPC,lc-gmgpc,Library of Congress Thesaurus for Graphic Materials
-LCSH,lcsh,Library of Congress Subject Headings
-LCNames,lc-names,Library of Congress Name authority records
-MESHId,mesh,MESH identifier
-CALMRecordId,calm-record-id,CALM record identifier
-PreservicaGUID,preservica-guid,Perservica GUID
-CALMAuthorityCode,calm-authority-code,CALM authority code
-ISBN,isbn,ISBN
-ISSN,issn,ISSN
+miro-image-number,Miro image number
+miro-library-reference,Miro library reference
+wellcome-library-videodisk-number,Wellcome library videodisk number
+sierra-system-number,Sierra system number
+sierra-identifier,Sierra identifier
+calm-ref-no,CALM ref no
+calm-altref-no,CALM alter no
+lc-gmgpc,Library of Congress Thesaurus for Graphic Materials
+lcsh,Library of Congress Subject Headings
+lc-names,Library of Congress Name authority records
+mesh,MESH identifier
+calm-record-id,CALM record identifier
+preservica-guid,Perservica GUID
+calm-authority-code,CALM authority code
+isbn,ISBN
+issn,ISSN

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
@@ -78,7 +78,7 @@ class DisplayCreatorsV1SerialisationTest
             canonicalId = "hgfedcba",
             identifiers = List(
               SourceIdentifier(
-                identifierType = IdentifierType("LCNames"),
+                identifierType = IdentifierType("lc-names"),
                 ontologyType = "Organisation",
                 value = "hv"
               )
@@ -91,7 +91,7 @@ class DisplayCreatorsV1SerialisationTest
             canonicalId = "abcdefgh",
             identifiers = List(
               SourceIdentifier(
-                identifierType = IdentifierType("LCNames"),
+                identifierType = IdentifierType("lc-names"),
                 ontologyType = "Organisation",
                 value = "uu"
               )
@@ -104,7 +104,7 @@ class DisplayCreatorsV1SerialisationTest
             canonicalId = "blahbluh",
             identifiers = List(
               SourceIdentifier(
-                identifierType = IdentifierType("LCNames"),
+                identifierType = IdentifierType("lc-names"),
                 ontologyType = "Organisation",
                 value = "uu"
               )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1Test.scala
@@ -19,7 +19,7 @@ class DisplayItemV1Test extends FunSpec with Matchers {
   }
 
   val identifier: SourceIdentifier = SourceIdentifier(
-    identifierType = IdentifierType("MiroImageNumber"),
+    identifierType = IdentifierType("miro-image-number"),
     ontologyType = "Item",
     value = "value"
   )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -231,7 +231,7 @@ class DisplayWorkV1SerialisationTest
 
   it("includes a list of identifiers on DisplayWorkV1") {
     val srcIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("MiroImageNumber"),
+      identifierType = IdentifierType("miro-image-number"),
       ontologyType = "Work",
       value = "Test1234"
     )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -47,7 +47,7 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
   }
 
   val sourceIdentifier = SourceIdentifier(
-    identifierType = IdentifierType("SierraSystemNumber"),
+    identifierType = IdentifierType("sierra-system-number"),
     ontologyType = "Work",
     value = "b1234567"
   )
@@ -173,7 +173,7 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
     "extracts creators from a Work with a mixture of identified/Unidentifiable Contributors") {
     val canonicalId = "abcdefgh"
     val sourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCNames"),
+      identifierType = IdentifierType("lc-names"),
       "Organisation",
       "EW")
     val work = IdentifiedWork(
@@ -213,7 +213,7 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
         identifiers = Some(
           List(
             DisplayIdentifierV1(
-              identifierScheme = IdentifierType("LCNames").id,
+              identifierScheme = IdentifierType("lc-names").id,
               sourceIdentifier.value))),
         label = "Juniper Journals"
       )
@@ -406,31 +406,31 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
 
   describe("correctly uses the WorksIncludes.identifiers include") {
     val publisherSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCNames"),
+      identifierType = IdentifierType("lc-names"),
       value = "lcnames/pp",
       ontologyType = "Agent"
     )
 
     val creatorAgentSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCNames"),
+      identifierType = IdentifierType("lc-names"),
       value = "lcnames/pp",
       ontologyType = "Agent"
     )
 
     val creatorPersonSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCNames"),
+      identifierType = IdentifierType("lc-names"),
       value = "lcnames/pri",
       ontologyType = "Agent"
     )
 
     val creatorOrganisationSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCNames"),
+      identifierType = IdentifierType("lc-names"),
       value = "lcnames/pri",
       ontologyType = "Agent"
     )
 
     val itemSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("MiroImageNumber"),
+      identifierType = IdentifierType("miro-image-number"),
       value = "miro/p0001",
       ontologyType = "Item"
     )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
@@ -63,7 +63,7 @@ class DisplayAbstractConceptSerialisationTest
       canonicalId = "uq4bt5us",
       identifiers = List(
         SourceIdentifier(
-          identifierType = IdentifierType("LCNames"),
+          identifierType = IdentifierType("lc-names"),
           ontologyType = "Concept",
           value = "lcsh/uq4"
         )),

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
@@ -40,7 +40,7 @@ class DisplayConceptTest extends FunSpec with Matchers {
 
   it("reads an identified Concept as a DisplayConcept with identifiers") {
     val sourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCNames"),
+      identifierType = IdentifierType("lc-names"),
       ontologyType = "Concept",
       value = "lcsh/ehw"
     )
@@ -61,7 +61,7 @@ class DisplayConceptTest extends FunSpec with Matchers {
 
   it("reads an identified Period as a DisplayPeriod with identifiers") {
     val sourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCNames"),
+      identifierType = IdentifierType("lc-names"),
       ontologyType = "Period",
       value = "lcsh/zbm"
     )
@@ -82,7 +82,7 @@ class DisplayConceptTest extends FunSpec with Matchers {
 
   it("reads an identified Place as a DisplayPlace with identifiers") {
     val sourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCNames"),
+      identifierType = IdentifierType("lc-names"),
       ontologyType = "Place",
       value = "lcsh/axt"
     )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
@@ -17,7 +17,7 @@ class DisplayGenreV2SerialisationTest
       canonicalId = "sqwyavpj",
       identifiers = List(
         SourceIdentifier(
-          identifierType = IdentifierType("LCNames"),
+          identifierType = IdentifierType("lc-names"),
           value = "lcsh/sqw",
           ontologyType = "Period"
         )),

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2Test.scala
@@ -19,7 +19,7 @@ class DisplayItemV2Test extends FunSpec with Matchers {
   }
 
   val identifier: SourceIdentifier = SourceIdentifier(
-    identifierType = IdentifierType("MiroImageNumber"),
+    identifierType = IdentifierType("miro-image-number"),
     ontologyType = "Item",
     value = "value"
   )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
@@ -17,7 +17,7 @@ class DisplaySubjectV2SerialisationTest
       canonicalId = "p4xe8u22",
       identifiers = List(
         SourceIdentifier(
-          identifierType = IdentifierType("LCNames"),
+          identifierType = IdentifierType("lc-names"),
           value = "lcsh/p4x",
           ontologyType = "Place"
         )),

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -233,7 +233,7 @@ class DisplayWorkV2SerialisationTest
 
   it("includes a list of identifiers on DisplayWorkV2") {
     val srcIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCNames"),
+      identifierType = IdentifierType("lc-names"),
       ontologyType = "Work",
       value = "Test1234"
     )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
@@ -47,7 +47,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
   }
 
   val sourceIdentifier = SourceIdentifier(
-    identifierType = IdentifierType("SierraSystemNumber"),
+    identifierType = IdentifierType("sierra-system-number"),
     ontologyType = "Work",
     value = "b1234567"
   )
@@ -253,7 +253,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
             canonicalId = "vs7jd5dx",
             identifiers = List(
               SourceIdentifier(
-                identifierType = IdentifierType("LCNames"),
+                identifierType = IdentifierType("lc-names"),
                 ontologyType = "Person",
                 value = "v1"
               )
@@ -284,7 +284,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
             List(
               DisplayIdentifierV2(
                 SourceIdentifier(
-                  identifierType = IdentifierType("LCNames"),
+                  identifierType = IdentifierType("lc-names"),
                   ontologyType = "Person",
                   value = "v1"
                 )
@@ -306,49 +306,49 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
 
   describe("correctly uses the WorksIncludes.identifiers include") {
     val publisherSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCNames"),
+      identifierType = IdentifierType("lc-names"),
       value = "lcnames/boo",
       ontologyType = "Agent"
     )
 
     val contributorAgentSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCNames"),
+      identifierType = IdentifierType("lc-names"),
       value = "lcnames/007",
       ontologyType = "Agent"
     )
 
     val contributorPersonSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCNames"),
+      identifierType = IdentifierType("lc-names"),
       value = "lcnames/bla",
       ontologyType = "Agent"
     )
 
     val contributorOrganisationSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCNames"),
+      identifierType = IdentifierType("lc-names"),
       value = "lcnames/bus",
       ontologyType = "Agent"
     )
 
     val itemSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("MiroImageNumber"),
+      identifierType = IdentifierType("miro-image-number"),
       value = "miro/b0001",
       ontologyType = "Item"
     )
 
     val conceptSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCSH"),
+      identifierType = IdentifierType("lcsh"),
       value = "lcsh/bonds",
       ontologyType = "Concept"
     )
 
     val periodSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCSH"),
+      identifierType = IdentifierType("lcsh"),
       value = "lcsh/before",
       ontologyType = "Concept"
     )
 
     val placeSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("LCSH"),
+      identifierType = IdentifierType("lcsh"),
       value = "lcsh/bul",
       ontologyType = "Concept"
     )

--- a/sbt_common/internal_model/src/main/resources/identifier-schemes.csv
+++ b/sbt_common/internal_model/src/main/resources/identifier-schemes.csv
@@ -1,16 +1,16 @@
-MiroImageNumber,miro-image-number,Miro image number
-MiroLibraryReference,miro-library-reference,Miro library reference
-WellcomeLibraryVideodiskNumber,wellcome-library-videodisk-number,Wellcome library videodisk number
-SierraSystemNumber,sierra-system-number,Sierra system number
-SierraIdentifier,sierra-identifier,Sierra identifier
-CALMRefNo,calm-ref-no,CALM ref no
-CALMAltRefNo,calm-altref-no,CALM alter no
-LCGMGPC,lc-gmgpc,Library of Congress Thesaurus for Graphic Materials
-LCSH,lcsh,Library of Congress Subject Headings
-LCNames,lc-names,Library of Congress Name authority records
-MESHId,mesh,MESH identifier
-CALMRecordId,calm-record-id,CALM record identifier
-PreservicaGUID,preservica-guid,Perservica GUID
-CALMAuthorityCode,calm-authority-code,CALM authority code
-ISBN,isbn,ISBN
-ISSN,issn,ISSN
+miro-image-number,Miro image number
+miro-library-reference,Miro library reference
+wellcome-library-videodisk-number,Wellcome library videodisk number
+sierra-system-number,Sierra system number
+sierra-identifier,Sierra identifier
+calm-ref-no,CALM ref no
+calm-altref-no,CALM alter no
+lc-gmgpc,Library of Congress Thesaurus for Graphic Materials
+lcsh,Library of Congress Subject Headings
+lc-names,Library of Congress Name authority records
+mesh,MESH identifier
+calm-record-id,CALM record identifier
+preservica-guid,Perservica GUID
+calm-authority-code,CALM authority code
+isbn,ISBN
+issn,ISSN

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdentifierType.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdentifierType.scala
@@ -19,21 +19,21 @@ case object IdentifierType {
   private val csvRows = source.mkString
     .split("\n")
 
-  // identifier-schemes.csv is a list of 3-tuples, e.g.:
+  // identifier-schemes.csv is a list of 2-tuples, e.g.:
   //
   //
-  //    MiroImageNumber,miro-image-number,Miro image number
-  //    WellcomeLibraryVideodiskNumber,wellcome-library-videodisk-number,Wellcome library videodisk number
-  //    SierraSystemNumber,sierra-system-number,Sierra system number
+  //    miro-image-number,Miro image number
+  //    wellcome-library-videodisk-number,Wellcome library videodisk number
+  //    sierra-system-number,Sierra system number
   //
   private val identifierTypeMap: Map[String, IdentifierType] = csvRows
     .map { row =>
       val columns = row.split(",").map(_.trim)
-      assert(columns.length == 3)
+      assert(columns.length == 2)
       Map(
         columns(0) -> IdentifierType(
-          id = columns(1),
-          label = columns(2)
+          id = columns(0),
+          label = columns(1)
         ))
     }
     .fold(Map()) { (x, y) =>

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedItemTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedItemTest.scala
@@ -12,8 +12,8 @@ class IdentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
       |  "canonicalId": "canonicalId",
       |  "sourceIdentifier": {
       |      "identifierType": {
-      |        "id": "${IdentifierType("MiroImageNumber").id}",
-      |        "label": "${IdentifierType("MiroImageNumber").label}",
+      |        "id": "${IdentifierType("miro-image-number").id}",
+      |        "label": "${IdentifierType("miro-image-number").label}",
       |        "ontologyType": "IdentifierType"
       |      },
       |      "ontologyType": "Item",
@@ -22,8 +22,8 @@ class IdentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
       |  "identifiers": [
       |    {
       |      "identifierType": {
-      |        "id": "${IdentifierType("MiroImageNumber").id}",
-      |        "label": "${IdentifierType("MiroImageNumber").label}",
+      |        "id": "${IdentifierType("miro-image-number").id}",
+      |        "label": "${IdentifierType("miro-image-number").label}",
       |        "ontologyType": "IdentifierType"
       |      },
       |      "ontologyType": "Item",
@@ -56,7 +56,7 @@ class IdentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
   )
 
   val identifier = SourceIdentifier(
-    identifierType = IdentifierType("MiroImageNumber"),
+    identifierType = IdentifierType("miro-image-number"),
     ontologyType = "Item",
     value = "value"
   )

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
@@ -48,8 +48,8 @@ class IdentifiedWorkTest
       |  "title": "title",
       |  "sourceIdentifier": {
       |      "identifierType": {
-      |        "id": "${IdentifierType("MiroImageNumber").id}",
-      |        "label": "${IdentifierType("MiroImageNumber").label}",
+      |        "id": "${IdentifierType("miro-image-number").id}",
+      |        "label": "${IdentifierType("miro-image-number").label}",
       |        "ontologyType": "IdentifierType"
       |      },
       |    "ontologyType": "Work",
@@ -59,8 +59,8 @@ class IdentifiedWorkTest
       |  "identifiers": [
       |    {
       |      "identifierType": {
-      |        "id": "${IdentifierType("MiroImageNumber").id}",
-      |        "label": "${IdentifierType("MiroImageNumber").label}",
+      |        "id": "${IdentifierType("miro-image-number").id}",
+      |        "label": "${IdentifierType("miro-image-number").label}",
       |        "ontologyType": "IdentifierType"
       |      },
       |      "ontologyType": "Work",
@@ -180,8 +180,8 @@ class IdentifiedWorkTest
       |      "canonicalId": "canonicalId",
       |      "sourceIdentifier": {
       |        "identifierType": {
-      |          "id": "${IdentifierType("MiroImageNumber").id}",
-      |          "label": "${IdentifierType("MiroImageNumber").label}",
+      |          "id": "${IdentifierType("miro-image-number").id}",
+      |          "label": "${IdentifierType("miro-image-number").label}",
       |          "ontologyType": "IdentifierType"
       |        },
       |        "ontologyType": "Item",
@@ -190,8 +190,8 @@ class IdentifiedWorkTest
       |      "identifiers": [
       |        {
       |          "identifierType": {
-      |            "id": "${IdentifierType("MiroImageNumber").id}",
-      |            "label": "${IdentifierType("MiroImageNumber").label}",
+      |            "id": "${IdentifierType("miro-image-number").id}",
+      |            "label": "${IdentifierType("miro-image-number").label}",
       |            "ontologyType": "IdentifierType"
       |          },
       |          "ontologyType": "Item",
@@ -246,13 +246,13 @@ class IdentifiedWorkTest
   )
 
   val workIdentifier = SourceIdentifier(
-    identifierType = IdentifierType("MiroImageNumber"),
+    identifierType = IdentifierType("miro-image-number"),
     ontologyType = "Work",
     value = "value"
   )
 
   val itemIdentifier = SourceIdentifier(
-    identifierType = IdentifierType("MiroImageNumber"),
+    identifierType = IdentifierType("miro-image-number"),
     ontologyType = "Item",
     value = "value"
   )

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifierTypeTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifierTypeTest.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.exceptions.GracefulFailureException
 
 class IdentifierTypeTest extends FunSpec with Matchers {
   it("looks up an identifier type in the CSV") {
-    IdentifierType("MiroImageNumber") shouldBe IdentifierType(
+    IdentifierType("miro-image-number") shouldBe IdentifierType(
       id = "miro-image-number",
       label = "Miro image number"
     )

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedItemTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedItemTest.scala
@@ -12,8 +12,8 @@ class UnidentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
       |{
       |  "sourceIdentifier": {
       |      "identifierType": {
-      |        "id": "${IdentifierType("MiroImageNumber").id}",
-      |        "label": "${IdentifierType("MiroImageNumber").label}",
+      |        "id": "${IdentifierType("miro-image-number").id}",
+      |        "label": "${IdentifierType("miro-image-number").label}",
       |        "ontologyType": "IdentifierType"
       |      },
       |      "ontologyType": "Item",
@@ -22,8 +22,8 @@ class UnidentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
       |  "identifiers": [
       |    {
       |      "identifierType": {
-      |        "id": "${IdentifierType("MiroImageNumber").id}",
-      |        "label": "${IdentifierType("MiroImageNumber").label}",
+      |        "id": "${IdentifierType("miro-image-number").id}",
+      |        "label": "${IdentifierType("miro-image-number").label}",
       |        "ontologyType": "IdentifierType"
       |      },
       |      "ontologyType": "Item",
@@ -56,7 +56,7 @@ class UnidentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
   )
 
   val identifier = SourceIdentifier(
-    identifierType = IdentifierType("MiroImageNumber"),
+    identifierType = IdentifierType("miro-image-number"),
     ontologyType = "Item",
     value = "value"
   )

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedWorkTest.scala
@@ -47,8 +47,8 @@ class UnidentifiedWorkTest
       |  "title": "title",
       |  "sourceIdentifier": {
       |      "identifierType": {
-      |        "id": "${IdentifierType("MiroImageNumber").id}",
-      |        "label": "${IdentifierType("MiroImageNumber").label}",
+      |        "id": "${IdentifierType("miro-image-number").id}",
+      |        "label": "${IdentifierType("miro-image-number").label}",
       |        "ontologyType": "IdentifierType"
       |      },
       |    "ontologyType": "Work",
@@ -58,8 +58,8 @@ class UnidentifiedWorkTest
       |  "identifiers": [
       |    {
       |      "identifierType": {
-      |        "id": "${IdentifierType("MiroImageNumber").id}",
-      |        "label": "${IdentifierType("MiroImageNumber").label}",
+      |        "id": "${IdentifierType("miro-image-number").id}",
+      |        "label": "${IdentifierType("miro-image-number").label}",
       |        "ontologyType": "IdentifierType"
       |      },
       |      "ontologyType": "Work",
@@ -177,8 +177,8 @@ class UnidentifiedWorkTest
       |    {
       |      "sourceIdentifier": {
       |        "identifierType": {
-      |          "id": "${IdentifierType("MiroImageNumber").id}",
-      |          "label": "${IdentifierType("MiroImageNumber").label}",
+      |          "id": "${IdentifierType("miro-image-number").id}",
+      |          "label": "${IdentifierType("miro-image-number").label}",
       |          "ontologyType": "IdentifierType"
       |        },
       |        "ontologyType": "Item",
@@ -187,8 +187,8 @@ class UnidentifiedWorkTest
       |      "identifiers": [
       |        {
       |          "identifierType": {
-      |            "id": "${IdentifierType("MiroImageNumber").id}",
-      |            "label": "${IdentifierType("MiroImageNumber").label}",
+      |            "id": "${IdentifierType("miro-image-number").id}",
+      |            "label": "${IdentifierType("miro-image-number").label}",
       |            "ontologyType": "IdentifierType"
       |          },
       |          "ontologyType": "Item",
@@ -245,13 +245,13 @@ class UnidentifiedWorkTest
   )
 
   val workIdentifier = SourceIdentifier(
-    identifierType = IdentifierType("MiroImageNumber"),
+    identifierType = IdentifierType("miro-image-number"),
     ontologyType = "Work",
     value = "value"
   )
 
   val itemIdentifier = SourceIdentifier(
-    identifierType = IdentifierType("MiroImageNumber"),
+    identifierType = IdentifierType("miro-image-number"),
     ontologyType = "Item",
     value = "value"
   )

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -30,7 +30,7 @@ trait WorksUtil {
   )
 
   val sourceIdentifier = SourceIdentifier(
-    identifierType = IdentifierType("MiroImageNumber"),
+    identifierType = IdentifierType("miro-image-number"),
     "Work",
     "sourceIdentifierFromWorksUtil"
   )
@@ -98,7 +98,7 @@ trait WorksUtil {
       version = 1,
       identifiers = List(
         SourceIdentifier(
-          identifierType = IdentifierType("MiroImageNumber"),
+          identifierType = IdentifierType("miro-image-number"),
           "Work",
           "5678")
       ),
@@ -170,7 +170,7 @@ trait WorksUtil {
 
   def defaultItemSourceIdentifier = {
     SourceIdentifier(
-      identifierType = IdentifierType("MiroImageNumber"),
+      identifierType = IdentifierType("miro-image-number"),
       "Item",
       "M0000001")
   }


### PR DESCRIPTION
It’s not obvious to me why we have the first column in identifiers-schemes.csv – we care more about the immutability of the snake case ID, as that’s what’s used to mint platform IDs.

This patch presents what happens if we remove that first column, and key on the immutable IDs.

Reviewers:

- [ ] @wellcometrust/platform-devs for the code changes
- [ ] @silveroliver to tell me whether it’s okay to remove this column