### PR TITLE
Expunge the definition of flags everywhere except in modules

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/ContextHelper.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/ContextHelper.scala
@@ -4,7 +4,6 @@ import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.platform.api.models.ApiConfig
 
 object ContextHelper {
-  def buildContextUri(apiConfig: ApiConfig,
-                      version: ApiVersions.Value) =
+  def buildContextUri(apiConfig: ApiConfig, version: ApiVersions.Value) =
     s"${apiConfig.scheme}://${apiConfig.host}${apiConfig.pathPrefix}/$version${apiConfig.contextSuffix}"
 }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/ContextHelper.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/ContextHelper.scala
@@ -1,12 +1,10 @@
 package uk.ac.wellcome.platform.api
 
 import uk.ac.wellcome.display.models.ApiVersions
+import uk.ac.wellcome.platform.api.models.ApiConfig
 
 object ContextHelper {
-  def buildContextUri(apiScheme: String,
-                      apiHost: String,
-                      apiPrefix: String,
-                      version: ApiVersions.Value,
-                      apiContextSuffix: String) =
-    s"$apiScheme://$apiHost$apiPrefix/$version$apiContextSuffix"
+  def buildContextUri(apiConfig: ApiConfig,
+                      version: ApiVersions.Value) =
+    s"${apiConfig.scheme}://${apiConfig.host}${apiConfig.pathPrefix}/$version${apiConfig.contextSuffix}"
 }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
@@ -19,31 +19,17 @@ import uk.ac.wellcome.platform.api.finatra.exceptions.{
   ElasticsearchResponseExceptionMapper,
   GeneralExceptionMapper
 }
