### PR TITLE
Limit log retention of pipeline applications to 30 days

### DIFF
--- a/catalogue_pipeline/terraform/service_id_minter.tf
+++ b/catalogue_pipeline/terraform/service_id_minter.tf
@@ -1,5 +1,5 @@
 module "id_minter" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v10.2.2"
   name   = "id_minter"
 
   source_queue_name  = "${module.id_minter_queue.name}"
@@ -37,4 +37,6 @@ module "id_minter" {
   enable_alb_alarm = false
 
   max_capacity = 15
+
+  log_retention_in_days = 60
 }

--- a/catalogue_pipeline/terraform/service_id_minter.tf
+++ b/catalogue_pipeline/terraform/service_id_minter.tf
@@ -38,5 +38,5 @@ module "id_minter" {
 
   max_capacity = 15
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }

--- a/catalogue_pipeline/terraform/service_ingestor.tf
+++ b/catalogue_pipeline/terraform/service_ingestor.tf
@@ -49,5 +49,5 @@ module "ingestor" {
 
   max_capacity = 15
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }

--- a/catalogue_pipeline/terraform/service_ingestor.tf
+++ b/catalogue_pipeline/terraform/service_ingestor.tf
@@ -8,7 +8,7 @@ data "template_file" "es_cluster_host_ingestor" {
 }
 
 module "ingestor" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v10.2.2"
   name   = "ingestor"
 
   source_queue_name  = "${module.es_ingest_queue.name}"
@@ -48,4 +48,6 @@ module "ingestor" {
   enable_alb_alarm = false
 
   max_capacity = 15
+
+  log_retention_in_days = 60
 }

