### PR TITLE
Fix the snapshot generator, alarm so we'll catch it next time

### DIFF
--- a/data_api/snapshot_generator/src/universal/conf/application.ini.template
+++ b/data_api/snapshot_generator/src/universal/conf/application.ini.template
@@ -3,7 +3,6 @@
 -aws.metrics.namespace=${metrics_namespace}
 -es.host=${es_host}
 -es.port=${es_port}
--es.name=${es_name}
 -es.index.v1=${es_index_v1}
 -es.index.v2=${es_index_v2}
 -es.type=${es_doc_type}

--- a/data_api/terraform/queues.tf
+++ b/data_api/terraform/queues.tf
@@ -8,3 +8,24 @@ module "snapshot_generator_queue" {
   alarm_topic_arn            = "${local.dlq_alarm_arn}"
   visibility_timeout_seconds = 1800
 }
+
+# We'll get alarms from the snapshot generator DLQ, but it's also a problem
+# if the main queue starts backfilling -- it means snapshots aren't being
+# created correctly.
+#
+resource "aws_cloudwatch_metric_alarm" "snapshot_scheduler_queue_not_empty" {
+  alarm_name          = "snapshot_scheduler_queue_not_empty"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = 60
+  threshold           = 2
+  statistic           = "Average"
+
+  dimensions {
+    QueueName = "${aws_sqs_queue.snapshot_generator_queue.name}"
+  }
+
+  alarm_actions = ["${local.dlq_alarm_arn}"]
+}

--- a/data_api/terraform/service_snapshot_generator.tf
+++ b/data_api/terraform/service_snapshot_generator.tf
@@ -22,7 +22,6 @@ module "snapshot_generator" {
     topic_arn         = "${module.snapshot_generation_complete_topic.arn}"
     es_host           = "${data.template_file.es_cluster_host_snapshot.rendered}"
     es_port           = "${var.es_cluster_credentials["port"]}"
-    es_name           = "${var.es_cluster_credentials["name"]}"
     es_username       = "${var.es_cluster_credentials["username"]}"
     es_password       = "${var.es_cluster_credentials["password"]}"
     es_protocol       = "${var.es_cluster_credentials["protocol"]}"
@@ -32,7 +31,7 @@ module "snapshot_generator" {
     metrics_namespace = "snapshot_generator"
   }
 
-  env_vars_length = 12
+  env_vars_length = 11
 
   memory = 3072
   cpu    = 2048


### PR DESCRIPTION
It turns out the snapshot generator hasn't been running for at least five days – it’s got the `-es.name` flag defined in its application.ini, but we removed the code for consuming that a while back.

This patch removes it, and also adds an alarm that checks if the snapshot generator queue starts filling up. It only gets one message a day, so this is a useful check.