### PR TITLE
timeAndCount -> count & reduce use

### DIFF
--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedder.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedder.scala
@@ -12,8 +12,8 @@ import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
-class IdEmbedder @Inject()(
-  identifierGenerator: IdentifierGenerator)(implicit ec: ExecutionContext)
+class IdEmbedder @Inject()(identifierGenerator: IdentifierGenerator)(
+  implicit ec: ExecutionContext)
     extends Logging {
 
   def embedId(json: Json): Future[Json] = Future {

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedder.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedder.scala
@@ -6,7 +6,6 @@ import io.circe.optics.JsonPath.root
 import io.circe.optics.JsonTraversalPath
 import io.circe.{Json, _}
 import uk.ac.wellcome.models.work.internal.SourceIdentifier
-import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.annotation.tailrec
@@ -14,7 +13,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 class IdEmbedder @Inject()(
-  metricsSender: MetricsSender,
   identifierGenerator: IdentifierGenerator)(implicit ec: ExecutionContext)
     extends Logging {
 

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedder.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedder.scala
@@ -18,14 +18,8 @@ class IdEmbedder @Inject()(
   identifierGenerator: IdentifierGenerator)(implicit ec: ExecutionContext)
     extends Logging {
 
-  def embedId(json: Json): Future[Json] = {
-    metricsSender.timeAndCount(
-      "generate-id",
-      () =>
-        Future {
-          iterate(root.each, addIdentifierToJson(json))
-      }
-    )
+  def embedId(json: Json): Future[Json] = Future {
+    iterate(root.each, addIdentifierToJson(json))
   }
 
   @tailrec

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
@@ -3,17 +3,13 @@ package uk.ac.wellcome.platform.idminter.steps
 import com.google.inject.Inject
 import com.twitter.inject.{Logging, TwitterModuleFlags}
 import uk.ac.wellcome.models.work.internal.SourceIdentifier
-import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.platform.idminter.database.IdentifiersDao
 import uk.ac.wellcome.platform.idminter.models.Identifier
 import uk.ac.wellcome.platform.idminter.utils.Identifiable
 
 import scala.util.Try
 
-class IdentifierGenerator @Inject()(
-  identifiersDao: IdentifiersDao,
-  metricsSender: MetricsSender
-) extends Logging
+class IdentifierGenerator @Inject()(identifiersDao: IdentifiersDao) extends Logging
     with TwitterModuleFlags {
 
   def retrieveOrGenerateCanonicalId(
@@ -25,16 +21,8 @@ class IdentifierGenerator @Inject()(
           sourceIdentifier = identifier
         )
         .flatMap {
-          case Some(id) =>
-            metricsSender.incrementCount("found-old-id")
-            Try(id.CanonicalId)
-          case None =>
-            val result =
-              generateAndSaveCanonicalId(identifier)
-            if (result.isSuccess)
-              metricsSender.incrementCount("generated-new-id")
-
-            result
+          case Some(id) => Try(id.CanonicalId)
+          case None => generateAndSaveCanonicalId(identifier)
         }
     }.flatten
   }

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
@@ -9,7 +9,8 @@ import uk.ac.wellcome.platform.idminter.utils.Identifiable
 
 import scala.util.Try
 
-class IdentifierGenerator @Inject()(identifiersDao: IdentifiersDao) extends Logging
+class IdentifierGenerator @Inject()(identifiersDao: IdentifiersDao)
+    extends Logging
     with TwitterModuleFlags {
 
   def retrieveOrGenerateCanonicalId(

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -10,6 +10,8 @@ import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 import uk.ac.wellcome.test.utils.{ExtendedPatience, JsonTestUtil}
 import uk.ac.wellcome.utils.JsonUtil._
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 import scala.util.Try
 
 class IdEmbedderTests

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -6,7 +6,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 import uk.ac.wellcome.test.utils.{ExtendedPatience, JsonTestUtil}
 import uk.ac.wellcome.utils.JsonUtil._
@@ -22,23 +21,19 @@ class IdEmbedderTests
     with MockitoSugar
     with Akka
     with JsonTestUtil
-    with MetricsSenderFixture
     with ExtendedPatience {
 
   private def withIdEmbedder(
     testWith: TestWith[(IdentifierGenerator, IdEmbedder), Assertion]) = {
     withActorSystem { actorSystem =>
-      withMetricsSender(actorSystem) { metricsSender =>
-        val identifierGenerator: IdentifierGenerator =
-          mock[IdentifierGenerator]
+      val identifierGenerator: IdentifierGenerator =
+        mock[IdentifierGenerator]
 
-        val idEmbedder = new IdEmbedder(
-          metricsSender = metricsSender,
-          identifierGenerator = identifierGenerator
-        )
+      val idEmbedder = new IdEmbedder(
+        identifierGenerator = identifierGenerator
+      )
 
-        testWith((identifierGenerator, idEmbedder))
-      }
+      testWith((identifierGenerator, idEmbedder))
     }
   }
 

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -12,8 +12,6 @@ import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.util.Try
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 class IdEmbedderTests
     extends FunSpec
     with ScalaFutures

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -11,7 +11,6 @@ import org.elasticsearch.client.ResponseException
 import org.elasticsearch.index.VersionType
 import uk.ac.wellcome.elasticsearch.ElasticsearchExceptionManager
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.utils.JsonUtil._
 
@@ -19,8 +18,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class WorkIndexer @Inject()(
-  elasticClient: HttpClient,
-  metricsSender: MetricsSender
+  elasticClient: HttpClient
 )(implicit ec: ExecutionContext)
     extends Logging
     with ElasticsearchExceptionManager {

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -30,9 +30,7 @@ class WorkIndexer @Inject()(
       toJson(t).get
   }
 
-  def indexWork(work: IdentifiedWork,
-                esIndex: String,
-                esType: String) = {
+  def indexWork(work: IdentifiedWork, esIndex: String, esType: String) = {
 
     info(s"Indexing work ${work.canonicalId}")
 
@@ -49,14 +47,12 @@ class WorkIndexer @Inject()(
       }
       .recover {
         case e: ResponseException
-          if getErrorType(e).contains(
-            "version_conflict_engine_exception") =>
+            if getErrorType(e).contains("version_conflict_engine_exception") =>
           warn(
             s"Trying to index work ${work.canonicalId} with older version: skipping.")
           ()
         case e: TimeoutException =>
-          warn(
-            s"Timeout indexing work ${work.canonicalId} into Elasticsearch")
+          warn(s"Timeout indexing work ${work.canonicalId} into Elasticsearch")
           throw new GracefulFailureException(e)
         case e: Throwable =>
           error(

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -14,7 +14,7 @@ import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.utils.JsonUtil._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 @Singleton
 class WorkIndexer @Inject()(

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
@@ -2,35 +2,23 @@ package uk.ac.wellcome.platform.ingestor.fixtures
 
 import com.sksamuel.elastic4s.http.HttpClient
 import org.scalatest.Suite
-import uk.ac.wellcome.monitoring.MetricsSender
-import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.ingestor.services.WorkIndexer
 import uk.ac.wellcome.test.fixtures._
 
-import scala.concurrent.ExecutionContext.Implicits.global
 
-trait WorkIndexerFixtures extends Akka with MetricsSenderFixture {
+trait WorkIndexerFixtures extends Akka {
   this: Suite =>
   def withWorkIndexer[R](
-    elasticClient: HttpClient,
-    metricsSender: MetricsSender)(testWith: TestWith[WorkIndexer, R]): R = {
-    val workIndexer = new WorkIndexer(
-      elasticClient = elasticClient,
-      metricsSender = metricsSender
-    )
-
+    elasticClient: HttpClient)(testWith: TestWith[WorkIndexer, R]): R = {
+    val workIndexer = new WorkIndexer(elasticClient = elasticClient)
     testWith(workIndexer)
   }
 
   def withWorkIndexerFixtures[R](esType: String, elasticClient: HttpClient)(
     testWith: TestWith[WorkIndexer, R]): R = {
     withActorSystem { actorSystem =>
-      withMetricsSender(actorSystem) { metricsSender =>
-        withWorkIndexer(
-          elasticClient = elasticClient,
-          metricsSender = metricsSender) { workIndexer =>
-          testWith(workIndexer)
-        }
+      withWorkIndexer(elasticClient = elasticClient) { workIndexer =>
+        testWith(workIndexer)
       }
     }
   }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
@@ -5,6 +5,8 @@ import org.scalatest.Suite
 import uk.ac.wellcome.platform.ingestor.services.WorkIndexer
 import uk.ac.wellcome.test.fixtures._
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 trait WorkIndexerFixtures extends Akka { this: Suite =>
   def withWorkIndexer[R](elasticClient: HttpClient)(
     testWith: TestWith[WorkIndexer, R]): R = {

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
@@ -5,11 +5,9 @@ import org.scalatest.Suite
 import uk.ac.wellcome.platform.ingestor.services.WorkIndexer
 import uk.ac.wellcome.test.fixtures._
 
-
-trait WorkIndexerFixtures extends Akka {
-  this: Suite =>
-  def withWorkIndexer[R](
-    elasticClient: HttpClient)(testWith: TestWith[WorkIndexer, R]): R = {
+trait WorkIndexerFixtures extends Akka { this: Suite =>
+  def withWorkIndexer[R](elasticClient: HttpClient)(
+    testWith: TestWith[WorkIndexer, R]): R = {
     val workIndexer = new WorkIndexer(elasticClient = elasticClient)
     testWith(workIndexer)
   }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -163,8 +163,7 @@ class IngestorWorkerServiceTest
                   HttpClient.fromRestClient(brokenRestClient)
 
                 val brokenWorkIndexer = new WorkIndexer(
-                  elasticClient = brokenElasticClient,
-                  metricsSender = metricsSender
+                  elasticClient = brokenElasticClient
                 )
 
                 withIngestorWorkerService[Assertion](
@@ -198,6 +197,7 @@ class IngestorWorkerServiceTest
                 }
               }
             }
+
         }
       }
     }
@@ -212,8 +212,7 @@ class IngestorWorkerServiceTest
           case queuePair @ QueuePair(queue, dlq) =>
             withLocalS3Bucket { bucket =>
               withWorkIndexer[R](
-                elasticClient = elasticClient,
-                metricsSender = metricsSender) { workIndexer =>
+                elasticClient = elasticClient) { workIndexer =>
                 withMessageStream[IdentifiedWork, R](
                   actorSystem,
                   bucket,

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -211,22 +211,22 @@ class IngestorWorkerServiceTest
         withLocalSqsQueueAndDlq {
           case queuePair @ QueuePair(queue, dlq) =>
             withLocalS3Bucket { bucket =>
-              withWorkIndexer[R](
-                elasticClient = elasticClient) { workIndexer =>
-                withMessageStream[IdentifiedWork, R](
-                  actorSystem,
-                  bucket,
-                  queue,
-                  metricsSender) { messageStream =>
-                  withIngestorWorkerService[R](
-                    esIndexV1,
-                    esIndexV2,
+              withWorkIndexer[R](elasticClient = elasticClient) {
+                workIndexer =>
+                  withMessageStream[IdentifiedWork, R](
                     actorSystem,
-                    workIndexer,
-                    messageStream) { _ =>
-                    testWith((queuePair, bucket))
+                    bucket,
+                    queue,
+                    metricsSender) { messageStream =>
+                    withIngestorWorkerService[R](
+                      esIndexV1,
+                      esIndexV2,
+                      actorSystem,
+                      workIndexer,
+                      messageStream) { _ =>
+                      testWith((queuePair, bucket))
+                    }
                   }
-                }
               }
             }
         }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiver.scala
@@ -29,22 +29,23 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 class NotificationMessageReceiver @Inject()(
-                                             messageWriter: MessageWriter[UnidentifiedWork],
-                                             s3Client: AmazonS3,
-                                             s3Config: S3Config,
-                                             metricsSender: MetricsSender)(
-                                             implicit miroTransformableStore: ObjectStore[MiroTransformable],
-                                             calmTransformableStore: ObjectStore[CalmTransformable],
-                                             sierraTransformableStore: ObjectStore[SierraTransformable],
-                                             ec: ExecutionContext
-                                           ) extends Logging {
+  messageWriter: MessageWriter[UnidentifiedWork],
+  s3Client: AmazonS3,
+  s3Config: S3Config,
+  metricsSender: MetricsSender)(
+  implicit miroTransformableStore: ObjectStore[MiroTransformable],
+  calmTransformableStore: ObjectStore[CalmTransformable],
+  sierraTransformableStore: ObjectStore[SierraTransformable],
+  ec: ExecutionContext
+) extends Logging {
 
   def receiveMessage(message: NotificationMessage): Future[Unit] = {
     debug(s"Starting to process message $message")
 
     val futurePublishAttempt = for {
       hybridRecord <- Future.fromTry(fromJson[HybridRecord](message.Message))
-      sourceMetadata <- Future.fromTry(fromJson[SourceMetadata](message.Message))
+      sourceMetadata <- Future.fromTry(
+        fromJson[SourceMetadata](message.Message))
       transformableRecord <- getTransformable(hybridRecord, sourceMetadata)
       cleanRecord <- Future.fromTry(
         transformTransformable(transformableRecord, hybridRecord.version))
@@ -62,9 +63,9 @@ class NotificationMessageReceiver @Inject()(
   }
 
   private def getTransformable(
-                                hybridRecord: HybridRecord,
-                                sourceMetadata: SourceMetadata
-                              ) = {
+    hybridRecord: HybridRecord,
+    sourceMetadata: SourceMetadata
+  ) = {
     val s3ObjectLocation = ObjectLocation(
       namespace = s3Config.bucketName,
       key = hybridRecord.s3key
@@ -78,9 +79,9 @@ class NotificationMessageReceiver @Inject()(
   }
 
   private def transformTransformable(
-                                      transformable: Transformable,
-                                      version: Int
-                                    ): Try[Option[UnidentifiedWork]] = {
+    transformable: Transformable,
+    version: Int
+  ): Try[Option[UnidentifiedWork]] = {
     val transformableTransformer = chooseTransformer(transformable)
     transformableTransformer.transform(transformable, version) map {
       transformed =>
@@ -102,7 +103,7 @@ class NotificationMessageReceiver @Inject()(
   }
 
   private def publishMessage(
-                              maybeWork: Option[UnidentifiedWork]): Future[Unit] =
+    maybeWork: Option[UnidentifiedWork]): Future[Unit] =
     maybeWork.fold(Future.successful(())) { work =>
       messageWriter.write(
         work,

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
@@ -247,21 +247,9 @@ class GoobiReaderWorkerServiceTest
     assertQueueHasSize(dlq, 1)
   }
 
-  private def assertFailureMetricNotIncremented(
-    mockMetricsSender: MetricsSender) = {
-    verify(mockMetricsSender, never())
-      .incrementCount(endsWith("_MessageProcessingFailure"), anyDouble())
-  }
-
   private def assertUpdateNotSaved(bucket: Bucket, table: Table) = {
     assertDynamoTableIsEmpty(table)
     assertS3StorageIsEmpty(bucket)
-  }
-
-  private def assertFailureMetricIncremented(
-    mockMetricsSender: MetricsSender) = {
-    verify(mockMetricsSender, times(3))
-      .incrementCount(endsWith("_MessageProcessingFailure"), anyDouble())
   }
 
   private def assertDynamoTableIsEmpty(table: Table) = {

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
@@ -7,8 +7,8 @@ import java.time.temporal.ChronoUnit
 import akka.actor.ActorSystem
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
 import com.gu.scanamo.Scanamo
-import org.mockito.Matchers.{any, anyDouble, endsWith}
-import org.mockito.Mockito.{never, times, verify, when}
+import org.mockito.Matchers.any
+import org.mockito.Mockito.when
 import org.scalatest.FunSpec
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
@@ -39,9 +39,9 @@ class SQSStream[T] @Inject()(actorSystem: ActorSystem,
       .mapAsyncUnordered(parallelism = sqsConfig.parallelism) { message =>
         debug(s"Processing message ${message.getMessageId}")
         val metricName = s"${streamName}_ProcessMessage"
-        metricsSender.timeAndCount(
-          metricName,
-          () => readAndProcess(streamName, message, process))
+        val op = readAndProcess(streamName, message, process)
+
+        metricsSender.count(metricName, op)
       }
       .map { m =>
         debug(s"Deleting message ${m.getMessageId}")

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
@@ -67,10 +67,6 @@ class SQSStream[T] @Inject()(actorSystem: ActorSystem,
         logger.error(
           s"Unrecognised failure while processing message ${message.getMessageId}",
           exception)
-        metricsSender.incrementCount(
-          metricName = s"${streamName}_MessageProcessingFailure",
-          count = 1.0
-        )
     }
     processMessageFuture
   }

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
@@ -93,7 +93,7 @@ class MessageStreamTest
         eventually {
 
           verify(metricsSender, never())
-            .incrementCount(endsWith("_MessageProcessingFailure"), anyDouble())
+            .incrementCount(endsWith("_processMessage_failure"), anyDouble())
           received shouldBe empty
 
           assertQueueEmpty(queue)
@@ -137,7 +137,7 @@ class MessageStreamTest
 
         eventually {
           verify(metricsSender, times(3)).incrementCount(
-            metricName = "test-stream_MessageProcessingFailure",
+            metricName = "test-stream_processMessage_failure",
             count = 1.0)
 
           received shouldBe empty

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
@@ -18,7 +18,7 @@ import uk.ac.wellcome.utils.JsonUtil._
 import scala.concurrent.Future
 
 class MessageStreamTest
-  extends FunSpec
+    extends FunSpec
     with Matchers
     with Messaging
     with Akka
@@ -70,9 +70,8 @@ class MessageStreamTest
           process = process(received))
 
         eventually {
-          verify(metricsSender, times(1)).count(
-            equalTo("test-stream_ProcessMessage"),
-            any[Future[Unit]]())
+          verify(metricsSender, times(1))
+            .count(equalTo("test-stream_ProcessMessage"), any[Future[Unit]]())
         }
     }
   }

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
@@ -136,8 +136,8 @@ class MessageStreamTest
           process = process(received))
 
         eventually {
-          verify(metricsSender, times(3)).incrementCount(
-            metricName = "test-stream_ProcessMessage_failure")
+          verify(metricsSender, times(3))
+            .incrementCount(metricName = "test-stream_ProcessMessage_failure")
 
           received shouldBe empty
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
@@ -18,7 +18,7 @@ import uk.ac.wellcome.utils.JsonUtil._
 import scala.concurrent.Future
 
 class MessageStreamTest
-    extends FunSpec
+  extends FunSpec
     with Matchers
     with Messaging
     with Akka
@@ -70,9 +70,9 @@ class MessageStreamTest
           process = process(received))
 
         eventually {
-          verify(metricsSender, times(1)).timeAndCount(
+          verify(metricsSender, times(1)).count(
             equalTo("test-stream_ProcessMessage"),
-            any[() => Future[Unit]]())
+            any[Future[Unit]]())
         }
     }
   }

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
@@ -71,7 +71,7 @@ class MessageStreamTest
 
         eventually {
           verify(metricsSender, times(1))
-            .count(equalTo("test-stream_processMessage"), any[Future[Unit]]())
+            .count(equalTo("test-stream_ProcessMessage"), any[Future[Unit]]())
         }
     }
   }
@@ -93,7 +93,7 @@ class MessageStreamTest
         eventually {
 
           verify(metricsSender, never())
-            .incrementCount(endsWith("_processMessage_failure"))
+            .incrementCount(endsWith("_ProcessMessage_failure"))
           received shouldBe empty
 
           assertQueueEmpty(queue)
@@ -137,7 +137,7 @@ class MessageStreamTest
 
         eventually {
           verify(metricsSender, times(3)).incrementCount(
-            metricName = "test-stream_processMessage_failure")
+            metricName = "test-stream_ProcessMessage_failure")
 
           received shouldBe empty
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.messaging.message
 
 import java.util.concurrent.ConcurrentLinkedQueue
 
-import org.mockito.Matchers.{any, anyDouble, endsWith, eq => equalTo}
+import org.mockito.Matchers.{any, endsWith, eq => equalTo}
 import org.mockito.Mockito.{never, times, verify}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
@@ -71,7 +71,7 @@ class MessageStreamTest
 
         eventually {
           verify(metricsSender, times(1))
-            .count(equalTo("test-stream_ProcessMessage"), any[Future[Unit]]())
+            .count(equalTo("test-stream_processMessage"), any[Future[Unit]]())
         }
     }
   }
@@ -93,7 +93,7 @@ class MessageStreamTest
         eventually {
 
           verify(metricsSender, never())
-            .incrementCount(endsWith("_processMessage_failure"), anyDouble())
+            .incrementCount(endsWith("_processMessage_failure"))
           received shouldBe empty
 
           assertQueueEmpty(queue)
@@ -137,8 +137,7 @@ class MessageStreamTest
 
         eventually {
           verify(metricsSender, times(3)).incrementCount(
-            metricName = "test-stream_processMessage_failure",
-            count = 1.0)
+            metricName = "test-stream_processMessage_failure")
 
           received shouldBe empty
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.messaging.sqs
 
 import java.util.concurrent.ConcurrentLinkedQueue
 
-import org.mockito.Matchers.{any, anyDouble, endsWith, eq => equalTo}
+import org.mockito.Matchers.{any, endsWith, eq => equalTo}
 import org.mockito.Mockito.{never, times, verify}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
@@ -91,7 +91,7 @@ class SQSStreamTest
 
         eventually {
           verify(metricsSender, never())
-            .incrementCount(endsWith("_failure"), anyDouble())
+            .incrementCount(endsWith("_failure"))
           received shouldBe empty
 
           assertQueueEmpty(queue)

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
@@ -69,9 +69,9 @@ class SQSStreamTest
           process = process(received))
 
         eventually {
-          verify(metricsSender, times(1)).timeAndCount(
+          verify(metricsSender, times(1)).count(
             equalTo("test-stream_ProcessMessage"),
-            any[() => Future[Unit]]())
+            any[Future[Unit]]())
         }
     }
   }

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
@@ -69,9 +69,8 @@ class SQSStreamTest
           process = process(received))
 
         eventually {
-          verify(metricsSender, times(1)).count(
-            equalTo("test-stream_ProcessMessage"),
-            any[Future[Unit]]())
+          verify(metricsSender, times(1))
+            .count(equalTo("test-stream_ProcessMessage"), any[Future[Unit]]())
         }
     }
   }

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
@@ -90,9 +90,8 @@ class SQSStreamTest
           process = process(received))
 
         eventually {
-
           verify(metricsSender, never())
-            .incrementCount(endsWith("_MessageProcessingFailure"), anyDouble())
+            .incrementCount(endsWith("_failure"), anyDouble())
           received shouldBe empty
 
           assertQueueEmpty(queue)

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSToDynamoStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSToDynamoStreamTest.scala
@@ -33,6 +33,8 @@ class SQSToDynamoStreamTest
     toJson(TestNotificationMessage(obj)).get
 
   private val streamName = "test-sqs-to-dynamo"
+  private val failureMetricName = s"${streamName}_ProcessMessage_failure"
+
   it("processes messages") {
     withFixtures {
       case (mockMetricSender, QueuePair(queue, dlq), stream) =>
@@ -43,7 +45,7 @@ class SQSToDynamoStreamTest
         eventually {
           messages should contain only testObject
           verify(mockMetricSender, never())
-            .incrementCount(s"${streamName}_MessageProcessingFailure", 1.0)
+            .incrementCount(failureMetricName, 1.0)
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
         }
@@ -68,7 +70,7 @@ class SQSToDynamoStreamTest
 
         eventually {
           verify(mockMetricSender, never())
-            .incrementCount(s"${streamName}_MessageProcessingFailure", 1.0)
+            .incrementCount(failureMetricName, 1.0)
           assertQueueEmpty(queue)
           assertQueueHasSize(dlq, size = 1)
         }
@@ -86,7 +88,7 @@ class SQSToDynamoStreamTest
 
           eventually {
             verify(mockMetricSender, never())
-              .incrementCount(s"${streamName}_MessageProcessingFailure", 1.0)
+              .incrementCount(failureMetricName, 1.0)
             assertQueueEmpty(queue)
             assertQueueHasSize(dlq, size = 1)
           }
@@ -106,7 +108,7 @@ class SQSToDynamoStreamTest
 
           eventually {
             verify(mockMetricSender, times(3))
-              .incrementCount(s"${streamName}_MessageProcessingFailure", 1.0)
+              .incrementCount(failureMetricName, 1.0)
             assertQueueEmpty(queue)
             assertQueueHasSize(dlq, size = 1)
           }

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSToDynamoStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSToDynamoStreamTest.scala
@@ -45,7 +45,7 @@ class SQSToDynamoStreamTest
         eventually {
           messages should contain only testObject
           verify(mockMetricSender, never())
-            .incrementCount(failureMetricName, 1.0)
+            .incrementCount(failureMetricName)
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
         }
@@ -70,7 +70,7 @@ class SQSToDynamoStreamTest
 
         eventually {
           verify(mockMetricSender, never())
-            .incrementCount(failureMetricName, 1.0)
+            .incrementCount(failureMetricName)
           assertQueueEmpty(queue)
           assertQueueHasSize(dlq, size = 1)
         }
@@ -88,7 +88,7 @@ class SQSToDynamoStreamTest
 
           eventually {
             verify(mockMetricSender, never())
-              .incrementCount(failureMetricName, 1.0)
+              .incrementCount(failureMetricName)
             assertQueueEmpty(queue)
             assertQueueHasSize(dlq, size = 1)
           }
@@ -108,7 +108,7 @@ class SQSToDynamoStreamTest
 
           eventually {
             verify(mockMetricSender, times(3))
-              .incrementCount(failureMetricName, 1.0)
+              .incrementCount(failureMetricName)
             assertQueueEmpty(queue)
             assertQueueHasSize(dlq, size = 1)
           }

--- a/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
+++ b/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
@@ -2,21 +2,16 @@ package uk.ac.wellcome.monitoring
 
 import java.util.Date
 
+import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source, SourceQueueWithComplete}
-import akka.stream.{
-  ActorMaterializer,
-  OverflowStrategy,
-  QueueOfferResult,
-  ThrottleMode
-}
+import akka.stream.{ActorMaterializer, OverflowStrategy, QueueOfferResult, ThrottleMode}
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model._
 import com.google.inject.Inject
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.monitoring.GlobalExecutionContext.context
 
-import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
@@ -24,7 +19,8 @@ import scala.util.{Failure, Success}
 class MetricsSender @Inject()(amazonCloudWatch: AmazonCloudWatch,
                               actorSystem: ActorSystem,
                               metricsConfig: MetricsConfig)
-    extends Logging {
+  extends Logging {
+
   implicit val system = actorSystem
   implicit val materialiser = ActorMaterializer()
 
@@ -34,90 +30,55 @@ class MetricsSender @Inject()(amazonCloudWatch: AmazonCloudWatch,
   private val metricDataListMaxSize = 20
   private val maxPutMetricDataRequestsPerSecond = 150
 
+  val sink: Sink[Seq[MetricDatum], Future[Done]] = Sink.foreach(
+    metricDataSeq =>
+      amazonCloudWatch.putMetricData(
+        new PutMetricDataRequest()
+          .withNamespace(metricsConfig.namespace)
+          .withMetricData(metricDataSeq: _*)
+      ))
+
+  val source: Source[MetricDatum, SourceQueueWithComplete[MetricDatum]] = Source
+    .queue[MetricDatum](5000, OverflowStrategy.backpressure)
+
+  val materializer = Flow[MetricDatum].groupedWithin(
+    metricDataListMaxSize,
+    metricsConfig.flushInterval)
+
   val sourceQueue: SourceQueueWithComplete[MetricDatum] =
-    Source
-      .queue[MetricDatum](5000, OverflowStrategy.backpressure)
-      // Group the MetricDatum objects into lists of at max 20 items.
-      // Send smaller chunks if not appearing within 10 seconds
-      .viaMat(
-        Flow[MetricDatum].groupedWithin(
-          metricDataListMaxSize,
-          metricsConfig.flushInterval))(Keep.left)
+    source
+      .viaMat(materializer)(Keep.left)
       // Make sure we don't exceed aws rate limit
-      .throttle(
-        maxPutMetricDataRequestsPerSecond,
-        1 second,
-        0,
-        ThrottleMode.shaping)
-      .to(
-        Sink.foreach(
-          metricDataSeq =>
-            amazonCloudWatch.putMetricData(
-              new PutMetricDataRequest()
-                .withNamespace(metricsConfig.namespace)
-                .withMetricData(metricDataSeq: _*)
-          )))
+      .throttle(maxPutMetricDataRequestsPerSecond, 1 second, 0, ThrottleMode.shaping)
+      .to(sink)
       .run()
 
-  def timeAndCount[T](metricName: String, fun: () => Future[T]): Future[T] = {
-    val start = new Date()
-    val future = Future.successful(()).flatMap(_ => fun())
+  def count[T](metricName: String, f: Future[T]): Future[T] = {
 
-    future.onComplete {
-      case Success(_) =>
-        val end = new Date()
-        incrementCount("success")
-        sendTime(
-          metricName,
-          (end.getTime - start.getTime) milliseconds,
-          Map("success" -> "true"))
-
-      case Failure(_) =>
-        val end = new Date()
-        incrementCount("failure")
-        sendTime(
-          metricName,
-          (end.getTime - start.getTime) milliseconds,
-          Map("success" -> "false"))
-
+    f.onComplete {
+      case Success(_) => incrementCount("success")
+      case Failure(_) => incrementCount("failure")
     }
 
-    future
+    f
   }
 
-  def incrementCount(metricName: String,
-                     count: Double = 1.0): Future[QueueOfferResult] = {
+  def incrementCount(
+    metricName: String,
+    count: Double = 1.0
+  ): Future[QueueOfferResult] = {
 
     val metricDatum = new MetricDatum()
       .withMetricName(metricName)
       .withValue(count)
       .withUnit(StandardUnit.Count)
       .withTimestamp(new Date())
-    sendToStream(metricDatum)
-  }
 
-  def sendTime(
-    metricName: String,
-    time: Duration,
-    dimensions: Map[String, String] = Map()): Future[QueueOfferResult] = {
-
-    val metricDatum = new MetricDatum()
-      .withMetricName(metricName)
-      .withDimensions(
-        dimensions.seq
-          .foldLeft(Nil: List[Dimension])((acc, pair) => {
-            val dimension =
-              new Dimension().withName(pair._1).withValue(pair._2)
-            dimension :: acc
-          })
-          .asJava)
-      .withValue(time.toMillis.toDouble)
-      .withUnit(StandardUnit.Milliseconds)
-      .withTimestamp(new Date())
     sendToStream(metricDatum)
   }
 
   private def sendToStream(
-    metricDatum: MetricDatum): Future[QueueOfferResult] =
+    metricDatum: MetricDatum
+  ): Future[QueueOfferResult] =
     sourceQueue.offer(metricDatum)
 }

--- a/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
+++ b/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
@@ -5,7 +5,12 @@ import java.util.Date
 import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source, SourceQueueWithComplete}
-import akka.stream.{ActorMaterializer, OverflowStrategy, QueueOfferResult, ThrottleMode}
+import akka.stream.{
+  ActorMaterializer,
+  OverflowStrategy,
+  QueueOfferResult,
+  ThrottleMode
+}
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model._
 import com.google.inject.Inject
@@ -61,7 +66,8 @@ class MetricsSender @Inject()(amazonCloudWatch: AmazonCloudWatch,
   def count[T](metricName: String, f: Future[T]): Future[T] = {
     f.onComplete {
       case Success(_) => incrementCount(s"${metricName}_success")
-      case Failure(_: GracefulFailureException) => incrementCount(s"${metricName}_gracefulFailure")
+      case Failure(_: GracefulFailureException) =>
+        incrementCount(s"${metricName}_gracefulFailure")
       case Failure(_) => incrementCount(s"${metricName}_failure")
     }
     f

--- a/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
+++ b/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
@@ -72,7 +72,7 @@ class MetricsSender @Inject()(amazonCloudWatch: AmazonCloudWatch,
     f
   }
 
-  def incrementCount(
+  private def incrementCount(
     metricName: String,
     count: Double = 1.0
   ): Future[QueueOfferResult] = {

--- a/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
+++ b/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
@@ -67,14 +67,10 @@ class MetricsSender @Inject()(amazonCloudWatch: AmazonCloudWatch,
     f
   }
 
-  def incrementCount(
-    metricName: String,
-    count: Double = 1.0
-  ): Future[QueueOfferResult] = {
-
+  def incrementCount(metricName: String): Future[QueueOfferResult] = {
     val metricDatum = new MetricDatum()
       .withMetricName(metricName)
-      .withValue(count)
+      .withValue(1.0)
       .withUnit(StandardUnit.Count)
       .withTimestamp(new Date())
 

--- a/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
+++ b/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
@@ -5,16 +5,12 @@ import java.util.Date
 import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source, SourceQueueWithComplete}
-import akka.stream.{
-  ActorMaterializer,
-  OverflowStrategy,
-  QueueOfferResult,
-  ThrottleMode
-}
+import akka.stream.{ActorMaterializer, OverflowStrategy, QueueOfferResult, ThrottleMode}
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model._
 import com.google.inject.Inject
 import grizzled.slf4j.Logging
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.monitoring.GlobalExecutionContext.context
 
 import scala.concurrent.Future
@@ -63,16 +59,15 @@ class MetricsSender @Inject()(amazonCloudWatch: AmazonCloudWatch,
       .run()
 
   def count[T](metricName: String, f: Future[T]): Future[T] = {
-
     f.onComplete {
-      case Success(_) => incrementCount("success")
-      case Failure(_) => incrementCount("failure")
+      case Success(_) => incrementCount(s"${metricName}_success")
+      case Failure(_: GracefulFailureException) => incrementCount(s"${metricName}_gracefulFailure")
+      case Failure(_) => incrementCount(s"${metricName}_failure")
     }
-
     f
   }
 
-  private def incrementCount(
+  def incrementCount(
     metricName: String,
     count: Double = 1.0
   ): Future[QueueOfferResult] = {

--- a/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/MetricsSenderTest.scala
+++ b/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/MetricsSenderTest.scala
@@ -19,7 +19,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{Future, Promise}
 
 class MetricsSenderTest
-    extends FunSpec
+  extends FunSpec
     with MockitoSugar
     with Matchers
     with ScalaFutures
@@ -29,8 +29,8 @@ class MetricsSenderTest
 
   import org.mockito.Mockito._
 
-  describe("timeAndCount") {
-    it("records the time and count of a successful future") {
+  describe("count") {
+    it("counts a successful future") {
       withActorSystem { actorSystem =>
         val amazonCloudWatch = mock[AmazonCloudWatch]
         val metricsConfig = MetricsConfig(
@@ -45,12 +45,14 @@ class MetricsSenderTest
         val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
         val expectedResult = "foo"
-        val timedFunction = Future { Thread.sleep(100); expectedResult }
+        val f = Future {
+          expectedResult
+        }
         val metricName = "bar"
 
-        val future = metricsSender.count(metricName, timedFunction)
+        metricsSender.count(metricName, f)
 
-        whenReady(future) { result =>
+        whenReady(f) { result =>
           result shouldBe expectedResult
           eventually {
 
@@ -58,20 +60,16 @@ class MetricsSenderTest
 
             val putMetricDataRequest = capture.getValue
             val metricData = putMetricDataRequest.getMetricData
-            metricData should have size 2
+            metricData should have size 1
             metricData.asScala.exists { metricDatum =>
               (metricDatum.getValue == 1.0) && metricDatum.getMetricName == "success"
-            } shouldBe true
-
-            metricData.asScala.exists { metricDatum =>
-              (metricDatum.getValue >= 100) && (metricDatum.getMetricName == "bar")
             } shouldBe true
           }
         }
       }
     }
 
-    it("records the time and count of a failed future") {
+    it("counts a failed future") {
       withActorSystem { actorSystem =>
         val amazonCloudWatch = mock[AmazonCloudWatch]
         val metricsConfig = MetricsConfig(
@@ -85,25 +83,23 @@ class MetricsSenderTest
         )
         val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
-        val timedFunction = Future { throw new RuntimeException() }
+        val f = Future {
+          throw new RuntimeException()
+        }
         val metricName = "bar"
 
-        val future = metricsSender.count(metricName, timedFunction)
+        metricsSender.count(metricName, f)
 
-        whenReady(future.failed) { _ =>
+        whenReady(f.failed) { _ =>
           eventually {
             verify(amazonCloudWatch, times(1)).putMetricData(capture.capture())
 
             val putMetricDataRequest = capture.getValue
             val metricData = putMetricDataRequest.getMetricData
-            metricData should have size 2
+            metricData should have size 1
 
             metricData.asScala.exists { metricDatum =>
               (metricDatum.getValue == 1.0) && metricDatum.getMetricName == "failure"
-            } shouldBe true
-
-            metricData.asScala.exists { metricDatum =>
-              metricDatum.getMetricName == "bar"
             } shouldBe true
           }
         }
@@ -122,13 +118,14 @@ class MetricsSenderTest
           actorSystem = actorSystem,
           metricsConfig = metricsConfig
         )
+
         val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
-        val emptyFunction = Future.successful(())
+        val f = Future.successful(())
         val metricName = "bar"
 
-        val futures = (1 to 15).map(i =>
-          metricsSender.count(s"${i}_$metricName", emptyFunction))
+        val futures = (1 to 40).map(i =>
+          metricsSender.count(s"$metricName", f))
 
         whenReady(Future.sequence(futures)) { _ =>
           eventually {
@@ -138,7 +135,7 @@ class MetricsSenderTest
             putMetricDataRequests should have size 2
 
             putMetricDataRequests.asScala.head.getMetricData should have size 20
-            putMetricDataRequests.asScala.tail.head.getMetricData should have size 10
+            putMetricDataRequests.asScala.tail.head.getMetricData should have size 20
           }
         }
       }
@@ -158,12 +155,15 @@ class MetricsSenderTest
         )
         val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
 
+        val f = Future.successful(())
+        val metricName = "bar"
+
         val expectedDuration = (1 second).toMillis
         val startTime = Instant.now
 
         // Each PutMetricRequest is made of 20 MetricDatum so we need
         // 20 * 150 = 3000 calls to incrementCount to get 150 PutMetricData calls
-        val futures = (1 to 3000).map(i => metricsSender.incrementCount("bar"))
+        val futures = (1 to 3000).map(i => metricsSender.count(s"${i}_$metricName", f))
 
         val promisedInstant = Promise[Instant]
 
@@ -183,35 +183,6 @@ class MetricsSenderTest
         whenReady(promisedInstant.future) { endTime =>
           val gap: Long = ChronoUnit.MILLIS.between(startTime, endTime)
           gap shouldBe >(expectedDuration)
-        }
-      }
-    }
-  }
-
-  describe("incrementCount") {
-    it("calls putMetricData with the correct value") {
-      withActorSystem { actorSystem =>
-        val amazonCloudWatch = mock[AmazonCloudWatch]
-        val metricsConfig = MetricsConfig(
-          namespace = "test",
-          flushInterval = 100 milliseconds
-        )
-        val metricsSender = new MetricsSender(
-          amazonCloudWatch = amazonCloudWatch,
-          actorSystem = actorSystem,
-          metricsConfig = metricsConfig
-        )
-        val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
-
-        val expectedValue = 3.0F
-
-        val metricFuture = metricsSender.incrementCount("foo", expectedValue)
-
-        whenReady(metricFuture) { _ =>
-          eventually {
-            verify(amazonCloudWatch).putMetricData(capture.capture())
-            capture.getValue.getMetricData.asScala.head.getValue shouldBe expectedValue
-          }
         }
       }
     }

--- a/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/MetricsSenderTest.scala
+++ b/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/MetricsSenderTest.scala
@@ -62,7 +62,7 @@ class MetricsSenderTest
             val metricData = putMetricDataRequest.getMetricData
             metricData should have size 1
             metricData.asScala.exists { metricDatum =>
-              (metricDatum.getValue == 1.0) && metricDatum.getMetricName == "success"
+              (metricDatum.getValue == 1.0) && metricDatum.getMetricName == s"${metricName}_success"
             } shouldBe true
           }
         }
@@ -99,7 +99,7 @@ class MetricsSenderTest
             metricData should have size 1
 
             metricData.asScala.exists { metricDatum =>
-              (metricDatum.getValue == 1.0) && metricDatum.getMetricName == "failure"
+              (metricDatum.getValue == 1.0) && metricDatum.getMetricName == s"${metricName}_failure"
             } shouldBe true
           }
         }

--- a/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/MetricsSenderTest.scala
+++ b/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/MetricsSenderTest.scala
@@ -19,7 +19,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{Future, Promise}
 
 class MetricsSenderTest
-  extends FunSpec
+    extends FunSpec
     with MockitoSugar
     with Matchers
     with ScalaFutures
@@ -124,8 +124,8 @@ class MetricsSenderTest
         val f = Future.successful(())
         val metricName = "bar"
 
-        val futures = (1 to 40).map(i =>
-          metricsSender.count(s"$metricName", f))
+        val futures =
+          (1 to 40).map(i => metricsSender.count(s"$metricName", f))
 
         whenReady(Future.sequence(futures)) { _ =>
           eventually {
@@ -163,7 +163,8 @@ class MetricsSenderTest
 
         // Each PutMetricRequest is made of 20 MetricDatum so we need
         // 20 * 150 = 3000 calls to incrementCount to get 150 PutMetricData calls
-        val futures = (1 to 3000).map(i => metricsSender.count(s"${i}_$metricName", f))
+        val futures =
+          (1 to 3000).map(i => metricsSender.count(s"${i}_$metricName", f))
 
         val promisedInstant = Promise[Instant]
 

--- a/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/MetricsSenderFixture.scala
+++ b/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/MetricsSenderFixture.scala
@@ -51,11 +51,11 @@ trait MetricsSenderFixture
 
   def assertFailureMetricNotIncremented(mockMetricsSender: MetricsSender) = {
     verify(mockMetricsSender, never())
-      .incrementCount(endsWith("_processMessage_failure"))
+      .incrementCount(endsWith("_ProcessMessage_failure"))
   }
 
   def assertFailureMetricIncremented(mockMetricsSender: MetricsSender) = {
     verify(mockMetricsSender, times(3))
-      .incrementCount(endsWith("_processMessage_failure"))
+      .incrementCount(endsWith("_ProcessMessage_failure"))
   }
 }

--- a/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/MetricsSenderFixture.scala
+++ b/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/MetricsSenderFixture.scala
@@ -2,8 +2,8 @@ package uk.ac.wellcome.monitoring.test.fixtures
 
 import akka.actor.ActorSystem
 import grizzled.slf4j.Logging
-import org.mockito.Matchers.{any, anyString}
-import org.mockito.Mockito.when
+import org.mockito.Matchers.{any, anyDouble, anyString, endsWith}
+import org.mockito.Mockito.{never, times, verify, when}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.mockito.MockitoSugar
@@ -49,4 +49,13 @@ trait MetricsSenderFixture
     }
   )
 
+  def assertFailureMetricNotIncremented(mockMetricsSender: MetricsSender) = {
+    verify(mockMetricsSender, never())
+      .incrementCount(endsWith("_processMessage_failure"), anyDouble())
+  }
+
+  private def assertFailureMetricIncremented(mockMetricsSender: MetricsSender) = {
+    verify(mockMetricsSender, times(3))
+      .incrementCount(endsWith("_processMessage_failure"), anyDouble())
+  }
 }

--- a/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/MetricsSenderFixture.scala
+++ b/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/MetricsSenderFixture.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.monitoring.test.fixtures
 
 import akka.actor.ActorSystem
 import grizzled.slf4j.Logging
-import org.mockito.Matchers.{any, anyDouble, anyString, endsWith}
+import org.mockito.Matchers.{any, anyString, endsWith}
 import org.mockito.Mockito.{never, times, verify, when}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
@@ -51,11 +51,11 @@ trait MetricsSenderFixture
 
   def assertFailureMetricNotIncremented(mockMetricsSender: MetricsSender) = {
     verify(mockMetricsSender, never())
-      .incrementCount(endsWith("_processMessage_failure"), anyDouble())
+      .incrementCount(endsWith("_processMessage_failure"))
   }
 
-  private def assertFailureMetricIncremented(mockMetricsSender: MetricsSender) = {
+  def assertFailureMetricIncremented(mockMetricsSender: MetricsSender) = {
     verify(mockMetricsSender, times(3))
-      .incrementCount(endsWith("_processMessage_failure"), anyDouble())
+      .incrementCount(endsWith("_processMessage_failure"))
   }
 }

--- a/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/MetricsSenderFixture.scala
+++ b/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/MetricsSenderFixture.scala
@@ -35,9 +35,9 @@ trait MetricsSenderFixture
       val metricsSender = mock[MetricsSender]
 
       when(
-        metricsSender.timeAndCount(
+        metricsSender.count(
           anyString(),
-          any[() => Future[Unit]]()
+          any[Future[Unit]]()
         )
       ).thenAnswer(new Answer[Future[Unit]] {
         override def answer(invocation: InvocationOnMock): Future[Unit] = {

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -50,8 +50,7 @@ class SierraBibMergerWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueHasSize(dlq, 1)
           verify(metricsSender, never()).incrementCount(
-            "SierraBibMergerUpdaterService_processMessage_failure",
-            1.0)
+            "SierraBibMergerUpdaterService_processMessage_failure")
         }
     }
   }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -50,7 +50,7 @@ class SierraBibMergerWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueHasSize(dlq, 1)
           verify(metricsSender, never()).incrementCount(
-            "SierraBibMergerUpdaterService_processMessage_failure")
+            "SierraBibMergerUpdaterService_ProcessMessage_failure")
         }
     }
   }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -50,7 +50,7 @@ class SierraBibMergerWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueHasSize(dlq, 1)
           verify(metricsSender, never()).incrementCount(
-            "SierraBibMergerUpdaterService_MessageProcessingFailure",
+            "SierraBibMergerUpdaterService_processMessage_failure",
             1.0)
         }
     }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -169,8 +169,7 @@ class SierraItemsToDynamoWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueHasSize(dlq, 1)
           verify(metricsSender, never()).incrementCount(
-            "SierraItemsToDynamoWorkerService_ProcessMessage_failure",
-            1.0)
+            "SierraItemsToDynamoWorkerService_ProcessMessage_failure")
         }
     }
   }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -169,7 +169,7 @@ class SierraItemsToDynamoWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueHasSize(dlq, 1)
           verify(metricsSender, never()).incrementCount(
-            "SierraItemsToDynamoWorkerService_MessageProcessingFailure",
+            "SierraItemsToDynamoWorkerService_ProcessMessage_failure",
             1.0)
         }
     }


### PR DESCRIPTION
### What is this PR trying to achieve?

Reduce the use of CloudWatch metrics where they are not useful and achieve cost saving from this.

### Who is this change for?

🤑 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.