--- a/catalogue_pipeline/terraform/service_matcher.tf
+++ b/catalogue_pipeline/terraform/service_matcher.tf
@@ -36,7 +36,7 @@ module "matcher" {
 
   max_capacity = 15
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "matcher_dynamo_to_sns" {

--- a/catalogue_pipeline/terraform/service_matcher.tf
+++ b/catalogue_pipeline/terraform/service_matcher.tf
@@ -1,5 +1,5 @@
 module "matcher" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v10.2.2"
   name   = "matcher"
 
   source_queue_name  = "${module.matcher_queue.name}"
@@ -35,6 +35,8 @@ module "matcher" {
   enable_alb_alarm = false
 
   max_capacity = 15
+
+  log_retention_in_days = 60
 }
 
 module "matcher_dynamo_to_sns" {

--- a/catalogue_pipeline/terraform/service_recorder.tf
+++ b/catalogue_pipeline/terraform/service_recorder.tf
@@ -35,5 +35,5 @@ module "recorder" {
 
   max_capacity = 15
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }

--- a/catalogue_pipeline/terraform/service_recorder.tf
+++ b/catalogue_pipeline/terraform/service_recorder.tf
@@ -1,5 +1,5 @@
 module "recorder" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v10.2.2"
   name   = "recorder"
 
   source_queue_name  = "${module.recorder_queue.name}"
@@ -34,4 +34,6 @@ module "recorder" {
   enable_alb_alarm = false
 
   max_capacity = 15
+
+  log_retention_in_days = 60
 }

--- a/catalogue_pipeline/terraform/service_transformer.tf
+++ b/catalogue_pipeline/terraform/service_transformer.tf
@@ -34,7 +34,7 @@ module "transformer" {
 
   max_capacity = 15
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "transformer_dynamo_to_sns" {

--- a/catalogue_pipeline/terraform/service_transformer.tf
+++ b/catalogue_pipeline/terraform/service_transformer.tf
@@ -1,5 +1,5 @@
 module "transformer" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v10.2.2"
   name   = "transformer"
 
   memory = "2560"
@@ -33,6 +33,8 @@ module "transformer" {
   enable_alb_alarm = false
 
   max_capacity = 15
+
+  log_retention_in_days = 60
 }
 
 module "transformer_dynamo_to_sns" {

--- a/data_api/terraform/service_snapshot_generator.tf
+++ b/data_api/terraform/service_snapshot_generator.tf
@@ -8,7 +8,7 @@ data "template_file" "es_cluster_host_snapshot" {
 }
 
 module "snapshot_generator" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v10.2.2"
   name   = "snapshot_generator"
 
   source_queue_name = "${module.snapshot_generator_queue.name}"
@@ -51,4 +51,6 @@ module "snapshot_generator" {
   max_capacity = 2
 
   scale_down_period_in_minutes = 30
+
+  log_retention_in_days = 60
 }

--- a/data_api/terraform/service_snapshot_generator.tf
+++ b/data_api/terraform/service_snapshot_generator.tf
@@ -52,5 +52,5 @@ module "snapshot_generator" {
 
   scale_down_period_in_minutes = 30
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }

--- a/data_api/terraform/snapshot_scheduler/lambdas.tf
+++ b/data_api/terraform/snapshot_scheduler/lambdas.tf
@@ -19,7 +19,7 @@ module "snapshot_scheduler_lambda" {
     PUBLIC_OBJECT_KEY_V2 = "${var.public_object_key_v2}"
   }
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "trigger_snapshot_scheduler_lambda" {

--- a/data_api/terraform/snapshot_scheduler/lambdas.tf
+++ b/data_api/terraform/snapshot_scheduler/lambdas.tf
@@ -1,5 +1,5 @@
 module "snapshot_scheduler_lambda" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.5"
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
   name = "snapshot_scheduler"
 
@@ -18,6 +18,8 @@ module "snapshot_scheduler_lambda" {
     PUBLIC_OBJECT_KEY_V1 = "${var.public_object_key_v1}"
     PUBLIC_OBJECT_KEY_V2 = "${var.public_object_key_v2}"
   }
+
+  log_retention_in_days = 60
 }
 
 module "trigger_snapshot_scheduler_lambda" {

--- a/monitoring/deployment_tracking/notify_old_deploys/main.tf
+++ b/monitoring/deployment_tracking/notify_old_deploys/main.tf
@@ -19,7 +19,7 @@ module "lambda_notify_old_deploys" {
   s3_bucket = "${var.infra_bucket}"
   s3_key    = "lambdas/monitoring/deployment_tracking/notify_old_deploys.zip"
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "trigger_notify_old_deploys" {

--- a/monitoring/deployment_tracking/notify_old_deploys/main.tf
+++ b/monitoring/deployment_tracking/notify_old_deploys/main.tf
@@ -1,7 +1,7 @@
 # Lambda for publishing out of date deployments to SNS
 
 module "lambda_notify_old_deploys" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
   name        = "notify_old_deploys"
   description = "For publishing out of date deployments to SNS"
@@ -18,6 +18,8 @@ module "lambda_notify_old_deploys" {
 
   s3_bucket = "${var.infra_bucket}"
   s3_key    = "lambdas/monitoring/deployment_tracking/notify_old_deploys.zip"
+
+  log_retention_in_days = 60
 }
 
 module "trigger_notify_old_deploys" {

--- a/monitoring/deployment_tracking/notify_pushes/main.tf
+++ b/monitoring/deployment_tracking/notify_pushes/main.tf
@@ -1,5 +1,5 @@
 module "lambda_notify_pushes" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
   s3_bucket = "${var.infra_bucket}"
   s3_key    = "lambdas/monitoring/deployment_tracking/notify_pushes.zip"
@@ -13,6 +13,8 @@ module "lambda_notify_pushes" {
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+
+  log_retention_in_days = 60
 }
 
 data "aws_sns_topic" "ecr_trigger_topic" {

--- a/monitoring/deployment_tracking/notify_pushes/main.tf
+++ b/monitoring/deployment_tracking/notify_pushes/main.tf
@@ -14,7 +14,7 @@ module "lambda_notify_pushes" {
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 data "aws_sns_topic" "ecr_trigger_topic" {

--- a/monitoring/deployment_tracking/service_deployment_status/main.tf
+++ b/monitoring/deployment_tracking/service_deployment_status/main.tf
@@ -16,7 +16,7 @@ module "lambda_service_deployment_status" {
   s3_bucket = "${var.infra_bucket}"
   s3_key    = "lambdas/monitoring/deployment_tracking/service_deployment_status.zip"
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "trigger_service_deployment_status" {

--- a/monitoring/deployment_tracking/service_deployment_status/main.tf
+++ b/monitoring/deployment_tracking/service_deployment_status/main.tf
@@ -1,7 +1,7 @@
 # Lambda for tracking deployment status in dynamo db
 
 module "lambda_service_deployment_status" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
   name        = "service_deployment_status"
   description = "Lambda for tracking deployment status in dynamo db"
@@ -15,6 +15,8 @@ module "lambda_service_deployment_status" {
 
   s3_bucket = "${var.infra_bucket}"
   s3_key    = "lambdas/monitoring/deployment_tracking/service_deployment_status.zip"
+
+  log_retention_in_days = 60
 }
 
 module "trigger_service_deployment_status" {

--- a/monitoring/ecs_dashboard/update_service_list/main.tf
+++ b/monitoring/ecs_dashboard/update_service_list/main.tf
@@ -1,5 +1,5 @@
 module "lambda_update_service_list" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
   s3_bucket = "${var.infra_bucket}"
   s3_key    = "lambdas/monitoring/ecs_dashboard/update_service_list.zip"
@@ -15,6 +15,8 @@ module "lambda_update_service_list" {
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+
+  log_retention_in_days = 60
 }
 
 module "trigger_update_service_list" {

--- a/monitoring/ecs_dashboard/update_service_list/main.tf
+++ b/monitoring/ecs_dashboard/update_service_list/main.tf
@@ -16,7 +16,7 @@ module "lambda_update_service_list" {
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "trigger_update_service_list" {

--- a/monitoring/load_test/gatling_to_cloudwatch/main.tf
+++ b/monitoring/load_test/gatling_to_cloudwatch/main.tf
@@ -1,5 +1,5 @@
 module "lambda_gatling_to_cloudwatch" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
   s3_bucket = "${var.infra_bucket}"
   s3_key    = "lambdas/monitoring/load_test/gatling_to_cloudwatch.zip"
@@ -9,6 +9,8 @@ module "lambda_gatling_to_cloudwatch" {
   timeout     = 5
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+
+  log_retention_in_days = 60
 }
 
 module "trigger_gatling_to_cloudwatch" {

--- a/monitoring/load_test/gatling_to_cloudwatch/main.tf
+++ b/monitoring/load_test/gatling_to_cloudwatch/main.tf
@@ -10,7 +10,7 @@ module "lambda_gatling_to_cloudwatch" {
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "trigger_gatling_to_cloudwatch" {

--- a/monitoring/load_test/script_tasks.tf
+++ b/monitoring/load_test/script_tasks.tf
@@ -12,7 +12,7 @@ module "gatling_loris" {
     "{\"name\": \"S3_BUCKET\", \"value\": \"${var.monitoring_bucket_id}\"}",
   ]
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "gatling_catalogue_api" {

--- a/monitoring/load_test/script_tasks.tf
+++ b/monitoring/load_test/script_tasks.tf
@@ -1,5 +1,5 @@
 module "gatling_loris" {
-  source        = "git::https://github.com/wellcometrust/terraform.git//ecs_script_task?ref=v1.0.0"
+  source        = "git::https://github.com/wellcometrust/terraform.git//ecs_script_task?ref=v10.2.2"
   task_name     = "gatling_loris"
   app_uri       = "${module.ecr_repository_gatling.repository_url}:${var.release_ids["gatling"]}"
   task_role_arn = "${module.ecs_gatling_iam.task_role_arn}"
@@ -11,6 +11,8 @@ module "gatling_loris" {
     "{\"name\": \"RESULTS_TOPIC_ARN\", \"value\": \"${module.load_test_results.arn}\"}",
     "{\"name\": \"S3_BUCKET\", \"value\": \"${var.monitoring_bucket_id}\"}",
   ]
+
+  log_retention_in_days = 60
 }
 
 module "gatling_catalogue_api" {

--- a/monitoring/post_to_slack/main.tf
+++ b/monitoring/post_to_slack/main.tf
@@ -16,7 +16,7 @@ module "lambda_post_to_slack" {
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "trigger_post_to_slack_dlqs_not_empty" {

--- a/monitoring/post_to_slack/main.tf
+++ b/monitoring/post_to_slack/main.tf
@@ -1,5 +1,5 @@
 module "lambda_post_to_slack" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
   s3_bucket = "${var.infra_bucket}"
   s3_key    = "lambdas/monitoring/post_to_slack.zip"
@@ -15,6 +15,8 @@ module "lambda_post_to_slack" {
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+
+  log_retention_in_days = 60
 }
 
 module "trigger_post_to_slack_dlqs_not_empty" {

--- a/monitoring/slack_budget_bot/main.tf
+++ b/monitoring/slack_budget_bot/main.tf
@@ -1,5 +1,5 @@
 module "slack_budget_bot" {
-  source        = "git::https://github.com/wellcometrust/terraform-modules.git//ecs_script_task?ref=v1.0.0"
+  source        = "git::https://github.com/wellcometrust/terraform-modules.git//ecs_script_task?ref=v10.2.2"
   task_name     = "slack_budget_bot"
   app_uri       = "${module.ecr_repository_slack_budget_bot.repository_url}:${var.release_ids["slack_budget_bot"]}"
   task_role_arn = "${module.ecs_slack_budget_bot_iam.task_role_arn}"
@@ -9,6 +9,8 @@ module "slack_budget_bot" {
     "{\"name\": \"ACCOUNT_ID\", \"value\": \"${var.account_id}\"}",
     "{\"name\": \"SLACK_WEBHOOK\", \"value\": \"${var.slack_webhook}\"}",
   ]
+
+  log_retention_in_days = 60
 }
 
 module "ecs_slack_budget_bot_iam" {

--- a/monitoring/slack_budget_bot/main.tf
+++ b/monitoring/slack_budget_bot/main.tf
@@ -10,7 +10,7 @@ module "slack_budget_bot" {
     "{\"name\": \"SLACK_WEBHOOK\", \"value\": \"${var.slack_webhook}\"}",
   ]
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "ecs_slack_budget_bot_iam" {

--- a/monitoring/terraform_tracker/main.tf
+++ b/monitoring/terraform_tracker/main.tf
@@ -16,7 +16,7 @@ module "lambda_terraform_tracker" {
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 data "aws_sns_topic" "trigger_topic" {

--- a/monitoring/terraform_tracker/main.tf
+++ b/monitoring/terraform_tracker/main.tf
@@ -1,5 +1,5 @@
 module "lambda_terraform_tracker" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
   s3_bucket = "${var.infra_bucket}"
   s3_key    = "lambdas/monitoring/terraform_tracker.zip"
@@ -15,6 +15,8 @@ module "lambda_terraform_tracker" {
   }
 
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+
+  log_retention_in_days = 60
 }
 
 data "aws_sns_topic" "trigger_topic" {

--- a/reindexer/terraform/lambda_complete_reindex.tf
+++ b/reindexer/terraform/lambda_complete_reindex.tf
@@ -15,7 +15,7 @@ module "complete_reindex_lambda" {
 
   alarm_topic_arn = "${local.lambda_error_alarm_arn}"
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "trigger_complete_reindex_lambda" {

--- a/reindexer/terraform/lambda_complete_reindex.tf
+++ b/reindexer/terraform/lambda_complete_reindex.tf
@@ -1,5 +1,5 @@
 module "complete_reindex_lambda" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.5"
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
   name      = "complete_reindex"
   s3_bucket = "${var.infra_bucket}"
@@ -14,6 +14,8 @@ module "complete_reindex_lambda" {
   }
 
   alarm_topic_arn = "${local.lambda_error_alarm_arn}"
+
+  log_retention_in_days = 60
 }
 
 module "trigger_complete_reindex_lambda" {

--- a/reindexer/terraform/lambda_reindex_job_creator.tf
+++ b/reindexer/terraform/lambda_reindex_job_creator.tf
@@ -1,5 +1,5 @@
 module "reindex_job_creator_lambda" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.5"
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
   name      = "reindex_job_creator"
   s3_bucket = "${var.infra_bucket}"
@@ -14,6 +14,8 @@ module "reindex_job_creator_lambda" {
   }
 
   alarm_topic_arn = "${local.lambda_error_alarm_arn}"
+
+  log_retention_in_days = 60
 }
 
 module "trigger_reindex_job_creator_lambda" {

--- a/reindexer/terraform/lambda_reindex_job_creator.tf
+++ b/reindexer/terraform/lambda_reindex_job_creator.tf
@@ -15,7 +15,7 @@ module "reindex_job_creator_lambda" {
 
   alarm_topic_arn = "${local.lambda_error_alarm_arn}"
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "trigger_reindex_job_creator_lambda" {

--- a/reindexer/terraform/lambda_reindex_shard_generator.tf
+++ b/reindexer/terraform/lambda_reindex_shard_generator.tf
@@ -1,5 +1,5 @@
 module "shard_generator_lambda" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v6.4.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
   name      = "reindex_shard_generator"
   s3_bucket = "${var.infra_bucket}"
@@ -14,6 +14,8 @@ module "shard_generator_lambda" {
   }
 
   alarm_topic_arn = "${local.lambda_error_alarm_arn}"
+
+  log_retention_in_days = 60
 }
 
 module "trigger_shard_generator_lambda" {

--- a/reindexer/terraform/lambda_reindex_shard_generator.tf
+++ b/reindexer/terraform/lambda_reindex_shard_generator.tf
@@ -15,7 +15,7 @@ module "shard_generator_lambda" {
 
   alarm_topic_arn = "${local.lambda_error_alarm_arn}"
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "trigger_shard_generator_lambda" {

--- a/reindexer/terraform/lambda_reindex_shard_tracker_ddb_to_sns.tf
+++ b/reindexer/terraform/lambda_reindex_shard_tracker_ddb_to_sns.tf
@@ -1,5 +1,5 @@
 module "reindex_shard_tracker_dynamo_to_sns" {
-  source = "git::https://github.com/wellcometrust/platform.git//shared_infra/dynamo_to_sns"
+  source = "../../shared_infra/dynamo_to_sns"
 
   name           = "reindex_shard_tracker_updates"
   src_stream_arn = "${aws_dynamodb_table.reindex_shard_tracker.stream_arn}"

--- a/reindexer/terraform/service_reindexer.tf
+++ b/reindexer/terraform/service_reindexer.tf
@@ -1,5 +1,5 @@
 module "reindexer" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v6.4.0"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v10.2.2"
   name   = "reindexer"
 
   source_queue_name = "${module.reindexer_queue.name}"
@@ -29,6 +29,8 @@ module "reindexer" {
   alb_client_error_alarm_arn = "${local.alb_client_error_alarm_arn}"
 
   enable_alb_alarm = false
+
+  log_retention_in_days = 60
 }
 
 resource "aws_iam_role_policy" "ecs_reindexer_task_sns" {

--- a/reindexer/terraform/service_reindexer.tf
+++ b/reindexer/terraform/service_reindexer.tf
@@ -30,7 +30,7 @@ module "reindexer" {
 
   enable_alb_alarm = false
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 resource "aws_iam_role_policy" "ecs_reindexer_task_sns" {

--- a/shared_infra/drain_ecs_container_instance/main.tf
+++ b/shared_infra/drain_ecs_container_instance/main.tf
@@ -1,5 +1,5 @@
 module "lambda_drain_ecs_container_instance" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
   name        = "drain_ecs_container_instance"
   description = "Drain ECS container instance when the corresponding EC2 instance is being terminated"
@@ -8,6 +8,8 @@ module "lambda_drain_ecs_container_instance" {
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
   s3_bucket       = "${var.infra_bucket}"
   s3_key          = "lambdas/shared_infra/drain_ecs_container_instance.zip"
+
+  log_retention_in_days = 60
 }
 
 module "trigger_drain_ecs_container_instance" {

--- a/shared_infra/drain_ecs_container_instance/main.tf
+++ b/shared_infra/drain_ecs_container_instance/main.tf
@@ -9,7 +9,7 @@ module "lambda_drain_ecs_container_instance" {
   s3_bucket       = "${var.infra_bucket}"
   s3_key          = "lambdas/shared_infra/drain_ecs_container_instance.zip"
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "trigger_drain_ecs_container_instance" {

--- a/shared_infra/dynamo_to_sns/main.tf
+++ b/shared_infra/dynamo_to_sns/main.tf
@@ -16,7 +16,7 @@ module "lambda_dynamo_to_sns" {
   s3_bucket       = "${var.infra_bucket}"
   s3_key          = "lambdas/shared_infra/dynamo_to_sns.zip"
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "trigger_dynamo_to_sns" {

--- a/shared_infra/dynamo_to_sns/main.tf
+++ b/shared_infra/dynamo_to_sns/main.tf
@@ -1,5 +1,5 @@
 module "lambda_dynamo_to_sns" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.2.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
   name        = "dynamo_to_sns_${var.name}"
   module_name = "dynamo_to_sns"
@@ -15,6 +15,8 @@ module "lambda_dynamo_to_sns" {
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
   s3_bucket       = "${var.infra_bucket}"
   s3_key          = "lambdas/shared_infra/dynamo_to_sns.zip"
+
+  log_retention_in_days = 60
 }
 
 module "trigger_dynamo_to_sns" {

--- a/shared_infra/ecs_ec2_instance_tagger/main.tf
+++ b/shared_infra/ecs_ec2_instance_tagger/main.tf
@@ -16,7 +16,7 @@ module "lambda_ecs_ec2_instance_tagger" {
   s3_bucket       = "${var.infra_bucket}"
   s3_key          = "lambdas/shared_infra/ecs_ec2_instance_tagger.zip"
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "trigger_ecs_ec2_instance_tagger" {

--- a/shared_infra/ecs_ec2_instance_tagger/main.tf
+++ b/shared_infra/ecs_ec2_instance_tagger/main.tf
@@ -1,7 +1,7 @@
 # Lambda for tagging EC2 instances with ECS cluster/container instance id
 
 module "lambda_ecs_ec2_instance_tagger" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
   name        = "ecs_ec2_instance_tagger"
   description = "Tag an EC2 instance with ECS cluster/container instance id"
@@ -15,6 +15,8 @@ module "lambda_ecs_ec2_instance_tagger" {
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
   s3_bucket       = "${var.infra_bucket}"
   s3_key          = "lambdas/shared_infra/ecs_ec2_instance_tagger.zip"
+
+  log_retention_in_days = 60
 }
 
 module "trigger_ecs_ec2_instance_tagger" {

--- a/shared_infra/run_ecs_task/main.tf
+++ b/shared_infra/run_ecs_task/main.tf
@@ -1,7 +1,7 @@
 # Lambda for publishing ECS service schedules to an SNS topic
 
 module "lambda_run_ecs_task" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
   name        = "run_ecs_task"
   description = "Run an ECS task from a message published to SNS"
@@ -9,6 +9,8 @@ module "lambda_run_ecs_task" {
   alarm_topic_arn = "${var.lambda_error_alarm_arn}"
   s3_bucket       = "${var.infra_bucket}"
   s3_key          = "lambdas/shared_infra/run_ecs_task.zip"
+
+  log_retention_in_days = 60
 }
 
 module "trigger_run_ecs_task" {

--- a/shared_infra/run_ecs_task/main.tf
+++ b/shared_infra/run_ecs_task/main.tf
@@ -10,7 +10,7 @@ module "lambda_run_ecs_task" {
   s3_bucket       = "${var.infra_bucket}"
   s3_key          = "lambdas/shared_infra/run_ecs_task.zip"
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "trigger_run_ecs_task" {

--- a/sierra_adapter/terraform/items_to_dynamo/services.tf
+++ b/sierra_adapter/terraform/items_to_dynamo/services.tf
@@ -3,7 +3,7 @@ data "aws_ecs_cluster" "cluster" {
 }
 
 module "sierra_to_dynamo_service" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v10.2.2"
   name   = "sierra_items_to_dynamo"
 
   source_queue_name  = "${module.demultiplexer_queue.name}"
@@ -35,4 +35,6 @@ module "sierra_to_dynamo_service" {
   enable_alb_alarm = false
 
   max_capacity = 50
+
+  log_retention_in_days = 60
 }

--- a/sierra_adapter/terraform/items_to_dynamo/services.tf
+++ b/sierra_adapter/terraform/items_to_dynamo/services.tf
@@ -36,5 +36,5 @@ module "sierra_to_dynamo_service" {
 
   max_capacity = 50
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }

--- a/sierra_adapter/terraform/merger/services.tf
+++ b/sierra_adapter/terraform/merger/services.tf
@@ -7,7 +7,7 @@ data "aws_ecs_cluster" "cluster" {
 }
 
 module "sierra_merger_service" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v10.2.2"
   name   = "sierra_${local.resource_type_singular}_merger"
 
   source_queue_name  = "${module.updates_queue.name}"
@@ -38,5 +38,7 @@ module "sierra_merger_service" {
 
   enable_alb_alarm = false
 
-  max_capacity = 50
+  max_capacity = 15
+
+  log_retention_in_days = 60
 }

--- a/sierra_adapter/terraform/merger/services.tf
+++ b/sierra_adapter/terraform/merger/services.tf
@@ -40,5 +40,5 @@ module "sierra_merger_service" {
 
   max_capacity = 15
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }

--- a/sierra_adapter/terraform/sierra_reader/service.tf
+++ b/sierra_adapter/terraform/sierra_reader/service.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "sierra_reader_service" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v8.1.0"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//sqs_autoscaling_service?ref=v10.2.2"
   name   = "${local.service_name}"
 
   source_queue_name  = "${module.windows_queue.name}"
@@ -44,4 +44,6 @@ module "sierra_reader_service" {
   enable_alb_alarm = false
 
   max_capacity = 1
+
+  log_retention_in_days = 60
 }

--- a/sierra_adapter/terraform/sierra_reader/service.tf
+++ b/sierra_adapter/terraform/sierra_reader/service.tf
@@ -45,5 +45,5 @@ module "sierra_reader_service" {
 
   max_capacity = 1
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }

--- a/sierra_adapter/terraform/sierra_window_generator/lambdas.tf
+++ b/sierra_adapter/terraform/sierra_window_generator/lambdas.tf
@@ -1,5 +1,5 @@
 module "window_generator_lambda" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v1.0.5"
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
   name = "sierra_${var.resource_type}_window_generator"
 
@@ -15,6 +15,8 @@ module "window_generator_lambda" {
     "TOPIC_ARN"             = "${module.windows_topic.arn}"
     "WINDOW_LENGTH_MINUTES" = "${var.window_length_minutes}"
   }
+
+  log_retention_in_days = 60
 }
 
 module "trigger_sierra_window_generator_lambda" {

--- a/sierra_adapter/terraform/sierra_window_generator/lambdas.tf
+++ b/sierra_adapter/terraform/sierra_window_generator/lambdas.tf
@@ -16,7 +16,7 @@ module "window_generator_lambda" {
     "WINDOW_LENGTH_MINUTES" = "${var.window_length_minutes}"
   }
 
-  log_retention_in_days = 60
+  log_retention_in_days = 30
 }
 
 module "trigger_sierra_window_generator_lambda" {


### PR DESCRIPTION
### What is this PR trying to achieve?

This patch limits the internal logs we store to 30 days. We rarely use logs that are more than a few days old, and applications change so frequently that log formats quickly become stale.

Additionally, keeping a rolling window of logs will make it easier to spot which applications are being chatty (for #2181).

When we deploy this, it’ll include all the changes to reduce logging from #2179.

Part of #2177. Closes #1731.

### Who is this change for?

🌴 🔪

### 'terraform apply' checklist

- [ ] catalogue_pipeline
- [ ] data_api
- [ ] monitoring
- [ ] reindexer
- [ ] shared_infra
- [ ] sierra_adapter