### PR TITLE
Also move out LinkedWorksIdentifiersList, replace with MatcherResult

### DIFF
--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcher.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcher.scala
@@ -1,9 +1,9 @@
 package uk.ac.wellcome.platform.matcher.matcher
 
 import com.google.inject.Inject
-import uk.ac.wellcome.models.matcher.MatchedIdentifiers
+import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult}
 import uk.ac.wellcome.models.work.internal.UnidentifiedWork
-import uk.ac.wellcome.platform.matcher.models._
+import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkUpdate}
 import uk.ac.wellcome.platform.matcher.storage.WorkGraphStore
 import uk.ac.wellcome.platform.matcher.workgraph.WorkGraphUpdater
 import uk.ac.wellcome.storage.GlobalExecutionContext._
@@ -12,7 +12,7 @@ import scala.concurrent.Future
 
 class LinkedWorkMatcher @Inject()(workGraphStore: WorkGraphStore) {
   def matchWork(work: UnidentifiedWork) =
-    matchLinkedWorks(work).map(LinkedWorksIdentifiersList)
+    matchLinkedWorks(work).map { MatcherResult(_) }
 
   private def matchLinkedWorks(
     work: UnidentifiedWork): Future[Set[MatchedIdentifiers]] = {

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/LinkedWorksIdentifiersList.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/LinkedWorksIdentifiersList.scala
@@ -1,5 +1,0 @@
-package uk.ac.wellcome.platform.matcher.models
-
-import uk.ac.wellcome.models.matcher.MatchedIdentifiers
-
-case class LinkedWorksIdentifiersList(linkedWorks: Set[MatchedIdentifiers])

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -12,7 +12,6 @@ import uk.ac.wellcome.models.work.internal.{
   UnidentifiedWork
 }
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
-import uk.ac.wellcome.platform.matcher.models.LinkedWorksIdentifiersList
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.storage.vhs.HybridRecord
 import uk.ac.wellcome.test.utils.ExtendedPatience
@@ -59,9 +58,9 @@ class MatcherFeatureTest
                 snsMessages.size should be >= 1
 
                 snsMessages.map { snsMessage =>
-                  val identifiersList =
-                    fromJson[LinkedWorksIdentifiersList](snsMessage.message).get
-                  identifiersList.linkedWorks shouldBe Set(
+                  val matcherResult =
+                    fromJson[MatcherResult](snsMessage.message).get
+                  matcherResult.works shouldBe Set(
                     MatchedIdentifiers(Set("sierra-system-number/id")))
                 }
               }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.s3.AmazonS3
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.models.matcher.MatchedIdentifiers
+import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult}
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
 import uk.ac.wellcome.models.work.internal.{
   IdentifierType,

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/LinkedWorkMatcherTest.scala
@@ -7,9 +7,9 @@ import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.matcher.MatchedIdentifiers
+import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult}
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
-import uk.ac.wellcome.platform.matcher.models._
+import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkNode, WorkUpdate}
 import uk.ac.wellcome.platform.matcher.storage.WorkGraphStore
 
 import scala.concurrent.Future
