### PR TITLE
Rename LinkedWorksGraph to WorkGraph

### DIFF
--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcher.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcher.scala
@@ -23,28 +23,27 @@ class LinkedWorkMatcher @Inject()(workGraphStore: WorkGraphStore) {
       work.identifiers.map(identifierToString).filterNot(_ == workId).toSet
 
     for {
-      linkedWorksGraph <- workGraphStore.findAffectedWorks(
+      existingGraph <- workGraphStore.findAffectedWorks(
         LinkedWorkUpdate(workId, linkedWorkIds))
-      updatedLinkedWorkGraph = LinkedWorkGraphUpdater.update(
+      updatedGraph = LinkedWorkGraphUpdater.update(
         LinkedWorkUpdate(workId, linkedWorkIds),
-        linkedWorksGraph)
-      _ <- workGraphStore.put(updatedLinkedWorkGraph)
+        existingGraph = existingGraph)
+      _ <- workGraphStore.put(updatedGraph)
 
     } yield {
-      convertToIdentifiersList(updatedLinkedWorkGraph)
+      convertToIdentifiersList(updatedGraph)
     }
   }
 
-  private def convertToIdentifiersList(
-    updatedLinkedWorkGraph: LinkedWorksGraph) = {
-    groupBySetId(updatedLinkedWorkGraph).map {
+  private def convertToIdentifiersList(updatedGraph: WorkGraph) = {
+    groupBySetId(updatedGraph).map {
       case (_, workNodeList) =>
         IdentifierList(workNodeList.map(_.id))
     }.toSet
   }
 
-  private def groupBySetId(updatedLinkedWorkGraph: LinkedWorksGraph) = {
-    updatedLinkedWorkGraph.linkedWorksSet
+  private def groupBySetId(updatedGraph: WorkGraph) = {
+    updatedGraph.nodes
       .groupBy(_.componentId)
   }
 }

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/LinkedWorksGraph.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/LinkedWorksGraph.scala
@@ -1,3 +1,0 @@
-package uk.ac.wellcome.platform.matcher.models
-
-case class LinkedWorksGraph(linkedWorksSet: Set[WorkNode])

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/WorkGraph.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/WorkGraph.scala
@@ -1,0 +1,9 @@
+package uk.ac.wellcome.platform.matcher.models
+
+// This holds a collection of nodes in our graph database.
+//
+// Each node describes the directed edges for which it is the source, so
+// this collection describes an entire graph -- a subgraph of the
+// entire graph in our database.
+//
+case class WorkGraph(nodes: Set[WorkNode])

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
@@ -2,10 +2,7 @@ package uk.ac.wellcome.platform.matcher.storage
 
 import com.google.inject.Inject
 import com.twitter.inject.Logging
-import uk.ac.wellcome.platform.matcher.models.{
-  LinkedWorkUpdate,
-  LinkedWorksGraph
-}
+import uk.ac.wellcome.platform.matcher.models.{LinkedWorkUpdate, WorkGraph}
 import uk.ac.wellcome.storage.GlobalExecutionContext._
 
 import scala.concurrent.Future
@@ -14,9 +11,7 @@ class WorkGraphStore @Inject()(
   linkedWorkDao: LinkedWorkDao
 ) extends Logging {
 
-  def findAffectedWorks(
-    workUpdate: LinkedWorkUpdate): Future[LinkedWorksGraph] = {
-
+  def findAffectedWorks(workUpdate: LinkedWorkUpdate): Future[WorkGraph] = {
     val directlyAffectedWorkIds = workUpdate.linkedIds + workUpdate.workId
 
     for {
@@ -24,12 +19,12 @@ class WorkGraphStore @Inject()(
       affectedSetIds = directlyAffectedWorks.map(workNode =>
         workNode.componentId)
       affectedWorks <- linkedWorkDao.getBySetIds(affectedSetIds)
-    } yield LinkedWorksGraph(affectedWorks)
+    } yield WorkGraph(affectedWorks)
   }
 
-  def put(graph: LinkedWorksGraph) = {
+  def put(graph: WorkGraph) = {
     Future.sequence(
-      graph.linkedWorksSet.map(linkedWorkDao.put)
+      graph.nodes.map(linkedWorkDao.put)
     )
   }
 }

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/LinkedWorkGraphUpdater.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/LinkedWorkGraphUpdater.scala
@@ -4,7 +4,7 @@ import scalax.collection.Graph
 import scalax.collection.GraphPredef._
 import uk.ac.wellcome.platform.matcher.models.{
   LinkedWorkUpdate,
-  LinkedWorksGraph,
+  WorkGraph,
   WorkNode
 }
 
@@ -12,16 +12,16 @@ import scala.collection.immutable.Iterable
 
 object LinkedWorkGraphUpdater {
   def update(workUpdate: LinkedWorkUpdate,
-             existingGraph: LinkedWorksGraph): LinkedWorksGraph = {
+             existingGraph: WorkGraph): WorkGraph = {
 
     val filteredLinkedWorks = existingGraphWithoutUpdatedNode(
       workUpdate.workId,
-      existingGraph.linkedWorksSet)
+      existingGraph.nodes)
     val edges = filteredLinkedWorks.flatMap(workNode => {
       toEdges(workNode.id, workNode.referencedWorkIds)
     }) ++ toEdges(workUpdate.workId, workUpdate.linkedIds)
 
-    val nodes = existingGraph.linkedWorksSet.flatMap(workNode => {
+    val nodes = existingGraph.nodes.flatMap(workNode => {
       allNodes(workNode)
     }) + workUpdate.workId
 
@@ -31,7 +31,7 @@ object LinkedWorkGraphUpdater {
       n.diSuccessors.map(_.value).toList.sorted
     }
 
-    LinkedWorksGraph(
+    WorkGraph(
       g.componentTraverser()
         .flatMap(component => {
           val nodeIds = component.nodes.map(_.value).toList

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/LinkedWorkGraphUpdater.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/LinkedWorkGraphUpdater.scala
@@ -14,9 +14,8 @@ object LinkedWorkGraphUpdater {
   def update(workUpdate: LinkedWorkUpdate,
              existingGraph: WorkGraph): WorkGraph = {
 
-    val filteredLinkedWorks = existingGraphWithoutUpdatedNode(
-      workUpdate.workId,
-      existingGraph.nodes)
+    val filteredLinkedWorks =
+      existingGraphWithoutUpdatedNode(workUpdate.workId, existingGraph.nodes)
     val edges = filteredLinkedWorks.flatMap(workNode => {
       toEdges(workNode.id, workNode.referencedWorkIds)
     }) ++ toEdges(workUpdate.workId, workUpdate.linkedIds)

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcherTest.scala
@@ -135,8 +135,8 @@ class LinkedWorkMatcherTest
       withLinkedWorkMatcher(table, mockWorkGraphStore) { linkedWorkMatcher =>
         val expectedException = new RuntimeException("Failed to put")
         when(mockWorkGraphStore.findAffectedWorks(any[LinkedWorkUpdate]))
-          .thenReturn(Future.successful(LinkedWorksGraph(Set.empty)))
-        when(mockWorkGraphStore.put(any[LinkedWorksGraph]))
+          .thenReturn(Future.successful(WorkGraph(Set.empty)))
+        when(mockWorkGraphStore.put(any[WorkGraph]))
           .thenReturn(Future.failed(expectedException))
         whenReady(linkedWorkMatcher.matchWork(anUnidentifiedSierraWork).failed) {
           actualException =>

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.platform.matcher.models.{
   LinkedWorkUpdate,
-  LinkedWorksGraph,
+  WorkGraph,
   WorkNode
 }
 
@@ -28,8 +28,8 @@ class WorkGraphStoreTest
         withWorkGraphStore(table) { workGraphStore =>
           whenReady(
             workGraphStore.findAffectedWorks(
-              LinkedWorkUpdate("Not-there", Set.empty))) { linkedWorkGraph =>
-            linkedWorkGraph shouldBe LinkedWorksGraph(Set.empty)
+              LinkedWorkUpdate("Not-there", Set.empty))) { workGraph =>
+            workGraph shouldBe WorkGraph(Set.empty)
           }
         }
       }
@@ -43,8 +43,8 @@ class WorkGraphStoreTest
           Scanamo.put(dynamoDbClient)(table.name)(workNode)
 
           whenReady(workGraphStore.findAffectedWorks(
-            LinkedWorkUpdate("A", Set.empty))) { linkedWorkGraph =>
-            linkedWorkGraph shouldBe LinkedWorksGraph(Set(workNode))
+            LinkedWorkUpdate("A", Set.empty))) { workGraph =>
+            workGraph shouldBe WorkGraph(Set(workNode))
           }
         }
       }
@@ -59,8 +59,8 @@ class WorkGraphStoreTest
           Scanamo.put(dynamoDbClient)(table.name)(workNodeB)
 
           whenReady(workGraphStore.findAffectedWorks(
-            LinkedWorkUpdate("A", Set("B")))) { linkedWorkGraph =>
-            linkedWorkGraph.linkedWorksSet shouldBe Set(workNodeA, workNodeB)
+            LinkedWorkUpdate("A", Set("B")))) { workGraph =>
+            workGraph.nodes shouldBe Set(workNodeA, workNodeB)
           }
         }
       }
@@ -75,8 +75,8 @@ class WorkGraphStoreTest
           Scanamo.put(dynamoDbClient)(table.name)(workNodeB)
 
           whenReady(workGraphStore.findAffectedWorks(
-            LinkedWorkUpdate("A", Set.empty))) { linkedWorkGraph =>
-            linkedWorkGraph.linkedWorksSet shouldBe Set(workNodeA, workNodeB)
+            LinkedWorkUpdate("A", Set.empty))) { workGraph =>
+            workGraph.nodes shouldBe Set(workNodeA, workNodeB)
           }
         }
       }
@@ -94,11 +94,8 @@ class WorkGraphStoreTest
           Scanamo.put(dynamoDbClient)(table.name)(workNodeC)
 
           whenReady(workGraphStore.findAffectedWorks(
-            LinkedWorkUpdate("A", Set.empty))) { linkedWorkGraph =>
-            linkedWorkGraph.linkedWorksSet shouldBe Set(
-              workNodeA,
-              workNodeB,
-              workNodeC)
+            LinkedWorkUpdate("A", Set.empty))) { workGraph =>
+            workGraph.nodes shouldBe Set(workNodeA, workNodeB, workNodeC)
           }
         }
       }
@@ -116,11 +113,8 @@ class WorkGraphStoreTest
           Scanamo.put(dynamoDbClient)(table.name)(workNodeC)
 
           whenReady(workGraphStore.findAffectedWorks(
-            LinkedWorkUpdate("B", Set("C")))) { linkedWorkGraph =>
-            linkedWorkGraph.linkedWorksSet shouldBe Set(
-              workNodeA,
-              workNodeB,
-              workNodeC)
+            LinkedWorkUpdate("B", Set("C")))) { workGraph =>
+            workGraph.nodes shouldBe Set(workNodeA, workNodeB, workNodeC)
           }
         }
       }
