### PR TITLE
Replace IdentifierList with MatchedIdentifiers + new namespace

### DIFF
--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcher.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcher.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.matcher.matcher
 
 import com.google.inject.Inject
-import uk.ac.wellcome.models.matcher.EquivalentIdentifiers
+import uk.ac.wellcome.models.matcher.MatchedIdentifiers
 import uk.ac.wellcome.models.work.internal.UnidentifiedWork
 import uk.ac.wellcome.platform.matcher.models._
 import uk.ac.wellcome.platform.matcher.storage.WorkGraphStore
@@ -15,7 +15,7 @@ class LinkedWorkMatcher @Inject()(workGraphStore: WorkGraphStore) {
     matchLinkedWorks(work).map(LinkedWorksIdentifiersList)
 
   private def matchLinkedWorks(
-    work: UnidentifiedWork): Future[Set[EquivalentIdentifiers]] = {
+    work: UnidentifiedWork): Future[Set[MatchedIdentifiers]] = {
     val workUpdate = WorkUpdate(work)
 
     for {
@@ -34,7 +34,7 @@ class LinkedWorkMatcher @Inject()(workGraphStore: WorkGraphStore) {
   private def convertToEquivalentIdentifiersSet(updatedGraph: WorkGraph) = {
     groupBySetId(updatedGraph).map {
       case (_, workNodeList) =>
-        EquivalentIdentifiers(workNodeList.map(_.id))
+        MatchedIdentifiers(workNodeList.map(_.id))
     }.toSet
   }
 

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcher.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcher.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.matcher.matcher
 
 import com.google.inject.Inject
+import uk.ac.wellcome.models.matcher.EquivalentIdentifiers
 import uk.ac.wellcome.models.work.internal.UnidentifiedWork
 import uk.ac.wellcome.platform.matcher.models._
 import uk.ac.wellcome.platform.matcher.storage.WorkGraphStore
@@ -14,7 +15,7 @@ class LinkedWorkMatcher @Inject()(workGraphStore: WorkGraphStore) {
     matchLinkedWorks(work).map(LinkedWorksIdentifiersList)
 
   private def matchLinkedWorks(
-    work: UnidentifiedWork): Future[Set[IdentifierList]] = {
+    work: UnidentifiedWork): Future[Set[EquivalentIdentifiers]] = {
     val workUpdate = WorkUpdate(work)
 
     for {
@@ -26,14 +27,14 @@ class LinkedWorkMatcher @Inject()(workGraphStore: WorkGraphStore) {
       _ <- workGraphStore.put(updatedGraph)
 
     } yield {
-      convertToIdentifiersList(updatedGraph)
+      convertToEquivalentIdentifiersSet(updatedGraph)
     }
   }
 
-  private def convertToIdentifiersList(updatedGraph: WorkGraph) = {
+  private def convertToEquivalentIdentifiersSet(updatedGraph: WorkGraph) = {
     groupBySetId(updatedGraph).map {
       case (_, workNodeList) =>
-        IdentifierList(workNodeList.map(_.id))
+        EquivalentIdentifiers(workNodeList.map(_.id))
     }.toSet
   }
 

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/IdentifierList.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/IdentifierList.scala
@@ -1,3 +1,0 @@
-package uk.ac.wellcome.platform.matcher.models
-
-case class IdentifierList(identifiers: Set[String])

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/LinkedWorksIdentifiersList.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/LinkedWorksIdentifiersList.scala
@@ -1,3 +1,5 @@
 package uk.ac.wellcome.platform.matcher.models
 
-case class LinkedWorksIdentifiersList(linkedWorks: Set[IdentifierList])
+import uk.ac.wellcome.models.matcher.EquivalentIdentifiers
+
+case class LinkedWorksIdentifiersList(linkedWorks: Set[EquivalentIdentifiers])

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/LinkedWorksIdentifiersList.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/LinkedWorksIdentifiersList.scala
@@ -1,5 +1,5 @@
 package uk.ac.wellcome.platform.matcher.models
 
-import uk.ac.wellcome.models.matcher.EquivalentIdentifiers
+import uk.ac.wellcome.models.matcher.MatchedIdentifiers
 
-case class LinkedWorksIdentifiersList(linkedWorks: Set[EquivalentIdentifiers])
+case class LinkedWorksIdentifiersList(linkedWorks: Set[MatchedIdentifiers])

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -6,7 +6,11 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.models.matcher.MatchedIdentifiers
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
-import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  IdentifierType,
+  SourceIdentifier,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.platform.matcher.models.LinkedWorksIdentifiersList
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -4,17 +4,11 @@ import com.amazonaws.services.s3.AmazonS3
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.models.matcher.EquivalentIdentifiers
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
-import uk.ac.wellcome.models.work.internal.{
-  IdentifierType,
-  SourceIdentifier,
-  UnidentifiedWork
-}
+import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier, UnidentifiedWork}
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
-import uk.ac.wellcome.platform.matcher.models.{
-  IdentifierList,
-  LinkedWorksIdentifiersList
-}
+import uk.ac.wellcome.platform.matcher.models.LinkedWorksIdentifiersList
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.storage.vhs.HybridRecord
 import uk.ac.wellcome.test.utils.ExtendedPatience
@@ -64,7 +58,7 @@ class MatcherFeatureTest
                   val identifiersList =
                     fromJson[LinkedWorksIdentifiersList](snsMessage.message).get
                   identifiersList.linkedWorks shouldBe Set(
-                    IdentifierList(Set("sierra-system-number/id")))
+                    EquivalentIdentifiers(Set("sierra-system-number/id")))
                 }
               }
             }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.s3.AmazonS3
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.models.matcher.EquivalentIdentifiers
+import uk.ac.wellcome.models.matcher.MatchedIdentifiers
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
 import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier, UnidentifiedWork}
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
@@ -58,7 +58,7 @@ class MatcherFeatureTest
                   val identifiersList =
                     fromJson[LinkedWorksIdentifiersList](snsMessage.message).get
                   identifiersList.linkedWorks shouldBe Set(
-                    EquivalentIdentifiers(Set("sierra-system-number/id")))
+                    MatchedIdentifiers(Set("sierra-system-number/id")))
                 }
               }
             }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcherTest.scala
