### PR TITLE
Rename LinkedWorkDao to WorkNodeDao

### DIFF
--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
@@ -8,23 +8,23 @@ import uk.ac.wellcome.storage.GlobalExecutionContext._
 import scala.concurrent.Future
 
 class WorkGraphStore @Inject()(
-  linkedWorkDao: LinkedWorkDao
+  workNodeDao: WorkNodeDao
 ) extends Logging {
 
   def findAffectedWorks(workUpdate: LinkedWorkUpdate): Future[WorkGraph] = {
     val directlyAffectedWorkIds = workUpdate.linkedIds + workUpdate.workId
 
     for {
-      directlyAffectedWorks <- linkedWorkDao.get(directlyAffectedWorkIds)
+      directlyAffectedWorks <- workNodeDao.get(directlyAffectedWorkIds)
       affectedSetIds = directlyAffectedWorks.map(workNode =>
         workNode.componentId)
-      affectedWorks <- linkedWorkDao.getBySetIds(affectedSetIds)
+      affectedWorks <- workNodeDao.getBySetIds(affectedSetIds)
     } yield WorkGraph(affectedWorks)
   }
 
   def put(graph: WorkGraph) = {
     Future.sequence(
-      graph.nodes.map(linkedWorkDao.put)
+      graph.nodes.map(workNodeDao.put)
     )
   }
 }

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
@@ -16,9 +16,9 @@ class WorkGraphStore @Inject()(
 
     for {
       directlyAffectedWorks <- workNodeDao.get(directlyAffectedWorkIds)
-      affectedSetIds = directlyAffectedWorks.map(workNode =>
+      affectedComponentIds = directlyAffectedWorks.map(workNode =>
         workNode.componentId)
-      affectedWorks <- workNodeDao.getBySetIds(affectedSetIds)
+      affectedWorks <- workNodeDao.getByComponentIds(affectedComponentIds)
     } yield WorkGraph(affectedWorks)
   }
 

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
 import scala.concurrent.Future
 
-class LinkedWorkDao @Inject()(
+class WorkNodeDao @Inject()(
   dynamoDbClient: AmazonDynamoDB,
   dynamoConfig: DynamoConfig
 ) extends Logging {

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
@@ -20,25 +20,22 @@ class WorkNodeDao @Inject()(
   val index = dynamoConfig.index.getOrElse(
     throw new RuntimeException("Index cannot be empty!"))
 
-  def getBySetIds(setIds: Set[String]): Future[Set[WorkNode]] =
-    Future.sequence(setIds.map(getBySetId)).map(_.flatten)
-
   def put(work: WorkNode): Future[Option[Either[DynamoReadError, WorkNode]]] = {
     Future {
       Scanamo.put(dynamoDbClient)(dynamoConfig.table)(work)
     }
   }
 
-  def get(workIds: Set[String]): Future[Set[WorkNode]] = {
+  def get(ids: Set[String]): Future[Set[WorkNode]] = {
     Future {
       Scanamo
-        .getAll[WorkNode](dynamoDbClient)(dynamoConfig.table)('id -> workIds)
+        .getAll[WorkNode](dynamoDbClient)(dynamoConfig.table)('id -> ids)
         .map {
           case Right(works) => works
           case Left(scanamoError) => {
             val exception = new RuntimeException(scanamoError.toString)
             error(
-              s"An error occurred while retrieving all workIds=$workIds from DynamoDB",
+              s"An error occurred while retrieving all workIds=$ids from DynamoDB",
               exception)
             throw exception
           }
@@ -46,11 +43,14 @@ class WorkNodeDao @Inject()(
     }
   }
 
-  private def getBySetId(setId: String) = {
+  def getByComponentIds(setIds: Set[String]): Future[Set[WorkNode]] =
+    Future.sequence(setIds.map(getByComponentId)).map(_.flatten)
+
+  private def getByComponentId(componentId: String) = {
     Future {
       Scanamo
         .queryIndex[WorkNode](dynamoDbClient)(dynamoConfig.table, index)(
-          'componentId -> setId)
+          'componentId -> componentId)
         .map {
           case Right(record) => {
             record
@@ -58,7 +58,7 @@ class WorkNodeDao @Inject()(
           case Left(scanamoError) => {
             val exception = new RuntimeException(scanamoError.toString)
             error(
-              s"An error occurred while retrieving bySetId=$setId from DynamoDB",
+              s"An error occurred while retrieving byComponentId=$componentId from DynamoDB",
               exception
             )
             throw exception

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.matcher.Server
 import uk.ac.wellcome.platform.matcher.matcher.LinkedWorkMatcher
 import uk.ac.wellcome.platform.matcher.messages.MatcherMessageReceiver
-import uk.ac.wellcome.platform.matcher.storage.{LinkedWorkDao, WorkGraphStore, WorkNodeDao}
+import uk.ac.wellcome.platform.matcher.storage.{WorkGraphStore, WorkNodeDao}
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.s3.{S3Config, S3TypeStore}
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -7,7 +7,11 @@ import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
-import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  IdentifierType,
+  SourceIdentifier,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.matcher.Server
 import uk.ac.wellcome.platform.matcher.matcher.LinkedWorkMatcher
@@ -109,8 +113,7 @@ trait MatcherFixtures
     }
   }
 
-  def withWorkNodeDao[R](table: Table)(
-    testWith: TestWith[WorkNodeDao, R]): R = {
+  def withWorkNodeDao[R](table: Table)(testWith: TestWith[WorkNodeDao, R]): R = {
     val workNodeDao = new WorkNodeDao(
       dynamoDbClient,
       DynamoConfig(table.name, Some(table.index)))

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -7,16 +7,12 @@ import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
-import uk.ac.wellcome.models.work.internal.{
-  IdentifierType,
-  SourceIdentifier,
-  UnidentifiedWork
-}
+import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier, UnidentifiedWork}
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.matcher.Server
 import uk.ac.wellcome.platform.matcher.matcher.LinkedWorkMatcher
 import uk.ac.wellcome.platform.matcher.messages.MatcherMessageReceiver
-import uk.ac.wellcome.platform.matcher.storage.{LinkedWorkDao, WorkGraphStore}
+import uk.ac.wellcome.platform.matcher.storage.{LinkedWorkDao, WorkGraphStore, WorkNodeDao}
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.s3.{S3Config, S3TypeStore}
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
@@ -107,18 +103,18 @@ trait MatcherFixtures
 
   def withWorkGraphStore[R](table: Table)(
     testWith: TestWith[WorkGraphStore, R]): R = {
-    withLinkedWorkDao(table) { linkedWorkDao =>
-      val workGraphStore = new WorkGraphStore(linkedWorkDao)
+    withWorkNodeDao(table) { workNodeDao =>
+      val workGraphStore = new WorkGraphStore(workNodeDao)
       testWith(workGraphStore)
     }
   }
 
-  def withLinkedWorkDao[R](table: Table)(
-    testWith: TestWith[LinkedWorkDao, R]): R = {
-    val linkedDao = new LinkedWorkDao(
+  def withWorkNodeDao[R](table: Table)(
+    testWith: TestWith[WorkNodeDao, R]): R = {
+    val workNodeDao = new WorkNodeDao(
       dynamoDbClient,
       DynamoConfig(table.name, Some(table.index)))
-    testWith(linkedDao)
+    testWith(workNodeDao)
   }
 
   def aSierraSourceIdentifier(id: String) =

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
@@ -144,11 +144,11 @@ class WorkGraphStoreTest
 
     it("throws if linkedDao fails to put") {
       withLocalDynamoDbTable { table =>
-        val mockLinkedWorkDao = mock[LinkedWorkDao]
+        val mockWorkNodeDao = mock[WorkNodeDao]
         val expectedException = new RuntimeException("FAILED")
-        when(mockLinkedWorkDao.put(any[WorkNode]))
+        when(mockWorkNodeDao.put(any[WorkNode]))
           .thenReturn(Future.failed(expectedException))
-        val workGraphStore = new WorkGraphStore(mockLinkedWorkDao)
+        val workGraphStore = new WorkGraphStore(mockWorkNodeDao)
 
         whenReady(
           workGraphStore

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
@@ -82,10 +82,10 @@ class WorkNodeDaoTest
   }
 
   describe("Get by SetIds") {
-    it("returns empty set if setIds are not in dynamo") {
+    it("returns empty set if componentIds are not in dynamo") {
       withLocalDynamoDbTable { table =>
         withWorkNodeDao(table) { workNodeDao =>
-          whenReady(workNodeDao.getBySetIds(Set("Not-there"))) {
+          whenReady(workNodeDao.getByComponentIds(Set("Not-there"))) {
             workNodeSet => workNodeSet shouldBe Set()
           }
         }
@@ -100,7 +100,7 @@ class WorkNodeDaoTest
           Scanamo.put(dynamoDbClient)(table.name)(workNodeA)
           Scanamo.put(dynamoDbClient)(table.name)(workNodeB)
 
-          whenReady(workNodeDao.getBySetIds(Set("A+B"))) { workNodeSet =>
+          whenReady(workNodeDao.getByComponentIds(Set("A+B"))) { workNodeSet =>
             workNodeSet shouldBe Set(workNodeA, workNodeB)
           }
         }
@@ -117,7 +117,7 @@ class WorkNodeDaoTest
           dynamoDbClient,
           DynamoConfig(table.name, Some(table.index)))
 
-        whenReady(workNodeDao.getBySetIds(Set("A+B")).failed) {
+        whenReady(workNodeDao.getByComponentIds(Set("A+B")).failed) {
           failedException =>
             failedException shouldBe expectedException
         }
@@ -131,7 +131,7 @@ class WorkNodeDaoTest
           val badRecord: BadRecord = BadRecord(id = "A", componentId = "A+B")
           Scanamo.put(dynamoDbClient)(table.name)(badRecord)
 
-          whenReady(workNodeDao.getBySetIds(Set("A+B")).failed) {
+          whenReady(workNodeDao.getByComponentIds(Set("A+B")).failed) {
             failedException =>
               failedException shouldBe a[RuntimeException]
           }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
@@ -86,7 +86,8 @@ class WorkNodeDaoTest
       withLocalDynamoDbTable { table =>
         withWorkNodeDao(table) { workNodeDao =>
           whenReady(workNodeDao.getByComponentIds(Set("Not-there"))) {
-            workNodeSet => workNodeSet shouldBe Set()
+            workNodeSet =>
+              workNodeSet shouldBe Set()
           }
         }
       }
@@ -146,8 +147,8 @@ class WorkNodeDaoTest
         withWorkNodeDao(table) { workNodeDao =>
           val workNode = WorkNode("A", List("B"), "A+B")
           whenReady(workNodeDao.put(workNode)) { _ =>
-            val savedWorkNode = Scanamo.get[WorkNode](dynamoDbClient)(
-              table.name)('id -> "A")
+            val savedWorkNode =
+              Scanamo.get[WorkNode](dynamoDbClient)(table.name)('id -> "A")
             savedWorkNode shouldBe Some(Right(workNode))
           }
         }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.platform.matcher.models.WorkNode
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
-class LinkedWorkDaoTest
+class WorkNodeDaoTest
     extends FunSpec
     with Matchers
     with MockitoSugar
@@ -27,8 +27,8 @@ class LinkedWorkDaoTest
   describe("Get from dynamo") {
     it("returns nothing if ids are not in dynamo") {
       withLocalDynamoDbTable { table =>
-        withLinkedWorkDao(table) { linkedWorkDao =>
-          whenReady(linkedWorkDao.get(Set("Not-there"))) { workNodeSet =>
+        withWorkNodeDao(table) { workNodeDao =>
+          whenReady(workNodeDao.get(Set("Not-there"))) { workNodeSet =>
             workNodeSet shouldBe Set.empty
           }
         }
@@ -37,13 +37,13 @@ class LinkedWorkDaoTest
 
     it("returns WorkNodes which are stored in DynamoDB") {
       withLocalDynamoDbTable { table =>
-        withLinkedWorkDao(table) { linkedWorkDao =>
+        withWorkNodeDao(table) { workNodeDao =>
           val workNodeA = WorkNode("A", List("B"), "A+B")
           val workNodeB = WorkNode("B", Nil, "A+B")
           Scanamo.put(dynamoDbClient)(table.name)(workNodeA)
           Scanamo.put(dynamoDbClient)(table.name)(workNodeB)
 
-          whenReady(linkedWorkDao.get(Set("A", "B"))) { workNodeSet =>
+          whenReady(workNodeDao.get(Set("A", "B"))) { workNodeSet =>
             workNodeSet shouldBe Set(workNodeA, workNodeB)
           }
         }
@@ -56,7 +56,7 @@ class LinkedWorkDaoTest
         val expectedException = new RuntimeException("FAILED!")
         when(dynamoDbClient.batchGetItem(any[BatchGetItemRequest]))
           .thenThrow(expectedException)
-        val matcherGraphDao = new LinkedWorkDao(
+        val matcherGraphDao = new WorkNodeDao(
           dynamoDbClient,
           DynamoConfig(table.name, Some(table.index)))
 
@@ -68,12 +68,12 @@ class LinkedWorkDaoTest
 
     it("returns an error if Scanamo fails") {
       withLocalDynamoDbTable { table =>
-        withLinkedWorkDao(table) { matcherGraphDao =>
+        withWorkNodeDao(table) { workNodeDao =>
           case class BadRecord(id: String)
           val badRecord: BadRecord = BadRecord(id = "A")
           Scanamo.put(dynamoDbClient)(table.name)(badRecord)
 
-          whenReady(matcherGraphDao.get(Set("A")).failed) { failedException =>
+          whenReady(workNodeDao.get(Set("A")).failed) { failedException =>
             failedException shouldBe a[RuntimeException]
           }
         }
@@ -84,10 +84,9 @@ class LinkedWorkDaoTest
   describe("Get by SetIds") {
     it("returns empty set if setIds are not in dynamo") {
       withLocalDynamoDbTable { table =>
-        withLinkedWorkDao(table) { matcherGraphDao =>
-          whenReady(matcherGraphDao.getBySetIds(Set("Not-there"))) {
-            workNodeSet =>
-              workNodeSet shouldBe Set()
+        withWorkNodeDao(table) { workNodeDao =>
+          whenReady(workNodeDao.getBySetIds(Set("Not-there"))) {
+            workNodeSet => workNodeSet shouldBe Set()
           }
         }
       }
@@ -95,13 +94,13 @@ class LinkedWorkDaoTest
 
     it("returns WorkNodes which are stored in DynamoDB") {
       withLocalDynamoDbTable { table =>
-        withLinkedWorkDao(table) { matcherGraphDao =>
+        withWorkNodeDao(table) { workNodeDao =>
           val workNodeA = WorkNode("A", List("B"), "A+B")
           val workNodeB = WorkNode("B", Nil, "A+B")
           Scanamo.put(dynamoDbClient)(table.name)(workNodeA)
           Scanamo.put(dynamoDbClient)(table.name)(workNodeB)
 
-          whenReady(matcherGraphDao.getBySetIds(Set("A+B"))) { workNodeSet =>
+          whenReady(workNodeDao.getBySetIds(Set("A+B"))) { workNodeSet =>
             workNodeSet shouldBe Set(workNodeA, workNodeB)
           }
         }
@@ -114,11 +113,11 @@ class LinkedWorkDaoTest
         val expectedException = new RuntimeException("FAILED")
         when(dynamoDbClient.query(any[QueryRequest]))
           .thenThrow(expectedException)
-        val linkedWordDao = new LinkedWorkDao(
+        val workNodeDao = new WorkNodeDao(
           dynamoDbClient,
           DynamoConfig(table.name, Some(table.index)))
 
-        whenReady(linkedWordDao.getBySetIds(Set("A+B")).failed) {
+        whenReady(workNodeDao.getBySetIds(Set("A+B")).failed) {
           failedException =>
             failedException shouldBe expectedException
         }
@@ -127,12 +126,12 @@ class LinkedWorkDaoTest
 
     it("returns an error if Scanamo fails") {
       withLocalDynamoDbTable { table =>
-        withLinkedWorkDao(table) { matcherGraphDao =>
+        withWorkNodeDao(table) { workNodeDao =>
           case class BadRecord(id: String, componentId: String)
           val badRecord: BadRecord = BadRecord(id = "A", componentId = "A+B")
           Scanamo.put(dynamoDbClient)(table.name)(badRecord)
 
-          whenReady(matcherGraphDao.getBySetIds(Set("A+B")).failed) {
+          whenReady(workNodeDao.getBySetIds(Set("A+B")).failed) {
             failedException =>
               failedException shouldBe a[RuntimeException]
           }
@@ -144,11 +143,11 @@ class LinkedWorkDaoTest
   describe("Insert into dynamo") {
     it("puts a WorkNode") {
       withLocalDynamoDbTable { table =>
-        withLinkedWorkDao(table) { linkedWordDao =>
+        withWorkNodeDao(table) { workNodeDao =>
           val workNode = WorkNode("A", List("B"), "A+B")
-          whenReady(linkedWordDao.put(workNode)) { _ =>
-            val savedWorkNode =
-              Scanamo.get[WorkNode](dynamoDbClient)(table.name)('id -> "A")
+          whenReady(workNodeDao.put(workNode)) { _ =>
+            val savedWorkNode = Scanamo.get[WorkNode](dynamoDbClient)(
+              table.name)('id -> "A")
             savedWorkNode shouldBe Some(Right(workNode))
           }
         }
@@ -161,11 +160,11 @@ class LinkedWorkDaoTest
         val expectedException = new RuntimeException("FAILED")
         when(dynamoDbClient.putItem(any[PutItemRequest]))
           .thenThrow(expectedException)
-        val linkedWordDao = new LinkedWorkDao(
+        val workNodeDao = new WorkNodeDao(
           dynamoDbClient,
           DynamoConfig(table.name, Some(table.index)))
 
-        whenReady(linkedWordDao.put(WorkNode("A", List("B"), "A+B")).failed) {
+        whenReady(workNodeDao.put(WorkNode("A", List("B"), "A+B")).failed) {
           failedException =>
             failedException shouldBe expectedException
         }
@@ -175,7 +174,7 @@ class LinkedWorkDaoTest
 
   it("cannot be instantiated if dynamoConfig.index is a None") {
     intercept[RuntimeException] {
-      new LinkedWorkDao(dynamoDbClient, DynamoConfig("something", None))
+      new WorkNodeDao(dynamoDbClient, DynamoConfig("something", None))
     }
   }
 


### PR DESCRIPTION
Follows #2155, #2156.

In particular, since we renamed LinkedWork to WorkNode in #2155, it doesn’t make much sense to have a LinkedWorkDao any more, so let’s fix that!