### PR TITLE
VHS: update uses metadata in both existing and not existing cases 

### DIFF
--- a/catalogue_pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
+++ b/catalogue_pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
@@ -26,13 +26,14 @@ class RecorderWorkerService @Inject()(
   def processMessage(work: UnidentifiedWork): Future[Unit] = {
     val newRecorderEntry = RecorderWorkEntry(work)
 
-    versionedHybridStore.updateRecord(newRecorderEntry.id)((newRecorderEntry, EmptyMetadata()))(
+    versionedHybridStore.updateRecord(newRecorderEntry.id)(
+      (newRecorderEntry, EmptyMetadata()))(
       (existingEntry, existingMetadata) =>
         if (existingEntry.work.version > newRecorderEntry.work.version) {
           (existingEntry, existingMetadata)
         } else {
           (newRecorderEntry, EmptyMetadata())
-        }
+      }
     )
   }
 

--- a/catalogue_pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
+++ b/catalogue_pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.storage.dynamo._
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContextExecutor, Future}
 
 class RecorderWorkerService @Inject()(
   versionedHybridStore: VersionedHybridStore[RecorderWorkEntry,
@@ -19,19 +19,21 @@ class RecorderWorkerService @Inject()(
   messageStream: MessageStream[UnidentifiedWork],
   system: ActorSystem) {
 
-  implicit val executionContext = system.dispatcher
+  implicit val executionContext: ExecutionContextExecutor = system.dispatcher
 
   messageStream.foreach(this.getClass.getSimpleName, processMessage)
 
   def processMessage(work: UnidentifiedWork): Future[Unit] = {
     val newRecorderEntry = RecorderWorkEntry(work)
 
-    versionedHybridStore.updateRecord(newRecorderEntry.id)(newRecorderEntry)(
-      (existingEntry, _) =>
+    versionedHybridStore.updateRecord(newRecorderEntry.id)((newRecorderEntry, EmptyMetadata()))(
+      (existingEntry, existingMetadata) =>
         if (existingEntry.work.version > newRecorderEntry.work.version) {
-          existingEntry
-        } else { newRecorderEntry }
-    )(EmptyMetadata())
+          (existingEntry, existingMetadata)
+        } else {
+          (newRecorderEntry, EmptyMetadata())
+        }
+    )
   }
 
   def stop(): Future[Terminated] = {

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
@@ -36,6 +36,9 @@ class VersionedHybridStore[T, Metadata, Store <: S3ObjectStore[T]] @Inject()(
   // The HybridRecordEnricher combines this with the HybridRecord, and stores
   // both of them as a single row in DynamoDB.
   //
+  // Update and version logic (e.g., do not store this record if a newer record already exists)
+  // is handled through the mappings ifNotExisting and ifExisting
+  //
   def updateRecord[DynamoRow](id: String)(ifNotExisting: => (T, Metadata))(
     ifExisting: (T, Metadata) => (T, Metadata))(
     implicit enricher: HybridRecordEnricher.Aux[Metadata, DynamoRow],

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
@@ -58,9 +58,10 @@ class VersionedHybridStore[T, Metadata, Store <: S3ObjectStore[T]] @Inject()(
             storedS3Record,
             storedMetadata)) =>
         debug(s"Existing object $id")
-        val (transformedS3Record, transformedMetadata) = ifExisting(storedS3Record, storedMetadata)
+        val (transformedS3Record, transformedMetadata) =
+          ifExisting(storedS3Record, storedMetadata)
 
-        if (transformedS3Record != storedS3Record || transformedMetadata != storedMetadata ) {
+        if (transformedS3Record != storedS3Record || transformedMetadata != storedMetadata) {
           debug("existing object changed, updating")
           putObject(
             id,

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
@@ -150,8 +150,8 @@ trait LocalVersionedHybridStore
         }
     }
 
-  protected def getRecordMetadata[T](table: Table, id: String)
-                                  (implicit dynamoFormat: DynamoFormat[T])=
+  protected def getRecordMetadata[T](table: Table, id: String)(
+    implicit dynamoFormat: DynamoFormat[T]) =
     Scanamo.get[T](dynamoDbClient)(table.name)('id -> id) match {
       case None => throw new RuntimeException(s"No object with id $id found!")
       case Some(read) =>

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/vhs/StreamStoreVersionedHybridStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/vhs/StreamStoreVersionedHybridStoreTest.scala
@@ -51,9 +51,8 @@ class StreamStoreVersionedHybridStoreTest
           val content = "A thousand thinking thanes thanking a therapod"
           val inputStream = new ByteArrayInputStream(content.getBytes)
 
-          val future = hybridStore.updateRecord(id)(
-            ifNotExisting = (inputStream, emptyMetadata))(
-            ifExisting = (t, m) => (t, m))
+          val future = hybridStore.updateRecord(id)(ifNotExisting =
+            (inputStream, emptyMetadata))(ifExisting = (t, m) => (t, m))
 
           whenReady(future) { _ =>
             getContentFor(bucket, table, id) shouldBe content
@@ -69,9 +68,8 @@ class StreamStoreVersionedHybridStoreTest
           val inputStream = new ByteArrayInputStream(content.getBytes)
 
           val putFuture =
-            hybridStore.updateRecord(id)(
-              ifNotExisting = (inputStream, emptyMetadata))(
-              ifExisting = (t, m) => (t, m))
+            hybridStore.updateRecord(id)(ifNotExisting =
+              (inputStream, emptyMetadata))(ifExisting = (t, m) => (t, m))
 
           val getFuture = putFuture.flatMap { _ =>
             hybridStore.getRecord(id)

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/vhs/StreamStoreVersionedHybridStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/vhs/StreamStoreVersionedHybridStoreTest.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.storage.vhs
 
 import java.io.{ByteArrayInputStream, InputStream}
+
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.storage.s3.S3StreamStore
@@ -10,9 +11,8 @@ import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
-import scala.util.Random
-
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Random
 
 class StreamStoreVersionedHybridStoreTest
     extends FunSpec
@@ -22,6 +22,8 @@ class StreamStoreVersionedHybridStoreTest
     with LocalVersionedHybridStore {
 
   import uk.ac.wellcome.storage.dynamo._
+
+  val emptyMetadata = EmptyMetadata()
 
   private def stringify(is: InputStream) =
     scala.io.Source.fromInputStream(is).mkString
@@ -49,8 +51,9 @@ class StreamStoreVersionedHybridStoreTest
           val content = "A thousand thinking thanes thanking a therapod"
           val inputStream = new ByteArrayInputStream(content.getBytes)
 
-          val future = hybridStore.updateRecord(id)(inputStream)((t, _) => t)(
-            EmptyMetadata())
+          val future = hybridStore.updateRecord(id)(
+            ifNotExisting = (inputStream, emptyMetadata))(
+            ifExisting = (t, m) => (t, m))
 
           whenReady(future) { _ =>
             getContentFor(bucket, table, id) shouldBe content
@@ -60,14 +63,15 @@ class StreamStoreVersionedHybridStoreTest
 
     it("retrieves an InputStream") {
       withS3StreamStoreFixtures {
-        case (bucket, table, hybridStore) =>
+        case (_, _, hybridStore) =>
           val id = Random.nextString(5)
           val content = "Five fishing flinging flint"
           val inputStream = new ByteArrayInputStream(content.getBytes)
 
           val putFuture =
-            hybridStore.updateRecord(id)(inputStream)((t, _) => t)(
-              EmptyMetadata())
+            hybridStore.updateRecord(id)(
+              ifNotExisting = (inputStream, emptyMetadata))(
+              ifExisting = (t, m) => (t, m))
 
           val getFuture = putFuture.flatMap { _ =>
             hybridStore.getRecord(id)

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/vhs/StringStoreVersionedHybridStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/vhs/StringStoreVersionedHybridStoreTest.scala
@@ -44,9 +44,8 @@ class StringStoreVersionedHybridStoreTest
           val id = Random.nextString(5)
           val record = "One ocelot in orange"
 
-          val future = hybridStore.updateRecord(id)(
-            ifNotExisting = (record, EmptyMetadata()))(
-            ifExisting = (t, m) => (t, m))
+          val future = hybridStore.updateRecord(id)(ifNotExisting =
+            (record, EmptyMetadata()))(ifExisting = (t, m) => (t, m))
 
           whenReady(future) { _ =>
             getContentFor(bucket, table, id) shouldBe record
@@ -61,11 +60,13 @@ class StringStoreVersionedHybridStoreTest
           val record = "Two teal turtles in Tenerife"
           val updatedRecord = "Throwing turquoise tangerines in Tanzania"
 
-          val future = hybridStore.updateRecord(id)((record, EmptyMetadata()))((t, m) => (t, m))
+          val future =
+            hybridStore.updateRecord(id)((record, EmptyMetadata()))((t, m) =>
+              (t, m))
           val updatedFuture = future.flatMap { _ =>
-            hybridStore.updateRecord(id)(
-              ifNotExisting = (updatedRecord, EmptyMetadata()))(
-              ifExisting = (_, m) => (updatedRecord, EmptyMetadata()))
+            hybridStore.updateRecord(id)(ifNotExisting =
+              (updatedRecord, EmptyMetadata()))(ifExisting = (_, m) =>
+              (updatedRecord, EmptyMetadata()))
           }
 
           whenReady(updatedFuture) { _ =>
@@ -92,11 +93,12 @@ class StringStoreVersionedHybridStoreTest
           val record = "Five fishing flinging flint"
 
           val putFuture =
-            hybridStore.updateRecord(id)(
-              ifNotExisting = (record, EmptyMetadata()))(
-              ifExisting = (t, m) => (t, m))
+            hybridStore.updateRecord(id)(ifNotExisting =
+              (record, EmptyMetadata()))(ifExisting = (t, m) => (t, m))
 
-          val getFuture = putFuture.flatMap { _ => hybridStore.getRecord(id) }
+          val getFuture = putFuture.flatMap { _ =>
+            hybridStore.getRecord(id)
+          }
 
           whenReady(getFuture) { result =>
             result shouldBe Some(record)
@@ -124,9 +126,8 @@ class StringStoreVersionedHybridStoreTest
           withLocalDynamoDbTable { table =>
             withStringVHS[ExtraData, Assertion](bucket, table) { hybridStore =>
               val future =
-                hybridStore.updateRecord(id)(
-                  ifNotExisting = (record, storedMetadata))(
-                  ifExisting = (t, m) => (t, m))
+                hybridStore.updateRecord(id)(ifNotExisting =
+                  (record, storedMetadata))(ifExisting = (t, m) => (t, m))
 
               whenReady(future) { _ =>
                 getRecordMetadata[ExtraData](table, id) shouldBe storedMetadata
@@ -141,14 +142,13 @@ class StringStoreVersionedHybridStoreTest
           withLocalDynamoDbTable { table =>
             withStringVHS[ExtraData, Assertion](bucket, table) { hybridStore =>
               val updatedMetadata = ExtraData("new-metadata", 22)
-              val future = hybridStore.updateRecord(id)(
-                ifNotExisting = (record, storedMetadata))(
-                ifExisting = (t, m) => (t, m))
+              val future = hybridStore.updateRecord(id)(ifNotExisting =
+                (record, storedMetadata))(ifExisting = (t, m) => (t, m))
 
               val updatedFuture = future.flatMap { _ =>
-                hybridStore.updateRecord(id)(
-                  ifNotExisting = ("not-this", ExtraData("x", 1)))(
-                  ifExisting = (t, _) => (t, updatedMetadata))
+                hybridStore.updateRecord(id)(ifNotExisting =
+                  ("not-this", ExtraData("x", 1)))(ifExisting = (t, _) =>
+                  (t, updatedMetadata))
               }
 
               whenReady(updatedFuture) { _ =>

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/vhs/TypeStoreVersionedHybridStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/vhs/TypeStoreVersionedHybridStoreTest.scala
@@ -54,9 +54,8 @@ class TypeStoreVersionedHybridStoreTest
             content = "One ocelot in orange"
           )
 
-          val future = hybridStore.updateRecord(record.id)(
-            ifNotExisting = (record, EmptyMetadata()))(
-            ifExisting = (t, m) => (t, m))
+          val future = hybridStore.updateRecord(record.id)(ifNotExisting =
+            (record, EmptyMetadata()))(ifExisting = (t, m) => (t, m))
 
           whenReady(future) { _ =>
             getJsonFor(bucket, table, record) shouldBe toJson(record).get
@@ -73,9 +72,8 @@ class TypeStoreVersionedHybridStoreTest
             content = "Hairy hyenas howling hatefully"
           )
           val putFuture =
-            hybridStore.updateRecord(id)(
-              ifNotExisting = (record, EmptyMetadata()))(
-              ifExisting = (t, m) => (t, m))
+            hybridStore.updateRecord(id)(ifNotExisting =
+              (record, EmptyMetadata()))(ifExisting = (t, m) => (t, m))
 
           val getFuture = putFuture.flatMap { _ =>
             hybridStore.getRecord(id)

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/vhs/TypeStoreVersionedHybridStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/vhs/TypeStoreVersionedHybridStoreTest.scala
@@ -54,9 +54,9 @@ class TypeStoreVersionedHybridStoreTest
             content = "One ocelot in orange"
           )
 
-          val future =
-            hybridStore.updateRecord(record.id)(record)((t, _) => t)(
-              EmptyMetadata())
+          val future = hybridStore.updateRecord(record.id)(
+            ifNotExisting = (record, EmptyMetadata()))(
+            ifExisting = (t, m) => (t, m))
 
           whenReady(future) { _ =>
             getJsonFor(bucket, table, record) shouldBe toJson(record).get
@@ -66,14 +66,16 @@ class TypeStoreVersionedHybridStoreTest
 
     it("retrieves the specified type") {
       withS3TypeStoreFixtures {
-        case (bucket, table, hybridStore) =>
+        case (_, _, hybridStore) =>
           val id = Random.nextString(5)
           val record = ExampleRecord(
             id = Random.nextString(5),
             content = "Hairy hyenas howling hatefully"
           )
           val putFuture =
-            hybridStore.updateRecord(id)(record)((t, _) => t)(EmptyMetadata())
+            hybridStore.updateRecord(id)(
+              ifNotExisting = (record, EmptyMetadata()))(
+              ifExisting = (t, m) => (t, m))
 
           val getFuture = putFuture.flatMap { _ =>
             hybridStore.getRecord(id)

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
@@ -27,7 +27,9 @@ class SierraBibMergerUpdaterService @Inject()(
     versionedHybridStore.updateRecord(Sourced.id(sourceName, bibRecord.id))(
       (SierraTransformable(bibRecord), SourceMetadata(sourceName)))(
       (existingSierraTransformable, existingMetadata) => {
-        (BibMerger.mergeBibRecord(existingSierraTransformable, bibRecord), existingMetadata)
+        (
+          BibMerger.mergeBibRecord(existingSierraTransformable, bibRecord),
+          existingMetadata)
       }
     )
   }

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
@@ -25,10 +25,10 @@ class SierraBibMergerUpdaterService @Inject()(
     val sourceName = "sierra"
 
     versionedHybridStore.updateRecord(Sourced.id(sourceName, bibRecord.id))(
-      SierraTransformable(bibRecord))(
-      (existingSierraTransformable, _) => {
-        BibMerger.mergeBibRecord(existingSierraTransformable, bibRecord)
+      (SierraTransformable(bibRecord), SourceMetadata(sourceName)))(
+      (existingSierraTransformable, existingMetadata) => {
+        (BibMerger.mergeBibRecord(existingSierraTransformable, bibRecord), existingMetadata)
       }
-    )(SourceMetadata(sourceName = sourceName))
+    )
   }
 }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -194,8 +194,7 @@ class SierraBibMergerFeatureTest
               )
 
               hybridStore
-                .updateRecord(oldRecord.id)(oldRecord)((t, _) => t)(
-                  SourceMetadata(oldRecord.sourceName))
+                .updateRecord(oldRecord.id)((oldRecord, SourceMetadata(oldRecord.sourceName)))((t, m) => (t, m))
                 .map { _ =>
                   sendMessageToSQS(toJson(record).get, queue)
                 }
@@ -253,8 +252,8 @@ class SierraBibMergerFeatureTest
 
               hybridStore
                 .updateRecord(expectedSierraTransformable.id)(
-                  expectedSierraTransformable)((t, _) => t)(
-                  SourceMetadata(expectedSierraTransformable.sourceName))
+                  (expectedSierraTransformable, SourceMetadata(expectedSierraTransformable.sourceName)))(
+                    (t, m) => (t, m))
                 .map { _ =>
                   sendMessageToSQS(toJson(record).get, queue)
                 }
@@ -299,8 +298,9 @@ class SierraBibMergerFeatureTest
               )
 
               val future =
-                hybridStore.updateRecord(newRecord.id)(newRecord)((t, _) => t)(
-                  SourceMetadata(newRecord.sourceName))
+                hybridStore.updateRecord(newRecord.id)(
+                  (newRecord, SourceMetadata(newRecord.sourceName)))(
+                  (t, m) => (t,m))
 
               future.map { _ =>
                 sendMessageToSQS(toJson(record).get, queue)

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -32,33 +32,33 @@ class SierraBibMergerFeatureTest
                       updatedDate: String,
                       title: String = "Lehrbuch und Atlas der Gastroskopie") =
     s"""
-      |{
-      |      "id": "$id",
-      |      "updatedDate": "$updatedDate",
-      |      "createdDate": "1999-11-01T16:36:51Z",
-      |      "deleted": false,
-      |      "suppressed": false,
-      |      "lang": {
-      |        "code": "ger",
-      |        "name": "German"
-      |      },
-      |      "title": "$title",
-      |      "author": "Schindler, Rudolf, 1888-",
-      |      "materialType": {
-      |        "code": "a",
-      |        "value": "Books"
-      |      },
-      |      "bibLevel": {
-      |        "code": "m",
-      |        "value": "MONOGRAPH"
-      |      },
-      |      "publishYear": 1923,
-      |      "catalogDate": "1999-01-01",
-      |      "country": {
-      |        "code": "gw ",
-      |        "name": "Germany"
-      |      }
-      |    }
+       |{
+       |      "id": "$id",
+       |      "updatedDate": "$updatedDate",
+       |      "createdDate": "1999-11-01T16:36:51Z",
+       |      "deleted": false,
+       |      "suppressed": false,
+       |      "lang": {
+       |        "code": "ger",
+       |        "name": "German"
+       |      },
+       |      "title": "$title",
+       |      "author": "Schindler, Rudolf, 1888-",
+       |      "materialType": {
+       |        "code": "a",
+       |        "value": "Books"
+       |      },
+       |      "bibLevel": {
+       |        "code": "m",
+       |        "value": "MONOGRAPH"
+       |      },
+       |      "publishYear": 1923,
+       |      "catalogDate": "1999-01-01",
+       |      "country": {
+       |        "code": "gw ",
+       |        "name": "Germany"
+       |      }
+       |    }
     """.stripMargin
 
   implicit val encoder = Encoder[SierraTransformable]
@@ -194,7 +194,9 @@ class SierraBibMergerFeatureTest
               )
 
               hybridStore
-                .updateRecord(oldRecord.id)((oldRecord, SourceMetadata(oldRecord.sourceName)))((t, m) => (t, m))
+                .updateRecord(oldRecord.id)(
+                  (oldRecord, SourceMetadata(oldRecord.sourceName)))((t, m) =>
+                  (t, m))
                 .map { _ =>
                   sendMessageToSQS(toJson(record).get, queue)
                 }
@@ -251,9 +253,10 @@ class SierraBibMergerFeatureTest
               )
 
               hybridStore
-                .updateRecord(expectedSierraTransformable.id)(
-                  (expectedSierraTransformable, SourceMetadata(expectedSierraTransformable.sourceName)))(
-                    (t, m) => (t, m))
+                .updateRecord(expectedSierraTransformable.id)((
+                  expectedSierraTransformable,
+                  SourceMetadata(expectedSierraTransformable.sourceName)))(
+                  (t, m) => (t, m))
                 .map { _ =>
                   sendMessageToSQS(toJson(record).get, queue)
                 }
@@ -299,8 +302,8 @@ class SierraBibMergerFeatureTest
 
               val future =
                 hybridStore.updateRecord(newRecord.id)(
-                  (newRecord, SourceMetadata(newRecord.sourceName)))(
-                  (t, m) => (t,m))
+                  (newRecord, SourceMetadata(newRecord.sourceName)))((t, m) =>
+                  (t, m))
 
               future.map { _ =>
                 sendMessageToSQS(toJson(record).get, queue)

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
@@ -29,13 +29,16 @@ class SierraItemMergerUpdaterService @Inject()(
 
     val mergeUpdateFutures = itemRecord.bibIds.map { bibId =>
       versionedHybridStore.updateRecord(Sourced.id(sourceName, bibId))(
-        ifNotExisting = (SierraTransformable(
-          sourceId = bibId,
-          itemData = Map(itemRecord.id -> itemRecord)),
+        ifNotExisting = (
+          SierraTransformable(
+            sourceId = bibId,
+            itemData = Map(itemRecord.id -> itemRecord)),
           SourceMetadata(sourceName)))(
         ifExisting = (existingSierraTransformable, _) => {
-          (ItemLinker.linkItemRecord(existingSierraTransformable, itemRecord), SourceMetadata(sourceName))
-      })
+          (
+            ItemLinker.linkItemRecord(existingSierraTransformable, itemRecord),
+            SourceMetadata(sourceName))
+        })
     }
 
     val unlinkUpdateFutures: Seq[Future[Unit]] =
@@ -43,10 +46,13 @@ class SierraItemMergerUpdaterService @Inject()(
         versionedHybridStore.updateRecord(
           Sourced.id(sourceName, unlinkedBibId))(
           ifNotExisting = throw GracefulFailureException(
-            new RuntimeException(s"Missing Bib record to unlink: $unlinkedBibId")
+            new RuntimeException(
+              s"Missing Bib record to unlink: $unlinkedBibId")
           ))(
           ifExisting = (record, _) =>
-            (ItemUnlinker.unlinkItemRecord(record, itemRecord), SourceMetadata(sourceName))
+            (
+              ItemUnlinker.unlinkItemRecord(record, itemRecord),
+              SourceMetadata(sourceName))
         )
       }
     Future.sequence(mergeUpdateFutures ++ unlinkUpdateFutures).map(_ => ())

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
@@ -29,30 +29,26 @@ class SierraItemMergerUpdaterService @Inject()(
 
     val mergeUpdateFutures = itemRecord.bibIds.map { bibId =>
       versionedHybridStore.updateRecord(Sourced.id(sourceName, bibId))(
-        ifNotExisting = SierraTransformable(
+        ifNotExisting = (SierraTransformable(
           sourceId = bibId,
-          itemData = Map(itemRecord.id -> itemRecord)
-        ))(ifExisting = (existingSierraTransformable, _) => {
-        ItemLinker.linkItemRecord(
-          existingSierraTransformable,
-          itemRecord
-        )
-      })(SourceMetadata(sourceName))
+          itemData = Map(itemRecord.id -> itemRecord)),
+          SourceMetadata(sourceName)))(
+        ifExisting = (existingSierraTransformable, _) => {
+          (ItemLinker.linkItemRecord(existingSierraTransformable, itemRecord), SourceMetadata(sourceName))
+      })
     }
 
     val unlinkUpdateFutures: Seq[Future[Unit]] =
       itemRecord.unlinkedBibIds.map { unlinkedBibId =>
         versionedHybridStore.updateRecord(
           Sourced.id(sourceName, unlinkedBibId))(
-          throw GracefulFailureException(
-            new RuntimeException(
-              s"Missing Bib record to unlink: $unlinkedBibId")
-          )
-        )((record, _) => ItemUnlinker.unlinkItemRecord(record, itemRecord))(
-          SourceMetadata(sourceName))
+          ifNotExisting = throw GracefulFailureException(
+            new RuntimeException(s"Missing Bib record to unlink: $unlinkedBibId")
+          ))(
+          ifExisting = (record, _) =>
+            (ItemUnlinker.unlinkItemRecord(record, itemRecord), SourceMetadata(sourceName))
+        )
       }
-
     Future.sequence(mergeUpdateFutures ++ unlinkUpdateFutures).map(_ => ())
   }
-
 }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -117,9 +117,9 @@ class SierraItemMergerUpdaterServiceTest
               )
             )
 
-            val f1 = hybridStore.updateRecord(oldRecord.id)(
-              ifNotExisting = (oldRecord, SourceMetadata(oldRecord.sourceName)))(
-              ifExisting = (t, m) => (t, m))
+            val f1 = hybridStore.updateRecord(oldRecord.id)(ifNotExisting =
+              (oldRecord, SourceMetadata(oldRecord.sourceName)))(ifExisting =
+              (t, m) => (t, m))
 
             val anotherItem = sierraItemRecord(
               id = "i999",
@@ -140,9 +140,9 @@ class SierraItemMergerUpdaterServiceTest
             )
 
             whenReady(f1) { _ =>
-              val f2 = hybridStore.updateRecord(newRecord.id)(
-                ifNotExisting = (newRecord, SourceMetadata(newRecord.sourceName)))(
-                ifExisting = (t, m) => (t, m))
+              val f2 = hybridStore.updateRecord(newRecord.id)(ifNotExisting =
+                (newRecord, SourceMetadata(newRecord.sourceName)))(ifExisting =
+                (t, m) => (t, m))
 
               whenReady(f2) { _ =>
                 whenReady(sierraUpdaterService.update(itemRecord)) { _ =>
@@ -199,9 +199,9 @@ class SierraItemMergerUpdaterServiceTest
                 ))
             )
 
-            val f1 = hybridStore.updateRecord(oldRecord.id)(
-              ifNotExisting = (oldRecord, SourceMetadata(oldRecord.sourceName)))(
-              ifExisting = (t, m) => (t, m))
+            val f1 = hybridStore.updateRecord(oldRecord.id)(ifNotExisting =
+              (oldRecord, SourceMetadata(oldRecord.sourceName)))(ifExisting =
+              (t, m) => (t, m))
 
             whenReady(f1) { _ =>
               val newItemRecord = sierraItemRecord(
@@ -230,7 +230,9 @@ class SierraItemMergerUpdaterServiceTest
   it("unlinks an item if it is updated with an unlinked item") {
     withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { table =>
-        withTypeVHS[SierraTransformable, SourceMetadata, Assertion](bucket, table) { hybridStore =>
+        withTypeVHS[SierraTransformable, SourceMetadata, Assertion](
+          bucket,
+          table) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val itemId = "i3000003"
 
@@ -257,12 +259,16 @@ class SierraItemMergerUpdaterServiceTest
             )
 
             val f1 = hybridStore.updateRecord(sierraTransformable1.id)(
-              ifNotExisting = (sierraTransformable1, SourceMetadata(sierraTransformable1.sourceName)))(
-              ifExisting = (t, m) => (t, m))
+              ifNotExisting = (
+                sierraTransformable1,
+                SourceMetadata(sierraTransformable1.sourceName)))(ifExisting =
+              (t, m) => (t, m))
 
             val f2 = hybridStore.updateRecord(sierraTransformable2.id)(
-              ifNotExisting = (sierraTransformable2, SourceMetadata(sierraTransformable2.sourceName)))(
-              ifExisting = (t, m) => (t, m))
+              ifNotExisting = (
+                sierraTransformable2,
+                SourceMetadata(sierraTransformable2.sourceName)))(ifExisting =
+              (t, m) => (t, m))
 
             val unlinkItemRecord = itemRecord.copy(
               bibIds = List(bibId2),
@@ -339,12 +345,16 @@ class SierraItemMergerUpdaterServiceTest
             )
 
             val f1 = hybridStore.updateRecord(sierraTransformable1.id)(
-              ifNotExisting = (sierraTransformable1, SourceMetadata(sierraTransformable1.sourceName)))(
-              ifExisting = (t, m) => (t, m))
+              ifNotExisting = (
+                sierraTransformable1,
+                SourceMetadata(sierraTransformable1.sourceName)))(ifExisting =
+              (t, m) => (t, m))
 
             val f2 = hybridStore.updateRecord(sierraTransformable2.id)(
-              ifNotExisting = (sierraTransformable2, SourceMetadata(sierraTransformable2.sourceName)))(
-              ifExisting = (t, m) => (t, m))
+              ifNotExisting = (
+                sierraTransformable2,
+                SourceMetadata(sierraTransformable2.sourceName)))(ifExisting =
+              (t, m) => (t, m))
 
             val unlinkItemRecord = itemRecord.copy(
               bibIds = List(bibId2),
@@ -416,12 +426,16 @@ class SierraItemMergerUpdaterServiceTest
             )
 
             val f1 = hybridStore.updateRecord(sierraTransformable1.id)(
-              ifNotExisting = (sierraTransformable1, SourceMetadata(sierraTransformable1.sourceName)))(
-              ifExisting = (t, m) => (t, m))
+              ifNotExisting = (
+                sierraTransformable1,
+                SourceMetadata(sierraTransformable1.sourceName)))(ifExisting =
+              (t, m) => (t, m))
 
             val f2 = hybridStore.updateRecord(sierraTransformable2.id)(
-              ifNotExisting = (sierraTransformable2, SourceMetadata(sierraTransformable2.sourceName)))(
-              ifExisting = (t, m) => (t, m))
+              ifNotExisting = (
+                sierraTransformable2,
+                SourceMetadata(sierraTransformable2.sourceName)))(ifExisting =
+              (t, m) => (t, m))
 
             val unlinkItemRecord = itemRecord.copy(
               bibIds = List(bibId2),
@@ -483,8 +497,8 @@ class SierraItemMergerUpdaterServiceTest
                 ))
             )
 
-            val f1 = hybridStore.updateRecord(sierraRecord.id)(
-              ifNotExisting = (sierraRecord, SourceMetadata(sierraRecord.sourceName)))(
+            val f1 = hybridStore.updateRecord(sierraRecord.id)(ifNotExisting =
+              (sierraRecord, SourceMetadata(sierraRecord.sourceName)))(
               ifExisting = (t, m) => (t, m))
 
             val oldItemRecord = sierraItemRecord(
@@ -517,8 +531,8 @@ class SierraItemMergerUpdaterServiceTest
               sourceId = bibId
             )
 
-            val f1 = hybridStore.updateRecord(sierraRecord.id)(
-              ifNotExisting = (sierraRecord, SourceMetadata(sierraRecord.sourceName)))(
+            val f1 = hybridStore.updateRecord(sierraRecord.id)(ifNotExisting =
+              (sierraRecord, SourceMetadata(sierraRecord.sourceName)))(
               ifExisting = (t, m) => (t, m))
 
             val itemRecord = sierraItemRecord(

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -118,8 +118,8 @@ class SierraItemMergerUpdaterServiceTest
             )
 
             val f1 = hybridStore.updateRecord(oldRecord.id)(
-              oldRecord
-            )((t, _) => t)(SourceMetadata(oldRecord.sourceName))
+              ifNotExisting = (oldRecord, SourceMetadata(oldRecord.sourceName)))(
+              ifExisting = (t, m) => (t, m))
 
             val anotherItem = sierraItemRecord(
               id = "i999",
@@ -141,8 +141,8 @@ class SierraItemMergerUpdaterServiceTest
 
             whenReady(f1) { _ =>
               val f2 = hybridStore.updateRecord(newRecord.id)(
-                newRecord
-              )((t, _) => t)(SourceMetadata(newRecord.sourceName))
+                ifNotExisting = (newRecord, SourceMetadata(newRecord.sourceName)))(
+                ifExisting = (t, m) => (t, m))
 
               whenReady(f2) { _ =>
                 whenReady(sierraUpdaterService.update(itemRecord)) { _ =>
@@ -200,8 +200,8 @@ class SierraItemMergerUpdaterServiceTest
             )
 
             val f1 = hybridStore.updateRecord(oldRecord.id)(
-              oldRecord
-            )((t, _) => t)(SourceMetadata(oldRecord.sourceName))
+              ifNotExisting = (oldRecord, SourceMetadata(oldRecord.sourceName)))(
+              ifExisting = (t, m) => (t, m))
 
             whenReady(f1) { _ =>
               val newItemRecord = sierraItemRecord(
@@ -230,9 +230,7 @@ class SierraItemMergerUpdaterServiceTest
   it("unlinks an item if it is updated with an unlinked item") {
     withLocalS3Bucket { bucket =>
       withLocalDynamoDbTable { table =>
-        withTypeVHS[SierraTransformable, SourceMetadata, Assertion](
-          bucket,
-          table) { hybridStore =>
+        withTypeVHS[SierraTransformable, SourceMetadata, Assertion](bucket, table) { hybridStore =>
           withSierraUpdaterService(hybridStore) { sierraUpdaterService =>
             val itemId = "i3000003"
 
@@ -259,26 +257,17 @@ class SierraItemMergerUpdaterServiceTest
             )
 
             val f1 = hybridStore.updateRecord(sierraTransformable1.id)(
-              sierraTransformable1
-            )((_, _) => sierraTransformable1)(
-              SourceMetadata(sierraTransformable1.sourceName))
+              ifNotExisting = (sierraTransformable1, SourceMetadata(sierraTransformable1.sourceName)))(
+              ifExisting = (t, m) => (t, m))
 
             val f2 = hybridStore.updateRecord(sierraTransformable2.id)(
-              sierraTransformable2
-            )((t, _) => t)(SourceMetadata(sierraTransformable2.sourceName))
+              ifNotExisting = (sierraTransformable2, SourceMetadata(sierraTransformable2.sourceName)))(
+              ifExisting = (t, m) => (t, m))
 
             val unlinkItemRecord = itemRecord.copy(
               bibIds = List(bibId2),
               unlinkedBibIds = List(bibId1),
               modifiedDate = itemRecord.modifiedDate.plusSeconds(1)
-            )
-
-            val expectedItemData = Map(
-              itemRecord.id -> itemRecord.copy(
-                bibIds = List(bibId2),
-                unlinkedBibIds = List(bibId1),
-                modifiedDate = unlinkItemRecord.modifiedDate
-              )
             )
 
             val unlinkItemRecordFuture = for {
@@ -291,6 +280,13 @@ class SierraItemMergerUpdaterServiceTest
                 itemData = Map.empty
               )
 
+              val expectedItemData = Map(
+                itemRecord.id -> itemRecord.copy(
+                  bibIds = List(bibId2),
+                  unlinkedBibIds = List(bibId1),
+                  modifiedDate = unlinkItemRecord.modifiedDate
+                )
+              )
               val expectedSierraRecord2 = sierraTransformable2.copy(
                 itemData = expectedItemData
               )
@@ -343,13 +339,12 @@ class SierraItemMergerUpdaterServiceTest
             )
 
             val f1 = hybridStore.updateRecord(sierraTransformable1.id)(
-              sierraTransformable1
-            )((_, _) => sierraTransformable1)(
-              SourceMetadata(sierraTransformable1.sourceName))
+              ifNotExisting = (sierraTransformable1, SourceMetadata(sierraTransformable1.sourceName)))(
+              ifExisting = (t, m) => (t, m))
 
             val f2 = hybridStore.updateRecord(sierraTransformable2.id)(
-              sierraTransformable2
-            )((t, _) => t)(SourceMetadata(sierraTransformable2.sourceName))
+              ifNotExisting = (sierraTransformable2, SourceMetadata(sierraTransformable2.sourceName)))(
+              ifExisting = (t, m) => (t, m))
 
             val unlinkItemRecord = itemRecord.copy(
               bibIds = List(bibId2),
@@ -421,13 +416,12 @@ class SierraItemMergerUpdaterServiceTest
             )
 
             val f1 = hybridStore.updateRecord(sierraTransformable1.id)(
-              sierraTransformable1
-            )((_, _) => sierraTransformable1)(
-              SourceMetadata(sierraTransformable1.sourceName))
+              ifNotExisting = (sierraTransformable1, SourceMetadata(sierraTransformable1.sourceName)))(
+              ifExisting = (t, m) => (t, m))
 
             val f2 = hybridStore.updateRecord(sierraTransformable2.id)(
-              sierraTransformable2
-            )((t, _) => t)(SourceMetadata(sierraTransformable2.sourceName))
+              ifNotExisting = (sierraTransformable2, SourceMetadata(sierraTransformable2.sourceName)))(
+              ifExisting = (t, m) => (t, m))
 
             val unlinkItemRecord = itemRecord.copy(
               bibIds = List(bibId2),
@@ -490,8 +484,8 @@ class SierraItemMergerUpdaterServiceTest
             )
 
             val f1 = hybridStore.updateRecord(sierraRecord.id)(
-              sierraRecord
-            )((t, _) => t)(SourceMetadata(sierraRecord.sourceName))
+              ifNotExisting = (sierraRecord, SourceMetadata(sierraRecord.sourceName)))(
+              ifExisting = (t, m) => (t, m))
 
             val oldItemRecord = sierraItemRecord(
               id = id,
@@ -524,8 +518,8 @@ class SierraItemMergerUpdaterServiceTest
             )
 
             val f1 = hybridStore.updateRecord(sierraRecord.id)(
-              sierraRecord
-            )((t, _) => t)(SourceMetadata(sierraRecord.sourceName))
+              ifNotExisting = (sierraRecord, SourceMetadata(sierraRecord.sourceName)))(
+              ifExisting = (t, m) => (t, m))
 
             val itemRecord = sierraItemRecord(
               id = "i7000007",


### PR DESCRIPTION
### What is this PR trying to achieve?
VHS update takes metadata for both existing and non-existing cases giving the caller control over what metadata should be saved in each case.
