### PR TITLE
Enable parallel execution in tests (again)

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -17,7 +17,7 @@ object Common {
       "-feature",
       "-language:postfixOps"
     ),
-    parallelExecution in Test := false,
+    parallelExecution in Test := true,
     libraryDependencies ++= Dependencies.sharedDependencies
   ) ++
     Search.settings ++


### PR DESCRIPTION
I thought we’d done this in #1941, but apparently not? Possibly this change got accidentally backed out in a rebase?