@@ -135,7 +129,7 @@ class WorkGraphStoreTest
           val workNodeB = WorkNode("B", Nil, "A+B")
 
           whenReady(
-            workGraphStore.put(LinkedWorksGraph(Set(workNodeA, workNodeB)))) {
+            workGraphStore.put(WorkGraph(Set(workNodeA, workNodeB)))) {
             _ =>
               val savedLinkedWorks = Scanamo
                 .scan[WorkNode](dynamoDbClient)(table.name)
@@ -158,7 +152,7 @@ class WorkGraphStoreTest
 
         whenReady(
           workGraphStore
-            .put(LinkedWorksGraph(Set(WorkNode("A", Nil, "A+B"))))
+            .put(WorkGraph(Set(WorkNode("A", Nil, "A+B"))))
             .failed) { failedException =>
           failedException shouldBe expectedException
         }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
@@ -128,8 +128,7 @@ class WorkGraphStoreTest
           val workNodeA = WorkNode("A", List("B"), "A+B")
           val workNodeB = WorkNode("B", Nil, "A+B")
 
-          whenReady(
-            workGraphStore.put(WorkGraph(Set(workNodeA, workNodeB)))) {
+          whenReady(workGraphStore.put(WorkGraph(Set(workNodeA, workNodeB)))) {
             _ =>
               val savedLinkedWorks = Scanamo
                 .scan[WorkNode](dynamoDbClient)(table.name)

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/LinkedWorkGraphUpdaterTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/LinkedWorkGraphUpdaterTest.scala
@@ -32,8 +32,8 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
           existingGraph = WorkGraph(Set.empty)
         )
         .nodes shouldBe Set(
-          WorkNode("A", List("B"), "A+B"),
-          WorkNode("B", List(), "A+B"))
+        WorkNode("A", List("B"), "A+B"),
+        WorkNode("B", List(), "A+B"))
     }
 
     it("updating nothing with B->A gives A+B:B->A") {
@@ -43,8 +43,8 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
           existingGraph = WorkGraph(Set.empty)
         )
         .nodes shouldBe Set(
-          WorkNode("B", List("A"), "A+B"),
-          WorkNode("A", List(), "A+B"))
+        WorkNode("B", List("A"), "A+B"),
+        WorkNode("A", List(), "A+B"))
     }
   }
 
