### PR TITLE
Use a model for License which is consistent with IdentifierType

### DIFF
--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1.scala
@@ -28,6 +28,11 @@ case class DisplayLicenseV1(
 
 case object DisplayLicenseV1 {
   def apply(license: License): DisplayLicenseV1 = DisplayLicenseV1(
+    // The old model for License had an uppercase "licenseType" field,
+    // e.g. "CC-BY" or "PDM".
+    //
+    // The current model uses lowercase IDs.  To preserve the V1 API,
+    // we uppercase the IDs before presenting them.
     licenseType = license.id.toUpperCase,
     label = license.label,
     url = license.url

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1.scala
@@ -13,7 +13,7 @@ case class DisplayLicenseV1(
   @ApiModelProperty(
     value =
       "A type of license under which the work in question is released to the public.",
-    allowableValues = "CC-BY, CC-BY-NC"
+    allowableValues = "CC-BY, CC-BY-NC, CC-BY-NC-ND, CC-0, PDM"
   ) licenseType: String,
   @ApiModelProperty(
     value = "The title or other short name of a license"

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1.scala
@@ -28,7 +28,7 @@ case class DisplayLicenseV1(
 
 case object DisplayLicenseV1 {
   def apply(license: License): DisplayLicenseV1 = DisplayLicenseV1(
-    licenseType = license.id,
+    licenseType = license.id.toUpperCase,
     label = license.label,
     url = license.url
   )

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1.scala
@@ -28,7 +28,7 @@ case class DisplayLicenseV1(
 
 case object DisplayLicenseV1 {
   def apply(license: License): DisplayLicenseV1 = DisplayLicenseV1(
-    licenseType = license.licenseType,
+    licenseType = license.id,
     label = license.label,
     url = license.url
   )

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLicenseV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLicenseV2.scala
@@ -13,8 +13,8 @@ case class DisplayLicenseV2(
   @ApiModelProperty(
     value =
       "A type of license under which the work in question is released to the public.",
-    allowableValues = "CC-BY, CC-BY-NC"
-  ) licenseType: String,
+    allowableValues = "cc-by, cc-by-nc, cc-by-nc-nd, cc-0, pdm"
+  ) id: String,
   @ApiModelProperty(
     value = "The title or other short name of a license"
   ) label: String,
@@ -28,7 +28,7 @@ case class DisplayLicenseV2(
 
 case object DisplayLicenseV2 {
   def apply(license: License): DisplayLicenseV2 = DisplayLicenseV2(
-    licenseType = license.id,
+    id = license.id,
     label = license.label,
     url = license.url
   )

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLicenseV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLicenseV2.scala
@@ -28,7 +28,7 @@ case class DisplayLicenseV2(
 
 case object DisplayLicenseV2 {
   def apply(license: License): DisplayLicenseV2 = DisplayLicenseV2(
-    licenseType = license.licenseType,
+    licenseType = license.id,
     label = license.label,
     url = license.url
   )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -53,7 +53,7 @@ trait DisplaySerialisationTestBase { this: Suite =>
   def license(license: License) =
     s"""{
       "label": "${license.label}",
-      "licenseType": "${license.licenseType}",
+      "licenseType": "${license.id}",
       "type": "${license.ontologyType}",
       "url": "${license.url}"
     }"""

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -50,13 +50,7 @@ trait DisplaySerialisationTestBase { this: Suite =>
        }
      """
 
-  def license(license: License) =
-    s"""{
-      "label": "${license.label}",
-      "licenseType": "${license.id}",
-      "type": "${license.ontologyType}",
-      "url": "${license.url}"
-    }"""
+  def license(license: License): String
 
   def identifier(identifier: SourceIdentifier): String
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1Test.scala
@@ -8,7 +8,7 @@ class DisplayLicenseV1Test extends FunSpec with Matchers {
   it("should read a License as a DisplayLicenseV1 correctly") {
     val displayLicense = DisplayLicenseV1(License_CCBY)
 
-    displayLicense.licenseType shouldBe License_CCBY.licenseType
+    displayLicense.licenseType shouldBe License_CCBY.id
     displayLicense.label shouldBe License_CCBY.label
     displayLicense.url shouldBe License_CCBY.url
     displayLicense.ontologyType shouldBe "License"

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1Test.scala
@@ -8,9 +8,9 @@ class DisplayLicenseV1Test extends FunSpec with Matchers {
   it("should read a License as a DisplayLicenseV1 correctly") {
     val displayLicense = DisplayLicenseV1(License_CCBY)
 
-    displayLicense.licenseType shouldBe License_CCBY.id
-    displayLicense.label shouldBe License_CCBY.label
-    displayLicense.url shouldBe License_CCBY.url
+    displayLicense.licenseType shouldBe "CC-BY"
+    displayLicense.label shouldBe "Attribution 4.0 International (CC BY 4.0)"
+    displayLicense.url shouldBe "http://creativecommons.org/licenses/by/4.0/"
     displayLicense.ontologyType shouldBe "License"
   }
 }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1Test.scala
@@ -8,6 +8,9 @@ class DisplayLicenseV1Test extends FunSpec with Matchers {
   it("should read a License as a DisplayLicenseV1 correctly") {
     val displayLicense = DisplayLicenseV1(License_CCBY)
 
+    // These outputs are deliberately hard-coded -- because the V1 API
+    // is public, we shouldn't be changing the output even when the
+    // internal model changes.
     displayLicense.licenseType shouldBe "CC-BY"
     displayLicense.label shouldBe "Attribution 4.0 International (CC BY 4.0)"
     displayLicense.url shouldBe "http://creativecommons.org/licenses/by/4.0/"

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayV1SerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayV1SerialisationTestBase.scala
@@ -2,10 +2,19 @@ package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.Suite
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
-import uk.ac.wellcome.models.work.internal.SourceIdentifier
+import uk.ac.wellcome.models.work.internal.{License, SourceIdentifier}
 
 trait DisplayV1SerialisationTestBase extends DisplaySerialisationTestBase {
   this: Suite =>
+
+  def license(license: License) =
+    s"""{
+      "label": "${license.label}",
+      "licenseType": "${license.id.toUpperCase}",
+      "type": "${license.ontologyType}",
+      "url": "${license.url}"
+    }"""
+
   def identifier(identifier: SourceIdentifier) =
     s"""{
       "type": "Identifier",

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLicenseV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLicenseV2Test.scala
@@ -8,7 +8,7 @@ class DisplayLicenseV2Test extends FunSpec with Matchers {
   it("should read a License as a DisplayLicenseV2 correctly") {
     val displayLicense = DisplayLicenseV2(License_CCBY)
 
-    displayLicense.licenseType shouldBe License_CCBY.id
+    displayLicense.id shouldBe License_CCBY.id
     displayLicense.label shouldBe License_CCBY.label
     displayLicense.url shouldBe License_CCBY.url
     displayLicense.ontologyType shouldBe "License"

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLicenseV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLicenseV2Test.scala
@@ -8,7 +8,7 @@ class DisplayLicenseV2Test extends FunSpec with Matchers {
   it("should read a License as a DisplayLicenseV2 correctly") {
     val displayLicense = DisplayLicenseV2(License_CCBY)
 
-    displayLicense.licenseType shouldBe License_CCBY.licenseType
+    displayLicense.licenseType shouldBe License_CCBY.id
     displayLicense.label shouldBe License_CCBY.label
     displayLicense.url shouldBe License_CCBY.url
     displayLicense.ontologyType shouldBe "License"

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayV2SerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayV2SerialisationTestBase.scala
@@ -2,10 +2,19 @@ package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.Suite
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
-import uk.ac.wellcome.models.work.internal.SourceIdentifier
+import uk.ac.wellcome.models.work.internal.{License, SourceIdentifier}
 
 trait DisplayV2SerialisationTestBase extends DisplaySerialisationTestBase {
   this: Suite =>
+
+  def license(license: License) =
+    s"""{
+      "label": "${license.label}",
+      "licenseType": "${license.id}",
+      "type": "${license.ontologyType}",
+      "url": "${license.url}"
+    }"""
+
   def identifier(identifier: SourceIdentifier) =
     s"""{
       "type": "Identifier",

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayV2SerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayV2SerialisationTestBase.scala
@@ -9,8 +9,8 @@ trait DisplayV2SerialisationTestBase extends DisplaySerialisationTestBase {
 
   def license(license: License) =
     s"""{
+      "id": "${license.id}",
       "label": "${license.label}",
-      "licenseType": "${license.id}",
       "type": "${license.ontologyType}",
       "url": "${license.url}"
     }"""

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -18,7 +18,7 @@ class WorksIndex @Inject()(client: HttpClient, elasticConfig: ElasticConfig)
 
   val license = objectField("license").fields(
     keywordField("ontologyType"),
-    keywordField("licenseType"),
+    keywordField("id"),
     textField("label"),
     textField("url")
   )

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.models.work.internal
 import io.circe.{Decoder, Encoder, Json}
 
 sealed trait License {
-  val licenseType: String
+  val id: String
   val label: String
   val url: String
   val ontologyType: String = "License"
@@ -13,7 +13,7 @@ object License {
   implicit val licenseEncoder = Encoder.instance[License](
     license =>
       Json.obj(
-        ("licenseType", Json.fromString(license.licenseType)),
+        ("id", Json.fromString(license.id)),
         ("label", Json.fromString(license.label)),
         ("url", Json.fromString(license.url)),
         ("ontologyType", Json.fromString(license.ontologyType))
@@ -21,52 +21,52 @@ object License {
 
   implicit val licenseDecoder = Decoder.instance[License](cursor =>
     for {
-      licenseType <- cursor.downField("licenseType").as[String]
+      id <- cursor.downField("id").as[String]
     } yield {
-      createLicense(licenseType)
+      createLicense(id)
   })
 
-  def createLicense(licenseType: String): License = {
-    licenseType match {
-      case s: String if s == License_CCBY.licenseType => License_CCBY
-      case s: String if s == License_CCBYNC.licenseType => License_CCBYNC
-      case s: String if s == License_CCBYNCND.licenseType => License_CCBYNCND
-      case s: String if s == License_CC0.licenseType => License_CC0
-      case s: String if s == License_PDM.licenseType => License_PDM
-      case licenseType =>
-        val errorMessage = s"$licenseType is not a valid licenseType"
+  def createLicense(id: String): License = {
+    id match {
+      case s: String if s == License_CCBY.id => License_CCBY
+      case s: String if s == License_CCBYNC.id => License_CCBYNC
+      case s: String if s == License_CCBYNCND.id => License_CCBYNCND
+      case s: String if s == License_CC0.id => License_CC0
+      case s: String if s == License_PDM.id => License_PDM
+      case id =>
+        val errorMessage = s"$id is not a valid id"
         throw new Exception(errorMessage)
     }
   }
 }
 
 case object License_CCBY extends License {
-  val licenseType = "CC-BY"
+  val id = "CC-BY"
   val label = "Attribution 4.0 International (CC BY 4.0)"
   val url = "http://creativecommons.org/licenses/by/4.0/"
 }
 
 case object License_CCBYNC extends License {
-  val licenseType = "CC-BY-NC"
+  val id = "CC-BY-NC"
   val label = "Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)"
   val url = "https://creativecommons.org/licenses/by-nc/4.0/"
 }
 
 case object License_CCBYNCND extends License {
-  val licenseType = "CC-BY-NC-ND"
+  val id = "CC-BY-NC-ND"
   val label =
     "Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)"
   val url = "https://creativecommons.org/licenses/by-nc-nd/4.0/"
 }
 
 case object License_CC0 extends License {
-  val licenseType = "CC-0"
+  val id = "CC-0"
   val label = "CC0 1.0 Universal"
   val url = "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
 }
 
 case object License_PDM extends License {
-  val licenseType = "PDM"
+  val id = "PDM"
   val label = "Public Domain Mark"
   val url = "https://creativecommons.org/share-your-work/public-domain/pdm/"
 }

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
@@ -41,32 +41,32 @@ object License {
 }
 
 case object License_CCBY extends License {
-  val id = "CC-BY"
+  val id = "cc-by"
   val label = "Attribution 4.0 International (CC BY 4.0)"
   val url = "http://creativecommons.org/licenses/by/4.0/"
 }
 
 case object License_CCBYNC extends License {
-  val id = "CC-BY-NC"
+  val id = "cc-by-nc"
   val label = "Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)"
   val url = "https://creativecommons.org/licenses/by-nc/4.0/"
 }
 
 case object License_CCBYNCND extends License {
-  val id = "CC-BY-NC-ND"
+  val id = "cc-by-nc-nd"
   val label =
     "Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)"
   val url = "https://creativecommons.org/licenses/by-nc-nd/4.0/"
 }
 
 case object License_CC0 extends License {
-  val id = "CC-0"
+  val id = "cc-0"
   val label = "CC0 1.0 Universal"
   val url = "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
 }
 
 case object License_PDM extends License {
-  val id = "PDM"
+  val id = "pdm"
   val label = "Public Domain Mark"
   val url = "https://creativecommons.org/share-your-work/public-domain/pdm/"
 }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedItemTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedItemTest.scala
@@ -36,7 +36,7 @@ class IdentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
       |      "url" : "",
       |      "credit" : null,
       |      "license": {
-      |        "licenseType": "${License_CCBY.licenseType}",
+      |        "id": "${License_CCBY.id}",
       |        "label": "${License_CCBY.label}",
       |        "url": "${License_CCBY.url}",
       |        "ontologyType": "License"

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifiedWorkTest.scala
@@ -13,7 +13,7 @@ class IdentifiedWorkTest
 
   private val license_CCBYJson =
     s"""{
-            "licenseType": "${License_CCBY.licenseType}",
+            "id": "${License_CCBY.id}",
             "label": "${License_CCBY.label}",
             "url": "${License_CCBY.url}",
             "ontologyType": "License"

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LicenseTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LicenseTest.scala
@@ -8,7 +8,7 @@ class LicenseTest extends FunSpec with Matchers {
   it("should serialise a License as JSON") {
     val result = JsonUtil.toJson[License](License_CCBY)
     result.isSuccess shouldBe true
-    result.get shouldBe """{"id":"CC-BY","label":"Attribution 4.0 International (CC BY 4.0)","url":"http://creativecommons.org/licenses/by/4.0/","ontologyType":"License"}"""
+    result.get shouldBe """{"id":"cc-by","label":"Attribution 4.0 International (CC BY 4.0)","url":"http://creativecommons.org/licenses/by/4.0/","ontologyType":"License"}"""
   }
 
   it("should deserialise a JSON string as a License") {

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LicenseTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LicenseTest.scala
@@ -8,17 +8,17 @@ class LicenseTest extends FunSpec with Matchers {
   it("should serialise a License as JSON") {
     val result = JsonUtil.toJson[License](License_CCBY)
     result.isSuccess shouldBe true
-    result.get shouldBe """{"licenseType":"CC-BY","label":"Attribution 4.0 International (CC BY 4.0)","url":"http://creativecommons.org/licenses/by/4.0/","ontologyType":"License"}"""
+    result.get shouldBe """{"id":"CC-BY","label":"Attribution 4.0 International (CC BY 4.0)","url":"http://creativecommons.org/licenses/by/4.0/","ontologyType":"License"}"""
   }
 
   it("should deserialise a JSON string as a License") {
-    val licenseType = License_CC0.licenseType
+    val id = License_CC0.id
     val label = License_CC0.label
     val url = License_CC0.url
 
     val jsonString = s"""
       {
-        "licenseType": "$licenseType",
+        "id": "$id",
         "label": "$label",
         "url": "$url",
         "ontologyType": "License"
@@ -27,7 +27,7 @@ class LicenseTest extends FunSpec with Matchers {
     result.isSuccess shouldBe true
 
     val license = result.get
-    license.licenseType shouldBe licenseType
+    license.id shouldBe id
     license.label shouldBe label
     license.url shouldBe url
   }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedItemTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedItemTest.scala
@@ -36,7 +36,7 @@ class UnidentifiedItemTest extends FunSpec with Matchers with JsonTestUtil {
       |      "url" : "",
       |      "credit" : null,
       |      "license": {
-      |        "licenseType": "${License_CCBY.licenseType}",
+      |        "id": "${License_CCBY.id}",
       |        "label": "${License_CCBY.label}",
       |        "url": "${License_CCBY.url}",
       |        "ontologyType": "License"

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedWorkTest.scala
@@ -13,7 +13,7 @@ class UnidentifiedWorkTest
 
   private val license_CCBYJson =
     s"""{
-            "licenseType": "${License_CCBY.licenseType}",
+            "id": "${License_CCBY.id}",
             "label": "${License_CCBY.label}",
             "url": "${License_CCBY.url}",
             "ontologyType": "License"


### PR DESCRIPTION
This updates our model for License (internal and display) to match the model proposed in #2137.