### PR TITLE
Fix the reindexer; error if you try to look up an unspecified DynamoDB index

### DIFF
--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
@@ -17,7 +17,7 @@ class WorkNodeDao @Inject()(
   dynamoConfig: DynamoConfig
 ) extends Logging {
 
-  val index = dynamoConfig.index.getOrElse(
+  val index = dynamoConfig.maybeIndex.getOrElse(
     throw new RuntimeException("Index cannot be empty!"))
 
   def put(work: WorkNode): Future[Option[Either[DynamoReadError, WorkNode]]] = {

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
@@ -17,8 +17,7 @@ class WorkNodeDao @Inject()(
   dynamoConfig: DynamoConfig
 ) extends Logging {
 
-  val index = dynamoConfig.maybeIndex.getOrElse(
-    throw new RuntimeException("Index cannot be empty!"))
+  val index = dynamoConfig.index
 
   def put(work: WorkNode): Future[Option[Either[DynamoReadError, WorkNode]]] = {
     Future {

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -116,7 +116,8 @@ trait MatcherFixtures
   def withWorkNodeDao[R](table: Table)(testWith: TestWith[WorkNodeDao, R]): R = {
     val workNodeDao = new WorkNodeDao(
       dynamoDbClient,
-      DynamoConfig(table.name, Some(table.index)))
+      DynamoConfig(table = table.name, index = table.index)
+    )
     testWith(workNodeDao)
   }
 

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
@@ -58,7 +58,8 @@ class WorkNodeDaoTest
           .thenThrow(expectedException)
         val matcherGraphDao = new WorkNodeDao(
           dynamoDbClient,
-          DynamoConfig(table.name, Some(table.index)))
+          DynamoConfig(table = table.name, index = table.index)
+        )
 
         whenReady(matcherGraphDao.get(Set("A")).failed) { failedException =>
           failedException shouldBe expectedException
@@ -116,7 +117,8 @@ class WorkNodeDaoTest
           .thenThrow(expectedException)
         val workNodeDao = new WorkNodeDao(
           dynamoDbClient,
-          DynamoConfig(table.name, Some(table.index)))
+          DynamoConfig(table = table.name, index = table.index)
+        )
 
         whenReady(workNodeDao.getByComponentIds(Set("A+B")).failed) {
           failedException =>
@@ -163,7 +165,8 @@ class WorkNodeDaoTest
           .thenThrow(expectedException)
         val workNodeDao = new WorkNodeDao(
           dynamoDbClient,
-          DynamoConfig(table.name, Some(table.index)))
+          DynamoConfig(table = table.name, index = table.index)
+        )
 
         whenReady(workNodeDao.put(WorkNode("A", List("B"), "A+B")).failed) {
           failedException =>
@@ -175,7 +178,7 @@ class WorkNodeDaoTest
 
   it("cannot be instantiated if dynamoConfig.index is a None") {
     intercept[RuntimeException] {
-      new WorkNodeDao(dynamoDbClient, DynamoConfig("something", None))
+      new WorkNodeDao(dynamoDbClient, DynamoConfig(table = "something", maybeIndex = None))
     }
   }
 

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.matcher.storage
 
+import javax.naming.ConfigurationException
+
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.model.{
   BatchGetItemRequest,
@@ -176,9 +178,12 @@ class WorkNodeDaoTest
     }
   }
 
-  it("cannot be instantiated if dynamoConfig.index is a None") {
-    intercept[RuntimeException] {
-      new WorkNodeDao(dynamoDbClient, DynamoConfig(table = "something", maybeIndex = None))
+  it("cannot be instantiated if dynamoConfig.maybeIndex is None") {
+    intercept[ConfigurationException] {
+      new WorkNodeDao(
+        dynamoDbClient = dynamoDbClient,
+        dynamoConfig = DynamoConfig(table = "something", maybeIndex = None)
+      )
     }
   }
 

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/Server.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/Server.scala
@@ -42,11 +42,6 @@ class Server extends HttpServer {
     AkkaModule
   )
 
-  flag[String](
-    "aws.dynamo.indexName",
-    "reindexTracker",
-    "Name of the reindex tracker GSI")
-
   override def configureHttp(router: HttpRouter) {
     router
       .filter[CommonFilters]

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
@@ -29,7 +29,7 @@ class ReindexService @Inject()(dynamoDBClient: AmazonDynamoDB,
 
     val table = Table[ReindexRecord](dynamoConfig.table)
 
-    val index = table.index(dynamoConfig.index.get)
+    val index = table.index(dynamoConfig.maybeIndex.get)
 
     // We start by querying DynamoDB for every record in the reindex shard
     // that has an out-of-date reindexVersion.  If a shard was especially

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
@@ -66,5 +66,4 @@ class ReindexService @Inject()(dynamoDbClient: AmazonDynamoDB,
         versionedDao.updateRecord[ReindexRecord](updatedRecord)
       }.map { _ => () }
     }
-  }
 }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
@@ -29,7 +29,7 @@ class ReindexService @Inject()(dynamoDBClient: AmazonDynamoDB,
 
     val table = Table[ReindexRecord](dynamoConfig.table)
 
-    val index = table.index(dynamoConfig.maybeIndex.get)
+    val index = table.index(indexName = dynamoConfig.index)
 
     // We start by querying DynamoDB for every record in the reindex shard
     // that has an out-of-date reindexVersion.  If a shard was especially

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
@@ -29,7 +29,7 @@ class ReindexService @Inject()(dynamoDbClient: AmazonDynamoDB,
   )
 
   def runReindex(reindexJob: ReindexJob): Future[List[Unit]] =
-    Future.sequence {
+    Future {
       info(s"ReindexService running $reindexJob")
 
       val table = Table[ReindexRecord](dynamoConfig.table)
@@ -42,12 +42,12 @@ class ReindexService @Inject()(dynamoDbClient: AmazonDynamoDB,
       // hoping that the shards/individual records are small enough for this
       // not to be a problem.
       val results: List[Either[DynamoReadError, ReindexRecord]] =
-        Scanamo.exec(dynamoDbClient)(
-          index.query(
-            'reindexShard -> reindexJob.shardId and
-              KeyIs('reindexVersion, LT, reindexJob.desiredVersion)
-          )
+      Scanamo.exec(dynamoDbClient)(
+        index.query(
+          'reindexShard -> reindexJob.shardId and
+            KeyIs('reindexVersion, LT, reindexJob.desiredVersion)
         )
+      )
 
       val outdatedRecords: List[ReindexRecord] = results.map {
         case Left(err: DynamoReadError) => {
@@ -62,9 +62,9 @@ class ReindexService @Inject()(dynamoDbClient: AmazonDynamoDB,
       // Then we PUT all the records.  It might be more efficient to do a
       // bulk update, but this will do for now.
       outdatedRecords.map { record: ReindexRecord =>
-        val updatedRecord =
-          record.copy(reindexVersion = reindexJob.desiredVersion)
+        val updatedRecord = record.copy(reindexVersion = reindexJob.desiredVersion)
         versionedDao.updateRecord[ReindexRecord](updatedRecord)
-      }
+      }.map { _ => () }
     }
+  }
 }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
@@ -91,8 +91,7 @@ class ReindexerFeatureTest
         withLocalDynamoDbTable { table =>
           val flags
             : Map[String, String] = snsLocalFlags(topic) ++ dynamoDbLocalEndpointFlags(
-            table) ++ sqsLocalFlags(queue) ++ Map(
-            "aws.dynamo.indexName" -> table.index)
+            table) ++ sqsLocalFlags(queue)
 
           withServer(flags) { _ =>
             val expectedRecords =
@@ -118,8 +117,7 @@ class ReindexerFeatureTest
         withLocalDynamoDbTable { table =>
           val flags
             : Map[String, String] = snsLocalFlags(topic) ++ dynamoDbLocalEndpointFlags(
-            table) ++ sqsLocalFlags(queue) ++ Map(
-            "aws.dynamo.indexName" -> table.index)
+            table) ++ sqsLocalFlags(queue)
 
           withServer(flags) { _ =>
             createReindexableData(queue, table)
@@ -152,8 +150,7 @@ class ReindexerFeatureTest
         withLocalDynamoDbTable { table =>
           val flags
             : Map[String, String] = snsLocalFlags(topic) ++ dynamoDbLocalEndpointFlags(table
-            .copy(name = "non_existent_table")) ++ sqsLocalFlags(queue) ++ Map(
-            "aws.dynamo.indexName" -> table.index)
+            .copy(name = "non_existent_table")) ++ sqsLocalFlags(queue)
 
           withServer(flags) { _ =>
             createReindexableData(queue, table)

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/ReindexerFeatureTest.scala
@@ -149,8 +149,9 @@ class ReindexerFeatureTest
       withLocalSnsTopic { topic =>
         withLocalDynamoDbTable { table =>
           val flags
-            : Map[String, String] = snsLocalFlags(topic) ++ dynamoDbLocalEndpointFlags(table
-            .copy(name = "non_existent_table")) ++ sqsLocalFlags(queue)
+            : Map[String, String] = snsLocalFlags(topic) ++ dynamoDbLocalEndpointFlags(
+            table
+              .copy(name = "non_existent_table")) ++ sqsLocalFlags(queue)
 
           withServer(flags) { _ =>
             createReindexableData(queue, table)

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
@@ -38,14 +38,19 @@ class ReindexServiceTest
     testWith: TestWith[ReindexService, Assertion]) = {
     withActorSystem { actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>
+        val dynamoConfig = DynamoConfig(
+          table = table.name,
+          index = table.index
+        )
         val reindexService =
           new ReindexService(
             dynamoDBClient = dynamoDbClient,
-            dynamoConfig = DynamoConfig(table.name, Some(table.index)),
+            dynamoConfig = dynamoConfig,
             metricsSender = metricsSender,
             versionedDao = new VersionedDao(
               dynamoDbClient = dynamoDbClient,
-              DynamoConfig(table.name, Some(table.index)))
+              dynamoConfig = dynamoConfig
+            )
           )
 
         testWith(reindexService)

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.reindex_worker.TestRecord
 import uk.ac.wellcome.platform.reindex_worker.models.ReindexJob
-import uk.ac.wellcome.storage.dynamo.{DynamoConfig, VersionedDao}
+import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDbVersioned
 import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
@@ -38,19 +38,14 @@ class ReindexServiceTest
     testWith: TestWith[ReindexService, Assertion]) = {
     withActorSystem { actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>
-        val dynamoConfig = DynamoConfig(
-          table = table.name,
-          index = table.index
-        )
         val reindexService =
           new ReindexService(
-            dynamoDBClient = dynamoDbClient,
-            dynamoConfig = dynamoConfig,
-            metricsSender = metricsSender,
-            versionedDao = new VersionedDao(
-              dynamoDbClient = dynamoDbClient,
-              dynamoConfig = dynamoConfig
-            )
+            dynamoDbClient = dynamoDbClient,
+            dynamoConfig = DynamoConfig(
+              table = table.name,
+              index = table.index
+            ),
+            metricsSender = metricsSender
           )
 
         testWith(reindexService)

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -73,7 +73,7 @@ class ReindexWorkerServiceTest
     testWith: TestWith[ReindexService, R]) = {
     val reindexService = new ReindexService(
       dynamoDbClient = dynamoDbClient,
-      dynamoConfig = DynamoConfig(table = table.name, index = table.index)
+      dynamoConfig = DynamoConfig(table = table.name, index = table.index),
       metricsSender = metricsSender
     )
     testWith(reindexService)

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -77,10 +77,10 @@ class ReindexWorkerServiceTest
       versionedDao = new VersionedDao(
         dynamoDbClient = dynamoDbClient,
         dynamoConfig =
-          DynamoConfig(table = table.name, index = Some(table.index))
+          DynamoConfig(table = table.name, index = table.index)
       ),
       dynamoConfig =
-        DynamoConfig(table = table.name, index = Some(table.index))
+        DynamoConfig(table = table.name, index = table.index)
     )
     testWith(reindexService)
   }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.reindex_worker.TestRecord
 import uk.ac.wellcome.platform.reindex_worker.models.ReindexJob
-import uk.ac.wellcome.storage.dynamo.{DynamoConfig, VersionedDao}
+import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDbVersioned
 import uk.ac.wellcome.test.fixtures._
@@ -72,15 +72,9 @@ class ReindexWorkerServiceTest
   def withReindexService[R](metricsSender: MetricsSender, table: Table)(
     testWith: TestWith[ReindexService, R]) = {
     val reindexService = new ReindexService(
-      dynamoDBClient = dynamoDbClient,
-      metricsSender = metricsSender,
-      versionedDao = new VersionedDao(
-        dynamoDbClient = dynamoDbClient,
-        dynamoConfig =
-          DynamoConfig(table = table.name, index = table.index)
-      ),
-      dynamoConfig =
-        DynamoConfig(table = table.name, index = table.index)
+      dynamoDbClient = dynamoDbClient,
+      dynamoConfig = DynamoConfig(table = table.name, index = table.index)
+      metricsSender = metricsSender
     )
     testWith(reindexService)
   }

--- a/reindexer/reindex_worker/src/universal/conf/application.ini.template
+++ b/reindexer/reindex_worker/src/universal/conf/application.ini.template
@@ -1,4 +1,5 @@
 -aws.dynamo.tableName=${dynamo_table_name}
+-aws.dynamo.tableIndex=reindexTracker
 -aws.sns.topic.arn=${reindex_complete_topic_arn}
 -aws.sqs.queue.url=${reindex_jobs_queue_id}
 -aws.metrics.namespace=${metrics_namespace}

--- a/sbt_common/finatra_storage/src/main/scala/uk/ac/wellcome/finatra/storage/DynamoConfigModule.scala
+++ b/sbt_common/finatra_storage/src/main/scala/uk/ac/wellcome/finatra/storage/DynamoConfigModule.scala
@@ -13,11 +13,9 @@ object DynamoConfigModule extends TwitterModule {
 
   @Singleton
   @Provides
-  def providesDynamoConfig(): DynamoConfig = {
-
+  def providesDynamoConfig(): DynamoConfig =
     DynamoConfig(
       table = tableName(),
-      index = if (tableIndex().isEmpty) None else Some(tableIndex()))
-
-  }
+      maybeIndex = if (tableIndex().isEmpty) None else Some(tableIndex())
+    )
 }

--- a/sbt_common/finatra_storage/src/main/scala/uk/ac/wellcome/finatra/storage/VHSConfigModule.scala
+++ b/sbt_common/finatra_storage/src/main/scala/uk/ac/wellcome/finatra/storage/VHSConfigModule.scala
@@ -24,7 +24,7 @@ object VHSConfigModule extends TwitterModule {
   @Singleton
   @Provides
   def providesVHSConfig(): VHSConfig = {
-    val dynamoConfig = DynamoConfig(table = tableName(), index = None)
+    val dynamoConfig = DynamoConfig(table = tableName())
     val s3Config = S3Config(bucketName = bucketName())
     VHSConfig(
       dynamoConfig = dynamoConfig,

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoConfig.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoConfig.scala
@@ -1,3 +1,11 @@
 package uk.ac.wellcome.storage.dynamo
 
-case class DynamoConfig(table: String, index: Option[String])
+case class DynamoConfig(table: String, maybeIndex: Option[String] = None)
+
+case object DynamoConfig {
+  def apply(table: String, index: String): DynamoConfig =
+    DynamoConfig(
+      table = table,
+      maybeIndex = Some(index)
+    )
+}

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoConfig.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoConfig.scala
@@ -1,6 +1,14 @@
 package uk.ac.wellcome.storage.dynamo
 
-case class DynamoConfig(table: String, maybeIndex: Option[String] = None)
+import javax.naming.ConfigurationException
+
+case class DynamoConfig(table: String, maybeIndex: Option[String] = None) {
+  def index: String = maybeIndex.getOrElse(
+    throw new ConfigurationException(
+      "Tried to look up the index, but no index is configured!"
+    )
+  )
+}
 
 case object DynamoConfig {
   def apply(table: String, index: String): DynamoConfig =

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/DynamoConfigTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/DynamoConfigTest.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.storage.dynamo
+
+import javax.naming.ConfigurationException
+
+import org.scalatest.{FunSpec, Matchers}
+
+class DynamoConfigTest extends FunSpec with Matchers {
+  it("allows looking up the index") {
+    val index = "myindex"
+    val config = DynamoConfig(table = "mytable", index = index)
+    config.index shouldBe index
+  }
+
+  it("throws a ConfigurationException if you look up the index without setting it") {
+    val config = DynamoConfig(table = "mytable")
+    config.maybeIndex shouldBe None
+
+    val caught = intercept[ConfigurationException] {
+      config.index
+    }
+    caught.getMessage shouldBe "Tried to look up the index, but no index is configured!"
+  }
+}

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/DynamoConfigTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/DynamoConfigTest.scala
@@ -11,7 +11,8 @@ class DynamoConfigTest extends FunSpec with Matchers {
     config.index shouldBe index
   }
 
-  it("throws a ConfigurationException if you look up the index without setting it") {
+  it(
+    "throws a ConfigurationException if you look up the index without setting it") {
     val config = DynamoConfig(table = "mytable")
     config.maybeIndex shouldBe None
 

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
@@ -280,7 +280,8 @@ class VersionedDaoTest
         val failingDao =
           new VersionedDao(
             dynamoDbClient,
-            dynamoConfig = DynamoConfig(table = table.name, index = table.index)
+            dynamoConfig =
+              DynamoConfig(table = table.name, index = table.index)
           )
 
         val testVersioned = TestVersioned(

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
@@ -34,8 +34,8 @@ class VersionedDaoTest
 
   def withVersionedDao[R](table: Table)(
     testWith: TestWith[VersionedDao, R]): R = {
-    val config = DynamoConfig(table.name, Some(table.index))
-    val dao = new VersionedDao(dynamoDbClient, config)
+    val dynamoConfig = DynamoConfig(table = table.name, index = table.index)
+    val dao = new VersionedDao(dynamoDbClient, dynamoConfig)
     testWith(dao)
   }
 
@@ -86,7 +86,8 @@ class VersionedDaoTest
         val testVersionedDaoMockedDynamoClient =
           new VersionedDao(
             dynamoDbClient,
-            DynamoConfig(table.name, Some(table.index)))
+            DynamoConfig(table = table.name, index = table.index)
+          )
 
         val future =
           testVersionedDaoMockedDynamoClient.getRecord[TestVersioned](
@@ -279,7 +280,8 @@ class VersionedDaoTest
         val failingDao =
           new VersionedDao(
             dynamoDbClient,
-            DynamoConfig(table.name, Some(table.index)))
+            dynamoConfig = DynamoConfig(table = table.name, index = table.index)
+          )
 
         val testVersioned = TestVersioned(
           id = "testSource/b1111",

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
@@ -47,7 +47,7 @@ trait LocalVersionedHybridStore
     implicit encoder: Encoder[T],
     decoder: Decoder[T]): R = {
     val s3Config = S3Config(bucketName = bucket.name)
-    val dynamoConfig = DynamoConfig(table = table.name, Some(table.index))
+    val dynamoConfig = DynamoConfig(table = table.name, index = table.index)
     val vhsConfig = VHSConfig(
       dynamoConfig = dynamoConfig,
       s3Config = s3Config,
@@ -74,8 +74,7 @@ trait LocalVersionedHybridStore
     : R = {
     val s3Config = S3Config(bucketName = bucket.name)
 
-    val dynamoConfig =
-      DynamoConfig(table = table.name, index = Some(table.index))
+    val dynamoConfig = DynamoConfig(table = table.name, index = table.index)
 
     val vhsConfig = VHSConfig(
       dynamoConfig = dynamoConfig,
@@ -102,8 +101,7 @@ trait LocalVersionedHybridStore
     testWith: TestWith[VersionedHybridStore[String, M, S3StringStore], R])
     : R = {
     val s3Config = S3Config(bucketName = bucket.name)
-    val dynamoConfig =
-      DynamoConfig(table = table.name, index = Some(table.index))
+    val dynamoConfig = DynamoConfig(table = table.name, index = table.index)
     val vhsConfig = VHSConfig(
       dynamoConfig = dynamoConfig,
       s3Config = s3Config,

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/DynamoInserterFixture.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/DynamoInserterFixture.scala
@@ -13,7 +13,7 @@ trait DynamoInserterFixture extends LocalDynamoDbVersioned {
     val dynamoInserter = new DynamoInserter(
       new VersionedDao(
         dynamoDbClient,
-        dynamoConfig = DynamoConfig(table.name, Some(table.index))
+        dynamoConfig = DynamoConfig(table = table.name, index = table.index)
       )
     )
 


### PR DESCRIPTION
### What is this PR trying to achieve?

This should fix the issues we’re currently hitting in the reindexer – specifically, it didn't have an index specified. Root cause is 82bf395, when the `@Flag` annotation was removed – but we didn’t notice the `flag` definition in the server had a default. When I deployed an updated reindex_worker yesterday, it all fell over.

This PR also refactors DynamoConfig to hide some of the optional-ness from the caller, and make errors more explicit if/when you look up an index that doesn’t exist.

### Who is this change for?

📥 🇩🇪 