@@ -56,8 +56,8 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
           existingGraph = WorkGraph(Set(WorkNode("A", List("B"), "A+B")))
         )
         .nodes shouldBe Set(
-          WorkNode("A", List("B"), "A+B"),
-          WorkNode("B", List(), "A+B"))
+        WorkNode("A", List("B"), "A+B"),
+        WorkNode("B", List(), "A+B"))
     }
 
     it("updating A->B with B->C gives A+B+C:(A->B, B->C, C)") {
@@ -67,9 +67,9 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
           existingGraph = WorkGraph(Set(WorkNode("A", List("B"), "A+B")))
         )
         .nodes shouldBe Set(
-          WorkNode("A", List("B"), "A+B+C"),
-          WorkNode("B", List("C"), "A+B+C"),
-          WorkNode("C", List(), "A+B+C")
+        WorkNode("A", List("B"), "A+B+C"),
+        WorkNode("B", List("C"), "A+B+C"),
+        WorkNode("C", List(), "A+B+C")
       )
     }
 
@@ -83,10 +83,10 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
               WorkNode("C", List("D"), "C+D")))
         )
         .nodes shouldBe Set(
-          WorkNode("A", List("B"), "A+B+C+D"),
-          WorkNode("B", List("C"), "A+B+C+D"),
-          WorkNode("C", List("D"), "A+B+C+D"),
-          WorkNode("D", List(), "A+B+C+D"))
+        WorkNode("A", List("B"), "A+B+C+D"),
+        WorkNode("B", List("C"), "A+B+C+D"),
+        WorkNode("C", List("D"), "A+B+C+D"),
+        WorkNode("D", List(), "A+B+C+D"))
     }
 
     it("updating A->B with B->[C,D] gives A+B+C+D:(A->B, B->C&D, C, D") {
@@ -96,10 +96,10 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
           existingGraph = WorkGraph(Set(WorkNode("A", List("B"), "A+B")))
         )
         .nodes shouldBe Set(
-          WorkNode("A", List("B"), "A+B+C+D"),
-          WorkNode("B", List("C", "D"), "A+B+C+D"),
-          WorkNode("C", List(), "A+B+C+D"),
-          WorkNode("D", List(), "A+B+C+D"))
+        WorkNode("A", List("B"), "A+B+C+D"),
+        WorkNode("B", List("C", "D"), "A+B+C+D"),
+        WorkNode("C", List(), "A+B+C+D"),
+        WorkNode("D", List(), "A+B+C+D"))
     }
 
     it("updating A->B->C with A->C gives A+B+C:(A->B, B->C, C->A") {
@@ -112,9 +112,9 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
               WorkNode("B", List("C"), "B+C")))
         )
         .nodes shouldBe Set(
-          WorkNode("A", List("B"), "A+B+C"),
-          WorkNode("B", List("C"), "A+B+C"),
-          WorkNode("C", List("A"), "A+B+C")
+        WorkNode("A", List("B"), "A+B+C"),
+        WorkNode("B", List("C"), "A+B+C"),
+        WorkNode("C", List("A"), "A+B+C")
       )
     }
   }
