### PR TITLE
Log when a work is successfully indexed in the ingestor

### DIFF
--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -47,12 +47,15 @@ class WorkIndexer @Inject()(
               .id(work.canonicalId)
               .doc(work)
           }
+          .map { _ =>
+            info(s"Successfully indexed work ${work.canonicalId}")
+          }
           .recover {
             case e: ResponseException
                 if getErrorType(e).contains(
                   "version_conflict_engine_exception") =>
               warn(
-                s"Trying to ingest work ${work.canonicalId} with older version: skipping.")
+                s"Trying to index work ${work.canonicalId} with older version: skipping.")
               ()
             case e: TimeoutException =>
               warn(


### PR DESCRIPTION
I’m trying to track down failures in the ingestor, and I can’t tell if it’s holding onto a record forever, or silently succeeding. This should make the two cases easier to distinguish.