### PR TITLE
Implement the new model for IdentifierType in the display classes

### DIFF
--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
@@ -6,7 +6,9 @@ import org.apache.commons.io.IOUtils
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.models.v1.DisplayV1SerialisationTestBase
 
-class ApiContextTest extends ApiWorksTestBase with DisplayV1SerialisationTestBase {
+class ApiContextTest
+    extends ApiWorksTestBase
+    with DisplayV1SerialisationTestBase {
 
   it("returns a context for all versions") {
     ApiVersions.values.toList.foreach { version: ApiVersions.Value =>

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
@@ -4,8 +4,9 @@ import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.apache.commons.io.IOUtils
 import uk.ac.wellcome.display.models.ApiVersions
+import uk.ac.wellcome.display.models.v1.DisplayV1SerialisationTestBase
 
-class ApiContextTest extends ApiWorksTestBase {
+class ApiContextTest extends ApiWorksTestBase with DisplayV1SerialisationTestBase {
 
   it("returns a context for all versions") {
     ApiVersions.values.toList.foreach { version: ApiVersions.Value =>

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
@@ -5,7 +5,9 @@ import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.models.v1.DisplayV1SerialisationTestBase
 
-class ApiErrorsTest extends ApiWorksTestBase with DisplayV1SerialisationTestBase {
+class ApiErrorsTest
+    extends ApiWorksTestBase
+    with DisplayV1SerialisationTestBase {
 
   it(
     "returns a BadRequest error when malformed query parameters are presented") {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
@@ -3,8 +3,9 @@ package uk.ac.wellcome.platform.api.works
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.display.models.ApiVersions
+import uk.ac.wellcome.display.models.v1.DisplayV1SerialisationTestBase
 
-class ApiErrorsTest extends ApiWorksTestBase {
+class ApiErrorsTest extends ApiWorksTestBase with DisplayV1SerialisationTestBase {
 
   it(
     "returns a BadRequest error when malformed query parameters are presented") {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -9,7 +9,6 @@ import uk.ac.wellcome.models.work.internal.{
   License_CCBY,
   SourceIdentifier
 }
-import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
 class ApiV1WorksTest extends ApiV1WorksTestBase {
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.models.work.internal.{
 }
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
-class ApiV1WorksTest extends ApiWorksTestBase {
+class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("returns a list of works") {
     withApiFixtures(ApiVersions.v1) {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestBase.scala
@@ -1,0 +1,9 @@
+package uk.ac.wellcome.platform.api.works.v1
+
+import uk.ac.wellcome.display.models.v1.DisplayV1SerialisationTestBase
+import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
+
+trait ApiV1WorksTestBase
+  extends ApiWorksTestBase
+  with DisplayV1SerialisationTestBase
+

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestBase.scala
@@ -4,6 +4,5 @@ import uk.ac.wellcome.display.models.v1.DisplayV1SerialisationTestBase
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
 trait ApiV1WorksTestBase
-  extends ApiWorksTestBase
-  with DisplayV1SerialisationTestBase
-
+    extends ApiWorksTestBase
+    with DisplayV1SerialisationTestBase

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
@@ -4,7 +4,6 @@ import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
-import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
 class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
-class ApiV1WorksTestInvisible extends ApiWorksTestBase {
+class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
 
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
     withApiFixtures(apiVersion = ApiVersions.v1) {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -9,7 +9,6 @@ import uk.ac.wellcome.models.work.internal.{
   License_CCBY,
   SourceIdentifier
 }
-import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
 class ApiV2WorksTest extends ApiV2WorksTestBase {
   def withV2Api[R] = withApiFixtures[R](ApiVersions.v2)(_)

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.models.work.internal.{
 }
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
-class ApiV2WorksTest extends ApiWorksTestBase {
+class ApiV2WorksTest extends ApiV2WorksTestBase {
   def withV2Api[R] = withApiFixtures[R](ApiVersions.v2)(_)
 
   it("returns a list of works") {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestBase.scala
@@ -1,0 +1,8 @@
+package uk.ac.wellcome.platform.api.works.v2
+
+import uk.ac.wellcome.display.models.v2.DisplayV2SerialisationTestBase
+import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
+
+trait ApiV2WorksTestBase
+  extends ApiWorksTestBase
+    with DisplayV2SerialisationTestBase

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestBase.scala
@@ -4,5 +4,5 @@ import uk.ac.wellcome.display.models.v2.DisplayV2SerialisationTestBase
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
 trait ApiV2WorksTestBase
-  extends ApiWorksTestBase
+    extends ApiWorksTestBase
     with DisplayV2SerialisationTestBase

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
-class ApiV2WorksTestInvisible extends ApiWorksTestBase {
+class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
   def withV2Api[R] = withApiFixtures[R](ApiVersions.v2)(_)
 
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
@@ -4,7 +4,6 @@ import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
-import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
 class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
   def withV2Api[R] = withApiFixtures[R](ApiVersions.v2)(_)

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayIdentifierType.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayIdentifierType.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.display.models.v2
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.models.work.internal.IdentifierType
+
+@ApiModel(
+  value = "IdentifierType"
+)
+case class DisplayIdentifierType(
+  @ApiModelProperty id: String,
+  @ApiModelProperty label: String
+) {
+  @JsonProperty("type") val ontologyType: String = "IdentifierType"
+}
+
+object DisplayIdentifierType {
+  def apply(identifierType: IdentifierType): DisplayIdentifierType =
+    DisplayIdentifierType(
+      id = identifierType.id,
+      label = identifierType.label
+    )
+}

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayIdentifierV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayIdentifierV2.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.models.work.internal.SourceIdentifier
 )
 case class DisplayIdentifierV2(
   @ApiModelProperty(value =
-    "Relates a Identifier to a particular authoritative source identifier scheme: for example, if the identifier is MS.49 this property might indicate that this identifier has its origins in the Wellcome Library's CALM archive management system.") identifierScheme: String,
+    "Relates a Identifier to a particular authoritative source identifier scheme: for example, if the identifier is MS.49 this property might indicate that this identifier has its origins in the Wellcome Library's CALM archive management system.") identifierType: DisplayIdentifierType,
   @ApiModelProperty(value = "The value of the thing. e.g. an identifier") value: String) {
   @ApiModelProperty(readOnly = true, value = "A type of thing")
   @JsonProperty("type") val ontologyType: String = "Identifier"
@@ -20,6 +20,6 @@ case class DisplayIdentifierV2(
 object DisplayIdentifierV2 {
   def apply(sourceIdentifier: SourceIdentifier): DisplayIdentifierV2 =
     DisplayIdentifierV2(
-      identifierScheme = sourceIdentifier.identifierType.id,
+      identifierType = DisplayIdentifierType(identifierType = sourceIdentifier.identifierType),
       value = sourceIdentifier.value)
 }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayIdentifierV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayIdentifierV2.scala
@@ -20,6 +20,7 @@ case class DisplayIdentifierV2(
 object DisplayIdentifierV2 {
   def apply(sourceIdentifier: SourceIdentifier): DisplayIdentifierV2 =
     DisplayIdentifierV2(
-      identifierType = DisplayIdentifierType(identifierType = sourceIdentifier.identifierType),
+      identifierType = DisplayIdentifierType(
+        identifierType = sourceIdentifier.identifierType),
       value = sourceIdentifier.value)
 }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -58,12 +58,7 @@ trait DisplaySerialisationTestBase { this: Suite =>
       "url": "${license.url}"
     }"""
 
-  def identifier(identifier: SourceIdentifier) =
-    s"""{
-      "type": "Identifier",
-      "identifierScheme": "${identifier.identifierType.id}",
-      "value": "${identifier.value}"
-    }"""
+  def identifier(identifier: SourceIdentifier): String
 
   // Some of our fields can be optionally identified (e.g. creators).
   //

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
@@ -1,17 +1,14 @@
 package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.{
-  DisplaySerialisationTestBase,
-  WorksIncludes
-}
+import uk.ac.wellcome.display.models.WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayCreatorsV1SerialisationTest
     extends FunSpec
-    with DisplaySerialisationTestBase
+    with DisplayV1SerialisationTestBase
     with JsonMapperTestUtil
     with WorksUtil {
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.display.models.v1
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
-import uk.ac.wellcome.models.work.internal.{IdentifiedItem, IdentifiedWork, PhysicalLocation}
+import uk.ac.wellcome.models.work.internal.{
+  IdentifiedItem,
+  IdentifiedWork,
+  PhysicalLocation
+}
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayLocationsV1SerialisationTest

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
@@ -1,21 +1,14 @@
 package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.{
-  DisplaySerialisationTestBase,
-  WorksIncludes
-}
+import uk.ac.wellcome.display.models.WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
-import uk.ac.wellcome.models.work.internal.{
-  IdentifiedItem,
-  IdentifiedWork,
-  PhysicalLocation
-}
+import uk.ac.wellcome.models.work.internal.{IdentifiedItem, IdentifiedWork, PhysicalLocation}
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayLocationsV1SerialisationTest
     extends FunSpec
-    with DisplaySerialisationTestBase
+    with DisplayV1SerialisationTestBase
     with JsonMapperTestUtil
     with WorksUtil {
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPlaceOfPublicationV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPlaceOfPublicationV1SerialisationTest.scala
@@ -1,14 +1,13 @@
 package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal.{IdentifiedWork, Place}
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayPlaceOfPublicationV1SerialisationTest
     extends FunSpec
-    with DisplaySerialisationTestBase
+    with DisplayV1SerialisationTestBase
     with JsonMapperTestUtil
     with WorksUtil {
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPublicationDateV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPublicationDateV1SerialisationTest.scala
@@ -1,14 +1,13 @@
 package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal.{IdentifiedWork, Period}
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayPublicationDateV1SerialisationTest
     extends FunSpec
-    with DisplaySerialisationTestBase
+    with DisplayV1SerialisationTestBase
     with JsonMapperTestUtil
     with WorksUtil {
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPublishersV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayPublishersV1SerialisationTest.scala
@@ -1,14 +1,13 @@
 package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayPublishersV1SerialisationTest
     extends FunSpec
-    with DisplaySerialisationTestBase
+    with DisplayV1SerialisationTestBase
     with JsonMapperTestUtil
     with WorksUtil {
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayV1SerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayV1SerialisationTestBase.scala
@@ -4,7 +4,8 @@ import org.scalatest.Suite
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.models.work.internal.SourceIdentifier
 
-trait DisplayV1SerialisationTestBase extends DisplaySerialisationTestBase { this: Suite =>
+trait DisplayV1SerialisationTestBase extends DisplaySerialisationTestBase {
+  this: Suite =>
   def identifier(identifier: SourceIdentifier) =
     s"""{
       "type": "Identifier",

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayV1SerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayV1SerialisationTestBase.scala
@@ -1,0 +1,14 @@
+package uk.ac.wellcome.display.models.v1
+
+import org.scalatest.Suite
+import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
+import uk.ac.wellcome.models.work.internal.SourceIdentifier
+
+trait DisplayV1SerialisationTestBase extends DisplaySerialisationTestBase { this: Suite =>
+  def identifier(identifier: SourceIdentifier) =
+    s"""{
+      "type": "Identifier",
+      "identifierScheme": "${identifier.identifierType.id}",
+      "value": "${identifier.value}"
+    }"""
+}

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -1,17 +1,14 @@
 package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.{
-  DisplaySerialisationTestBase,
-  WorksIncludes
-}
+import uk.ac.wellcome.display.models.WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayWorkV1SerialisationTest
     extends FunSpec
-    with DisplaySerialisationTestBase
+    with DisplayV1SerialisationTestBase
     with JsonMapperTestUtil
     with WorksUtil {
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
@@ -1,13 +1,12 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
 
 class DisplayAbstractConceptSerialisationTest
     extends FunSpec
-    with DisplaySerialisationTestBase
+    with DisplayV2SerialisationTestBase
     with JsonMapperTestUtil {
 
   it("serialises an unidentified DisplayConcept") {

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
@@ -1,13 +1,12 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
 
 class DisplayGenreV2SerialisationTest
     extends FunSpec
-    with DisplaySerialisationTestBase
+    with DisplayV2SerialisationTestBase
     with JsonMapperTestUtil {
 
   it("serialises a DisplayGenre constructed from a Genre correctly") {

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationsV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationsV2SerialisationTest.scala
@@ -1,10 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.{
-  DisplaySerialisationTestBase,
-  WorksIncludes
-}
+import uk.ac.wellcome.display.models.WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal.{
   IdentifiedItem,
@@ -15,7 +12,7 @@ import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayLocationsV2SerialisationTest
     extends FunSpec
-    with DisplaySerialisationTestBase
+    with DisplayV2SerialisationTestBase
     with JsonMapperTestUtil
     with WorksUtil {
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPlaceOfPublicationV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPlaceOfPublicationV2SerialisationTest.scala
@@ -1,14 +1,13 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal.{IdentifiedWork, Place}
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayPlaceOfPublicationV2SerialisationTest
     extends FunSpec
-    with DisplaySerialisationTestBase
+    with DisplayV2SerialisationTestBase
     with JsonMapperTestUtil
     with WorksUtil {
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPublicationDateV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPublicationDateV2SerialisationTest.scala
@@ -1,14 +1,13 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal.{IdentifiedWork, Period}
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayPublicationDateV2SerialisationTest
     extends FunSpec
-    with DisplaySerialisationTestBase
+    with DisplayV2SerialisationTestBase
     with JsonMapperTestUtil
     with WorksUtil {
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPublishersV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayPublishersV2SerialisationTest.scala
@@ -1,14 +1,13 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayPublishersV2SerialisationTest
     extends FunSpec
-    with DisplaySerialisationTestBase
+    with DisplayV2SerialisationTestBase
     with JsonMapperTestUtil
     with WorksUtil {
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
@@ -1,13 +1,12 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
 
 class DisplaySubjectV2SerialisationTest
     extends FunSpec
-    with DisplaySerialisationTestBase
+    with DisplayV2SerialisationTestBase
     with JsonMapperTestUtil {
 
   it("serialises a DisplaySubject constructed from a Subject correctly") {

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayV2SerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayV2SerialisationTestBase.scala
@@ -4,7 +4,8 @@ import org.scalatest.Suite
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.models.work.internal.SourceIdentifier
 
-trait DisplayV2SerialisationTestBase extends DisplaySerialisationTestBase { this: Suite =>
+trait DisplayV2SerialisationTestBase extends DisplaySerialisationTestBase {
+  this: Suite =>
   def identifier(identifier: SourceIdentifier) =
     s"""{
       "type": "Identifier",

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayV2SerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayV2SerialisationTestBase.scala
@@ -1,0 +1,14 @@
+package uk.ac.wellcome.display.models.v2
+
+import org.scalatest.Suite
+import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
+import uk.ac.wellcome.models.work.internal.SourceIdentifier
+
+trait DisplayV2SerialisationTestBase extends DisplaySerialisationTestBase { this: Suite =>
+  def identifier(identifier: SourceIdentifier) =
+    s"""{
+      "type": "Identifier",
+      "identifierScheme": "${identifier.identifierType.id}",
+      "value": "${identifier.value}"
+    }"""
+}

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayV2SerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayV2SerialisationTestBase.scala
@@ -8,7 +8,11 @@ trait DisplayV2SerialisationTestBase extends DisplaySerialisationTestBase { this
   def identifier(identifier: SourceIdentifier) =
     s"""{
       "type": "Identifier",
-      "identifierScheme": "${identifier.identifierType.id}",
+      "identifierType": {
+        "id": "${identifier.identifierType.id}",
+        "label": "${identifier.identifierType.label}",
+        "type": "${identifier.identifierType.ontologyType}"
+      },
       "value": "${identifier.value}"
     }"""
 }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -1,17 +1,14 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.{
-  DisplaySerialisationTestBase,
-  WorksIncludes
-}
+import uk.ac.wellcome.display.models.WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 
 class DisplayWorkV2SerialisationTest
     extends FunSpec
-    with DisplaySerialisationTestBase
+    with DisplayV2SerialisationTestBase
     with JsonMapperTestUtil
     with WorksUtil {
 


### PR DESCRIPTION
### What is this PR trying to achieve?

As described in #2030. This completes the Scala changes – in the V2 API, identifiers are now serialised with an IdentifierType with an ID and a label.

### Who is this change for?

📦 🏷 