### PR TITLE
Fork more of the display models

### DIFF
--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1.scala
@@ -23,7 +23,6 @@ case class DisplayItemV1(
       "Relates the item to a unique system-generated identifier that governs interaction between systems and is regarded as canonical within the Wellcome data ecosystem."
   ) identifiers: Option[List[DisplayIdentifierV1]] = None,
   @ApiModelProperty(
-    dataType = "List[uk.ac.wellcome.display.models.DisplayLocation]",
     value = "List of locations that provide access to the item"
   ) locations: List[DisplayLocationV1] = List()
 ) {

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.display.models.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.display.models.DisplayLocation
 import uk.ac.wellcome.models.work.internal.{
   IdentifiedItem,
   Location,
@@ -26,7 +25,7 @@ case class DisplayItemV1(
   @ApiModelProperty(
     dataType = "List[uk.ac.wellcome.display.models.DisplayLocation]",
     value = "List of locations that provide access to the item"
-  ) locations: List[DisplayLocation] = List()
+  ) locations: List[DisplayLocationV1] = List()
 ) {
   @ApiModelProperty(readOnly = true, value = "A type of thing")
   @JsonProperty("type") val ontologyType: String = "Item"
@@ -50,7 +49,7 @@ object DisplayItemV1 {
           } else None,
       locations = // Same as with identifiers
         Option[List[Location]](item.locations) match {
-          case Some(locations) => locations.map(DisplayLocation(_))
+          case Some(locations) => locations.map(DisplayLocationV1(_))
           case None => List()
         }
     )

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.display.models
+package uk.ac.wellcome.display.models.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
@@ -9,7 +9,7 @@ import uk.ac.wellcome.models.work.internal.License
   description =
     "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
 )
