### PR TITLE
Fix the Terraform config for the matcher table

### DIFF
--- a/catalogue_pipeline/terraform/dynamo_matcher.tf
+++ b/catalogue_pipeline/terraform/dynamo_matcher.tf
@@ -5,18 +5,18 @@ resource "aws_dynamodb_table" "matcher_graph_table" {
   hash_key       = "workId"
 
   attribute {
-    name = "workId"
+    name = "id"
     type = "S"
   }
 
   attribute {
-    name = "setId"
+    name = "componentId"
     type = "S"
   }
 
   global_secondary_index {
     name            = "${var.matcher_table_index}"
-    hash_key        = "setId"
+    hash_key        = "componentId"
     write_capacity  = 1
     read_capacity   = 1
     projection_type = "ALL"


### PR DESCRIPTION
Required now that we’ve renamed the parameters on WorkNode.

Also, this puts the table definition in its own file – in general, we prefer to have each database/S3 bucket in a separate file to reduce the risk of making changes to the wrong thing.