### PR TITLE
Deduplicate concept identifiers from Sierra

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConcepts.scala
@@ -24,7 +24,7 @@ trait SierraConcepts extends MarcUtils {
     varField: VarField): MaybeDisplayable[T] = {
     val identifierSubfields = varField.subfields.filter { _.tag == "0" }
 
-    identifierSubfields match {
+    identifierSubfields.distinct match {
       case Seq() => Unidentifiable(agent = concept)
       case Seq(identifierSubfield) =>
         maybeAddIdentifier[T](

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraGenresTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraGenresTest.scala
@@ -240,6 +240,43 @@ class SierraGenresTest extends FunSpec with Matchers {
     expectedSourceIdentifiers shouldBe actualSourceIdentifiers
   }
 
+  it("deduplicates identifiers in subfield 0") {
+    val bibData = SierraBibData(
+      id = "b1962617",
+      title = Some("Basic Beeblebrox Books"),
+      varFields = List(
+        VarField(
+          fieldTag = "p",
+          marcTag = "655",
+          indicator1 = "",
+          indicator2 = "2",
+          subfields = List(
+            MarcSubfield(tag = "0", content = "lcsh/bbb"),
+            MarcSubfield(tag = "0", content = "lcsh/bbb")
+          )
+        )
+      )
+    )
+
+    val expectedSourceIdentifiers = List(
+      SourceIdentifier(
+        identifierType = IdentifierType("lc-subjects"),
+        value = "lcsh/bbb",
+        ontologyType = "Concept"
+      )
+    )
+
+    val actualSourceIdentifiers = transformer
+      .getGenres(bibData)
+      .map { _.concepts.head }
+      .map {
+        case Identifiable(_: Concept, sourceIdentifier, _) => sourceIdentifier
+        case other => assert(false, other)
+      }
+
+    expectedSourceIdentifiers shouldBe actualSourceIdentifiers
+  }
+
   it(s"throws an error if it sees too many subfield $$0 instances") {
     val bibData = SierraBibData(
       id = "b0918723",

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraGenresTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraGenresTest.scala
@@ -249,8 +249,9 @@ class SierraGenresTest extends FunSpec with Matchers {
           fieldTag = "p",
           marcTag = "655",
           indicator1 = "",
-          indicator2 = "2",
+          indicator2 = "0",
           subfields = List(
+            MarcSubfield(tag = "a", content = "hitchhiking"),
             MarcSubfield(tag = "0", content = "lcsh/bbb"),
             MarcSubfield(tag = "0", content = "lcsh/bbb")
           )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraSubjectsTest.scala
@@ -287,7 +287,6 @@ class SierraSubjectsTest extends FunSpec with Matchers {
     expectedSourceIdentifiers shouldBe actualSourceIdentifiers
   }
 
-
   it("deduplicates identifiers in subfield 0") {
     val bibData = SierraBibData(
       id = "b9811628",

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraSubjectsTest.scala
@@ -287,6 +287,44 @@ class SierraSubjectsTest extends FunSpec with Matchers {
     expectedSourceIdentifiers shouldBe actualSourceIdentifiers
   }
 
+
+  it("deduplicates identifiers in subfield 0") {
+    val bibData = SierraBibData(
+      id = "b9811628",
+      title = Some("Serious Soldier Stories"),
+      varFields = List(
+        VarField(
+          fieldTag = "p",
+          marcTag = "650",
+          indicator1 = "",
+          indicator2 = "2",
+          subfields = List(
+            MarcSubfield(tag = "0", content = "lcsh/sss"),
+            MarcSubfield(tag = "0", content = "lcsh/sss")
+          )
+        )
+      )
+    )
+
+    val expectedSourceIdentifiers = List(
+      SourceIdentifier(
+        identifierType = IdentifierType("lc-subjects"),
+        value = "lcsh/sss",
+        ontologyType = "Concept"
+      )
+    )
+
+    val actualSourceIdentifiers = transformer
+      .getSubjects(bibData)
+      .map { _.concepts.head }
+      .map {
+        case Identifiable(_: Concept, sourceIdentifier, _) => sourceIdentifier
+        case other => assert(false, other)
+      }
+
+    expectedSourceIdentifiers shouldBe actualSourceIdentifiers
+  }
+
   it(s"throws an error if it sees too many subfield $$0 instances") {
     val bibData = SierraBibData(
       id = "b9171786",

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraSubjectsTest.scala
@@ -297,8 +297,9 @@ class SierraSubjectsTest extends FunSpec with Matchers {
           fieldTag = "p",
           marcTag = "650",
           indicator1 = "",
-          indicator2 = "2",
+          indicator2 = "0",
           subfields = List(
+            MarcSubfield(tag = "a", content = "solders"),
             MarcSubfield(tag = "0", content = "lcsh/sss"),
             MarcSubfield(tag = "0", content = "lcsh/sss")
           )


### PR DESCRIPTION
Picking off a little piece of #2163 to make the transformer more reliable.