### PR TITLE
Add a script for finding chatty CloudWatch log groups

### DIFF
--- a/monitoring/find_chatty_cloudwatch_log_groups.py
+++ b/monitoring/find_chatty_cloudwatch_log_groups.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8
+"""
+Find chatty CloudWatch log groups.
+
+This script looks at all the log groups in your account, and prints a
+bar chart showing the groups with the most stored logs.  This can be helpful
+whe trying to find unusually chatty applications.
+
+"""
 
 import boto3
 

--- a/monitoring/find_chatty_cloudwatch_log_groups.py
+++ b/monitoring/find_chatty_cloudwatch_log_groups.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8
+
+import boto3
+
+
+def describe_all_log_groups():
+    """
+    Generates describes of CloudWatch log groups, as returned by the
+    DescribeLogGroups API.
+
+    https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogGroups.html
+
+    """
+    client = boto3.client('logs')
+    paginator = client.get_paginator('describe_log_groups')
+
+    for page in paginator.paginate():
+        yield from page['logGroups']
+
+
+if __name__ == '__main__':
+    stored_sizes = {
+        group['logGroupName']: group['storedBytes']
+        for group in describe_all_log_groups()
+    }
+
+    import collections
+    from pprint import pprint
+
+    pprint(collections.Counter(stored_sizes).most_common(10))

--- a/monitoring/find_chatty_cloudwatch_log_groups.py
+++ b/monitoring/find_chatty_cloudwatch_log_groups.py
@@ -51,23 +51,34 @@ def print_bar_chart(data):
         # If the bar is empty, add a left one-eighth block
         bar = bar or  '▏'
 
-        print(f'{label.rjust(longest_label_length)} ▏ {count:#14d} {bar}')
+        print(f'{label.rjust(longest_label_length)} ▏ {count:#6.2f} {bar}')
 
 
 if __name__ == '__main__':
 
-    # All our log group names are of one of two forms:
-    #
-    #   platform/:service_name
-    #   /aws/lambda/:lambda_name
-    #
-    # We don't care about the prefix, so we can strip it off to make the
-    # results easier to read.
-    #
-    stored_sizes = {
-        group['logGroupName'].split('/')[-1]: group['storedBytes']
-        for group in describe_all_log_groups()
-    }
+    stored_sizes = {}
+
+    for group in describe_all_log_groups():
+
+        # All our log group names are of one of two forms:
+        #
+        #   platform/:service_name
+        #   /aws/lambda/:lambda_name
+        #
+        # We don't care about the prefix, so we can strip it off to make the
+        # results easier to read.
+        #
+        name = group['logGroupName'].split('/')[-1]
+
+        # The CloudWatch API counts stored bytes.  This isn't an especially
+        # useful metric, so convert it to gigabytes instead.
+        size = group['storedBytes'] / 1024 / 1024 / 1024
+
+        stored_sizes[name] = size
+    # stored_sizes = {
+    #     : group['storedBytes']
+    #     for group in describe_all_log_groups()
+    # }
 
     import collections
     chattiest_groups = collections.Counter(stored_sizes).most_common(10)

--- a/monitoring/find_chatty_cloudwatch_log_groups.py
+++ b/monitoring/find_chatty_cloudwatch_log_groups.py
@@ -57,7 +57,7 @@ def print_bar_chart(data):
             bar += chr(ord('█') + (8 - remainder))
 
         # If the bar is empty, add a left one-eighth block
-        bar = bar or  '▏'
+        bar = bar or '▏'
 
         print(f'{label.rjust(longest_label_length)} ▏ {count:#6.2f} {bar}')
 


### PR DESCRIPTION
Per the docstring. This is a diagnostic tool I wrote on Friday for #2177.

Example output:

![carbon](https://user-images.githubusercontent.com/301220/40903651-f7c5d7d0-67cf-11e8-8aa1-e2a4bc2224e5.png)