@@ -27,11 +27,10 @@ class LinkedWorkMatcherTest
       withWorkGraphStore(table) { workGraphStore =>
         withLinkedWorkMatcher(table, workGraphStore) { linkedWorkMatcher =>
           whenReady(linkedWorkMatcher.matchWork(anUnidentifiedSierraWork)) {
-            identifiersList =>
+            matcherResult =>
               val workId = "sierra-system-number/id"
-              identifiersList shouldBe
-                LinkedWorksIdentifiersList(
-                  Set(MatchedIdentifiers(Set(workId))))
+              matcherResult shouldBe
+                MatcherResult(Set(MatchedIdentifiers(Set(workId))))
 
               val savedLinkedWork = Scanamo
                 .get[WorkNode](dynamoDbClient)(table.name)('id -> workId)
@@ -53,9 +52,9 @@ class LinkedWorkMatcherTest
           val work = anUnidentifiedSierraWork.copy(
             sourceIdentifier = aIdentifier,
             identifiers = List(aIdentifier, linkedIdentifier))
-          whenReady(linkedWorkMatcher.matchWork(work)) { identifiersList =>
-            identifiersList shouldBe
-              LinkedWorksIdentifiersList(Set(MatchedIdentifiers(
+          whenReady(linkedWorkMatcher.matchWork(work)) { matcherResult =>
+            matcherResult shouldBe
+              MatcherResult(Set(MatchedIdentifiers(
                 Set("sierra-system-number/A", "sierra-system-number/B"))))
 
             val savedWorkNodes = Scanamo
@@ -98,9 +97,9 @@ class LinkedWorkMatcherTest
             sourceIdentifier = bIdentifier,
             identifiers = List(bIdentifier, cIdentifier))
 
-          whenReady(linkedWorkMatcher.matchWork(work)) { identifiersList =>
-            identifiersList shouldBe
-              LinkedWorksIdentifiersList(
+          whenReady(linkedWorkMatcher.matchWork(work)) { matcherResult =>
+            matcherResult shouldBe
+              MatcherResult(
                 Set(
                   MatchedIdentifiers(
                     Set(

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
@@ -179,9 +179,7 @@ class MatcherMessageReceiverTest
     }
   }
 
-  private def assertMessageSent(
-    topic: Topic,
-    matcherResult: MatcherResult) = {
+  private def assertMessageSent(topic: Topic, matcherResult: MatcherResult) = {
     val snsMessages = listMessagesReceivedFromSNS(topic)
     snsMessages.size should be >= 1
 

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
@@ -6,11 +6,10 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS
-import uk.ac.wellcome.models.matcher.MatchedIdentifiers
+import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult}
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
 import uk.ac.wellcome.models.work.internal.UnidentifiedWork
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
-import uk.ac.wellcome.platform.matcher.models.LinkedWorksIdentifiersList
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.storage.vhs.HybridRecord
 import uk.ac.wellcome.test.utils.ExtendedPatience
@@ -33,7 +32,7 @@ class MatcherMessageReceiverTest
             eventually {
               assertMessageSent(
                 topic,
-                LinkedWorksIdentifiersList(
+                MatcherResult(
                   Set(MatchedIdentifiers(Set("sierra-system-number/id"))))
               )
             }
@@ -60,7 +59,7 @@ class MatcherMessageReceiverTest
             eventually {
               assertMessageSent(
                 topic,
-                LinkedWorksIdentifiersList(Set(MatchedIdentifiers(
+                MatcherResult(Set(MatchedIdentifiers(
                   Set("sierra-system-number/A", "sierra-system-number/B"))))
               )
             }
@@ -89,7 +88,7 @@ class MatcherMessageReceiverTest
 
               assertMessageSent(
                 topic,
-                LinkedWorksIdentifiersList(
+                MatcherResult(
                   Set(
                     MatchedIdentifiers(
                       Set(
@@ -108,7 +107,7 @@ class MatcherMessageReceiverTest
 
                 assertMessageSent(
                   topic,
-                  LinkedWorksIdentifiersList(
+                  MatcherResult(
                     Set(
                       MatchedIdentifiers(
                         Set(
@@ -143,7 +142,7 @@ class MatcherMessageReceiverTest
 
               assertMessageSent(
                 topic,
-                LinkedWorksIdentifiersList(
+                MatcherResult(
                   Set(
                     MatchedIdentifiers(
                       Set(
@@ -162,7 +161,7 @@ class MatcherMessageReceiverTest
 
                 assertMessageSent(
                   topic,
-                  LinkedWorksIdentifiersList(
+                  MatcherResult(
                     Set(
                       MatchedIdentifiers(Set(
                         "sierra-system-number/A"
@@ -182,14 +181,14 @@ class MatcherMessageReceiverTest
 
   private def assertMessageSent(
     topic: Topic,
-    identifiersList: LinkedWorksIdentifiersList) = {
+    matcherResult: MatcherResult) = {
     val snsMessages = listMessagesReceivedFromSNS(topic)
     snsMessages.size should be >= 1
 
     val actualMatchedWorkLists = snsMessages.map { snsMessage =>
-      fromJson[LinkedWorksIdentifiersList](snsMessage.message).get
+      fromJson[MatcherResult](snsMessage.message).get
     }
-    actualMatchedWorkLists should contain(identifiersList)
+    actualMatchedWorkLists should contain(matcherResult)
   }
 
   private def sendSQS(queue: SQS.Queue,

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/MatcherResult.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/MatcherResult.scala
@@ -16,4 +16,4 @@ package uk.ac.wellcome.models.matcher
 // then the merger should create three works, one from A1-A2-A3, a second
 // from B1-B2, a third from C1-C2-C3.
 //
-case class MatcherResult(works: Set[EquivalentIdentifiers])
+case class MatcherResult(works: Set[MatchedIdentifiers])

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/MatcherResult.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/MatcherResult.scala
@@ -1,0 +1,19 @@
+package uk.ac.wellcome.models.matcher
+
+// Represents the output from the matcher.
+//
+// Each entry in the set of works is a collection of identifiers, each of
+// which should be merged into a single work.
+//
+// For example, if we had the result:
+//
+//    MatchResult([
+//      {A1, A2, A3},
+//      {B1, B2},
+//      {C1, C2, C3}
+//    ])
+//
+// then the merger should create three works, one from A1-A2-A3, a second
+// from B1-B2, a third from C1-C2-C3.
+//
+case class MatcherResult(works: Set[EquivalentIdentifiers])


### PR DESCRIPTION
Like #2160, move out one of the shared models from the matcher and give it a better name.

Related: #2155.