-case class DisplayLicense(
+case class DisplayLicenseV1(
   @ApiModelProperty(
     value =
       "A type of license under which the work in question is released to the public.",
@@ -26,8 +26,8 @@ case class DisplayLicense(
   @JsonProperty("type") val ontologyType: String = "License"
 }
 
-case object DisplayLicense {
-  def apply(license: License): DisplayLicense = DisplayLicense(
+case object DisplayLicenseV1 {
+  def apply(license: License): DisplayLicenseV1 = DisplayLicenseV1(
     licenseType = license.licenseType,
     label = license.label,
     url = license.url

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLocationV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLocationV1.scala
@@ -1,0 +1,72 @@
+package uk.ac.wellcome.display.models.v1
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.display.models.DisplayLicense
+import uk.ac.wellcome.models.work.internal.{DigitalLocation, Location, PhysicalLocation}
+
+@ApiModel(
+  value = "Location",
+  description = "A location that provides access to an item",
+  subTypes =
+    Array(classOf[DisplayDigitalLocationV1], classOf[DisplayPhysicalLocationV1])
+)
+sealed trait DisplayLocationV1
+
+object DisplayLocationV1 {
+  def apply(location: Location): DisplayLocationV1 = location match {
+    case l: DigitalLocation =>
+      DisplayDigitalLocationV1(
+        locationType = l.locationType,
+        url = l.url,
+        credit = l.credit,
+        license = DisplayLicense(l.license)
+      )
+    case l: PhysicalLocation =>
+      DisplayPhysicalLocationV1(locationType = l.locationType, label = l.label)
+  }
+}
+
+@ApiModel(
+  value = "DigitalLocation",
+  description = "A digital location that provides access to an item"
+)
+case class DisplayDigitalLocationV1(
+  @ApiModelProperty(
+    value = "The type of location that an item is accessible from.",
+    allowableValues = "thumbnail-image, iiif-image"
+  ) locationType: String,
+  @ApiModelProperty(
+    dataType = "String",
+    value = "The URL of the digital asset."
+  ) url: String,
+  @ApiModelProperty(
+    dataType = "String",
+    value = "Who to credit the image to"
+  ) credit: Option[String] = None,
+  @ApiModelProperty(
+    value =
+      "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
+  ) license: DisplayLicense
+) extends DisplayLocationV1 {
+  @ApiModelProperty(readOnly = true, value = "A type of thing")
+  @JsonProperty("type") val ontologyType: String = "DigitalLocation"
+}
+
+@ApiModel(
+  value = "PhysicalLocation",
+  description = "A physical location that provides access to an item"
+)
+case class DisplayPhysicalLocationV1(
+  @ApiModelProperty(
+    value = "The type of location that an item is accessible from.",
+    allowableValues = ""
+  ) locationType: String,
+  @ApiModelProperty(
+    dataType = "String",
+    value = "The title or other short name of the location."
+  ) label: String
+) extends DisplayLocationV1 {
+  @ApiModelProperty(readOnly = true, value = "A type of thing")
+  @JsonProperty("type") val ontologyType: String = "PhysicalLocation"
+}

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLocationV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLocationV1.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.display.models.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.display.models.DisplayLicense
 import uk.ac.wellcome.models.work.internal.{DigitalLocation, Location, PhysicalLocation}
 
 @ApiModel(
@@ -20,7 +19,7 @@ object DisplayLocationV1 {
         locationType = l.locationType,
         url = l.url,
         credit = l.credit,
-        license = DisplayLicense(l.license)
+        license = DisplayLicenseV1(l.license)
       )
     case l: PhysicalLocation =>
       DisplayPhysicalLocationV1(locationType = l.locationType, label = l.label)
@@ -47,7 +46,7 @@ case class DisplayDigitalLocationV1(
   @ApiModelProperty(
     value =
       "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
-  ) license: DisplayLicense
+  ) license: DisplayLicenseV1
 ) extends DisplayLocationV1 {
   @ApiModelProperty(readOnly = true, value = "A type of thing")
   @JsonProperty("type") val ontologyType: String = "DigitalLocation"

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLocationV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLocationV1.scala
@@ -2,13 +2,18 @@ package uk.ac.wellcome.display.models.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.work.internal.{DigitalLocation, Location, PhysicalLocation}
+import uk.ac.wellcome.models.work.internal.{
+  DigitalLocation,
+  Location,
+  PhysicalLocation
+}
 
 @ApiModel(
   value = "Location",
   description = "A location that provides access to an item",
-  subTypes =
-    Array(classOf[DisplayDigitalLocationV1], classOf[DisplayPhysicalLocationV1])
+  subTypes = Array(
+    classOf[DisplayDigitalLocationV1],
+    classOf[DisplayPhysicalLocationV1])
 )
 sealed trait DisplayLocationV1
 

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
@@ -68,7 +68,7 @@ case class DisplayWorkV1(
     dataType = "uk.ac.wellcome.display.models.DisplayLocation",
     value =
       "Relates any thing to the location of a representative thumbnail image"
-  ) thumbnail: Option[DisplayLocation] = None,
+  ) thumbnail: Option[DisplayLocationV1] = None,
   @ApiModelProperty(
     dataType = "List[uk.ac.wellcome.display.models.v1.DisplayItemV1]",
     value = "List of items related to this work."
@@ -137,7 +137,7 @@ case object DisplayWorkV1 {
       workType = work.workType.map { DisplayWorkType(_) },
       thumbnail =
         if (includes.thumbnail)
-          work.thumbnail.map { DisplayLocation(_) } else None,
+          work.thumbnail.map { DisplayLocationV1(_) } else None,
       items =
         if (includes.items)
           Some(work.items.map {

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
@@ -65,7 +65,7 @@ case class DisplayWorkV1(
     value = "Relates a work to the genre that describes the work's content."
   ) genres: List[DisplayConceptV1] = List(),
   @ApiModelProperty(
-    dataType = "uk.ac.wellcome.display.models.DisplayLocation",
+    dataType = "uk.ac.wellcome.display.models.DisplayLocationV1",
     value =
       "Relates any thing to the location of a representative thumbnail image"
   ) thumbnail: Option[DisplayLocationV1] = None,

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
@@ -65,7 +65,7 @@ case class DisplayWorkV1(
     value = "Relates a work to the genre that describes the work's content."
   ) genres: List[DisplayConceptV1] = List(),
   @ApiModelProperty(
-    dataType = "uk.ac.wellcome.display.models.DisplayLocationV1",
+    dataType = "uk.ac.wellcome.display.models.v1.DisplayLocationV1",
     value =
       "Relates any thing to the location of a representative thumbnail image"
   ) thumbnail: Option[DisplayLocationV1] = None,

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2.scala
@@ -23,7 +23,6 @@ case class DisplayItemV2(
       "Relates the item to a unique system-generated identifier that governs interaction between systems and is regarded as canonical within the Wellcome data ecosystem."
   ) identifiers: Option[List[DisplayIdentifierV2]] = None,
   @ApiModelProperty(
-    dataType = "List[uk.ac.wellcome.display.models.DisplayLocation]",
     value = "List of locations that provide access to the item"
   ) locations: List[DisplayLocationV2] = List()
 ) {

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.display.models.DisplayLocation
 import uk.ac.wellcome.models.work.internal.{
   IdentifiedItem,
   Location,
@@ -26,7 +25,7 @@ case class DisplayItemV2(
   @ApiModelProperty(
     dataType = "List[uk.ac.wellcome.display.models.DisplayLocation]",
     value = "List of locations that provide access to the item"
-  ) locations: List[DisplayLocation] = List()
+  ) locations: List[DisplayLocationV2] = List()
 ) {
   @ApiModelProperty(readOnly = true, value = "A type of thing")
   @JsonProperty("type") val ontologyType: String = "Item"
@@ -50,7 +49,7 @@ object DisplayItemV2 {
           } else None,
       locations = // Same as with identifiers
         Option[List[Location]](item.locations) match {
-          case Some(locations) => locations.map(DisplayLocation(_))
+          case Some(locations) => locations.map(DisplayLocationV2(_))
           case None => List()
         }
     )

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLicenseV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLicenseV2.scala
@@ -1,0 +1,35 @@
+package uk.ac.wellcome.display.models.v2
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.models.work.internal.License
+
+@ApiModel(
+  value = "License",
+  description =
+    "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
+)
+case class DisplayLicenseV2(
+  @ApiModelProperty(
+    value =
+      "A type of license under which the work in question is released to the public.",
+    allowableValues = "CC-BY, CC-BY-NC"
+  ) licenseType: String,
+  @ApiModelProperty(
+    value = "The title or other short name of a license"
+  ) label: String,
+  @ApiModelProperty(
+    value = "URL to the full text of a license"
+  ) url: String
+) {
+  @ApiModelProperty(readOnly = true, value = "A type of thing")
+  @JsonProperty("type") val ontologyType: String = "License"
+}
+
+case object DisplayLicenseV2 {
+  def apply(license: License): DisplayLicenseV2 = DisplayLicenseV2(
+    licenseType = license.licenseType,
+    label = license.label,
+    url = license.url
+  )
+}

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLocationV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLocationV2.scala
@@ -2,13 +2,18 @@ package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.work.internal.{DigitalLocation, Location, PhysicalLocation}
+import uk.ac.wellcome.models.work.internal.{
+  DigitalLocation,
+  Location,
+  PhysicalLocation
+}
 
 @ApiModel(
   value = "Location",
   description = "A location that provides access to an item",
-  subTypes =
-    Array(classOf[DisplayDigitalLocationV2], classOf[DisplayPhysicalLocationV2])
+  subTypes = Array(
+    classOf[DisplayDigitalLocationV2],
+    classOf[DisplayPhysicalLocationV2])
 )
 sealed trait DisplayLocationV2
 

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLocationV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLocationV2.scala
@@ -1,32 +1,29 @@
-package uk.ac.wellcome.display.models
+package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.work.internal.{
-  DigitalLocation,
-  Location,
-  PhysicalLocation
-}
+import uk.ac.wellcome.display.models.DisplayLicense
+import uk.ac.wellcome.models.work.internal.{DigitalLocation, Location, PhysicalLocation}
 
 @ApiModel(
   value = "Location",
   description = "A location that provides access to an item",
   subTypes =
-    Array(classOf[DisplayDigitalLocation], classOf[DisplayPhysicalLocation])
+    Array(classOf[DisplayDigitalLocationV2], classOf[DisplayPhysicalLocationV2])
 )
-sealed trait DisplayLocation
+sealed trait DisplayLocationV2
 
-object DisplayLocation {
-  def apply(location: Location): DisplayLocation = location match {
+object DisplayLocationV2 {
+  def apply(location: Location): DisplayLocationV2 = location match {
     case l: DigitalLocation =>
-      DisplayDigitalLocation(
+      DisplayDigitalLocationV2(
         locationType = l.locationType,
         url = l.url,
         credit = l.credit,
         license = DisplayLicense(l.license)
       )
     case l: PhysicalLocation =>
-      DisplayPhysicalLocation(locationType = l.locationType, label = l.label)
+      DisplayPhysicalLocationV2(locationType = l.locationType, label = l.label)
   }
 }
 
@@ -34,7 +31,7 @@ object DisplayLocation {
   value = "DigitalLocation",
   description = "A digital location that provides access to an item"
 )
-case class DisplayDigitalLocation(
+case class DisplayDigitalLocationV2(
   @ApiModelProperty(
     value = "The type of location that an item is accessible from.",
     allowableValues = "thumbnail-image, iiif-image"
@@ -51,7 +48,7 @@ case class DisplayDigitalLocation(
     value =
       "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
   ) license: DisplayLicense
-) extends DisplayLocation {
+) extends DisplayLocationV2 {
   @ApiModelProperty(readOnly = true, value = "A type of thing")
   @JsonProperty("type") val ontologyType: String = "DigitalLocation"
 }
@@ -60,7 +57,7 @@ case class DisplayDigitalLocation(
   value = "PhysicalLocation",
   description = "A physical location that provides access to an item"
 )
-case class DisplayPhysicalLocation(
+case class DisplayPhysicalLocationV2(
   @ApiModelProperty(
     value = "The type of location that an item is accessible from.",
     allowableValues = ""
@@ -69,7 +66,7 @@ case class DisplayPhysicalLocation(
     dataType = "String",
     value = "The title or other short name of the location."
   ) label: String
-) extends DisplayLocation {
+) extends DisplayLocationV2 {
   @ApiModelProperty(readOnly = true, value = "A type of thing")
   @JsonProperty("type") val ontologyType: String = "PhysicalLocation"
 }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLocationV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLocationV2.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.display.models.DisplayLicense
 import uk.ac.wellcome.models.work.internal.{DigitalLocation, Location, PhysicalLocation}
 
 @ApiModel(
@@ -20,7 +19,7 @@ object DisplayLocationV2 {
         locationType = l.locationType,
         url = l.url,
         credit = l.credit,
-        license = DisplayLicense(l.license)
+        license = DisplayLicenseV2(l.license)
       )
     case l: PhysicalLocation =>
       DisplayPhysicalLocationV2(locationType = l.locationType, label = l.label)
@@ -47,7 +46,7 @@ case class DisplayDigitalLocationV2(
   @ApiModelProperty(
     value =
       "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
-  ) license: DisplayLicense
+  ) license: DisplayLicenseV2
 ) extends DisplayLocationV2 {
   @ApiModelProperty(readOnly = true, value = "A type of thing")
   @JsonProperty("type") val ontologyType: String = "DigitalLocation"

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
@@ -61,7 +61,7 @@ case class DisplayWorkV2(
     value = "Relates a work to the genre that describes the work's content."
   ) genres: List[DisplayGenre] = List(),
   @ApiModelProperty(
-    dataType = "uk.ac.wellcome.display.models.DisplayLocation",
+    dataType = "uk.ac.wellcome.display.models.DisplayLocationV2",
     value =
       "Relates any thing to the location of a representative thumbnail image"
   ) thumbnail: Option[DisplayLocationV2] = None,

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
@@ -61,7 +61,7 @@ case class DisplayWorkV2(
     value = "Relates a work to the genre that describes the work's content."
   ) genres: List[DisplayGenre] = List(),
   @ApiModelProperty(
-    dataType = "uk.ac.wellcome.display.models.DisplayLocationV2",
+    dataType = "uk.ac.wellcome.display.models.v2.DisplayLocationV2",
     value =
       "Relates any thing to the location of a representative thumbnail image"
   ) thumbnail: Option[DisplayLocationV2] = None,

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
@@ -64,7 +64,7 @@ case class DisplayWorkV2(
     dataType = "uk.ac.wellcome.display.models.DisplayLocation",
     value =
       "Relates any thing to the location of a representative thumbnail image"
-  ) thumbnail: Option[DisplayLocation] = None,
+  ) thumbnail: Option[DisplayLocationV2] = None,
   @ApiModelProperty(
     dataType = "List[uk.ac.wellcome.display.models.v2.DisplayItemV2]",
     value = "List of items related to this work."
@@ -134,7 +134,7 @@ case object DisplayWorkV2 {
       workType = work.workType.map { DisplayWorkType(_) },
       thumbnail =
         if (includes.thumbnail)
-          work.thumbnail.map { DisplayLocation(_) } else None,
+          work.thumbnail.map { DisplayLocationV2(_) } else None,
       items =
         if (includes.items)
           Some(work.items.map {

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1Test.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.display.models.DisplayLocation
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.utils.JsonUtil._
 
@@ -38,7 +37,7 @@ class DisplayItemV1Test extends FunSpec with Matchers {
     )
 
     displayItemV1.id shouldBe item.canonicalId
-    displayItemV1.locations shouldBe List(DisplayLocation(location))
+    displayItemV1.locations shouldBe List(DisplayLocationV1(location))
     displayItemV1.identifiers shouldBe Some(
       List(DisplayIdentifierV1(identifier)))
     displayItemV1.ontologyType shouldBe "Item"

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1Test.scala
@@ -1,12 +1,12 @@
-package uk.ac.wellcome.display.models
+package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal.License_CCBY
 
-class DisplayLicenseTest extends FunSpec with Matchers {
+class DisplayLicenseV1Test extends FunSpec with Matchers {
 
-  it("should read a License as a DisplayLicense correctly") {
-    val displayLicense = DisplayLicense(License_CCBY)
+  it("should read a License as a DisplayLicenseV1 correctly") {
+    val displayLicense = DisplayLicenseV1(License_CCBY)
 
     displayLicense.licenseType shouldBe License_CCBY.licenseType
     displayLicense.label shouldBe License_CCBY.label

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationV1Test.scala
@@ -1,0 +1,64 @@
+package uk.ac.wellcome.display.models.v1
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.internal.{
+  DigitalLocation,
+  License_CCBY,
+  PhysicalLocation
+}
+
+class DisplayLocationV1Test extends FunSpec with Matchers {
+
+  describe("DisplayDigitalLocationV1") {
+    it("should read a DigitalLocation as a DisplayDigitalLocationV1 correctly") {
+      val thumbnailUrl = "https://iiif.example.org/V0000001/default.jpg"
+      val locationType = "thumbnail-image"
+
+      val internalLocation = DigitalLocation(
+        locationType = locationType,
+        url = thumbnailUrl,
+        license = License_CCBY
+      )
+      val displayLocation = DisplayLocationV1(internalLocation)
+
+      displayLocation shouldBe a[DisplayDigitalLocationV1]
+      val displayDigitalLocation =
+        displayLocation.asInstanceOf[DisplayDigitalLocationV1]
+      displayDigitalLocation.locationType shouldBe locationType
+      displayDigitalLocation.url shouldBe thumbnailUrl
+      displayDigitalLocation.license shouldBe DisplayLicenseV1(
+        internalLocation.license)
+      displayDigitalLocation.ontologyType shouldBe "DigitalLocation"
+    }
+
+    it("should read the credit field from a Location correctly") {
+      val location = DigitalLocation(
+        locationType = "thumbnail-image",
+        url = "",
+        credit = Some("Science Museum, Wellcome"),
+        license = License_CCBY
+      )
+      val displayLocation = DisplayLocationV1(location)
+
+      displayLocation shouldBe a[DisplayDigitalLocationV1]
+      val displayDigitalLocation =
+        displayLocation.asInstanceOf[DisplayDigitalLocationV1]
+      displayDigitalLocation.credit shouldBe location.credit
+    }
+  }
+
+  describe("DisplayPhysicalLocationV1") {
+    it("should create a DisplayPhysicalLocationV1 from a PhysicalLocation") {
+      val locationType = "sgmed"
+      val locationLabel = "The collection of cold cauldrons"
+      val physicalLocation =
+        PhysicalLocation(locationType = locationType, label = locationLabel)
+
+      val displayLocation = DisplayLocationV1(physicalLocation)
+
+      displayLocation shouldBe DisplayPhysicalLocationV1(
+        locationType,
+        locationLabel)
+    }
+  }
+}

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2Test.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.display.models.DisplayLocation
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.utils.JsonUtil._
 
@@ -38,7 +37,7 @@ class DisplayItemV2Test extends FunSpec with Matchers {
     )
 
     displayItemV2.id shouldBe item.canonicalId
-    displayItemV2.locations shouldBe List(DisplayLocation(location))
+    displayItemV2.locations shouldBe List(DisplayLocationV2(location))
     displayItemV2.identifiers shouldBe Some(
       List(DisplayIdentifierV2(identifier)))
     displayItemV2.ontologyType shouldBe "Item"

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLicenseV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLicenseV2Test.scala
@@ -1,0 +1,16 @@
+package uk.ac.wellcome.display.models.v2
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.internal.License_CCBY
+
+class DisplayLicenseV2Test extends FunSpec with Matchers {
+
+  it("should read a License as a DisplayLicenseV2 correctly") {
+    val displayLicense = DisplayLicenseV2(License_CCBY)
+
+    displayLicense.licenseType shouldBe License_CCBY.licenseType
+    displayLicense.label shouldBe License_CCBY.label
+    displayLicense.url shouldBe License_CCBY.url
+    displayLicense.ontologyType shouldBe "License"
+  }
+}

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationV2Test.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.display.models
+package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal.{
@@ -7,10 +7,10 @@ import uk.ac.wellcome.models.work.internal.{
   PhysicalLocation
 }
 
-class DisplayLocationTest extends FunSpec with Matchers {
+class DisplayLocationV2Test extends FunSpec with Matchers {
 
-  describe("DisplayDigitalLocation") {
-    it("should read a DigitalLocation as a DisplayDigitalLocation correctly") {
+  describe("DisplayDigitalLocationV2") {
+    it("should read a DigitalLocation as a DisplayDigitalLocationV2 correctly") {
       val thumbnailUrl = "https://iiif.example.org/V0000001/default.jpg"
       val locationType = "thumbnail-image"
 
@@ -19,14 +19,14 @@ class DisplayLocationTest extends FunSpec with Matchers {
         url = thumbnailUrl,
         license = License_CCBY
       )
-      val displayLocation = DisplayLocation(internalLocation)
+      val displayLocation = DisplayLocationV2(internalLocation)
 
-      displayLocation shouldBe a[DisplayDigitalLocation]
+      displayLocation shouldBe a[DisplayDigitalLocationV2]
       val displayDigitalLocation =
-        displayLocation.asInstanceOf[DisplayDigitalLocation]
+        displayLocation.asInstanceOf[DisplayDigitalLocationV2]
       displayDigitalLocation.locationType shouldBe locationType
       displayDigitalLocation.url shouldBe thumbnailUrl
-      displayDigitalLocation.license shouldBe DisplayLicense(
+      displayDigitalLocation.license shouldBe DisplayLicenseV2(
         internalLocation.license)
       displayDigitalLocation.ontologyType shouldBe "DigitalLocation"
     }
@@ -38,25 +38,25 @@ class DisplayLocationTest extends FunSpec with Matchers {
         credit = Some("Science Museum, Wellcome"),
         license = License_CCBY
       )
-      val displayLocation = DisplayLocation(location)
+      val displayLocation = DisplayLocationV2(location)
 
-      displayLocation shouldBe a[DisplayDigitalLocation]
+      displayLocation shouldBe a[DisplayDigitalLocationV2]
       val displayDigitalLocation =
-        displayLocation.asInstanceOf[DisplayDigitalLocation]
+        displayLocation.asInstanceOf[DisplayDigitalLocationV2]
       displayDigitalLocation.credit shouldBe location.credit
     }
   }
 
-  describe("DisplayPhysicalLocation") {
-    it("should create a DisplayPhysicalLocation from a PhysicalLocation") {
+  describe("DisplayPhysicalLocationV2") {
+    it("should create a DisplayPhysicalLocationV2 from a PhysicalLocation") {
       val locationType = "sgmed"
       val locationLabel = "The collection of cold cauldrons"
       val physicalLocation =
         PhysicalLocation(locationType = locationType, label = locationLabel)
 
-      val displayLocation = DisplayLocation(physicalLocation)
+      val displayLocation = DisplayLocationV2(physicalLocation)
 
-      displayLocation shouldBe DisplayPhysicalLocation(
+      displayLocation shouldBe DisplayPhysicalLocationV2(
         locationType,
         locationLabel)
     }


### PR DESCRIPTION
We’ll be changing the Location and License models for V2 (see #2137) so start by forking the models with no changes, so the next patch can just make the required edits to the V2 models.