+import uk.ac.wellcome.platform.api.modules.ApiConfigModule
 
 object ServerMain extends Server
 
 class Server extends HttpServer {
   override val name = "uk.ac.wellcome.platform.api Platformapi"
   override val modules = Seq(
+    ApiConfigModule,
     ElasticClientModule,
     ElasticConfigModule
   )
-
-  flag(name = "api.host", default = "localhost:8888", help = "API hostname")
-  flag(name = "api.scheme", default = "https", help = "API protocol scheme")
-  flag(name = "api.pageSize", default = 10, help = "API default page size")
-
-  private final val apiName =
-    flag(name = "api.name", default = "catalogue", help = "API name path part")
-  flag[String](
-    name = "api.prefix",
-    default = "/" + apiName(),
-    help = "API path prefix")
-
-  flag(
-    name = "api.context.suffix",
-    default = "/context.json",
-    help = "Relative API JSON-LD context")
 
   override def jacksonModule = DisplayJacksonModule
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/ContextController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/ContextController.scala
@@ -1,17 +1,16 @@
 package uk.ac.wellcome.platform.api.controllers
 
-import com.twitter.inject.annotations.Flag
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
 import javax.inject.{Inject, Singleton}
+
 import uk.ac.wellcome.display.models.ApiVersions
+import uk.ac.wellcome.platform.api.models.ApiConfig
 
 @Singleton
-class ContextController @Inject()(
-  @Flag("api.prefix") apiPrefix: String
-) extends Controller {
+class ContextController @Inject()(apiConfig: ApiConfig) extends Controller {
 
-  prefix(apiPrefix) {
+  prefix(apiConfig.pathPrefix) {
     setupContextEndpoint(ApiVersions.v1)
     setupContextEndpoint(ApiVersions.v2)
   }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
@@ -1,33 +1,26 @@
 package uk.ac.wellcome.platform.api.controllers
 
-import com.twitter.inject.annotations.Flag
 import javax.inject.{Inject, Singleton}
+
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.elasticsearch.ElasticConfig
+import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.platform.api.services.WorksService
 
 @Singleton
 class V1WorksController @Inject()(
-  @Flag("api.prefix") apiPrefix: String,
-  @Flag("api.context.suffix") apiContextSuffix: String,
-  @Flag("api.host") apiHost: String,
-  @Flag("api.scheme") apiScheme: String,
-  @Flag("api.pageSize") defaultPageSize: Int,
+  apiConfig: ApiConfig,
   elasticConfig: ElasticConfig,
   worksService: WorksService)
     extends WorksController(
-      apiPrefix = apiPrefix,
-      apiContextSuffix = apiContextSuffix,
-      apiHost = apiHost,
-      apiScheme = apiScheme,
+      apiConfig = apiConfig,
       indexName = elasticConfig.indexV1name,
-      defaultPageSize = defaultPageSize,
       worksService = worksService
     ) {
   implicit protected val swagger = ApiV1Swagger
 
-  prefix(s"$apiPrefix/${ApiVersions.v1.toString}") {
+  prefix(s"${apiConfig.pathPrefix}/${ApiVersions.v1.toString}") {
     setupResultListEndpoint(ApiVersions.v1, "/works", DisplayWorkV1.apply)
     setupSingleWorkEndpoint(ApiVersions.v1, "/works/:id", DisplayWorkV1.apply)
   }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
@@ -9,10 +9,9 @@ import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.platform.api.services.WorksService
 
 @Singleton
-class V1WorksController @Inject()(
-  apiConfig: ApiConfig,
-  elasticConfig: ElasticConfig,
-  worksService: WorksService)
+class V1WorksController @Inject()(apiConfig: ApiConfig,
+                                  elasticConfig: ElasticConfig,
+                                  worksService: WorksService)
     extends WorksController(
       apiConfig = apiConfig,
       indexName = elasticConfig.indexV1name,

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
@@ -2,8 +2,10 @@ package uk.ac.wellcome.platform.api.controllers
 
 import com.twitter.inject.annotations.Flag
 import javax.inject.{Inject, Singleton}
+
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
+import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.platform.api.services.WorksService
 
 @Singleton
@@ -13,14 +15,14 @@ class V2WorksController @Inject()(
   @Flag("api.host") apiHost: String,
   @Flag("api.scheme") apiScheme: String,
   @Flag("api.pageSize") defaultPageSize: Int,
-  @Flag("es.index.v2") indexName: String,
+  elasticConfig: ElasticConfig,
   worksService: WorksService)
     extends WorksController(
       apiPrefix = apiPrefix,
       apiContextSuffix = apiContextSuffix,
       apiHost = apiHost,
       apiScheme = apiScheme,
-      indexName = indexName,
+      indexName = elasticConfig.indexV2name,
       defaultPageSize = defaultPageSize,
       worksService = worksService
     ) {

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
@@ -9,10 +9,9 @@ import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.platform.api.services.WorksService
 
 @Singleton
-class V2WorksController @Inject()(
-  apiConfig: ApiConfig,
-  elasticConfig: ElasticConfig,
-  worksService: WorksService)
+class V2WorksController @Inject()(apiConfig: ApiConfig,
+                                  elasticConfig: ElasticConfig,
+                                  worksService: WorksService)
     extends WorksController(
       apiConfig = apiConfig,
       indexName = elasticConfig.indexV2name,

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
@@ -1,34 +1,26 @@
 package uk.ac.wellcome.platform.api.controllers
 
-import com.twitter.inject.annotations.Flag
 import javax.inject.{Inject, Singleton}
 
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
 import uk.ac.wellcome.elasticsearch.ElasticConfig
+import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.platform.api.services.WorksService
 
 @Singleton
 class V2WorksController @Inject()(
-  @Flag("api.prefix") apiPrefix: String,
-  @Flag("api.context.suffix") apiContextSuffix: String,
-  @Flag("api.host") apiHost: String,
-  @Flag("api.scheme") apiScheme: String,
-  @Flag("api.pageSize") defaultPageSize: Int,
+  apiConfig: ApiConfig,
   elasticConfig: ElasticConfig,
   worksService: WorksService)
     extends WorksController(
-      apiPrefix = apiPrefix,
-      apiContextSuffix = apiContextSuffix,
-      apiHost = apiHost,
-      apiScheme = apiScheme,
+      apiConfig = apiConfig,
       indexName = elasticConfig.indexV2name,
-      defaultPageSize = defaultPageSize,
       worksService = worksService
     ) {
   implicit protected val swagger = ApiV2Swagger
 
-  prefix(s"$apiPrefix/${ApiVersions.v2.toString}") {
+  prefix(s"${apiConfig.pathPrefix}/${ApiVersions.v2.toString}") {
     setupResultListEndpoint(ApiVersions.v2, "/works", DisplayWorkV2.apply)
     setupSingleWorkEndpoint(ApiVersions.v2, "/works/:id", DisplayWorkV2.apply)
   }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -77,7 +77,8 @@ abstract class WorksController(apiConfig: ApiConfig,
     } { request: SingleWorkRequest =>
       val includes = request.includes.getOrElse(WorksIncludes())
 
-      val contextUri = buildContextUri(apiConfig = apiConfig, version = version)
+      val contextUri =
+        buildContextUri(apiConfig = apiConfig, version = version)
       for {
         maybeWork <- worksService.findWorkById(
           canonicalId = request.id,

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/CaseClassMappingExceptionWrapper.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/CaseClassMappingExceptionWrapper.scala
@@ -12,9 +12,8 @@ import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error}
 import uk.ac.wellcome.platform.api.responses.ResultResponse
 
 @Singleton
-class CaseClassMappingExceptionWrapper @Inject()(
-  response: ResponseBuilder,
-  apiConfig: ApiConfig)
+class CaseClassMappingExceptionWrapper @Inject()(response: ResponseBuilder,
+                                                 apiConfig: ApiConfig)
     extends ExceptionMapper[CaseClassMappingException]
     with Logging {
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
@@ -13,9 +13,8 @@ import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error}
 import uk.ac.wellcome.platform.api.responses.ResultResponse
 
 @Singleton
-class ElasticsearchResponseExceptionMapper @Inject()(
-  response: ResponseBuilder,
-  apiConfig: ApiConfig)
+class ElasticsearchResponseExceptionMapper @Inject()(response: ResponseBuilder,
+                                                     apiConfig: ApiConfig)
     extends ExceptionMapper[ResponseException]
     with Logging {
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
@@ -5,7 +5,6 @@ import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.exceptions.ExceptionMapper
 import com.twitter.finatra.http.response.ResponseBuilder
 import com.twitter.inject.Logging
-import com.twitter.inject.annotations.Flag
 import javax.inject.{Inject, Singleton}
 
 import org.elasticsearch.client.ResponseException

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/GeneralExceptionMapper.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/GeneralExceptionMapper.scala
@@ -1,28 +1,25 @@
 package uk.ac.wellcome.platform.api.finatra.exceptions
 
 import javax.inject.{Inject, Singleton}
+
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.exceptions.ExceptionMapper
 import com.twitter.finatra.http.response.ResponseBuilder
-import com.twitter.inject.annotations.Flag
 import com.twitter.inject.Logging
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
-import uk.ac.wellcome.platform.api.models.{DisplayError, Error}
+import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error}
 import uk.ac.wellcome.platform.api.responses.ResultResponse
 
 @Singleton
 class GeneralExceptionMapper @Inject()(
   response: ResponseBuilder,
-  @Flag("api.context.suffix") apiContextSuffix: String,
-  @Flag("api.host") apiHost: String,
-  @Flag("api.prefix") apiPrefix: String,
-  @Flag("api.scheme") apiScheme: String)
+  apiConfig: ApiConfig)
     extends ExceptionMapper[Exception]
     with Logging {
 
   override def toResponse(request: Request, exception: Exception): Response = {
 
-    val version = getVersion(request, s"$apiPrefix")
+    val version = getVersion(request, apiPrefix = apiConfig.pathPrefix)
 
     error(s"Sending HTTP 500 from GeneralExceptionMapper", exception)
     val result = DisplayError(
@@ -31,12 +28,7 @@ class GeneralExceptionMapper @Inject()(
         description = None
       ))
     val errorResponse = ResultResponse(
-      context = buildContextUri(
-        apiScheme,
-        apiHost,
-        apiPrefix,
-        version,
-        apiContextSuffix),
+      context = buildContextUri(apiConfig = apiConfig, version = version),
       result = result)
     response.internalServerError.json(errorResponse)
   }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/GeneralExceptionMapper.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/GeneralExceptionMapper.scala
@@ -11,9 +11,8 @@ import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error}
 import uk.ac.wellcome.platform.api.responses.ResultResponse
 
 @Singleton
-class GeneralExceptionMapper @Inject()(
-  response: ResponseBuilder,
-  apiConfig: ApiConfig)
+class GeneralExceptionMapper @Inject()(response: ResponseBuilder,
+                                       apiConfig: ApiConfig)
     extends ExceptionMapper[Exception]
     with Logging {
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/ApiConfig.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/ApiConfig.scala
@@ -1,0 +1,10 @@
+package uk.ac.wellcome.platform.api.models
+
+case class ApiConfig(
+  host: String,
+  scheme: String,
+  defaultPageSize: Int,
+  name: String,
+  pathPrefix: String,
+  contextSuffix: String
+)

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/modules/ApiConfigModule.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/modules/ApiConfigModule.scala
@@ -7,9 +7,12 @@ import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.platform.api.models.ApiConfig
 
 object ApiConfigModule extends TwitterModule {
-  private val host = flag(name = "api.host", default = "localhost:8888", help = "API hostname")
-  private val scheme = flag(name = "api.scheme", default = "https", help = "API protocol scheme")
-  private val defaultPageSize = flag(name = "api.pageSize", default = 10, help = "API default page size")
+  private val host =
+    flag(name = "api.host", default = "localhost:8888", help = "API hostname")
+  private val scheme =
+    flag(name = "api.scheme", default = "https", help = "API protocol scheme")
+  private val defaultPageSize =
+    flag(name = "api.pageSize", default = 10, help = "API default page size")
 
   private final val apiName =
     flag(name = "api.name", default = "catalogue", help = "API name path part")

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/modules/ApiConfigModule.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/modules/ApiConfigModule.scala
@@ -1,0 +1,37 @@
+package uk.ac.wellcome.platform.api.modules
+
+import javax.inject.Singleton
+
+import com.google.inject.Provides
+import com.twitter.inject.TwitterModule
+import uk.ac.wellcome.platform.api.models.ApiConfig
+
+object ApiConfigModule extends TwitterModule {
+  private val host = flag(name = "api.host", default = "localhost:8888", help = "API hostname")
+  private val scheme = flag(name = "api.scheme", default = "https", help = "API protocol scheme")
+  private val defaultPageSize = flag(name = "api.pageSize", default = 10, help = "API default page size")
+
+  private final val apiName =
+    flag(name = "api.name", default = "catalogue", help = "API name path part")
+  private val pathPrefix = flag[String](
+    name = "api.prefix",
+    default = "/" + apiName(),
+    help = "API path prefix")
+
+  private val contextSuffix = flag(
+    name = "api.context.suffix",
+    default = "/context.json",
+    help = "Relative API JSON-LD context")
+
+  @Provides
+  @Singleton
+  def providesApiConfig(): ApiConfig =
+    ApiConfig(
+      host = host(),
+      scheme = scheme(),
+      defaultPageSize = defaultPageSize(),
+      name = apiName(),
+      pathPrefix = pathPrefix(),
+      contextSuffix = contextSuffix()
+    )
+}

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchService.scala
@@ -4,14 +4,17 @@ import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.http.get.GetResponse
 import com.sksamuel.elastic4s.http.search.SearchResponse
-import com.twitter.inject.annotations.Flag
 import javax.inject.{Inject, Singleton}
+
+import uk.ac.wellcome.elasticsearch.ElasticConfig
 
 import scala.concurrent.Future
 
 @Singleton
-class ElasticSearchService @Inject()(@Flag("es.type") documentType: String,
-                                     elasticClient: HttpClient) {
+class ElasticSearchService @Inject()(elasticClient: HttpClient,
+                                     elasticConfig: ElasticConfig) {
+
+  val documentType = elasticConfig.documentType
 
   def findResultById(canonicalId: String,
                      indexName: String): Future[GetResponse] =

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -1,10 +1,10 @@
 package uk.ac.wellcome.platform.api.services
 
 import com.sksamuel.elastic4s.http.search.SearchHit
-import com.twitter.inject.annotations.Flag
 import javax.inject.{Inject, Singleton}
+
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
-import uk.ac.wellcome.platform.api.models.ResultList
+import uk.ac.wellcome.platform.api.models.{ApiConfig, ResultList}
 import uk.ac.wellcome.platform.api.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil._
 
@@ -12,7 +12,7 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 @Singleton
-class WorksService @Inject()(@Flag("api.pageSize") defaultPageSize: Int,
+class WorksService @Inject()(apiConfig: ApiConfig,
                              searchService: ElasticSearchService) {
 
   def findWorkById(canonicalId: String,
@@ -26,7 +26,7 @@ class WorksService @Inject()(@Flag("api.pageSize") defaultPageSize: Int,
       }
 
   def listWorks(indexName: String,
-                pageSize: Int = defaultPageSize,
+                pageSize: Int = apiConfig.defaultPageSize,
                 pageNumber: Int = 1): Future[ResultList] =
     searchService
       .listResults(
@@ -46,7 +46,7 @@ class WorksService @Inject()(@Flag("api.pageSize") defaultPageSize: Int,
 
   def searchWorks(query: String,
                   indexName: String,
-                  pageSize: Int = defaultPageSize,
+                  pageSize: Int = apiConfig.defaultPageSize,
                   pageNumber: Int = 1): Future[ResultList] =
     searchService
       .simpleStringQueryResults(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ElasticsearchServiceFixture.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ElasticsearchServiceFixture.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.api.fixtures
 
 import org.scalatest.{Assertion, Suite}
+import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.platform.api.services.ElasticSearchService
 import uk.ac.wellcome.test.fixtures.TestWith
@@ -10,8 +11,12 @@ trait ElasticsearchServiceFixture extends ElasticsearchFixtures {
   def withElasticSearchService(indexName: String, itemType: String)(
     testWith: TestWith[ElasticSearchService, Assertion]) = {
     val searchService = new ElasticSearchService(
-      documentType = itemType,
-      elasticClient = elasticClient
+      elasticClient = elasticClient,
+      elasticConfig = ElasticConfig(
+        documentType = itemType,
+        indexV1name = indexName,
+        indexV2name = indexName
+      )
     )
     testWith(searchService)
   }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/WorksServiceFixture.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/WorksServiceFixture.scala
@@ -5,13 +5,21 @@ import uk.ac.wellcome.platform.api.services.{
   ElasticSearchService,
   WorksService
 }
+import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.test.fixtures.TestWith
 
 trait WorksServiceFixture { this: Suite =>
   def withWorksService(searchService: ElasticSearchService)(
     testWith: TestWith[WorksService, Assertion]) = {
     val worksService = new WorksService(
-      defaultPageSize = 10,
+      apiConfig = ApiConfig(
+        host = "example.org",
+        scheme = "https",
+        defaultPageSize = 10,
+        name = "testing",
+        pathPrefix = "/catalogue/works",
+        contextSuffix = "/conext.json"
+      ),
       searchService = searchService
     )
     testWith(worksService)

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/Server.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/Server.scala
@@ -25,6 +25,7 @@ class Server extends HttpServer {
   override val name = "uk.ac.wellcome.platform.id_minter IdMinter"
   override val modules = Seq(
     MysqlModule,
+    IdentifiersTableConfigModule,
     AkkaModule,
     IdMinterWorkerModule,
     SQSClientModule,

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/TableProvisioner.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/TableProvisioner.scala
@@ -1,22 +1,20 @@
 package uk.ac.wellcome.platform.idminter.database
 
 import com.google.inject.Inject
-import com.twitter.inject.annotations.Flag
 import org.flywaydb.core.Flyway
+import uk.ac.wellcome.platform.idminter.models.RDSClientConfig
 
 import scala.collection.JavaConverters._
 
-class TableProvisioner @Inject()(@Flag("aws.rds.host") host: String,
-                                 @Flag("aws.rds.port") port: String,
-                                 @Flag("aws.rds.userName") userName: String,
-                                 @Flag("aws.rds.password") password: String) {
+class TableProvisioner @Inject()(rdsClientConfig: RDSClientConfig) {
 
   def provision(database: String, tableName: String): Unit = {
     val flyway = new Flyway()
     flyway.setDataSource(
-      s"jdbc:mysql://$host:$port/$database",
-      userName,
-      password)
+      s"jdbc:mysql://${rdsClientConfig.host}:${rdsClientConfig.port}/$database",
+      rdsClientConfig.username,
+      rdsClientConfig.password
+    )
     flyway.setPlaceholders(
       Map("database" -> database, "tableName" -> tableName).asJava)
     flyway.migrate()

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/models/IdentifiersTable.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/models/IdentifiersTable.scala
@@ -1,15 +1,13 @@
 package uk.ac.wellcome.platform.idminter.models
 
 import com.google.inject.Inject
-import com.twitter.inject.annotations.Flag
 import scalikejdbc._
 
 class IdentifiersTable @Inject()(
-  @Flag("aws.rds.identifiers.database") database: String,
-  @Flag("aws.rds.identifiers.table") table: String)
+  identifiersTableConfig: IdentifiersTableConfig)
     extends SQLSyntaxSupport[Identifier] {
-  override val schemaName = Some(database)
-  override val tableName = table
+  override val schemaName = Some(identifiersTableConfig.database)
+  override val tableName = identifiersTableConfig.tableName
   override val useSnakeCaseColumnName = false
   override val columns = Seq(
     "CanonicalId",

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/models/IdentifiersTableConfig.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/models/IdentifiersTableConfig.scala
@@ -1,0 +1,6 @@
+package uk.ac.wellcome.platform.idminter.models
+
+case class IdentifiersTableConfig(
+  database: String,
+  tableName: String
+)

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/models/RDSClientConfig.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/models/RDSClientConfig.scala
@@ -1,0 +1,8 @@
+package uk.ac.wellcome.platform.idminter.models
+
+case class RDSClientConfig(
+  host: String,
+  port: String,
+  username: String,
+  password: String
+)

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerModule.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerModule.scala
@@ -3,22 +3,18 @@ package uk.ac.wellcome.platform.idminter.modules
 import akka.actor.ActorSystem
 import com.twitter.inject.{Injector, TwitterModule}
 import uk.ac.wellcome.platform.idminter.database.TableProvisioner
+import uk.ac.wellcome.platform.idminter.models.IdentifiersTableConfig
 import uk.ac.wellcome.platform.idminter.services.IdMinterWorkerService
 
 object IdMinterWorkerModule extends TwitterModule {
-  val database = flag[String](
-    "aws.rds.identifiers.database",
-    "",
-    "Name of the identifiers database")
-  val tableName = flag[String](
-    "aws.rds.identifiers.table",
-    "",
-    "Name of the identifiers table")
-
   override def singletonStartup(injector: Injector) {
     val tableProvisioner = injector.instance[TableProvisioner]
+    val identifiersTableConfig = injector.instance[IdentifiersTableConfig]
 
-    tableProvisioner.provision(database(), tableName())
+    tableProvisioner.provision(
+      database = identifiersTableConfig.database,
+      tableName = identifiersTableConfig.tableName
+    )
 
     injector.instance[IdMinterWorkerService]
     super.singletonStartup(injector)

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/IdentifiersTableConfigModule.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/IdentifiersTableConfigModule.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.platform.idminter.modules
+
+import com.google.inject.Provides
+import com.twitter.inject.TwitterModule
+import uk.ac.wellcome.platform.idminter.models.IdentifiersTableConfig
+
+object IdentifiersTableConfigModule extends TwitterModule {
+  val database = flag[String](
+    "aws.rds.identifiers.database",
+    "",
+    "Name of the identifiers database")
+  val tableName = flag[String](
+    "aws.rds.identifiers.table",
+    "",
+    "Name of the identifiers table")
+
+  @Provides
+  def providesIdentifiersTableConfig(): IdentifiersTableConfig =
+    IdentifiersTableConfig(
+      database = database(),
+      tableName = tableName()
+    )
+}

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/MysqlModule.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/MysqlModule.scala
@@ -3,29 +3,19 @@ package uk.ac.wellcome.platform.idminter.modules
 import com.google.inject.Provides
 import com.twitter.inject.TwitterModule
 import scalikejdbc.{ConnectionPool, DB}
+import uk.ac.wellcome.platform.idminter.models.RDSClientConfig
 
 object MysqlModule extends TwitterModule {
-
-  private val host =
-    flag[String]("aws.rds.host", "", "Host of the MySQL database")
-  private val port =
-    flag[String]("aws.rds.port", "3306", "Port of the MySQL database")
-  private val userName = flag[String](
-    "aws.rds.userName",
-    "",
-    "User to connect to the MySQL database")
-  private val password = flag[String](
-    "aws.rds.password",
-    "",
-    "Password to connect to the MySQL database")
+  override val modules = Seq(RDSClientConfigModule)
 
   @Provides
-  def providesDB(): DB = {
+  def providesDB(rdsClientConfig: RDSClientConfig): DB = {
     Class.forName("com.mysql.jdbc.Driver")
     ConnectionPool.singleton(
-      s"jdbc:mysql://${host()}:${port()}",
-      userName(),
-      password())
+      s"jdbc:mysql://${rdsClientConfig.host}:${rdsClientConfig.port}",
+      user = rdsClientConfig.username,
+      password = rdsClientConfig.password
+    )
     DB.connect()
   }
 }

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/RDSClientConfigModule.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/RDSClientConfigModule.scala
@@ -1,0 +1,30 @@
+package uk.ac.wellcome.platform.idminter.modules
+
+import com.google.inject.Provides
+import com.twitter.inject.TwitterModule
+import uk.ac.wellcome.platform.idminter.models.RDSClientConfig
+
+object RDSClientConfigModule extends TwitterModule {
+
+  private val host =
+    flag[String]("aws.rds.host", "", "Host of the MySQL database")
+  private val port =
+    flag[String]("aws.rds.port", "3306", "Port of the MySQL database")
+  private val username = flag[String](
+    "aws.rds.userName",
+    "",
+    "User to connect to the MySQL database")
+  private val password = flag[String](
+    "aws.rds.password",
+    "",
+    "Password to connect to the MySQL database")
+
+  @Provides
+  def providesRdsClientConfig(): RDSClientConfig =
+    RDSClientConfig(
+      host = host(),
+      port = port(),
+      username = username(),
+      password = password()
+    )
+}

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -33,13 +33,13 @@ class IdMinterFeatureTest
     withLocalSqsQueue { queue =>
       withLocalSnsTopic { topic =>
         withLocalS3Bucket { bucket =>
-          withIdentifiersDatabase { dbConfig =>
+          withIdentifiersDatabase { identifiersTableConfig =>
             val flags =
-              dbConfig.flags ++
+              identifiersLocalDbFlags(identifiersTableConfig) ++
                 messagingLocalFlags(bucket, topic, queue)
 
             withServer(flags) { _ =>
-              eventuallyTableExists(dbConfig)
+              eventuallyTableExists(identifiersTableConfig)
 
               val miroID = "M0001234"
               val title = "A limerick about a lion"
@@ -91,10 +91,10 @@ class IdMinterFeatureTest
   it("continues if something fails processing a message") {
     withLocalSqsQueue { queue =>
       withLocalSnsTopic { topic =>
-        withIdentifiersDatabase { dbConfig =>
+        withIdentifiersDatabase { identifiersTableConfig =>
           withLocalS3Bucket { bucket =>
             val flags =
-              dbConfig.flags ++
+              identifiersLocalDbFlags(identifiersTableConfig) ++
                 messagingLocalFlags(bucket, topic, queue)
 
             withServer(flags) { _ =>

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/ServerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/ServerTest.scala
@@ -17,9 +17,9 @@ class ServerTest
     withLocalSqsQueue { queue =>
       withLocalSnsTopic { topic =>
         withLocalS3Bucket { bucket =>
-          withIdentifiersDatabase { dbConfig =>
+          withIdentifiersDatabase { identifiersTableConfig =>
             val flags = messagingLocalFlags(bucket, topic, queue) ++
-              dbConfig.flags
+              identifiersLocalDbFlags(identifiersTableConfig)
 
             withServer(flags) { server =>
               server.httpGet(

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -18,21 +18,20 @@ class IdentifiersDaoTest
 
   def withIdentifiersDao[R](
     testWith: TestWith[(IdentifiersDao, IdentifiersTable), R]): R =
-    withIdentifiersDatabase {
-      case (rdsClientConfig, identifiersTableConfig) =>
-        val identifiersTable = new IdentifiersTable(identifiersTableConfig)
+    withIdentifiersDatabase { identifiersTableConfig =>
+      val identifiersTable = new IdentifiersTable(identifiersTableConfig)
 
-        new TableProvisioner(rdsClientConfig)
-          .provision(
-            database = identifiersTableConfig.database,
-            tableName = identifiersTableConfig.tableName
-          )
+      new TableProvisioner(rdsClientConfig)
+        .provision(
+          database = identifiersTableConfig.database,
+          tableName = identifiersTableConfig.tableName
+        )
 
-        val identifiersDao = new IdentifiersDao(DB.connect(), identifiersTable)
+      val identifiersDao = new IdentifiersDao(DB.connect(), identifiersTable)
 
-        eventuallyTableExists(identifiersTableConfig)
+      eventuallyTableExists(identifiersTableConfig)
 
-        testWith((identifiersDao, identifiersTable))
+      testWith((identifiersDao, identifiersTable))
     }
 
   describe("lookupID") {

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -5,7 +5,6 @@ import scalikejdbc._
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier}
 import uk.ac.wellcome.platform.idminter.fixtures
-import uk.ac.wellcome.platform.idminter.fixtures.DatabaseConfig
 import uk.ac.wellcome.platform.idminter.models.{Identifier, IdentifiersTable}
 import uk.ac.wellcome.test.fixtures.TestWith
 

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -16,194 +16,201 @@ class IdentifiersDaoTest
     with fixtures.IdentifiersDatabase
     with Matchers {
 
-  def withIdentifiersDao[R](testWith: TestWith[(IdentifiersDao, IdentifiersTable), R]): R =
-    withIdentifiersDatabase { case (rdsClientConfig, identifiersTableConfig) =>
-      val identifiersTable = new IdentifiersTable(identifiersTableConfig)
+  def withIdentifiersDao[R](
+    testWith: TestWith[(IdentifiersDao, IdentifiersTable), R]): R =
+    withIdentifiersDatabase {
+      case (rdsClientConfig, identifiersTableConfig) =>
+        val identifiersTable = new IdentifiersTable(identifiersTableConfig)
 
-      new TableProvisioner(rdsClientConfig)
-        .provision(
-          database = identifiersTableConfig.database,
-          tableName = identifiersTableConfig.tableName
-        )
+        new TableProvisioner(rdsClientConfig)
+          .provision(
+            database = identifiersTableConfig.database,
+            tableName = identifiersTableConfig.tableName
+          )
 
-      val identifiersDao = new IdentifiersDao(DB.connect(), identifiersTable)
+        val identifiersDao = new IdentifiersDao(DB.connect(), identifiersTable)
 
-      eventuallyTableExists(identifiersTableConfig)
+        eventuallyTableExists(identifiersTableConfig)
 
-      testWith((identifiersDao, identifiersTable))
+        testWith((identifiersDao, identifiersTable))
     }
 
   describe("lookupID") {
     it("gets an Identifier if it finds a matching SourceSystem and SourceId") {
-      withIdentifiersDao { case (identifiersDao, _) =>
-        val identifier = Identifier(
-          CanonicalId = "A turtle turns to try to taste",
-          SourceId = "A tangerine",
-          SourceSystem = IdentifierType("miro-image-number").id,
-          OntologyType = "t-t-t-turtles"
-        )
-        identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
+      withIdentifiersDao {
+        case (identifiersDao, _) =>
+          val identifier = Identifier(
+            CanonicalId = "A turtle turns to try to taste",
+            SourceId = "A tangerine",
+            SourceSystem = IdentifierType("miro-image-number").id,
+            OntologyType = "t-t-t-turtles"
+          )
+          identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
 
-        val sourceIdentifier = SourceIdentifier(
-          identifierType = IdentifierType("miro-image-number"),
-          identifier.OntologyType,
-          value = identifier.SourceId
-        )
+          val sourceIdentifier = SourceIdentifier(
+            identifierType = IdentifierType("miro-image-number"),
+            identifier.OntologyType,
+            value = identifier.SourceId
+          )
 
-        val triedLookup = identifiersDao.lookupId(
-          sourceIdentifier = sourceIdentifier
-        )
+          val triedLookup = identifiersDao.lookupId(
+            sourceIdentifier = sourceIdentifier
+          )
 
-        triedLookup shouldBe Success(Some(identifier))
+          triedLookup shouldBe Success(Some(identifier))
       }
     }
 
     it(
       "does not get an identifier if there is no matching SourceSystem and SourceId") {
-      withIdentifiersDao { case (identifiersDao, _) =>
-        val identifier = Identifier(
-          CanonicalId = "A turtle turns to try to taste",
-          SourceId = "A tangerine",
-          SourceSystem = IdentifierType("miro-image-number").id,
-          OntologyType = "t-t-t-turtles"
-        )
+      withIdentifiersDao {
+        case (identifiersDao, _) =>
+          val identifier = Identifier(
+            CanonicalId = "A turtle turns to try to taste",
+            SourceId = "A tangerine",
+            SourceSystem = IdentifierType("miro-image-number").id,
+            OntologyType = "t-t-t-turtles"
+          )
 
-        identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
+          identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
 
-        val sourceIdentifier = SourceIdentifier(
-          identifierType = IdentifierType("miro-image-number"),
-          identifier.OntologyType,
-          value = "not_an_existing_value"
-        )
+          val sourceIdentifier = SourceIdentifier(
+            identifierType = IdentifierType("miro-image-number"),
+            identifier.OntologyType,
+            value = "not_an_existing_value"
+          )
 
-        val triedLookup = identifiersDao.lookupId(
-          sourceIdentifier = sourceIdentifier
-        )
+          val triedLookup = identifiersDao.lookupId(
+            sourceIdentifier = sourceIdentifier
+          )
 
-        triedLookup shouldBe Success(None)
+          triedLookup shouldBe Success(None)
       }
     }
   }
 
   describe("saveIdentifier") {
     it("inserts the provided identifier into the database") {
-      withIdentifiersDao { case (identifiersDao, identifiersTable) =>
-        implicit val session = AutoSession
+      withIdentifiersDao {
+        case (identifiersDao, identifiersTable) =>
+          implicit val session = AutoSession
 
-        val identifier = Identifier(
-          CanonicalId = "A provision of porpoises",
-          OntologyType = "Work",
-          SourceSystem = IdentifierType("miro-image-number").id,
-          SourceId = "A picture of pangolins"
-        )
-        identifiersDao.saveIdentifier(identifier)
-        val maybeIdentifier = withSQL {
-          select
-            .from(identifiersTable as identifiersTable.i)
-            .where
-            .eq(
-              identifiersTable.i.SourceSystem,
-              IdentifierType("miro-image-number").id)
-            .and
-            .eq(
-              identifiersTable.i.CanonicalId,
-              identifier.CanonicalId)
-        }.map(Identifier(identifiersTable.i)).single.apply()
+          val identifier = Identifier(
+            CanonicalId = "A provision of porpoises",
+            OntologyType = "Work",
+            SourceSystem = IdentifierType("miro-image-number").id,
+            SourceId = "A picture of pangolins"
+          )
+          identifiersDao.saveIdentifier(identifier)
+          val maybeIdentifier = withSQL {
+            select
+              .from(identifiersTable as identifiersTable.i)
+              .where
+              .eq(
+                identifiersTable.i.SourceSystem,
+                IdentifierType("miro-image-number").id)
+              .and
+              .eq(identifiersTable.i.CanonicalId, identifier.CanonicalId)
+          }.map(Identifier(identifiersTable.i)).single.apply()
 
-        maybeIdentifier shouldBe defined
-        maybeIdentifier.get shouldBe identifier
+          maybeIdentifier shouldBe defined
+          maybeIdentifier.get shouldBe identifier
       }
     }
 
     it("fails to insert a record with a duplicate CanonicalId") {
-      withIdentifiersDao { case (identifiersDao, _) =>
-        val identifier = new Identifier(
-          CanonicalId = "A failed field of flowers",
-          SourceId = "A farm full of fruit",
-          SourceSystem = "France",
-          OntologyType = "Fruits"
-        )
-        val duplicateIdentifier = new Identifier(
-          CanonicalId = identifier.CanonicalId,
-          SourceId = "Fuel for a factory",
-          SourceSystem = "Space",
-          OntologyType = "Fuels"
-        )
+      withIdentifiersDao {
+        case (identifiersDao, _) =>
+          val identifier = new Identifier(
+            CanonicalId = "A failed field of flowers",
+            SourceId = "A farm full of fruit",
+            SourceSystem = "France",
+            OntologyType = "Fruits"
+          )
+          val duplicateIdentifier = new Identifier(
+            CanonicalId = identifier.CanonicalId,
+            SourceId = "Fuel for a factory",
+            SourceSystem = "Space",
+            OntologyType = "Fuels"
+          )
 
-        identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
+          identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
 
-        val triedSave = identifiersDao.saveIdentifier(duplicateIdentifier)
+          val triedSave = identifiersDao.saveIdentifier(duplicateIdentifier)
 
-        triedSave shouldBe a[Failure[_]]
-        triedSave.failed.get shouldBe a[GracefulFailureException]
+          triedSave shouldBe a[Failure[_]]
+          triedSave.failed.get shouldBe a[GracefulFailureException]
       }
     }
 
     it(
       "saves records with the same SourceSystem and SourceId but different OntologyType") {
-      withIdentifiersDao { case (identifiersDao, _) =>
-        val identifier = new Identifier(
-          CanonicalId = "A mountain of muesli",
-          SourceSystem = "A maize made of maze",
-          SourceId = "A maize made of maze",
-          OntologyType = "Cereals"
-        )
+      withIdentifiersDao {
+        case (identifiersDao, _) =>
+          val identifier = new Identifier(
+            CanonicalId = "A mountain of muesli",
+            SourceSystem = "A maize made of maze",
+            SourceId = "A maize made of maze",
+            OntologyType = "Cereals"
+          )
 
-        val secondIdentifier = new Identifier(
-          CanonicalId = "A mere mango",
-          SourceSystem = identifier.SourceSystem,
-          SourceId = "A maize made of maze",
-          OntologyType = "Fruits"
-        )
+          val secondIdentifier = new Identifier(
+            CanonicalId = "A mere mango",
+            SourceSystem = identifier.SourceSystem,
+            SourceId = "A maize made of maze",
+            OntologyType = "Fruits"
+          )
 
-        identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
-        identifiersDao.saveIdentifier(secondIdentifier) shouldBe Success(1)
+          identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
+          identifiersDao.saveIdentifier(secondIdentifier) shouldBe Success(1)
       }
     }
 
     it(
       "saves records with different SourceId but the same OntologyType and SourceSystem") {
-      withIdentifiersDao { case (identifiersDao, _) =>
-        val identifier = new Identifier(
-          CanonicalId = "Overflowing with okra",
-          SourceId = "Olive oil in an orchard",
-          SourceSystem = "A hedge maze in Loughborough",
-          OntologyType = "Crops"
-        )
-        val secondIdentifier = new Identifier(
-          CanonicalId = "An order of onions",
-          SourceId = "Only orange orbs",
-          SourceSystem = "A hedge maze in Loughborough",
-          OntologyType = identifier.OntologyType
-        )
+      withIdentifiersDao {
+        case (identifiersDao, _) =>
+          val identifier = new Identifier(
+            CanonicalId = "Overflowing with okra",
+            SourceId = "Olive oil in an orchard",
+            SourceSystem = "A hedge maze in Loughborough",
+            OntologyType = "Crops"
+          )
+          val secondIdentifier = new Identifier(
+            CanonicalId = "An order of onions",
+            SourceId = "Only orange orbs",
+            SourceSystem = "A hedge maze in Loughborough",
+            OntologyType = identifier.OntologyType
+          )
 
-        identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
-        identifiersDao.saveIdentifier(secondIdentifier) shouldBe Success(1)
+          identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
+          identifiersDao.saveIdentifier(secondIdentifier) shouldBe Success(1)
       }
     }
 
     it(
       "does not insert records with the same SourceId, SourceSystem and OntologyType") {
-      withIdentifiersDao { case (identifiersDao, _) =>
-        val identifier = new Identifier(
-          CanonicalId = "A surplus of strawberries",
-          SourceId = "Sunflower seeds in a sack",
-          SourceSystem = "The microscopic world of eyelash lice",
-          OntologyType = "Cropssss"
-        )
-        val duplicateIdentifier = new Identifier(
-          CanonicalId = "Sweeteners and sugar cane",
-          SourceId = identifier.SourceId,
-          SourceSystem = identifier.SourceSystem,
-          OntologyType = identifier.OntologyType
-        )
+      withIdentifiersDao {
+        case (identifiersDao, _) =>
+          val identifier = new Identifier(
+            CanonicalId = "A surplus of strawberries",
+            SourceId = "Sunflower seeds in a sack",
+            SourceSystem = "The microscopic world of eyelash lice",
+            OntologyType = "Cropssss"
+          )
+          val duplicateIdentifier = new Identifier(
+            CanonicalId = "Sweeteners and sugar cane",
+            SourceId = identifier.SourceId,
+            SourceSystem = identifier.SourceSystem,
+            OntologyType = identifier.OntologyType
+          )
 
-        identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
+          identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
 
-        val triedSave = identifiersDao.saveIdentifier(duplicateIdentifier)
+          val triedSave = identifiersDao.saveIdentifier(duplicateIdentifier)
 
-        triedSave shouldBe a[Failure[_]]
-        triedSave.failed.get shouldBe a[GracefulFailureException]
+          triedSave shouldBe a[Failure[_]]
+          triedSave.failed.get shouldBe a[GracefulFailureException]
       }
     }
   }

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/TableProvisionerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/TableProvisionerTest.scala
@@ -14,14 +14,14 @@ class TableProvisionerTest
     with Matchers {
 
   it("should create the Identifiers table") {
-    withIdentifiersDatabase { databaseConfig =>
-      val databaseName = databaseConfig.databaseName
-      val tableName = databaseConfig.tableName
+    withIdentifiersDatabase { identifiersTableConfig =>
+      val databaseName = identifiersTableConfig.database
+      val tableName = identifiersTableConfig.tableName
 
-      new TableProvisioner(host, port, username, password)
+      new TableProvisioner(rdsClientConfig)
         .provision(databaseName, tableName)
 
-      eventuallyTableExists(databaseConfig)
+      eventuallyTableExists(identifiersTableConfig)
     }
   }
 }

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/IdentifersDatabase.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/IdentifersDatabase.scala
@@ -25,8 +25,8 @@ trait IdentifiersDatabase
   val password = "password"
 
   def eventuallyTableExists(tableConfig: IdentifiersTableConfig) = eventually {
-    val database = tableConfig.database
-    val table = tableConfig.tableName
+    val database: SQLSyntax = SQLSyntax.createUnsafely(tableConfig.database)
+    val table: SQLSyntax = SQLSyntax.createUnsafely(tableConfig.tableName)
 
     val fields = DB readOnly { implicit session =>
       sql"DESCRIBE $database.$table"

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/IdentifersDatabase.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/IdentifersDatabase.scala
@@ -6,18 +6,10 @@ import scalikejdbc.{AutoSession, ConnectionPool, DB, SQLSyntax}
 import uk.ac.wellcome.test.fixtures.TestWith
 import scalikejdbc._
 import uk.ac.wellcome.platform.idminter.database.FieldDescription
+import uk.ac.wellcome.platform.idminter.models.{IdentifiersTableConfig, RDSClientConfig}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
 import scala.util.Random
-
-case class DatabaseConfig(
-  databaseName: String,
-  tableName: String,
-  database: SQLSyntax,
-  table: SQLSyntax,
-  flags: Map[String, String],
-  session: AutoSession.type
-)
 
 trait IdentifiersDatabase
     extends Eventually
@@ -29,9 +21,9 @@ trait IdentifiersDatabase
   val username = "root"
   val password = "password"
 
-  def eventuallyTableExists(databaseConfig: DatabaseConfig) = eventually {
-    val database = databaseConfig.database
-    val table = databaseConfig.table
+  def eventuallyTableExists(tableConfig: IdentifiersTableConfig) = eventually {
+    val database = tableConfig.database
+    val table = tableConfig.tableName
 
     val fields = DB readOnly { implicit session =>
       sql"DESCRIBE $database.$table"
@@ -80,7 +72,7 @@ trait IdentifiersDatabase
     Stream continually nextAlpha
   }
 
-  def withIdentifiersDatabase[R](testWith: TestWith[DatabaseConfig, R]) = {
+  def withIdentifiersDatabase[R](testWith: TestWith[(RDSClientConfig, IdentifiersTableConfig), R]) = {
     Class.forName("com.mysql.jdbc.Driver")
     ConnectionPool.singleton(s"jdbc:mysql://$host:$port", username, password)
 
@@ -115,19 +107,22 @@ trait IdentifiersDatabase
       "aws.rds.identifiers.database" -> databaseName
     )
 
-    val config = DatabaseConfig(
-      databaseName = databaseName,
-      tableName = tableName,
-      database = identifiersDatabase,
-      table = identifiersTable,
-      flags = flags,
-      session = session
+    val rdsClientConfig = RDSClientConfig(
+      host = host,
+      port = port,
+      username = username,
+      password = password
+    )
+
+    val identifiersTableConfig = IdentifiersTableConfig(
+      database = databaseName,
+      tableName = tableName
     )
 
     try {
       sql"CREATE DATABASE $identifiersDatabase".execute().apply()
 
-      testWith(config)
+      testWith((rdsClientConfig, identifiersTableConfig))
     } finally {
       DB localTx { implicit session =>
         sql"DROP DATABASE IF EXISTS $identifiersDatabase".execute().apply()

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/IdentifersDatabase.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/IdentifersDatabase.scala
@@ -120,7 +120,6 @@ trait IdentifiersDatabase
     val tableName: String = alphabetic take 10 mkString
 
     val identifiersDatabase: SQLSyntax = SQLSyntax.createUnsafely(databaseName)
-    val identifiersTable: SQLSyntax = SQLSyntax.createUnsafely(tableName)
 
     val identifiersTableConfig = IdentifiersTableConfig(
       database = databaseName,

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/IdentifersDatabase.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/IdentifersDatabase.scala
@@ -6,7 +6,10 @@ import scalikejdbc.{AutoSession, ConnectionPool, DB, SQLSyntax}
 import uk.ac.wellcome.test.fixtures.TestWith
 import scalikejdbc._
 import uk.ac.wellcome.platform.idminter.database.FieldDescription
-import uk.ac.wellcome.platform.idminter.models.{IdentifiersTableConfig, RDSClientConfig}
+import uk.ac.wellcome.platform.idminter.models.{
+  IdentifiersTableConfig,
+  RDSClientConfig
+}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
 import scala.util.Random
@@ -72,7 +75,8 @@ trait IdentifiersDatabase
     Stream continually nextAlpha
   }
 
-  def withIdentifiersDatabase[R](testWith: TestWith[(RDSClientConfig, IdentifiersTableConfig), R]) = {
+  def withIdentifiersDatabase[R](
+    testWith: TestWith[(RDSClientConfig, IdentifiersTableConfig), R]) = {
     Class.forName("com.mysql.jdbc.Driver")
     ConnectionPool.singleton(s"jdbc:mysql://$host:$port", username, password)
 

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
@@ -43,8 +43,8 @@ class IdMinterWorkerTest
               modifyServer = (server: EmbeddedHttpServer) => {
                 server.bind[IdentifiersDao].toInstance(identifiersDao)
               }) { _ =>
-              val database = identifiersTableConfig.database
-              val table = identifiersTableConfig.tableName
+              val database: SQLSyntax = SQLSyntax.createUnsafely(identifiersTableConfig.database)
+              val table: SQLSyntax = SQLSyntax.createUnsafely(identifiersTableConfig.tableName)
 
               eventually {
                 val fields = DB readOnly { implicit session =>

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
@@ -33,7 +33,8 @@ class IdMinterWorkerTest
         withIdentifiersDatabase { identifiersTableConfig =>
           withLocalS3Bucket { bucket =>
             val flags =
-              messagingLocalFlags(bucket, topic, queue) ++ identifiersLocalDbFlags(identifiersTableConfig)
+              messagingLocalFlags(bucket, topic, queue) ++ identifiersLocalDbFlags(
+                identifiersTableConfig)
 
             val identifiersDao = mock[IdentifiersDao]
 

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
@@ -30,10 +30,10 @@ class IdMinterWorkerTest
   it("should create the Identifiers table in MySQL upon startup") {
     withLocalSqsQueue { queue =>
       withLocalSnsTopic { topic =>
-        withIdentifiersDatabase { dbConfig =>
+        withIdentifiersDatabase { identifiersTableConfig =>
           withLocalS3Bucket { bucket =>
             val flags =
-              messagingLocalFlags(bucket, topic, queue) ++ dbConfig.flags
+              messagingLocalFlags(bucket, topic, queue) ++ identifiersLocalDbFlags(identifiersTableConfig)
 
             val identifiersDao = mock[IdentifiersDao]
 
@@ -42,8 +42,8 @@ class IdMinterWorkerTest
               modifyServer = (server: EmbeddedHttpServer) => {
                 server.bind[IdentifiersDao].toInstance(identifiersDao)
               }) { _ =>
-              val database = dbConfig.database
-              val table = dbConfig.table
+              val database = identifiersTableConfig.database
+              val table = identifiersTableConfig.tableName
 
               eventually {
                 val fields = DB readOnly { implicit session =>

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
@@ -43,8 +43,10 @@ class IdMinterWorkerTest
               modifyServer = (server: EmbeddedHttpServer) => {
                 server.bind[IdentifiersDao].toInstance(identifiersDao)
               }) { _ =>
-              val database: SQLSyntax = SQLSyntax.createUnsafely(identifiersTableConfig.database)
-              val table: SQLSyntax = SQLSyntax.createUnsafely(identifiersTableConfig.tableName)
+              val database: SQLSyntax =
+                SQLSyntax.createUnsafely(identifiersTableConfig.database)
+              val table: SQLSyntax =
+                SQLSyntax.createUnsafely(identifiersTableConfig.tableName)
 
               eventually {
                 val fields = DB readOnly { implicit session =>

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -28,7 +28,7 @@ class IdentifierGeneratorTest
   def withIdentifierGenerator[R](maybeIdentifiersDao: Option[IdentifiersDao] =
                                    None)(
     testWith: TestWith[(IdentifierGenerator, IdentifiersTable), R]) =
-    withIdentifiersDatabase[R] { identifiersTableConfig=>
+    withIdentifiersDatabase[R] { identifiersTableConfig =>
       val identifiersTable = new IdentifiersTable(identifiersTableConfig)
 
       new TableProvisioner(rdsClientConfig)

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -31,7 +31,9 @@ class IngestorWorkerService @Inject()(
           esType = elasticConfig.documentType
         )
       }
-      Future.sequence(futureResults).map { _ => ()}
+      Future.sequence(futureResults).map { _ =>
+        ()
+      }
     }
   }
   def stop(): Future[Terminated] = {

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -23,18 +23,16 @@ class IngestorWorkerService @Inject()(
   def processMessage(work: IdentifiedWork): Future[Unit] = {
     val futureIndices: Future[List[String]] =
       Future.fromTry(Try(decideTargetIndices(work)))
-    futureIndices.flatMap(indices => {
+    futureIndices.flatMap { indices =>
       val futureResults = indices.map { esIndex =>
         identifiedWorkIndexer.indexWork(
           work = work,
           esIndex = esIndex,
           esType = elasticConfig.documentType
         )
-      })
-      Future.sequence(futureResults).map { _ =>
-        ()
       }
-    })
+      Future.sequence(futureResults).map { _ => ()}
+    }
   }
   def stop(): Future[Terminated] = {
     system.terminate()

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -24,7 +24,13 @@ class IngestorWorkerService @Inject()(
     val futureIndices: Future[List[String]] =
       Future.fromTry(Try(decideTargetIndices(work)))
     futureIndices.flatMap(indices => {
-      val futureResults = indices.map(identifiedWorkIndexer.indexWork(work, _))
+      val futureResults = indices.map { esIndex =>
+        identifiedWorkIndexer.indexWork(
+          work = work,
+          esIndex = esIndex,
+          esType = elasticConfig.documentType
+        )
+      })
       Future.sequence(futureResults).map { _ =>
         ()
       }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -6,7 +6,6 @@ import com.sksamuel.elastic4s.Indexable
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.HttpClient
 import com.twitter.inject.Logging
-import com.twitter.inject.annotations.Flag
 import javax.inject.{Inject, Singleton}
 import org.elasticsearch.client.ResponseException
 import org.elasticsearch.index.VersionType
@@ -21,7 +20,6 @@ import scala.concurrent.Future
 
 @Singleton
 class WorkIndexer @Inject()(
-  @Flag("es.type") esType: String,
   elasticClient: HttpClient,
   metricsSender: MetricsSender
 ) extends Logging
@@ -32,7 +30,7 @@ class WorkIndexer @Inject()(
       toJson(t).get
   }
 
-  def indexWork(work: IdentifiedWork, esIndex: String): Future[Any] = {
+  def indexWork(work: IdentifiedWork, esIndex: String, esType: String): Future[Any] = {
 
     metricsSender.timeAndCount[Any](
       "ingestor-index-work",

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -30,7 +30,9 @@ class WorkIndexer @Inject()(
       toJson(t).get
   }
 
-  def indexWork(work: IdentifiedWork, esIndex: String, esType: String): Future[Any] = {
+  def indexWork(work: IdentifiedWork,
+                esIndex: String,
+                esType: String): Future[Any] = {
 
     metricsSender.timeAndCount[Any](
       "ingestor-index-work",

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorksIndexMappingCreatorService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorksIndexMappingCreatorService.scala
@@ -1,15 +1,13 @@
 package uk.ac.wellcome.platform.ingestor.services
 
 import com.google.inject.Inject
-import com.twitter.inject.annotations.Flag
-import uk.ac.wellcome.elasticsearch.WorksIndex
+import uk.ac.wellcome.elasticsearch.{ElasticConfig, WorksIndex}
 
 class WorksIndexMappingCreatorService @Inject()(
-  @Flag("es.index.v1") esIndexV1: String,
-  @Flag("es.index.v2") esIndexV2: String,
+  elasticConfig: ElasticConfig,
   worksIndex: WorksIndex) {
 
-  worksIndex.create(esIndexV1)
-  worksIndex.create(esIndexV2)
+  worksIndex.create(elasticConfig.indexV1name)
+  worksIndex.create(elasticConfig.indexV2name)
 
 }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorksIndexMappingCreatorService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorksIndexMappingCreatorService.scala
@@ -3,9 +3,8 @@ package uk.ac.wellcome.platform.ingestor.services
 import com.google.inject.Inject
 import uk.ac.wellcome.elasticsearch.{ElasticConfig, WorksIndex}
 
-class WorksIndexMappingCreatorService @Inject()(
-  elasticConfig: ElasticConfig,
-  worksIndex: WorksIndex) {
+class WorksIndexMappingCreatorService @Inject()(elasticConfig: ElasticConfig,
+                                                worksIndex: WorksIndex) {
 
   worksIndex.create(elasticConfig.indexV1name)
   worksIndex.create(elasticConfig.indexV2name)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
@@ -14,7 +14,6 @@ trait WorkIndexerFixtures extends Akka with MetricsSenderFixture {
     elasticClient: HttpClient,
     metricsSender: MetricsSender)(testWith: TestWith[WorkIndexer, R]): R = {
     val workIndexer = new WorkIndexer(
-      esType = esType,
       elasticClient = elasticClient,
       metricsSender = metricsSender
     )
@@ -26,7 +25,7 @@ trait WorkIndexerFixtures extends Akka with MetricsSenderFixture {
     testWith: TestWith[WorkIndexer, R]): R = {
     withActorSystem { actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>
-        withWorkIndexer(esType, elasticClient, metricsSender) { workIndexer =>
+        withWorkIndexer(elasticClient = elasticClient, metricsSender = metricsSender) { workIndexer =>
           testWith(workIndexer)
         }
       }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
@@ -25,7 +25,9 @@ trait WorkIndexerFixtures extends Akka with MetricsSenderFixture {
     testWith: TestWith[WorkIndexer, R]): R = {
     withActorSystem { actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>
-        withWorkIndexer(elasticClient = elasticClient, metricsSender = metricsSender) { workIndexer =>
+        withWorkIndexer(
+          elasticClient = elasticClient,
+          metricsSender = metricsSender) { workIndexer =>
           testWith(workIndexer)
         }
       }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
@@ -10,7 +10,6 @@ import uk.ac.wellcome.test.fixtures._
 trait WorkIndexerFixtures extends Akka with MetricsSenderFixture {
   this: Suite =>
   def withWorkIndexer[R](
-    esType: String,
     elasticClient: HttpClient,
     metricsSender: MetricsSender)(testWith: TestWith[WorkIndexer, R]): R = {
     val workIndexer = new WorkIndexer(

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -164,16 +164,15 @@ class IngestorWorkerServiceTest
       withMetricsSender(actorSystem) { metricsSender =>
         withWorkIndexer[R](
           elasticClient = elasticClient,
-          metricsSender = metricsSender) {
-          workIndexer =>
-            withIngestorWorkerService[R](
-              esIndexV1,
-              esIndexV2,
-              actorSystem,
-              metricsSender,
-              workIndexer) { service =>
-              testWith(service)
-            }
+          metricsSender = metricsSender) { workIndexer =>
+          withIngestorWorkerService[R](
+            esIndexV1,
+            esIndexV2,
+            actorSystem,
+            metricsSender,
+            workIndexer) { service =>
+            testWith(service)
+          }
         }
       }
     }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -162,7 +162,9 @@ class IngestorWorkerServiceTest
     esIndexV2: String)(testWith: TestWith[IngestorWorkerService, R]): R = {
     withActorSystem { actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>
-        withWorkIndexer[R](itemType, elasticClient, metricsSender) {
+        withWorkIndexer[R](
+          elasticClient = elasticClient,
+          metricsSender = metricsSender) {
           workIndexer =>
             withIngestorWorkerService[R](
               esIndexV1,

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -130,7 +130,6 @@ class IngestorWorkerServiceTest
     withActorSystem { actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>
         val brokenWorkIndexer = new WorkIndexer(
-          esType = "work",
           elasticClient = brokenElasticClient,
           metricsSender = metricsSender
         )

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -71,7 +71,11 @@ class WorkIndexerTest
       insertIntoElasticsearch(indexName = indexName, itemType = esType, work)
 
       withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
-        val future = workIndexer.indexWork(olderWork, indexName)
+        val future = workIndexer.indexWork(
+          work = olderWork,
+          esIndex = indexName,
+          esType = esType
+        )
 
         whenReady(future) { _ =>
           // Give Elasticsearch enough time to ingest the work

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -44,11 +44,13 @@ class WorkIndexerTest
       withWorkIndexerFixtures[Assertion](esType, elasticClient) {
         workIndexer =>
           val future = Future.sequence(
-            (1 to 2).map(_ => workIndexer.indexWork(
-              work = work,
-              esIndex = indexName,
-              esType = esType
-            ))
+            (1 to 2).map(
+              _ =>
+                workIndexer.indexWork(
+                  work = work,
+                  esIndex = indexName,
+                  esType = esType
+              ))
           )
 
           whenReady(future) { _ =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -44,7 +44,11 @@ class WorkIndexerTest
       withWorkIndexerFixtures[Assertion](esType, elasticClient) {
         workIndexer =>
           val future = Future.sequence(
-            (1 to 2).map(_ => workIndexer.indexWork(work, indexName))
+            (1 to 2).map(_ => workIndexer.indexWork(
+              work = work,
+              esIndex = indexName,
+              esType = esType
+            ))
           )
 
           whenReady(future) { _ =>
@@ -88,7 +92,11 @@ class WorkIndexerTest
       insertIntoElasticsearch(indexName = indexName, itemType = esType, work)
 
       withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
-        val future = workIndexer.indexWork(updatedWork, indexName)
+        val future = workIndexer.indexWork(
+          work = updatedWork,
+          esIndex = indexName,
+          esType = esType
+        )
 
         whenReady(future) { _ =>
           assertElasticsearchEventuallyHasWork(

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -18,20 +18,20 @@ class WorkIndexerTest
     with WorksUtil
     with WorkIndexerFixtures {
 
-  val itemType = "work"
+  val esType = "work"
 
   it("inserts an identified Work into Elasticsearch") {
     val work = createVersionedWork()
 
-    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withWorkIndexerFixtures(itemType, elasticClient) { workIndexer =>
-        val future = workIndexer.indexWork(work, indexName)
+    withLocalElasticsearchIndex(itemType = esType) { indexName =>
+      withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
+        val future = workIndexer.indexWork(work, indexName, esType)
 
         whenReady(future) { _ =>
           assertElasticsearchEventuallyHasWork(
             work,
             indexName = indexName,
-            itemType = itemType)
+            itemType = esType)
         }
       }
     }
@@ -40,8 +40,8 @@ class WorkIndexerTest
   it("only adds one record when the same ID is ingested multiple times") {
     val work = createVersionedWork()
 
-    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withWorkIndexerFixtures[Assertion](itemType, elasticClient) {
+    withLocalElasticsearchIndex(itemType = esType) { indexName =>
+      withWorkIndexerFixtures[Assertion](esType, elasticClient) {
         workIndexer =>
           val future = Future.sequence(
             (1 to 2).map(_ => workIndexer.indexWork(work, indexName))
@@ -51,7 +51,7 @@ class WorkIndexerTest
             assertElasticsearchEventuallyHasWork(
               work,
               indexName = indexName,
-              itemType = itemType)
+              itemType = esType)
           }
       }
     }
@@ -61,10 +61,10 @@ class WorkIndexerTest
     val work = createVersionedWork(version = 3)
     val olderWork = work.copy(version = 1)
 
-    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      insertIntoElasticsearch(indexName = indexName, itemType = itemType, work)
+    withLocalElasticsearchIndex(itemType = esType) { indexName =>
+      insertIntoElasticsearch(indexName = indexName, itemType = esType, work)
 
-      withWorkIndexerFixtures(itemType, elasticClient) { workIndexer =>
+      withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
         val future = workIndexer.indexWork(olderWork, indexName)
 
         whenReady(future) { _ =>
@@ -74,7 +74,7 @@ class WorkIndexerTest
           assertElasticsearchEventuallyHasWork(
             work,
             indexName = indexName,
-            itemType = itemType)
+            itemType = esType)
         }
       }
     }
@@ -84,17 +84,17 @@ class WorkIndexerTest
     val work = createVersionedWork(version = 3)
     val updatedWork = work.copy(title = Some("boring title"))
 
-    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      insertIntoElasticsearch(indexName = indexName, itemType = itemType, work)
+    withLocalElasticsearchIndex(itemType = esType) { indexName =>
+      insertIntoElasticsearch(indexName = indexName, itemType = esType, work)
 
-      withWorkIndexerFixtures(itemType, elasticClient) { workIndexer =>
+      withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
         val future = workIndexer.indexWork(updatedWork, indexName)
 
         whenReady(future) { _ =>
           assertElasticsearchEventuallyHasWork(
             updatedWork,
             indexName = indexName,
-            itemType = itemType)
+            itemType = esType)
         }
       }
     }

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
@@ -9,8 +9,9 @@ import akka.util.ByteString
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.sksamuel.elastic4s.http.HttpClient
 import com.twitter.inject.Logging
-import com.twitter.inject.annotations.Flag
 import javax.inject.Inject
+import javax.naming.ConfigurationException
+
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
 import uk.ac.wellcome.display.models.{ApiVersions, DisplayWork, WorksIncludes}
@@ -34,11 +35,14 @@ class SnapshotService @Inject()(actorSystem: ActorSystem,
                                 akkaS3Client: S3Client,
                                 elasticClient: HttpClient,
                                 elasticConfig: ElasticConfig,
-                                @Flag("aws.s3.endpoint") s3Endpoint: String,
                                 objectMapper: ObjectMapper)
     extends Logging {
   implicit val system: ActorSystem = actorSystem
   implicit val materializer = ActorMaterializer()
+
+  val s3Endpoint = akkaS3Client.s3Settings.endpointUrl.getOrElse(
+    throw new ConfigurationException("No S3 endpoint specified?")
+  )
 
   def generateSnapshot(
     snapshotJob: SnapshotJob): Future[CompletedSnapshotJob] = {

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -67,7 +67,6 @@ class SnapshotServiceTest
       elasticClient = elasticClient,
       elasticConfig = elasticConfig,
       akkaS3Client = s3AkkaClient,
-      s3Endpoint = localS3EndpointUrl,
       objectMapper = mapper
     )
 

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -318,7 +318,6 @@ class SnapshotServiceTest
               elasticClient = elasticClient,
               elasticConfig = elasticConfig,
               akkaS3Client = s3Client,
-              s3Endpoint = localS3EndpointUrl,
               objectMapper = mapper
             )
             val snapshotJob = SnapshotJob(

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/Server.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/Server.scala
@@ -2,14 +2,22 @@ package uk.ac.wellcome.platform.sierra_reader
 
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.HttpServer
-import com.twitter.finatra.http.filters.{CommonFilters, LoggingMDCFilter, TraceIdMDCFilter}
+import com.twitter.finatra.http.filters.{
+  CommonFilters,
+  LoggingMDCFilter,
+  TraceIdMDCFilter
+}
 import com.twitter.finatra.http.routing.HttpRouter
 import uk.ac.wellcome.finatra.akka.AkkaModule
 import uk.ac.wellcome.finatra.messaging.{SQSClientModule, SQSConfigModule}
 import uk.ac.wellcome.finatra.controllers.ManagementController
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
 import uk.ac.wellcome.finatra.storage.{S3ClientModule, S3ConfigModule}
-import uk.ac.wellcome.platform.sierra_reader.modules.{ReaderConfigModule, SierraConfigModule, SierraReaderModule}
+import uk.ac.wellcome.platform.sierra_reader.modules.{
+  ReaderConfigModule,
+  SierraConfigModule,
+  SierraReaderModule
+}
 
 object ServerMain extends Server
 

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/Server.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/Server.scala
@@ -2,18 +2,14 @@ package uk.ac.wellcome.platform.sierra_reader
 
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.HttpServer
-import com.twitter.finatra.http.filters.{
-  CommonFilters,
-  LoggingMDCFilter,
-  TraceIdMDCFilter
-}
+import com.twitter.finatra.http.filters.{CommonFilters, LoggingMDCFilter, TraceIdMDCFilter}
 import com.twitter.finatra.http.routing.HttpRouter
 import uk.ac.wellcome.finatra.akka.AkkaModule
 import uk.ac.wellcome.finatra.messaging.{SQSClientModule, SQSConfigModule}
 import uk.ac.wellcome.finatra.controllers.ManagementController
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
 import uk.ac.wellcome.finatra.storage.{S3ClientModule, S3ConfigModule}
-import uk.ac.wellcome.platform.sierra_reader.modules.SierraReaderModule
+import uk.ac.wellcome.platform.sierra_reader.modules.{ReaderConfigModule, SierraConfigModule, SierraReaderModule}
 
 object ServerMain extends Server
 
@@ -22,6 +18,8 @@ class Server extends HttpServer {
     "uk.ac.wellcome.platform.sierra_reader SierraReader"
   override val modules = Seq(
     SierraReaderModule,
+    ReaderConfigModule,
+    SierraConfigModule,
     MetricsSenderModule,
     S3ClientModule,
     S3ConfigModule,

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/models/ReaderConfig.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/models/ReaderConfig.scala
@@ -1,0 +1,5 @@
+package uk.ac.wellcome.platform.sierra_reader.models
+
+case class ReaderConfig(
+  batchSize: Int
+)

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/models/SierraConfig.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/models/SierraConfig.scala
@@ -1,0 +1,9 @@
+package uk.ac.wellcome.platform.sierra_reader.models
+
+case class SierraConfig(
+  resourceType: SierraResourceTypes.Value,
+  apiUrl: String,
+  oauthKey: String,
+  oauthSec: String,
+  fields: String
+)

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/ReaderConfigModule.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/ReaderConfigModule.scala
@@ -1,0 +1,18 @@
+package uk.ac.wellcome.platform.sierra_reader.modules
+
+import javax.inject.Singleton
+
+import com.google.inject.Provides
+import com.twitter.inject.TwitterModule
+import uk.ac.wellcome.platform.sierra_reader.models.ReaderConfig
+
+object ReaderConfigModule extends TwitterModule {
+  private val batchSize = flag[Int]("reader.batchSize", 50, "Number of records in a single json batch")
+
+  @Singleton
+  @Provides
+  def providesReaderConfig(): ReaderConfig =
+    ReaderConfig(
+      batchSize = batchSize()
+    )
+}

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/ReaderConfigModule.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/ReaderConfigModule.scala
@@ -7,7 +7,10 @@ import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.platform.sierra_reader.models.ReaderConfig
 
 object ReaderConfigModule extends TwitterModule {
-  private val batchSize = flag[Int]("reader.batchSize", 50, "Number of records in a single json batch")
+  private val batchSize = flag[Int](
+    "reader.batchSize",
+    50,
+    "Number of records in a single json batch")
 
   @Singleton
   @Provides

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/SierraConfigModule.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/SierraConfigModule.scala
@@ -5,13 +5,19 @@ import javax.inject.Singleton
 import com.google.inject.Provides
 import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.platform.sierra_reader.models.SierraConfig
-import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes.{bibs, items}
+import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes.{
+  bibs,
+  items
+}
 
 object SierraConfigModule extends TwitterModule {
-  private val resourceTypeFlag = flag[String]("reader.resourceType", "Sierra resource type")
+  private val resourceTypeFlag =
+    flag[String]("reader.resourceType", "Sierra resource type")
   private val apiUrl = flag[String]("sierra.apiUrl", "", "Sierra API url")
-  private val oauthKey = flag[String]("sierra.oauthKey", "", "Sierra API oauth key")
-  private val oauthSec = flag[String]("sierra.oauthSecret", "", "Sierra API oauth secret")
+  private val oauthKey =
+    flag[String]("sierra.oauthKey", "", "Sierra API oauth key")
+  private val oauthSec =
+    flag[String]("sierra.oauthSecret", "", "Sierra API oauth secret")
   private val fields = flag[String](
     "sierra.fields",
     "",

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/SierraConfigModule.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/SierraConfigModule.scala
@@ -1,0 +1,39 @@
+package uk.ac.wellcome.platform.sierra_reader.modules
+
+import javax.inject.Singleton
+
+import com.google.inject.Provides
+import com.twitter.inject.TwitterModule
+import uk.ac.wellcome.platform.sierra_reader.models.SierraConfig
+import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes.{bibs, items}
+
+object SierraConfigModule extends TwitterModule {
+  private val resourceTypeFlag = flag[String]("reader.resourceType", "Sierra resource type")
+  private val apiUrl = flag[String]("sierra.apiUrl", "", "Sierra API url")
+  private val oauthKey = flag[String]("sierra.oauthKey", "", "Sierra API oauth key")
+  private val oauthSec = flag[String]("sierra.oauthSecret", "", "Sierra API oauth secret")
+  private val fields = flag[String](
+    "sierra.fields",
+    "",
+    "List of fields to include in the Sierra API response")
+
+  @Singleton
+  @Provides
+  def providesSierraConfig(): SierraConfig = {
+    val resourceType = resourceTypeFlag() match {
+      case s: String if s == bibs.toString => bibs
+      case s: String if s == items.toString => items
+      case s: String =>
+        throw new IllegalArgumentException(
+          s"$s is not a valid Sierra resource type")
+    }
+
+    SierraConfig(
+      resourceType = resourceType,
+      apiUrl = apiUrl(),
+      oauthKey = oauthKey(),
+      oauthSec = oauthSec(),
+      fields = fields()
+    )
+  }
+}

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/SierraReaderModule.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/SierraReaderModule.scala
@@ -1,30 +1,10 @@
 package uk.ac.wellcome.platform.sierra_reader.modules
 
-import javax.inject.Singleton
-
 import akka.actor.ActorSystem
-import com.google.inject.Provides
-import com.twitter.inject.annotations.Flag
 import com.twitter.inject.{Injector, TwitterModule}
-import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
-import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes.{
-  bibs,
-  items
-}
 import uk.ac.wellcome.platform.sierra_reader.services.SierraReaderWorkerService
 
 object SierraReaderModule extends TwitterModule {
-  flag[String]("reader.resourceType", "Sierra resource type")
-  flag[Int]("reader.batchSize", 50, "Number of records in a single json batch")
-  flag[String]("sierra.apiUrl", "", "Sierra API url")
-  flag[String]("sierra.oauthKey", "", "Sierra API oauth key")
-  flag[String]("sierra.oauthSecret", "", "Sierra API oauth secret")
-  flag[String](
-    "sierra.fields",
-    "",
-    "List of fields to include in the Sierra API response")
-
-  // eagerly load worker service
   override def singletonStartup(injector: Injector) {
     super.singletonStartup(injector)
     injector.instance[SierraReaderWorkerService]
@@ -35,19 +15,5 @@ object SierraReaderModule extends TwitterModule {
 
     val system = injector.instance[ActorSystem]
     system.terminate()
-  }
-
-  @Singleton
-  @Provides
-  def providesSierraResourceType(
-    @Flag("reader.resourceType") resourceTypeString: String)
-    : SierraResourceTypes.Value = {
-    resourceTypeString match {
-      case s: String if s == bibs.toString => bibs
-      case s: String if s == items.toString => items
-      case s: String =>
-        throw new IllegalArgumentException(
-          s"$s is not a valid Sierra resource type")
-    }
   }
 }

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
@@ -3,9 +3,8 @@ package uk.ac.wellcome.platform.sierra_reader.modules
 import com.amazonaws.services.s3.AmazonS3
 import com.google.inject.Inject
 import com.twitter.inject.Logging
-import com.twitter.inject.annotations.Flag
 import org.apache.commons.io.IOUtils
-import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
+import uk.ac.wellcome.platform.sierra_reader.models.SierraConfig
 import uk.ac.wellcome.platform.sierra_reader.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.exceptions.GracefulFailureException
@@ -21,8 +20,7 @@ case class WindowStatus(id: Option[String], offset: Int)
 class WindowManager @Inject()(
   s3client: AmazonS3,
   s3Config: S3Config,
-  @Flag("sierra.fields") fields: String,
-  resourceType: SierraResourceTypes.Value
+  sierraConfig: SierraConfig
 ) extends Logging {
 
   def getCurrentStatus(window: String): Future[WindowStatus] = Future {
@@ -82,7 +80,7 @@ class WindowManager @Inject()(
   }
 
   def buildWindowShard(window: String) =
-    s"records_${resourceType.toString}/${buildWindowLabel(window)}/"
+    s"records_${sierraConfig.resourceType.toString}/${buildWindowLabel(window)}/"
 
   def buildWindowLabel(window: String) =
     // Window is a string like [2013-12-01T01:01:01Z,2013-12-01T01:01:01Z].

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -8,7 +8,11 @@ import com.google.inject.Inject
 import com.twitter.inject.Logging
 import uk.ac.wellcome.messaging.sqs._
 import uk.ac.wellcome.platform.sierra_reader.flow.SierraRecordWrapperFlow
-import uk.ac.wellcome.platform.sierra_reader.models.{ReaderConfig, SierraConfig, SierraResourceTypes}
+import uk.ac.wellcome.platform.sierra_reader.models.{
+  ReaderConfig,
+  SierraConfig,
+  SierraResourceTypes
+}
 import uk.ac.wellcome.sierra.{SierraSource, ThrottleRate}
 import uk.ac.wellcome.sierra_adapter.services.WindowExtractor
 import uk.ac.wellcome.storage.s3.S3Config
@@ -57,7 +61,8 @@ class SierraReaderWorkerService @Inject()(
 
     info(s"Running the stream with window=$window and status=$windowStatus")
 
-    val baseParams = Map("updatedDate" -> window, "fields" -> sierraConfig.fields)
+    val baseParams =
+      Map("updatedDate" -> window, "fields" -> sierraConfig.fields)
     val params = windowStatus.id match {
       case Some(id) => baseParams ++ Map("id" -> s"[$id,]")
       case None => baseParams
@@ -75,7 +80,9 @@ class SierraReaderWorkerService @Inject()(
       oauthKey = sierraConfig.oauthKey,
       oauthSecret = sierraConfig.oauthSec,
       throttleRate = ThrottleRate(3, per = 1.second),
-      timeoutMs = 60000)(resourceType = sierraConfig.resourceType.toString, params)
+      timeoutMs = 60000)(
+      resourceType = sierraConfig.resourceType.toString,
+      params)
 
     val outcome = sierraSource
       .via(SierraRecordWrapperFlow())
@@ -89,7 +96,8 @@ class SierraReaderWorkerService @Inject()(
     outcome.map { _ =>
       s3client.putObject(
         s3Config.bucketName,
-        s"windows_${sierraConfig.resourceType.toString}_complete/${windowManager.buildWindowLabel(window)}",
+        s"windows_${sierraConfig.resourceType.toString}_complete/${windowManager
+          .buildWindowLabel(window)}",
         "")
     }
   }

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -10,8 +10,7 @@ import uk.ac.wellcome.messaging.sqs._
 import uk.ac.wellcome.platform.sierra_reader.flow.SierraRecordWrapperFlow
 import uk.ac.wellcome.platform.sierra_reader.models.{
   ReaderConfig,
-  SierraConfig,
-  SierraResourceTypes
+  SierraConfig
 }
 import uk.ac.wellcome.sierra.{SierraSource, ThrottleRate}
 import uk.ac.wellcome.sierra_adapter.services.WindowExtractor

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -6,10 +6,9 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.PutObjectResult
 import com.google.inject.Inject
 import com.twitter.inject.Logging
-import com.twitter.inject.annotations.Flag
 import uk.ac.wellcome.messaging.sqs._
 import uk.ac.wellcome.platform.sierra_reader.flow.SierraRecordWrapperFlow
-import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
+import uk.ac.wellcome.platform.sierra_reader.models.{ReaderConfig, SierraConfig, SierraResourceTypes}
 import uk.ac.wellcome.sierra.{SierraSource, ThrottleRate}
 import uk.ac.wellcome.sierra_adapter.services.WindowExtractor
 import uk.ac.wellcome.storage.s3.S3Config
@@ -31,12 +30,8 @@ class SierraReaderWorkerService @Inject()(
   windowManager: WindowManager,
   s3client: AmazonS3,
   s3Config: S3Config,
-  @Flag("reader.batchSize") batchSize: Int,
-  resourceType: SierraResourceTypes.Value,
-  @Flag("sierra.apiUrl") apiUrl: String,
-  @Flag("sierra.oauthKey") sierraOauthKey: String,
-  @Flag("sierra.oauthSecret") sierraOauthSecret: String,
-  @Flag("sierra.fields") fields: String
+  readerConfig: ReaderConfig,
+  sierraConfig: SierraConfig
 ) extends Logging {
 
   implicit val actorSystem = system
@@ -62,7 +57,7 @@ class SierraReaderWorkerService @Inject()(
 
     info(s"Running the stream with window=$window and status=$windowStatus")
 
-    val baseParams = Map("updatedDate" -> window, "fields" -> fields)
+    val baseParams = Map("updatedDate" -> window, "fields" -> sierraConfig.fields)
     val params = windowStatus.id match {
       case Some(id) => baseParams ++ Map("id" -> s"[$id,]")
       case None => baseParams
@@ -76,15 +71,15 @@ class SierraReaderWorkerService @Inject()(
     )
 
     val sierraSource = SierraSource(
-      apiUrl,
-      sierraOauthKey,
-      sierraOauthSecret,
+      apiUrl = sierraConfig.apiUrl,
+      oauthKey = sierraConfig.oauthKey,
+      oauthSecret = sierraConfig.oauthSec,
       throttleRate = ThrottleRate(3, per = 1.second),
-      timeoutMs = 60000)(resourceType = resourceType.toString, params)
+      timeoutMs = 60000)(resourceType = sierraConfig.resourceType.toString, params)
 
     val outcome = sierraSource
       .via(SierraRecordWrapperFlow())
-      .grouped(batchSize)
+      .grouped(readerConfig.batchSize)
       .map(recordBatch => recordBatch.asJson)
       .zipWithIndex
       .runWith(s3sink)
@@ -94,7 +89,7 @@ class SierraReaderWorkerService @Inject()(
     outcome.map { _ =>
       s3client.putObject(
         s3Config.bucketName,
-        s"windows_${resourceType.toString}_complete/${windowManager.buildWindowLabel(window)}",
+        s"windows_${sierraConfig.resourceType.toString}_complete/${windowManager.buildWindowLabel(window)}",
         "")
     }
   }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
+import uk.ac.wellcome.platform.sierra_reader.models.{SierraConfig, SierraResourceTypes}
 import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.test.fixtures.S3
@@ -24,11 +24,18 @@ class WindowManagerTest
 
   private def withWindowManager(bucket: Bucket)(
     testWith: TestWith[WindowManager, Assertion]) = {
+    val sierraConfig = SierraConfig(
+      resourceType = SierraResourceTypes.bibs,
+      apiUrl = "http://example.org",
+      oauthKey = "0au1hk3y",
+      oauthSec = "o4uth5ec",
+      fields = "title"
+    )
+
     val windowManager = new WindowManager(
       s3client = s3Client,
       s3Config = S3Config(bucket.name),
-      fields = "title",
-      resourceType = SierraResourceTypes.bibs
+      sierraConfig = sierraConfig
     )
 
     testWith(windowManager)

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -6,7 +6,10 @@ import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.platform.sierra_reader.models.{SierraConfig, SierraResourceTypes}
+import uk.ac.wellcome.platform.sierra_reader.models.{
+  SierraConfig,
+  SierraResourceTypes
+}
 import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.test.fixtures.S3

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -20,7 +20,7 @@ import org.scalatest.compatible.Assertion
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
-import uk.ac.wellcome.platform.sierra_reader.models.{SierraConfig, SierraResourceTypes}
+import uk.ac.wellcome.platform.sierra_reader.models.{ReaderConfig, SierraConfig, SierraResourceTypes}
 
 import collection.JavaConverters._
 
@@ -51,10 +51,10 @@ class SierraReaderWorkerServiceTest
           withLocalS3Bucket { bucket =>
             val sierraConfig = SierraConfig(
               resourceType = resourceType,
-              apiUrl = "http://example.org",
-              oauthKey = "0au1hk3y",
-              oauthSec = "o4uth5ec",
-              fields = "title"
+              apiUrl = apiUrl,
+              oauthKey = "key",
+              oauthSec = "secret",
+              fields = fields
             )
 
             val worker = new SierraReaderWorkerService(
@@ -76,12 +76,8 @@ class SierraReaderWorkerServiceTest
                 S3Config(bucket.name),
                 sierraConfig = sierraConfig
               ),
-              batchSize = batchSize,
-              resourceType = resourceType,
-              apiUrl = apiUrl,
-              sierraOauthKey = "key",
-              sierraOauthSecret = "secret",
-              fields = fields
+              readerConfig = ReaderConfig(batchSize = batchSize),
+              sierraConfig = sierraConfig
             )
 
             testWith(FixtureParams(worker, queue, bucket))

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -20,7 +20,7 @@ import org.scalatest.compatible.Assertion
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
-import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
+import uk.ac.wellcome.platform.sierra_reader.models.{SierraConfig, SierraResourceTypes}
 
 import collection.JavaConverters._
 
@@ -49,6 +49,14 @@ class SierraReaderWorkerServiceTest
       withMetricsSender(actorSystem) { metricsSender =>
         withLocalSqsQueue { queue =>
           withLocalS3Bucket { bucket =>
+            val sierraConfig = SierraConfig(
+              resourceType = resourceType,
+              apiUrl = "http://example.org",
+              oauthKey = "0au1hk3y",
+              oauthSec = "o4uth5ec",
+              fields = "title"
+            )
+
             val worker = new SierraReaderWorkerService(
               system = actorSystem,
               sqsStream = new SQSStream(
@@ -66,8 +74,8 @@ class SierraReaderWorkerServiceTest
               windowManager = new WindowManager(
                 s3Client,
                 S3Config(bucket.name),
-                fields,
-                resourceType),
+                sierraConfig = sierraConfig
+              ),
               batchSize = batchSize,
               resourceType = resourceType,
               apiUrl = apiUrl,

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -20,7 +20,11 @@ import org.scalatest.compatible.Assertion
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
-import uk.ac.wellcome.platform.sierra_reader.models.{ReaderConfig, SierraConfig, SierraResourceTypes}
+import uk.ac.wellcome.platform.sierra_reader.models.{
+  ReaderConfig,
+  SierraConfig,
+  SierraResourceTypes
+}
 
 import collection.JavaConverters._
 


### PR DESCRIPTION
### What is this PR trying to achieve?

The root cause of #2173 is that a flag was consumed (with `@Flag`) separately from its definition (with `flag[String]`, on a Server), so it wasn't obvious that the flag had a default value.

This patch updates all of our code to use modules/config objects, so flags are always defined and consumed in the same file. This makes our code more consistent, and reduces the risk of us making the same mistake again.

### Who is this change for?

🎏 🛬 