@@ -125,13 +125,11 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
         .update(
           workUpdate = LinkedWorkUpdate("A", Set.empty),
           existingGraph = WorkGraph(
-            Set(
-              WorkNode("A", List("B"), "A+B"),
-              WorkNode("B", List(), "A+B")))
+            Set(WorkNode("A", List("B"), "A+B"), WorkNode("B", List(), "A+B")))
         )
         .nodes shouldBe Set(
-          WorkNode("A", List(), "A"),
-          WorkNode("B", List(), "B"))
+        WorkNode("A", List(), "A"),
+        WorkNode("B", List(), "B"))
     }
 
     it(
@@ -142,8 +140,8 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
           existingGraph = WorkGraph(Set(WorkNode("A", List("B"), "A+B")))
         )
         .nodes shouldBe Set(
-          WorkNode("A", List(), "A"),
-          WorkNode("B", List(), "B"))
+        WorkNode("A", List(), "A"),
+        WorkNode("B", List(), "B"))
     }
 
     it("updating A->B->C with B gives A+B:(A->B, B) and C:C") {
@@ -156,9 +154,9 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
               WorkNode("B", List("C"), "A+B+C")))
         )
         .nodes shouldBe Set(
-          WorkNode("A", List("B"), "A+B"),
-          WorkNode("B", List(), "A+B"),
-          WorkNode("C", List(), "C"))
+        WorkNode("A", List("B"), "A+B"),
+        WorkNode("B", List(), "A+B"),
+        WorkNode("C", List(), "C"))
     }
 
     it("updating A<->B->C with B->C gives A+B+C:(A->B, B->C, C)") {
@@ -172,9 +170,9 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
               WorkNode("C", List(), "A+B+C")))
         )
         .nodes shouldBe Set(
-          WorkNode("A", List("B"), "A+B+C"),
-          WorkNode("B", List("C"), "A+B+C"),
-          WorkNode("C", List(), "A+B+C"))
+        WorkNode("A", List("B"), "A+B+C"),
+        WorkNode("B", List("C"), "A+B+C"),
+        WorkNode("C", List(), "A+B+C"))
     }
   }
 }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/LinkedWorkGraphUpdaterTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/LinkedWorkGraphUpdaterTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.matcher.workgraph
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.matcher.models.{
   LinkedWorkUpdate,
-  LinkedWorksGraph,
+  WorkGraph,
   WorkNode
 }
 
