### PR TITLE
Make sure we throw graceful exceptions if subfield $a is missing

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributors.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributors.scala
@@ -126,9 +126,11 @@ trait SierraContributors extends MarcUtils {
 
     maybeSubfieldA match {
       case Some(content) => content
-      case None => throw GracefulFailureException(new RuntimeException(
-        s"Unable to find subfield $$a?  $subfields"
-      ))
+      case None =>
+        throw GracefulFailureException(
+          new RuntimeException(
+            s"Unable to find subfield $$a?  $subfields"
+          ))
     }
   }
 
@@ -180,8 +182,9 @@ trait SierraContributors extends MarcUtils {
         )
       }
       case _ =>
-        throw GracefulFailureException(new RuntimeException(
-          s"Multiple identifiers in subfield $$0: $codes"))
+        throw GracefulFailureException(
+          new RuntimeException(
+            s"Multiple identifiers in subfield $$0: $codes"))
     }
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributorsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributorsTest.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.source.{
   MarcSubfield,
@@ -651,6 +652,20 @@ class SierraContributorsTest extends FunSpec with Matchers {
     }
   }
 
+  it("throws a GracefulFailureException if subfield $$a is missing") {
+    val varFields = List(
+      VarField(
+        fieldTag = "p",
+        marcTag = "100",
+        indicator1 = "",
+        indicator2 = "",
+        subfields = List()
+      )
+    )
+
+    assertTransformFails(varFields)
+  }
+
   private def transformAndCheckContributors(
     varFields: List[VarField],
     expectedContributors: List[Contributor[MaybeDisplayable[AbstractAgent]]]
@@ -664,7 +679,7 @@ class SierraContributorsTest extends FunSpec with Matchers {
     val bibData =
       SierraBibData(id = "1663540", title = None, varFields = varFields)
 
-    intercept[RuntimeException] {
+    intercept[GracefulFailureException] {
       transformer.getContributors(bibData)
     }
   }


### PR DESCRIPTION
Because we've seen that on a few records. This makes it a nicer error (previously it was a slightly cryptic NoSuchElementException because of the None.get) and makes it a graceful exception, so we won't log a complete traceback.

Discovered in #2163.