### PR TITLE
Rename LinkedWork to WorkNode

### DIFF
--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcher.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcher.scala
@@ -38,13 +38,13 @@ class LinkedWorkMatcher @Inject()(workGraphStore: WorkGraphStore) {
   private def convertToIdentifiersList(
     updatedLinkedWorkGraph: LinkedWorksGraph) = {
     groupBySetId(updatedLinkedWorkGraph).map {
-      case (_, linkedWorkList) =>
-        IdentifierList(linkedWorkList.map(_.workId))
+      case (_, workNodeList) =>
+        IdentifierList(workNodeList.map(_.id))
     }.toSet
   }
 
   private def groupBySetId(updatedLinkedWorkGraph: LinkedWorksGraph) = {
     updatedLinkedWorkGraph.linkedWorksSet
-      .groupBy(_.setId)
+      .groupBy(_.componentId)
   }
 }

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/LinkedWork.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/LinkedWork.scala
@@ -1,3 +1,0 @@
-package uk.ac.wellcome.platform.matcher.models
-
-case class LinkedWork(workId: String, linkedIds: List[String], setId: String)

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/LinkedWorksGraph.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/LinkedWorksGraph.scala
@@ -1,3 +1,3 @@
 package uk.ac.wellcome.platform.matcher.models
 