@@ -20,31 +20,31 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
       LinkedWorkGraphUpdater
         .update(
           workUpdate = LinkedWorkUpdate("A", Set.empty),
-          existingGraph = LinkedWorksGraph(Set.empty)
+          existingGraph = WorkGraph(Set.empty)
         )
-        .linkedWorksSet shouldBe Set(WorkNode("A", List(), "A"))
+        .nodes shouldBe Set(WorkNode("A", List(), "A"))
     }
 
     it("updating nothing with A->B gives A+B:A->B") {
       LinkedWorkGraphUpdater
         .update(
           workUpdate = LinkedWorkUpdate("A", Set("B")),
-          existingGraph = LinkedWorksGraph(Set.empty)
+          existingGraph = WorkGraph(Set.empty)
         )
-        .linkedWorksSet shouldBe Set(
-        WorkNode("A", List("B"), "A+B"),
-        WorkNode("B", List(), "A+B"))
+        .nodes shouldBe Set(
+          WorkNode("A", List("B"), "A+B"),
+          WorkNode("B", List(), "A+B"))
     }
 
     it("updating nothing with B->A gives A+B:B->A") {
       LinkedWorkGraphUpdater
         .update(
           workUpdate = LinkedWorkUpdate("B", Set("A")),
-          existingGraph = LinkedWorksGraph(Set.empty)
+          existingGraph = WorkGraph(Set.empty)
         )
-        .linkedWorksSet shouldBe Set(
-        WorkNode("B", List("A"), "A+B"),
-        WorkNode("A", List(), "A+B"))
+        .nodes shouldBe Set(
+          WorkNode("B", List("A"), "A+B"),
+          WorkNode("A", List(), "A+B"))
     }
   }
 
