### PR TITLE
Adds /management/manifest endpoint exposing APP_NAME

### DIFF
--- a/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/controllers/ManagementController.scala
+++ b/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/controllers/ManagementController.scala
@@ -7,7 +7,13 @@ import com.twitter.finatra.http.Controller
 
 @Singleton
 class ManagementController @Inject()() extends Controller {
+  val appName = scala.util.Properties.envOrElse("APP_NAME", "not-specified" )
+
   get("/management/healthcheck") { request: Request =>
     response.ok.json(Map("message" -> "ok"))
+  }
+
+  get("/management/manifest") { request: Request =>
+    response.ok.json(Map("name" -> appName))
   }
 }

--- a/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/controllers/ManagementController.scala
+++ b/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/controllers/ManagementController.scala
@@ -7,7 +7,7 @@ import com.twitter.finatra.http.Controller
 
 @Singleton
 class ManagementController @Inject()() extends Controller {
-  val appName = scala.util.Properties.envOrElse("APP_NAME", "not-specified" )
+  val appName = scala.util.Properties.envOrElse("APP_NAME", "not-specified")
 
   get("/management/healthcheck") { request: Request =>
     response.ok.json(Map("message" -> "ok"))


### PR DESCRIPTION
### What is this PR trying to achieve?

In order to identify quickly the running version of an application it can identify itself via a REST endpoint.

This exposes the `APP_NAME` environment variable.

**Note:** This requires a pending change to the terraform modules provisioning our services to make this variable available.

Depends: https://github.com/wellcometrust/terraform-modules/pull/74

### Who is this change for?

Developers who want to know what it deployed

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.