-case class LinkedWorksGraph(linkedWorksSet: Set[LinkedWork])
+case class LinkedWorksGraph(linkedWorksSet: Set[WorkNode])

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/WorkNode.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/WorkNode.scala
@@ -1,0 +1,27 @@
+package uk.ac.wellcome.platform.matcher.models
+
+// Represents an individual node in our graph database.
+//
+//   - id is the source identifier of the original Work
+//   - referencedWorkIds is the list of all the works which this Work
+//     has a reference to.  In graph terms, it's the edges starting
+//     from this work
+//   - componentId is an ID that represents all the works in the same
+//     connected component as this work
+//
+// For example:
+//
+//      A -----> B <----> C <----- D
+//
+// In this graph, the WorkNode for B would have:
+//
+//    - id = B
+//    - referencedWorkIds = {C}, because B itself only refers to C
+//    - componentId = Id({A, B, C, D}), because these are the four nodes
+//      in this connected component.  A, C and D have the same componentId.
+//
+case class WorkNode(
+  id: String,
+  referencedWorkIds: List[String],
+  componentId: String
+)

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/LinkedWorkDao.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/LinkedWorkDao.scala
@@ -34,7 +34,7 @@ class LinkedWorkDao @Inject()(
     Future {
       Scanamo
         .getAll[WorkNode](dynamoDbClient)(dynamoConfig.table)(
-          'workId -> workIds)
+          'id -> workIds)
         .map {
           case Right(works) => works
           case Left(scanamoError) => {
@@ -52,7 +52,7 @@ class LinkedWorkDao @Inject()(
     Future {
       Scanamo
         .queryIndex[WorkNode](dynamoDbClient)(dynamoConfig.table, index)(
-          'setId -> setId)
+          'componentId -> setId)
         .map {
           case Right(record) => {
             record

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/LinkedWorkDao.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/LinkedWorkDao.scala
@@ -23,8 +23,7 @@ class LinkedWorkDao @Inject()(
   def getBySetIds(setIds: Set[String]): Future[Set[WorkNode]] =
     Future.sequence(setIds.map(getBySetId)).map(_.flatten)
 
-  def put(
-    work: WorkNode): Future[Option[Either[DynamoReadError, WorkNode]]] = {
+  def put(work: WorkNode): Future[Option[Either[DynamoReadError, WorkNode]]] = {
     Future {
       Scanamo.put(dynamoDbClient)(dynamoConfig.table)(work)
     }
@@ -33,8 +32,7 @@ class LinkedWorkDao @Inject()(
   def get(workIds: Set[String]): Future[Set[WorkNode]] = {
     Future {
       Scanamo
-        .getAll[WorkNode](dynamoDbClient)(dynamoConfig.table)(
-          'id -> workIds)
+        .getAll[WorkNode](dynamoDbClient)(dynamoConfig.table)('id -> workIds)
         .map {
           case Right(works) => works
           case Left(scanamoError) => {

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/LinkedWorkDao.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/LinkedWorkDao.scala
@@ -6,7 +6,7 @@ import com.gu.scanamo.Scanamo
 import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo.syntax._
 import com.twitter.inject.Logging
-import uk.ac.wellcome.platform.matcher.models.LinkedWork
+import uk.ac.wellcome.platform.matcher.models.WorkNode
 import uk.ac.wellcome.storage.GlobalExecutionContext._
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
@@ -20,20 +20,20 @@ class LinkedWorkDao @Inject()(
   val index = dynamoConfig.index.getOrElse(
     throw new RuntimeException("Index cannot be empty!"))
 
-  def getBySetIds(setIds: Set[String]): Future[Set[LinkedWork]] =
+  def getBySetIds(setIds: Set[String]): Future[Set[WorkNode]] =
     Future.sequence(setIds.map(getBySetId)).map(_.flatten)
 
   def put(
-    work: LinkedWork): Future[Option[Either[DynamoReadError, LinkedWork]]] = {
+    work: WorkNode): Future[Option[Either[DynamoReadError, WorkNode]]] = {
     Future {
       Scanamo.put(dynamoDbClient)(dynamoConfig.table)(work)
     }
   }
 
-  def get(workIds: Set[String]): Future[Set[LinkedWork]] = {
+  def get(workIds: Set[String]): Future[Set[WorkNode]] = {
     Future {
       Scanamo
-        .getAll[LinkedWork](dynamoDbClient)(dynamoConfig.table)(
+        .getAll[WorkNode](dynamoDbClient)(dynamoConfig.table)(
           'workId -> workIds)
         .map {
           case Right(works) => works
@@ -51,7 +51,7 @@ class LinkedWorkDao @Inject()(
   private def getBySetId(setId: String) = {
     Future {
       Scanamo
-        .queryIndex[LinkedWork](dynamoDbClient)(dynamoConfig.table, index)(
+        .queryIndex[WorkNode](dynamoDbClient)(dynamoConfig.table, index)(
           'setId -> setId)
         .map {
           case Right(record) => {

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
@@ -21,8 +21,8 @@ class WorkGraphStore @Inject()(
 
     for {
       directlyAffectedWorks <- linkedWorkDao.get(directlyAffectedWorkIds)
-      affectedSetIds = directlyAffectedWorks.map(linkedWork =>
-        linkedWork.setId)
+      affectedSetIds = directlyAffectedWorks.map(workNode =>
+        workNode.componentId)
       affectedWorks <- linkedWorkDao.getBySetIds(affectedSetIds)
     } yield LinkedWorksGraph(affectedWorks)
   }

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/LinkedWorkGraphUpdater.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/LinkedWorkGraphUpdater.scala
@@ -56,9 +56,8 @@ object LinkedWorkGraphUpdater {
     linkedWorkIds.map(workId ~> _)
   }
 
-  private def existingGraphWithoutUpdatedNode(
-    workId: String,
-    workNodes: Set[WorkNode]) = {
+  private def existingGraphWithoutUpdatedNode(workId: String,
+                                              workNodes: Set[WorkNode]) = {
     workNodes.filterNot(_.id == workId)
   }
 }

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/LinkedWorkGraphUpdater.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/LinkedWorkGraphUpdater.scala
@@ -21,8 +21,8 @@ object LinkedWorkGraphUpdater {
       toEdges(workNode.id, workNode.referencedWorkIds)
     }) ++ toEdges(workUpdate.workId, workUpdate.linkedIds)
 
-    val nodes = existingGraph.linkedWorksSet.flatMap(linkedWork => {
-      allNodes(linkedWork)
+    val nodes = existingGraph.linkedWorksSet.flatMap(workNode => {
+      allNodes(workNode)
     }) + workUpdate.workId
 
     val g = Graph.from(edges = edges, nodes = nodes)

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/LocalLinkedWorkDynamoDb.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/LocalLinkedWorkDynamoDb.scala
@@ -13,14 +13,14 @@ trait LocalLinkedWorkDynamoDb
       new CreateTableRequest()
         .withTableName(table.name)
         .withKeySchema(new KeySchemaElement()
-          .withAttributeName("workId")
+          .withAttributeName("id")
           .withKeyType(KeyType.HASH))
         .withAttributeDefinitions(
           new AttributeDefinition()
-            .withAttributeName("workId")
+            .withAttributeName("id")
             .withAttributeType("S"),
           new AttributeDefinition()
-            .withAttributeName("setId")
+            .withAttributeName("componentId")
             .withAttributeType("S"),
         )
         .withProvisionedThroughput(new ProvisionedThroughput()
@@ -33,7 +33,7 @@ trait LocalLinkedWorkDynamoDb
               new Projection().withProjectionType(ProjectionType.ALL))
             .withKeySchema(
               new KeySchemaElement()
-                .withAttributeName("setId")
+                .withAttributeName("componentId")
                 .withKeyType(KeyType.HASH)
             )
             .withProvisionedThroughput(new ProvisionedThroughput()

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcherTest.scala
@@ -32,9 +32,9 @@ class LinkedWorkMatcherTest
                 LinkedWorksIdentifiersList(Set(IdentifierList(Set(workId))))
 
               val savedLinkedWork = Scanamo
-                .get[LinkedWork](dynamoDbClient)(table.name)('workId -> workId)
+                .get[WorkNode](dynamoDbClient)(table.name)('workId -> workId)
                 .map(_.right.get)
-              savedLinkedWork shouldBe Some(LinkedWork(workId, Nil, workId))
+              savedLinkedWork shouldBe Some(WorkNode(workId, Nil, workId))
           }
         }
       }
@@ -56,15 +56,15 @@ class LinkedWorkMatcherTest
               LinkedWorksIdentifiersList(Set(IdentifierList(
                 Set("sierra-system-number/A", "sierra-system-number/B"))))
 
-            val savedLinkedWorks = Scanamo
-              .scan[LinkedWork](dynamoDbClient)(table.name)
+            val savedWorkNodes = Scanamo
+              .scan[WorkNode](dynamoDbClient)(table.name)
               .map(_.right.get)
-            savedLinkedWorks should contain theSameElementsAs List(
-              LinkedWork(
+            savedWorkNodes should contain theSameElementsAs List(
+              WorkNode(
                 "sierra-system-number/A",
                 List("sierra-system-number/B"),
                 "sierra-system-number/A+sierra-system-number/B"),
-              LinkedWork(
+              WorkNode(
                 "sierra-system-number/B",
                 Nil,
                 "sierra-system-number/A+sierra-system-number/B")
@@ -79,11 +79,11 @@ class LinkedWorkMatcherTest
     withLocalDynamoDbTable { table =>
       withWorkGraphStore(table) { workGraphStore =>
         withLinkedWorkMatcher(table, workGraphStore) { linkedWorkMatcher =>
-          val existingWorkA = LinkedWork(
+          val existingWorkA = WorkNode(
             "sierra-system-number/A",
             List("sierra-system-number/B"),
             "sierra-system-number/A+sierra-system-number/B")
-          val existingWorkB = LinkedWork(
+          val existingWorkB = WorkNode(
             "sierra-system-number/B",
             Nil,
             "sierra-system-number/A+sierra-system-number/B")
@@ -106,19 +106,19 @@ class LinkedWorkMatcherTest
                       "sierra-system-number/B",
                       "sierra-system-number/C"))))
 
-            val savedLinkedWorks = Scanamo
-              .scan[LinkedWork](dynamoDbClient)(table.name)
+            val savedWorkNodes = Scanamo
+              .scan[WorkNode](dynamoDbClient)(table.name)
               .map(_.right.get)
-            savedLinkedWorks should contain theSameElementsAs List(
-              LinkedWork(
+            savedWorkNodes should contain theSameElementsAs List(
+              WorkNode(
                 "sierra-system-number/A",
                 List("sierra-system-number/B"),
                 "sierra-system-number/A+sierra-system-number/B+sierra-system-number/C"),
-              LinkedWork(
+              WorkNode(
                 "sierra-system-number/B",
                 List("sierra-system-number/C"),
                 "sierra-system-number/A+sierra-system-number/B+sierra-system-number/C"),
-              LinkedWork(
+              WorkNode(
                 "sierra-system-number/C",
                 Nil,
                 "sierra-system-number/A+sierra-system-number/B+sierra-system-number/C")

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcherTest.scala
@@ -32,7 +32,7 @@ class LinkedWorkMatcherTest
                 LinkedWorksIdentifiersList(Set(IdentifierList(Set(workId))))
 
               val savedLinkedWork = Scanamo
-                .get[WorkNode](dynamoDbClient)(table.name)('workId -> workId)
+                .get[WorkNode](dynamoDbClient)(table.name)('id -> workId)
                 .map(_.right.get)
               savedLinkedWork shouldBe Some(WorkNode(workId, Nil, workId))
           }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/LinkedWorkDaoTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/LinkedWorkDaoTest.scala
@@ -137,7 +137,7 @@ class LinkedWorkDaoTest
   }
 
   describe("Insert into dynamo") {
-    it("puts a linkedWork") {
+    it("puts a WorkNode") {
       withLocalDynamoDbTable { table =>
         withLinkedWorkDao(table) { linkedWordDao =>
           val workNode = WorkNode("A", List("B"), "A+B")

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/LinkedWorkDaoTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/LinkedWorkDaoTest.scala
@@ -143,7 +143,7 @@ class LinkedWorkDaoTest
           val workNode = WorkNode("A", List("B"), "A+B")
           whenReady(linkedWordDao.put(workNode)) { _ =>
             val savedWorkNode = Scanamo.get[WorkNode](dynamoDbClient)(
-              table.name)('workId -> "A")
+              table.name)('id -> "A")
             savedWorkNode shouldBe Some(Right(workNode))
           }
         }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/LinkedWorkDaoTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/LinkedWorkDaoTest.scala
@@ -69,8 +69,8 @@ class LinkedWorkDaoTest
     it("returns an error if Scanamo fails") {
       withLocalDynamoDbTable { table =>
         withLinkedWorkDao(table) { matcherGraphDao =>
-          case class BadRecord(workId: String)
-          val badRecord: BadRecord = BadRecord(workId = "A")
+          case class BadRecord(id: String)
+          val badRecord: BadRecord = BadRecord(id = "A")
           Scanamo.put(dynamoDbClient)(table.name)(badRecord)
 
           whenReady(matcherGraphDao.get(Set("A")).failed) { failedException =>
@@ -128,8 +128,8 @@ class LinkedWorkDaoTest
     it("returns an error if Scanamo fails") {
       withLocalDynamoDbTable { table =>
         withLinkedWorkDao(table) { matcherGraphDao =>
-          case class BadRecord(workId: String, setId: String)
-          val badRecord: BadRecord = BadRecord(workId = "A", setId = "A+B")
+          case class BadRecord(id: String, componentId: String)
+          val badRecord: BadRecord = BadRecord(id = "A", componentId = "A+B")
           Scanamo.put(dynamoDbClient)(table.name)(badRecord)
 
           whenReady(matcherGraphDao.getBySetIds(Set("A+B")).failed) {

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/LinkedWorkDaoTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/LinkedWorkDaoTest.scala
@@ -1,7 +1,11 @@
 package uk.ac.wellcome.platform.matcher.storage
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.amazonaws.services.dynamodbv2.model.{BatchGetItemRequest, PutItemRequest, QueryRequest}
+import com.amazonaws.services.dynamodbv2.model.{
+  BatchGetItemRequest,
+  PutItemRequest,
+  QueryRequest
+}
 import com.gu.scanamo.Scanamo
 import com.gu.scanamo.syntax._
 import org.mockito.Matchers.any
@@ -82,7 +86,8 @@ class LinkedWorkDaoTest
       withLocalDynamoDbTable { table =>
         withLinkedWorkDao(table) { matcherGraphDao =>
           whenReady(matcherGraphDao.getBySetIds(Set("Not-there"))) {
-            workNodeSet => workNodeSet shouldBe Set()
+            workNodeSet =>
+              workNodeSet shouldBe Set()
           }
         }
       }
@@ -142,8 +147,8 @@ class LinkedWorkDaoTest
         withLinkedWorkDao(table) { linkedWordDao =>
           val workNode = WorkNode("A", List("B"), "A+B")
           whenReady(linkedWordDao.put(workNode)) { _ =>
-            val savedWorkNode = Scanamo.get[WorkNode](dynamoDbClient)(
-              table.name)('id -> "A")
+            val savedWorkNode =
+              Scanamo.get[WorkNode](dynamoDbClient)(table.name)('id -> "A")
             savedWorkNode shouldBe Some(Right(workNode))
           }
         }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
@@ -127,7 +127,7 @@ class WorkGraphStoreTest
           val workNodeA = WorkNode("A", List("B"), "A+B")
           val workNodeB = WorkNode("B", Nil, "A+B")
 
-          whenReady(workGraphStore.put(LinkedWorksGraph(Set(workA, workB)))) {
+          whenReady(workGraphStore.put(LinkedWorksGraph(Set(workNodeA, workNodeB)))) {
             _ =>
               val savedLinkedWorks = Scanamo
                 .scan[WorkNode](dynamoDbClient)(table.name)

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
@@ -35,7 +35,8 @@ class WorkGraphStoreTest
       }
     }
 
-    it("returns a WorkNode if it has no links and it's the only node in the setId") {
+    it(
+      "returns a WorkNode if it has no links and it's the only node in the setId") {
       withLocalDynamoDbTable { table =>
         withWorkGraphStore(table) { workGraphStore =>
           val workNode = WorkNode("A", Nil, "A")
@@ -94,7 +95,10 @@ class WorkGraphStoreTest
 
           whenReady(workGraphStore.findAffectedWorks(
             LinkedWorkUpdate("A", Set.empty))) { linkedWorkGraph =>
-            linkedWorkGraph.linkedWorksSet shouldBe Set(workNodeA, workNodeB, workNodeC)
+            linkedWorkGraph.linkedWorksSet shouldBe Set(
+              workNodeA,
+              workNodeB,
+              workNodeC)
           }
         }
       }
@@ -113,7 +117,10 @@ class WorkGraphStoreTest
 
           whenReady(workGraphStore.findAffectedWorks(
             LinkedWorkUpdate("B", Set("C")))) { linkedWorkGraph =>
-            linkedWorkGraph.linkedWorksSet shouldBe Set(workNodeA, workNodeB, workNodeC)
+            linkedWorkGraph.linkedWorksSet shouldBe Set(
+              workNodeA,
+              workNodeB,
+              workNodeC)
           }
         }
       }
@@ -127,7 +134,8 @@ class WorkGraphStoreTest
           val workNodeA = WorkNode("A", List("B"), "A+B")
           val workNodeB = WorkNode("B", Nil, "A+B")
 
-          whenReady(workGraphStore.put(LinkedWorksGraph(Set(workNodeA, workNodeB)))) {
+          whenReady(
+            workGraphStore.put(LinkedWorksGraph(Set(workNodeA, workNodeB)))) {
             _ =>
               val savedLinkedWorks = Scanamo
                 .scan[WorkNode](dynamoDbClient)(table.name)

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
@@ -8,9 +8,9 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.platform.matcher.models.{
-  LinkedWork,
   LinkedWorkUpdate,
-  LinkedWorksGraph
+  LinkedWorksGraph,
+  WorkNode
 }
 
 import scala.concurrent.Future
@@ -35,90 +35,85 @@ class WorkGraphStoreTest
       }
     }
 
-    it(
-      "returns a LinkedWork if it has no links and it's the only node in the setId") {
+    it("returns a WorkNode if it has no links and it's the only node in the setId") {
       withLocalDynamoDbTable { table =>
         withWorkGraphStore(table) { workGraphStore =>
-          val work = LinkedWork(workId = "A", linkedIds = Nil, setId = "A")
-          Scanamo.put(dynamoDbClient)(table.name)(work)
+          val workNode = WorkNode("A", Nil, "A")
+          Scanamo.put(dynamoDbClient)(table.name)(workNode)
 
           whenReady(workGraphStore.findAffectedWorks(
             LinkedWorkUpdate("A", Set.empty))) { linkedWorkGraph =>
-            linkedWorkGraph shouldBe LinkedWorksGraph(Set(work))
+            linkedWorkGraph shouldBe LinkedWorksGraph(Set(workNode))
           }
         }
       }
     }
 
-    it("returns a LinkedWork and the links in the workUpdate") {
+    it("returns a WorkNode and the links in the workUpdate") {
       withLocalDynamoDbTable { table =>
         withWorkGraphStore(table) { workGraphStore =>
-          val workA = LinkedWork(workId = "A", linkedIds = Nil, setId = "A")
-          val workB = LinkedWork(workId = "B", linkedIds = Nil, setId = "B")
-          Scanamo.put(dynamoDbClient)(table.name)(workA)
-          Scanamo.put(dynamoDbClient)(table.name)(workB)
+          val workNodeA = WorkNode("A", Nil, "A")
+          val workNodeB = WorkNode("B", Nil, "B")
+          Scanamo.put(dynamoDbClient)(table.name)(workNodeA)
+          Scanamo.put(dynamoDbClient)(table.name)(workNodeB)
 
           whenReady(workGraphStore.findAffectedWorks(
             LinkedWorkUpdate("A", Set("B")))) { linkedWorkGraph =>
-            linkedWorkGraph.linkedWorksSet shouldBe Set(workA, workB)
+            linkedWorkGraph.linkedWorksSet shouldBe Set(workNodeA, workNodeB)
           }
         }
       }
     }
 
-    it("returns a LinkedWork and the links in the database") {
+    it("returns a WorkNode and the links in the database") {
       withLocalDynamoDbTable { table =>
         withWorkGraphStore(table) { workGraphStore =>
-          val workA =
-            LinkedWork(workId = "A", linkedIds = List("B"), setId = "AB")
-          val workB = LinkedWork(workId = "B", linkedIds = Nil, setId = "AB")
-          Scanamo.put(dynamoDbClient)(table.name)(workA)
-          Scanamo.put(dynamoDbClient)(table.name)(workB)
+          val workNodeA = WorkNode("A", List("B"), "AB")
+          val workNodeB = WorkNode("B", Nil, "AB")
+          Scanamo.put(dynamoDbClient)(table.name)(workNodeA)
+          Scanamo.put(dynamoDbClient)(table.name)(workNodeB)
 
           whenReady(workGraphStore.findAffectedWorks(
             LinkedWorkUpdate("A", Set.empty))) { linkedWorkGraph =>
-            linkedWorkGraph.linkedWorksSet shouldBe Set(workA, workB)
+            linkedWorkGraph.linkedWorksSet shouldBe Set(workNodeA, workNodeB)
           }
         }
       }
     }
 
     it(
-      "returns a LinkedWork and the links in the database more than one level down") {
+      "returns a WorkNode and the links in the database more than one level down") {
       withLocalDynamoDbTable { table =>
         withWorkGraphStore(table) { workGraphStore =>
-          val workA =
-            LinkedWork(workId = "A", linkedIds = List("B"), setId = "ABC")
-          val workB =
-            LinkedWork(workId = "B", linkedIds = List("C"), setId = "ABC")
-          val workC = LinkedWork(workId = "C", linkedIds = Nil, setId = "ABC")
-          Scanamo.put(dynamoDbClient)(table.name)(workA)
-          Scanamo.put(dynamoDbClient)(table.name)(workB)
-          Scanamo.put(dynamoDbClient)(table.name)(workC)
+          val workNodeA = WorkNode("A", List("B"), "ABC")
+          val workNodeB = WorkNode("B", List("C"), "ABC")
+          val workNodeC = WorkNode("C", Nil, "ABC")
+          Scanamo.put(dynamoDbClient)(table.name)(workNodeA)
+          Scanamo.put(dynamoDbClient)(table.name)(workNodeB)
+          Scanamo.put(dynamoDbClient)(table.name)(workNodeC)
 
           whenReady(workGraphStore.findAffectedWorks(
             LinkedWorkUpdate("A", Set.empty))) { linkedWorkGraph =>
-            linkedWorkGraph.linkedWorksSet shouldBe Set(workA, workB, workC)
+            linkedWorkGraph.linkedWorksSet shouldBe Set(workNodeA, workNodeB, workNodeC)
           }
         }
       }
     }
 
     it(
-      "returns a LinkedWork and the links in the database where an update joins two sets of works") {
+      "returns a WorkNode and the links in the database where an update joins two sets of works") {
       withLocalDynamoDbTable { table =>
         withWorkGraphStore(table) { workGraphStore =>
-          val workA =
-            LinkedWork(workId = "A", linkedIds = List("B"), setId = "AB")
-          val workB = LinkedWork(workId = "B", linkedIds = Nil, setId = "AB")
-          val workC = LinkedWork(workId = "C", linkedIds = Nil, setId = "C")
-          Scanamo.put(dynamoDbClient)(table.name)(workA)
-          Scanamo.put(dynamoDbClient)(table.name)(workB)
-          Scanamo.put(dynamoDbClient)(table.name)(workC)
+          val workNodeA = WorkNode("A", List("B"), "AB")
+          val workNodeB = WorkNode("B", Nil, "AB")
+          val workNodeC = WorkNode("C", Nil, "C")
+          Scanamo.put(dynamoDbClient)(table.name)(workNodeA)
+          Scanamo.put(dynamoDbClient)(table.name)(workNodeB)
+          Scanamo.put(dynamoDbClient)(table.name)(workNodeC)
 
           whenReady(workGraphStore.findAffectedWorks(
             LinkedWorkUpdate("B", Set("C")))) { linkedWorkGraph =>
-            linkedWorkGraph.linkedWorksSet shouldBe Set(workA, workB, workC)
+            linkedWorkGraph.linkedWorksSet shouldBe Set(workNodeA, workNodeB, workNodeC)
           }
         }
       }
@@ -129,17 +124,17 @@ class WorkGraphStoreTest
     it("puts a simple graph") {
       withLocalDynamoDbTable { table =>
         withWorkGraphStore(table) { workGraphStore =>
-          val workA = LinkedWork("A", List("B"), "A+B")
-          val workB = LinkedWork("B", Nil, "A+B")
+          val workNodeA = WorkNode("A", List("B"), "A+B")
+          val workNodeB = WorkNode("B", Nil, "A+B")
 
           whenReady(workGraphStore.put(LinkedWorksGraph(Set(workA, workB)))) {
             _ =>
               val savedLinkedWorks = Scanamo
-                .scan[LinkedWork](dynamoDbClient)(table.name)
+                .scan[WorkNode](dynamoDbClient)(table.name)
                 .map(_.right.get)
               savedLinkedWorks should contain theSameElementsAs List(
-                workA,
-                workB)
+                workNodeA,
+                workNodeB)
           }
         }
       }
@@ -149,13 +144,13 @@ class WorkGraphStoreTest
       withLocalDynamoDbTable { table =>
         val mockLinkedWorkDao = mock[LinkedWorkDao]
         val expectedException = new RuntimeException("FAILED")
-        when(mockLinkedWorkDao.put(any[LinkedWork]))
+        when(mockLinkedWorkDao.put(any[WorkNode]))
           .thenReturn(Future.failed(expectedException))
         val workGraphStore = new WorkGraphStore(mockLinkedWorkDao)
 
         whenReady(
           workGraphStore
-            .put(LinkedWorksGraph(Set(LinkedWork("A", Nil, "A+B"))))
+            .put(LinkedWorksGraph(Set(WorkNode("A", Nil, "A+B"))))
             .failed) { failedException =>
           failedException shouldBe expectedException
         }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/LinkedWorkGraphUpdaterTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/LinkedWorkGraphUpdaterTest.scala
@@ -32,8 +32,8 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
           existingGraph = LinkedWorksGraph(Set.empty)
         )
         .linkedWorksSet shouldBe Set(
-          WorkNode("A", List("B"), "A+B"),
-          WorkNode("B", List(), "A+B"))
+        WorkNode("A", List("B"), "A+B"),
+        WorkNode("B", List(), "A+B"))
     }
 
     it("updating nothing with B->A gives A+B:B->A") {
@@ -43,8 +43,8 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
           existingGraph = LinkedWorksGraph(Set.empty)
         )
         .linkedWorksSet shouldBe Set(
-          WorkNode("B", List("A"), "A+B"),
-          WorkNode("A", List(), "A+B"))
+        WorkNode("B", List("A"), "A+B"),
+        WorkNode("A", List(), "A+B"))
     }
   }
 
@@ -57,9 +57,7 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
             LinkedWorksGraph(Set(WorkNode("A", List("B"), "A+B")))
         )
         .linkedWorksSet should contain theSameElementsAs
-        List(
-          WorkNode("A", List("B"), "A+B"),
-          WorkNode("B", List(), "A+B"))
+        List(WorkNode("A", List("B"), "A+B"), WorkNode("B", List(), "A+B"))
     }
 
     it("updating A->B with B->C gives A+B+C:(A->B, B->C, C)") {
@@ -70,9 +68,9 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
             LinkedWorksGraph(Set(WorkNode("A", List("B"), "A+B")))
         )
         .linkedWorksSet shouldBe Set(
-          WorkNode("A", List("B"), "A+B+C"),
-          WorkNode("B", List("C"), "A+B+C"),
-          WorkNode("C", List(), "A+B+C")
+        WorkNode("A", List("B"), "A+B+C"),
+        WorkNode("B", List("C"), "A+B+C"),
+        WorkNode("C", List(), "A+B+C")
       )
     }
 
@@ -119,9 +117,9 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
               WorkNode("B", List("C"), "B+C")))
         )
         .linkedWorksSet shouldBe Set(
-          WorkNode("A", List("B"), "A+B+C"),
-          WorkNode("B", List("C"), "A+B+C"),
-          WorkNode("C", List("A"), "A+B+C")
+        WorkNode("A", List("B"), "A+B+C"),
+        WorkNode("B", List("C"), "A+B+C"),
+        WorkNode("C", List("A"), "A+B+C")
       )
     }
   }
@@ -132,13 +130,11 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
         .update(
           workUpdate = LinkedWorkUpdate("A", Set.empty),
           existingGraph = LinkedWorksGraph(
-            Set(
-              WorkNode("A", List("B"), "A+B"),
-              WorkNode("B", List(), "A+B")))
+            Set(WorkNode("A", List("B"), "A+B"), WorkNode("B", List(), "A+B")))
         )
         .linkedWorksSet shouldBe Set(
-          WorkNode("A", List(), "A"),
-          WorkNode("B", List(), "B"))
+        WorkNode("A", List(), "A"),
+        WorkNode("B", List(), "B"))
     }
 
     it(
@@ -150,8 +146,8 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
             LinkedWorksGraph(Set(WorkNode("A", List("B"), "A+B")))
         )
         .linkedWorksSet shouldBe Set(
-          WorkNode("A", List(), "A"),
-          WorkNode("B", List(), "B"))
+        WorkNode("A", List(), "A"),
+        WorkNode("B", List(), "B"))
     }
 
     it("updating A->B->C with B gives A+B:(A->B, B) and C:C") {
@@ -164,9 +160,9 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
               WorkNode("B", List("C"), "A+B+C")))
         )
         .linkedWorksSet shouldBe Set(
-          WorkNode("A", List("B"), "A+B"),
-          WorkNode("B", List(), "A+B"),
-          WorkNode("C", List(), "C"))
+        WorkNode("A", List("B"), "A+B"),
+        WorkNode("B", List(), "A+B"),
+        WorkNode("C", List(), "C"))
     }
 
     it("updating A<->B->C with B->C gives A+B+C:(A->B, B->C, C)") {
@@ -180,9 +176,9 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
               WorkNode("C", List(), "A+B+C")))
         )
         .linkedWorksSet shouldBe Set(
-          WorkNode("A", List("B"), "A+B+C"),
-          WorkNode("B", List("C"), "A+B+C"),
-          WorkNode("C", List(), "A+B+C"))
+        WorkNode("A", List("B"), "A+B+C"),
+        WorkNode("B", List("C"), "A+B+C"),
+        WorkNode("C", List(), "A+B+C"))
     }
   }
 }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/LinkedWorkGraphUpdaterTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/LinkedWorkGraphUpdaterTest.scala
@@ -2,9 +2,9 @@ package uk.ac.wellcome.platform.matcher.workgraph
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.matcher.models.{
-  LinkedWork,
   LinkedWorkUpdate,
-  LinkedWorksGraph
+  LinkedWorksGraph,
+  WorkNode
 }
 
 class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
@@ -22,7 +22,7 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
           workUpdate = LinkedWorkUpdate("A", Set.empty),
           existingGraph = LinkedWorksGraph(Set.empty)
         )
-        .linkedWorksSet shouldBe Set(LinkedWork("A", List(), setId = "A"))
+        .linkedWorksSet shouldBe Set(WorkNode("A", List(), "A"))
     }
 
     it("updating nothing with A->B gives A+B:A->B") {
@@ -32,8 +32,8 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
           existingGraph = LinkedWorksGraph(Set.empty)
         )
         .linkedWorksSet shouldBe Set(
-        LinkedWork("A", List("B"), setId = "A+B"),
-        LinkedWork("B", List(), setId = "A+B"))
+          WorkNode("A", List("B"), "A+B"),
+          WorkNode("B", List(), "A+B"))
     }
 
     it("updating nothing with B->A gives A+B:B->A") {
@@ -43,8 +43,8 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
           existingGraph = LinkedWorksGraph(Set.empty)
         )
         .linkedWorksSet shouldBe Set(
-        LinkedWork("B", List("A"), setId = "A+B"),
-        LinkedWork("A", List(), setId = "A+B"))
+          WorkNode("B", List("A"), "A+B"),
+          WorkNode("A", List(), "A+B"))
     }
   }
 
@@ -54,12 +54,12 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
         .update(
           workUpdate = LinkedWorkUpdate("A", Set("B")),
           existingGraph =
-            LinkedWorksGraph(Set(LinkedWork("A", List("B"), "A+B")))
+            LinkedWorksGraph(Set(WorkNode("A", List("B"), "A+B")))
         )
         .linkedWorksSet should contain theSameElementsAs
         List(
-          LinkedWork("A", List("B"), setId = "A+B"),
-          LinkedWork("B", List(), setId = "A+B"))
+          WorkNode("A", List("B"), "A+B"),
+          WorkNode("B", List(), "A+B"))
     }
 
     it("updating A->B with B->C gives A+B+C:(A->B, B->C, C)") {
@@ -67,12 +67,12 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
         .update(
           workUpdate = LinkedWorkUpdate("B", Set("C")),
           existingGraph =
-            LinkedWorksGraph(Set(LinkedWork("A", List("B"), "A+B")))
+            LinkedWorksGraph(Set(WorkNode("A", List("B"), "A+B")))
         )
         .linkedWorksSet shouldBe Set(
-        LinkedWork("A", List("B"), setId = "A+B+C"),
-        LinkedWork("B", List("C"), setId = "A+B+C"),
-        LinkedWork("C", List(), setId = "A+B+C")
+          WorkNode("A", List("B"), "A+B+C"),
+          WorkNode("B", List("C"), "A+B+C"),
+          WorkNode("C", List(), "A+B+C")
       )
     }
 
@@ -82,15 +82,15 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
           workUpdate = LinkedWorkUpdate("B", Set("C")),
           existingGraph = LinkedWorksGraph(
             Set(
-              LinkedWork("A", List("B"), "A+B"),
-              LinkedWork("C", List("D"), "C+D")))
+              WorkNode("A", List("B"), "A+B"),
+              WorkNode("C", List("D"), "C+D")))
         )
         .linkedWorksSet should contain theSameElementsAs
         List(
-          LinkedWork("A", List("B"), "A+B+C+D"),
-          LinkedWork("B", List("C"), "A+B+C+D"),
-          LinkedWork("C", List("D"), "A+B+C+D"),
-          LinkedWork("D", List(), setId = "A+B+C+D"))
+          WorkNode("A", List("B"), "A+B+C+D"),
+          WorkNode("B", List("C"), "A+B+C+D"),
+          WorkNode("C", List("D"), "A+B+C+D"),
+          WorkNode("D", List(), "A+B+C+D"))
     }
 
     it("updating A->B with B->[C,D] gives A+B+C+D:(A->B, B->C&D, C, D") {
@@ -98,14 +98,14 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
         .update(
           workUpdate = LinkedWorkUpdate("B", Set("C", "D")),
           existingGraph =
-            LinkedWorksGraph(Set(LinkedWork("A", List("B"), "A+B")))
+            LinkedWorksGraph(Set(WorkNode("A", List("B"), "A+B")))
         )
         .linkedWorksSet should contain theSameElementsAs
         List(
-          LinkedWork("A", List("B"), setId = "A+B+C+D"),
-          LinkedWork("B", List("C", "D"), setId = "A+B+C+D"),
-          LinkedWork("C", List(), setId = "A+B+C+D"),
-          LinkedWork("D", List(), setId = "A+B+C+D")
+          WorkNode("A", List("B"), "A+B+C+D"),
+          WorkNode("B", List("C", "D"), "A+B+C+D"),
+          WorkNode("C", List(), "A+B+C+D"),
+          WorkNode("D", List(), "A+B+C+D")
         )
     }
 
@@ -115,13 +115,13 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
           workUpdate = LinkedWorkUpdate("C", Set("A")),
           existingGraph = LinkedWorksGraph(
             Set(
-              LinkedWork("A", List("B"), "A+B"),
-              LinkedWork("B", List("C"), "B+C")))
+              WorkNode("A", List("B"), "A+B"),
+              WorkNode("B", List("C"), "B+C")))
         )
         .linkedWorksSet shouldBe Set(
-        LinkedWork("A", List("B"), setId = "A+B+C"),
-        LinkedWork("B", List("C"), setId = "A+B+C"),
-        LinkedWork("C", List("A"), setId = "A+B+C")
+          WorkNode("A", List("B"), "A+B+C"),
+          WorkNode("B", List("C"), "A+B+C"),
+          WorkNode("C", List("A"), "A+B+C")
       )
     }
   }
@@ -133,12 +133,12 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
           workUpdate = LinkedWorkUpdate("A", Set.empty),
           existingGraph = LinkedWorksGraph(
             Set(
-              LinkedWork("A", List("B"), "A+B"),
-              LinkedWork("B", List(), "A+B")))
+              WorkNode("A", List("B"), "A+B"),
+              WorkNode("B", List(), "A+B")))
         )
         .linkedWorksSet shouldBe Set(
-        LinkedWork("A", List(), setId = "A"),
-        LinkedWork("B", List(), setId = "B"))
+          WorkNode("A", List(), "A"),
+          WorkNode("B", List(), "B"))
     }
 
     it(
@@ -147,11 +147,11 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
         .update(
           workUpdate = LinkedWorkUpdate("A", Set.empty),
           existingGraph =
-            LinkedWorksGraph(Set(LinkedWork("A", List("B"), "A+B")))
+            LinkedWorksGraph(Set(WorkNode("A", List("B"), "A+B")))
         )
         .linkedWorksSet shouldBe Set(
-        LinkedWork("A", List(), setId = "A"),
-        LinkedWork("B", List(), setId = "B"))
+          WorkNode("A", List(), "A"),
+          WorkNode("B", List(), "B"))
     }
 
     it("updating A->B->C with B gives A+B:(A->B, B) and C:C") {
@@ -160,13 +160,13 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
           workUpdate = LinkedWorkUpdate("B", Set.empty),
           existingGraph = LinkedWorksGraph(
             Set(
-              LinkedWork("A", List("B"), "A+B+C"),
-              LinkedWork("B", List("C"), "A+B+C")))
+              WorkNode("A", List("B"), "A+B+C"),
+              WorkNode("B", List("C"), "A+B+C")))
         )
         .linkedWorksSet shouldBe Set(
-        LinkedWork("A", List("B"), setId = "A+B"),
-        LinkedWork("B", List(), setId = "A+B"),
-        LinkedWork("C", List(), setId = "C"))
+          WorkNode("A", List("B"), "A+B"),
+          WorkNode("B", List(), "A+B"),
+          WorkNode("C", List(), "C"))
     }
 
     it("updating A<->B->C with B->C gives A+B+C:(A->B, B->C, C)") {
@@ -175,14 +175,14 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
           workUpdate = LinkedWorkUpdate("B", Set("C")),
           existingGraph = LinkedWorksGraph(
             Set(
-              LinkedWork("A", List("B"), "A+B+C"),
-              LinkedWork("B", List("A", "C"), "A+B+C"),
-              LinkedWork("C", List(), "A+B+C")))
+              WorkNode("A", List("B"), "A+B+C"),
+              WorkNode("B", List("A", "C"), "A+B+C"),
+              WorkNode("C", List(), "A+B+C")))
         )
         .linkedWorksSet shouldBe Set(
-        LinkedWork("A", List("B"), setId = "A+B+C"),
-        LinkedWork("B", List("C"), setId = "A+B+C"),
-        LinkedWork("C", List(), setId = "A+B+C"))
+          WorkNode("A", List("B"), "A+B+C"),
+          WorkNode("B", List("C"), "A+B+C"),
+          WorkNode("C", List(), "A+B+C"))
     }
   }
 }


### PR DESCRIPTION
After chatting to @mklander yesterday, we decided some of the internal names in the matcher aren't ideal, and we came up with some better names.

This is the first of a stack of PRs I’m about to open which rename/renamespace a bunch of the internal models. Each rename is moderately large, so I think we should review/evaluate them individually.

This PR renames “LinkedWork” to “WorkNode”, and renames some of the internal fields to boot. This makes it clearer how it relates to the graph we store, but because the DynamoDB schema changes, we’ll need to rebuild the matcher table. Oh well, what are reindexes for?