@@ -7,7 +7,7 @@ import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.matcher.EquivalentIdentifiers
+import uk.ac.wellcome.models.matcher.MatchedIdentifiers
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.platform.matcher.models._
 import uk.ac.wellcome.platform.matcher.storage.WorkGraphStore
@@ -30,7 +30,7 @@ class LinkedWorkMatcherTest
             identifiersList =>
               val workId = "sierra-system-number/id"
               identifiersList shouldBe
-                LinkedWorksIdentifiersList(Set(EquivalentIdentifiers(Set(workId))))
+                LinkedWorksIdentifiersList(Set(MatchedIdentifiers(Set(workId))))
 
               val savedLinkedWork = Scanamo
                 .get[WorkNode](dynamoDbClient)(table.name)('id -> workId)
@@ -54,7 +54,7 @@ class LinkedWorkMatcherTest
             identifiers = List(aIdentifier, linkedIdentifier))
           whenReady(linkedWorkMatcher.matchWork(work)) { identifiersList =>
             identifiersList shouldBe
-              LinkedWorksIdentifiersList(Set(EquivalentIdentifiers(
+              LinkedWorksIdentifiersList(Set(MatchedIdentifiers(
                 Set("sierra-system-number/A", "sierra-system-number/B"))))
 
             val savedWorkNodes = Scanamo
@@ -101,7 +101,7 @@ class LinkedWorkMatcherTest
             identifiersList shouldBe
               LinkedWorksIdentifiersList(
                 Set(
-                  EquivalentIdentifiers(
+                  MatchedIdentifiers(
                     Set(
                       "sierra-system-number/A",
                       "sierra-system-number/B",

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcherTest.scala
@@ -30,7 +30,8 @@ class LinkedWorkMatcherTest
             identifiersList =>
               val workId = "sierra-system-number/id"
               identifiersList shouldBe
-                LinkedWorksIdentifiersList(Set(MatchedIdentifiers(Set(workId))))
+                LinkedWorksIdentifiersList(
+                  Set(MatchedIdentifiers(Set(workId))))
 
               val savedLinkedWork = Scanamo
                 .get[WorkNode](dynamoDbClient)(table.name)('id -> workId)

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcherTest.scala
@@ -7,6 +7,7 @@ import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.matcher.EquivalentIdentifiers
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.platform.matcher.models._
 import uk.ac.wellcome.platform.matcher.storage.WorkGraphStore
@@ -29,7 +30,7 @@ class LinkedWorkMatcherTest
             identifiersList =>
               val workId = "sierra-system-number/id"
               identifiersList shouldBe
-                LinkedWorksIdentifiersList(Set(IdentifierList(Set(workId))))
+                LinkedWorksIdentifiersList(Set(EquivalentIdentifiers(Set(workId))))
 
               val savedLinkedWork = Scanamo
                 .get[WorkNode](dynamoDbClient)(table.name)('id -> workId)
@@ -53,7 +54,7 @@ class LinkedWorkMatcherTest
             identifiers = List(aIdentifier, linkedIdentifier))
           whenReady(linkedWorkMatcher.matchWork(work)) { identifiersList =>
             identifiersList shouldBe
-              LinkedWorksIdentifiersList(Set(IdentifierList(
+              LinkedWorksIdentifiersList(Set(EquivalentIdentifiers(
                 Set("sierra-system-number/A", "sierra-system-number/B"))))
 
             val savedWorkNodes = Scanamo
@@ -100,7 +101,7 @@ class LinkedWorkMatcherTest
             identifiersList shouldBe
               LinkedWorksIdentifiersList(
                 Set(
-                  IdentifierList(
+                  EquivalentIdentifiers(
                     Set(
                       "sierra-system-number/A",
                       "sierra-system-number/B",

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS
-import uk.ac.wellcome.models.matcher.EquivalentIdentifiers
+import uk.ac.wellcome.models.matcher.MatchedIdentifiers
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
 import uk.ac.wellcome.models.work.internal.UnidentifiedWork
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
@@ -34,7 +34,7 @@ class MatcherMessageReceiverTest
               assertMessageSent(
                 topic,
                 LinkedWorksIdentifiersList(
-                  Set(EquivalentIdentifiers(Set("sierra-system-number/id"))))
+                  Set(MatchedIdentifiers(Set("sierra-system-number/id"))))
               )
             }
           }
@@ -60,7 +60,7 @@ class MatcherMessageReceiverTest
             eventually {
               assertMessageSent(
                 topic,
-                LinkedWorksIdentifiersList(Set(EquivalentIdentifiers(
+                LinkedWorksIdentifiersList(Set(MatchedIdentifiers(
                   Set("sierra-system-number/A", "sierra-system-number/B"))))
               )
             }
@@ -91,7 +91,7 @@ class MatcherMessageReceiverTest
                 topic,
                 LinkedWorksIdentifiersList(
                   Set(
-                    EquivalentIdentifiers(
+                    MatchedIdentifiers(
                       Set(
                         "sierra-system-number/A",
                         "sierra-system-number/B"
@@ -110,7 +110,7 @@ class MatcherMessageReceiverTest
                   topic,
                   LinkedWorksIdentifiersList(
                     Set(
-                      EquivalentIdentifiers(
+                      MatchedIdentifiers(
                         Set(
                           "sierra-system-number/A",
                           "sierra-system-number/B",
@@ -145,7 +145,7 @@ class MatcherMessageReceiverTest
                 topic,
                 LinkedWorksIdentifiersList(
                   Set(
-                    EquivalentIdentifiers(
+                    MatchedIdentifiers(
                       Set(
                         "sierra-system-number/A",
                         "sierra-system-number/B"
@@ -164,10 +164,10 @@ class MatcherMessageReceiverTest
                   topic,
                   LinkedWorksIdentifiersList(
                     Set(
-                      EquivalentIdentifiers(Set(
+                      MatchedIdentifiers(Set(
                         "sierra-system-number/A"
                       )),
-                      EquivalentIdentifiers(Set(
+                      MatchedIdentifiers(Set(
                         "sierra-system-number/B"
                       ))
                     ))

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
@@ -6,13 +6,11 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS
+import uk.ac.wellcome.models.matcher.EquivalentIdentifiers
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
 import uk.ac.wellcome.models.work.internal.UnidentifiedWork
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
-import uk.ac.wellcome.platform.matcher.models.{
-  IdentifierList,
-  LinkedWorksIdentifiersList
-}
+import uk.ac.wellcome.platform.matcher.models.LinkedWorksIdentifiersList
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.storage.vhs.HybridRecord
 import uk.ac.wellcome.test.utils.ExtendedPatience
@@ -36,7 +34,7 @@ class MatcherMessageReceiverTest
               assertMessageSent(
                 topic,
                 LinkedWorksIdentifiersList(
-                  Set(IdentifierList(Set("sierra-system-number/id"))))
+                  Set(EquivalentIdentifiers(Set("sierra-system-number/id"))))
               )
             }
           }
@@ -62,7 +60,7 @@ class MatcherMessageReceiverTest
             eventually {
               assertMessageSent(
                 topic,
-                LinkedWorksIdentifiersList(Set(IdentifierList(
+                LinkedWorksIdentifiersList(Set(EquivalentIdentifiers(
                   Set("sierra-system-number/A", "sierra-system-number/B"))))
               )
             }
@@ -93,7 +91,7 @@ class MatcherMessageReceiverTest
                 topic,
                 LinkedWorksIdentifiersList(
                   Set(
-                    IdentifierList(
+                    EquivalentIdentifiers(
                       Set(
                         "sierra-system-number/A",
                         "sierra-system-number/B"
@@ -112,7 +110,7 @@ class MatcherMessageReceiverTest
                   topic,
                   LinkedWorksIdentifiersList(
                     Set(
-                      IdentifierList(
+                      EquivalentIdentifiers(
                         Set(
                           "sierra-system-number/A",
                           "sierra-system-number/B",
@@ -147,7 +145,7 @@ class MatcherMessageReceiverTest
                 topic,
                 LinkedWorksIdentifiersList(
                   Set(
-                    IdentifierList(
+                    EquivalentIdentifiers(
                       Set(
                         "sierra-system-number/A",
                         "sierra-system-number/B"
@@ -166,10 +164,10 @@ class MatcherMessageReceiverTest
                   topic,
                   LinkedWorksIdentifiersList(
                     Set(
-                      IdentifierList(Set(
+                      EquivalentIdentifiers(Set(
                         "sierra-system-number/A"
                       )),
-                      IdentifierList(Set(
+                      EquivalentIdentifiers(Set(
                         "sierra-system-number/B"
                       ))
                     ))

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/EquivalentIdentifiers.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/EquivalentIdentifiers.scala
@@ -1,0 +1,10 @@
+package uk.ac.wellcome.models.matcher
+
+// Represents a collection of identifiers that represent the same Work.i
+//
+// The identifiers in this set should be merged together.
+//
+// For example, if the matcher sends EquivalentIdentifiers({A, B, C}), it
+// means the merger should combine these into a single work.
+//
+case class EquivalentIdentifiers(identifiers: Set[String])

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/MatchedIdentifiers.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/MatchedIdentifiers.scala
@@ -4,7 +4,7 @@ package uk.ac.wellcome.models.matcher
 //
 // The identifiers in this set should be merged together.
 //
-// For example, if the matcher sends EquivalentIdentifiers({A, B, C}), it
+// For example, if the matcher sends MatchedIdentifiers({A, B, C}), it
 // means the merger should combine these into a single work.
 //
-case class EquivalentIdentifiers(identifiers: Set[String])
+case class MatchedIdentifiers(identifiers: Set[String])


### PR DESCRIPTION
This model needs to be shared with the merger, so it shouldn't live in the matcher namespace.

Additionally, I think "EquivalentIdentifiers" better express the notion that this isn't just an arbitrary collection, but it's a collection of related identifiers.

More renaming for #2155.