### PR TITLE
Use a for comprehension in the reindexer

### DIFF
--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
@@ -58,9 +58,11 @@ class ReindexService @Inject()(dynamoDbClient: AmazonDynamoDB,
 
     // Then we PUT all the records.  It might be more efficient to do a
     // bulk update, but this will do for now.
-    outdatedRecordsFuture.flatMap {
-      outdatedRecords: List[ReindexRecord] => Future.sequence {
-        outdatedRecords.map { updateIndividualRecord(_, desiredVersion = reindexJob.desiredVersion) }
+    outdatedRecordsFuture.flatMap { outdatedRecords: List[ReindexRecord] =>
+      Future.sequence {
+        outdatedRecords.map {
+          updateIndividualRecord(_, desiredVersion = reindexJob.desiredVersion)
+        }
       }
     }
   }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
@@ -7,6 +7,7 @@ import com.gu.scanamo.syntax._
 import com.gu.scanamo.{Scanamo, _}
 import com.twitter.inject.Logging
 import javax.inject.Inject
+
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.platform.reindex_worker.GlobalExecutionContext.context
@@ -17,6 +18,7 @@ import uk.ac.wellcome.platform.reindex_worker.models.{
 import uk.ac.wellcome.storage.dynamo.{DynamoConfig, VersionedDao}
 
 import scala.concurrent.Future
+import scala.util.Try
 
 class ReindexService @Inject()(dynamoDbClient: AmazonDynamoDB,
                                dynamoConfig: DynamoConfig,
@@ -28,35 +30,30 @@ class ReindexService @Inject()(dynamoDbClient: AmazonDynamoDB,
     dynamoConfig = dynamoConfig
   )
 
-  def runReindex(reindexJob: ReindexJob): Future[List[Unit]] =
-    Future {
-      info(s"ReindexService running $reindexJob")
-
-      val table = Table[ReindexRecord](dynamoConfig.table)
-
-      val index = table.index(indexName = dynamoConfig.index)
+  def runReindex(reindexJob: ReindexJob): Future[List[Unit]] = {
+    info(s"ReindexService running $reindexJob")
+    val table = Table[ReindexRecord](dynamoConfig.table)
+    for {
+      index: SecondaryIndex[ReindexRecord] <- Future.fromTry(Try {
+        table.index(indexName = dynamoConfig.index)
+      })
 
       // We start by querying DynamoDB for every record in the reindex shard
       // that has an out-of-date reindexVersion.  If a shard was especially
       // large, this might cause out-of-memory errors -- in practice, we're
       // hoping that the shards/individual records are small enough for this
       // not to be a problem.
-      val results: List[Either[DynamoReadError, ReindexRecord]] =
+      results: List[Either[DynamoReadError, ReindexRecord]] <- Future {
         Scanamo.exec(dynamoDbClient)(
           index.query(
             'reindexShard -> reindexJob.shardId and
               KeyIs('reindexVersion, LT, reindexJob.desiredVersion)
           )
         )
+      }
 
-      val outdatedRecords: List[ReindexRecord] = results.map {
-        case Left(err: DynamoReadError) => {
-          warn(s"Failed to read Dynamo records: $err")
-          throw GracefulFailureException(
-            new RuntimeException(s"Error in the DynamoDB query: $err")
-          )
-        }
-        case Right(r: ReindexRecord) => r
+      outdatedRecords: List[ReindexRecord] = results.map {
+        extractRecord(_)
       }
 
       // Then we PUT all the records.  It might be more efficient to do a
@@ -71,4 +68,20 @@ class ReindexService @Inject()(dynamoDbClient: AmazonDynamoDB,
           ()
         }
     }
+
+  private def extractRecord(scanamoResult: Either[DynamoReadError, ReindexRecord]): ReindexRecord =
+    scanamoResult match {
+      case Left(err: DynamoReadError) => {
+        warn(s"Failed to read Dynamo records: $err")
+        throw GracefulFailureException(
+          new RuntimeException(s"Error in the DynamoDB query: $err")
+        )
+      }
+      case Right(r: ReindexRecord) => r
+    }
+
+  private def updateIndividualRecord(record: ReindexRecord, desiredVersion: Int): Future[Unit] = {
+    val updatedRecord = record.copy(reindexVersion = desiredVersion)
+    versionedDao.updateRecord[ReindexRecord](updatedRecord)
+  }
 }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
@@ -69,7 +69,8 @@ class ReindexService @Inject()(dynamoDbClient: AmazonDynamoDB,
         }
     }
 
-  private def extractRecord(scanamoResult: Either[DynamoReadError, ReindexRecord]): ReindexRecord =
+  private def extractRecord(
+    scanamoResult: Either[DynamoReadError, ReindexRecord]): ReindexRecord =
     scanamoResult match {
       case Left(err: DynamoReadError) => {
         warn(s"Failed to read Dynamo records: $err")
@@ -80,7 +81,8 @@ class ReindexService @Inject()(dynamoDbClient: AmazonDynamoDB,
       case Right(r: ReindexRecord) => r
     }
 
-  private def updateIndividualRecord(record: ReindexRecord, desiredVersion: Int): Future[Unit] = {
+  private def updateIndividualRecord(record: ReindexRecord,
+                                     desiredVersion: Int): Future[Unit] = {
     val updatedRecord = record.copy(reindexVersion = desiredVersion)
     versionedDao.updateRecord[ReindexRecord](updatedRecord)
   }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexServiceTest.scala
@@ -169,11 +169,12 @@ class ReindexServiceTest
           reindexVersion: Int
         )
 
-        Scanamo.put(dynamoDbClient)(table.name)(BadRecord(
-          id = "badId1",
-          reindexShard = shardName,
-          reindexVersion = currentVersion
-        ))
+        Scanamo.put(dynamoDbClient)(table.name)(
+          BadRecord(
+            id = "badId1",
+            reindexShard = shardName,
+            reindexVersion = currentVersion
+          ))
 
         val reindexJob = ReindexJob(
           shardId = shardName,
@@ -182,7 +183,7 @@ class ReindexServiceTest
 
         val future = reindexService.runReindex(reindexJob)
         whenReady(future.failed) {
-          _ shouldBe a [GracefulFailureException]
+          _ shouldBe a[GracefulFailureException]
         }
       }
     }


### PR DESCRIPTION
As discussed with @kenoir, this use of a for comprehension means we're not wrapping a Future in a Future and returning early.