@@ -53,24 +53,23 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
       LinkedWorkGraphUpdater
         .update(
           workUpdate = LinkedWorkUpdate("A", Set("B")),
-          existingGraph =
-            LinkedWorksGraph(Set(WorkNode("A", List("B"), "A+B")))
+          existingGraph = WorkGraph(Set(WorkNode("A", List("B"), "A+B")))
         )
-        .linkedWorksSet should contain theSameElementsAs
-        List(WorkNode("A", List("B"), "A+B"), WorkNode("B", List(), "A+B"))
+        .nodes shouldBe Set(
+          WorkNode("A", List("B"), "A+B"),
+          WorkNode("B", List(), "A+B"))
     }
 
     it("updating A->B with B->C gives A+B+C:(A->B, B->C, C)") {
       LinkedWorkGraphUpdater
         .update(
           workUpdate = LinkedWorkUpdate("B", Set("C")),
-          existingGraph =
-            LinkedWorksGraph(Set(WorkNode("A", List("B"), "A+B")))
+          existingGraph = WorkGraph(Set(WorkNode("A", List("B"), "A+B")))
         )
-        .linkedWorksSet shouldBe Set(
-        WorkNode("A", List("B"), "A+B+C"),
-        WorkNode("B", List("C"), "A+B+C"),
-        WorkNode("C", List(), "A+B+C")
+        .nodes shouldBe Set(
+          WorkNode("A", List("B"), "A+B+C"),
+          WorkNode("B", List("C"), "A+B+C"),
+          WorkNode("C", List(), "A+B+C")
       )
     }
 
@@ -78,13 +77,12 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
       LinkedWorkGraphUpdater
         .update(
           workUpdate = LinkedWorkUpdate("B", Set("C")),
-          existingGraph = LinkedWorksGraph(
+          existingGraph = WorkGraph(
             Set(
               WorkNode("A", List("B"), "A+B"),
               WorkNode("C", List("D"), "C+D")))
         )
-        .linkedWorksSet should contain theSameElementsAs
-        List(
+        .nodes shouldBe Set(
           WorkNode("A", List("B"), "A+B+C+D"),
           WorkNode("B", List("C"), "A+B+C+D"),
           WorkNode("C", List("D"), "A+B+C+D"),
@@ -95,31 +93,28 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
       LinkedWorkGraphUpdater
         .update(
           workUpdate = LinkedWorkUpdate("B", Set("C", "D")),
-          existingGraph =
-            LinkedWorksGraph(Set(WorkNode("A", List("B"), "A+B")))
+          existingGraph = WorkGraph(Set(WorkNode("A", List("B"), "A+B")))
         )
-        .linkedWorksSet should contain theSameElementsAs
-        List(
+        .nodes shouldBe Set(
           WorkNode("A", List("B"), "A+B+C+D"),
           WorkNode("B", List("C", "D"), "A+B+C+D"),
           WorkNode("C", List(), "A+B+C+D"),
-          WorkNode("D", List(), "A+B+C+D")
-        )
+          WorkNode("D", List(), "A+B+C+D"))
     }
 
     it("updating A->B->C with A->C gives A+B+C:(A->B, B->C, C->A") {
       LinkedWorkGraphUpdater
         .update(
           workUpdate = LinkedWorkUpdate("C", Set("A")),
-          existingGraph = LinkedWorksGraph(
+          existingGraph = WorkGraph(
             Set(
               WorkNode("A", List("B"), "A+B"),
               WorkNode("B", List("C"), "B+C")))
         )
-        .linkedWorksSet shouldBe Set(
-        WorkNode("A", List("B"), "A+B+C"),
-        WorkNode("B", List("C"), "A+B+C"),
-        WorkNode("C", List("A"), "A+B+C")
+        .nodes shouldBe Set(
+          WorkNode("A", List("B"), "A+B+C"),
+          WorkNode("B", List("C"), "A+B+C"),
+          WorkNode("C", List("A"), "A+B+C")
       )
     }
   }
@@ -129,12 +124,14 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
       LinkedWorkGraphUpdater
         .update(
           workUpdate = LinkedWorkUpdate("A", Set.empty),
-          existingGraph = LinkedWorksGraph(
-            Set(WorkNode("A", List("B"), "A+B"), WorkNode("B", List(), "A+B")))
+          existingGraph = WorkGraph(
+            Set(
+              WorkNode("A", List("B"), "A+B"),
+              WorkNode("B", List(), "A+B")))
         )
-        .linkedWorksSet shouldBe Set(
-        WorkNode("A", List(), "A"),
-        WorkNode("B", List(), "B"))
+        .nodes shouldBe Set(
+          WorkNode("A", List(), "A"),
+          WorkNode("B", List(), "B"))
     }
 
     it(
@@ -142,43 +139,42 @@ class LinkedWorkGraphUpdaterTest extends FunSpec with Matchers {
       LinkedWorkGraphUpdater
         .update(
           workUpdate = LinkedWorkUpdate("A", Set.empty),
-          existingGraph =
-            LinkedWorksGraph(Set(WorkNode("A", List("B"), "A+B")))
+          existingGraph = WorkGraph(Set(WorkNode("A", List("B"), "A+B")))
         )
-        .linkedWorksSet shouldBe Set(
-        WorkNode("A", List(), "A"),
-        WorkNode("B", List(), "B"))
+        .nodes shouldBe Set(
+          WorkNode("A", List(), "A"),
+          WorkNode("B", List(), "B"))
     }
 
     it("updating A->B->C with B gives A+B:(A->B, B) and C:C") {
       LinkedWorkGraphUpdater
         .update(
           workUpdate = LinkedWorkUpdate("B", Set.empty),
-          existingGraph = LinkedWorksGraph(
+          existingGraph = WorkGraph(
             Set(
               WorkNode("A", List("B"), "A+B+C"),
               WorkNode("B", List("C"), "A+B+C")))
         )
-        .linkedWorksSet shouldBe Set(
-        WorkNode("A", List("B"), "A+B"),
-        WorkNode("B", List(), "A+B"),
-        WorkNode("C", List(), "C"))
+        .nodes shouldBe Set(
+          WorkNode("A", List("B"), "A+B"),
+          WorkNode("B", List(), "A+B"),
+          WorkNode("C", List(), "C"))
     }
 
     it("updating A<->B->C with B->C gives A+B+C:(A->B, B->C, C)") {
       LinkedWorkGraphUpdater
         .update(
           workUpdate = LinkedWorkUpdate("B", Set("C")),
-          existingGraph = LinkedWorksGraph(
+          existingGraph = WorkGraph(
             Set(
               WorkNode("A", List("B"), "A+B+C"),
               WorkNode("B", List("A", "C"), "A+B+C"),
               WorkNode("C", List(), "A+B+C")))
         )
-        .linkedWorksSet shouldBe Set(
-        WorkNode("A", List("B"), "A+B+C"),
-        WorkNode("B", List("C"), "A+B+C"),
-        WorkNode("C", List(), "A+B+C"))
+        .nodes shouldBe Set(
+          WorkNode("A", List("B"), "A+B+C"),
+          WorkNode("B", List("C"), "A+B+C"),
+          WorkNode("C", List(), "A+B+C"))
     }
   }
 }


### PR DESCRIPTION
Continuing the graph-centric terminology and renaming established in #2155.