### PR TITLE
Reduce failures in the Miro transformer – explicitly handle "Do not use" and "Image withdrawn"

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
@@ -11,6 +11,7 @@ class MiroTransformableTransformer
     extends TransformableTransformer[MiroTransformable]
     with MiroContributors
     with MiroGenres
+    with MiroLicenses
     with MiroSubjects {
   // TODO this class is too big as the different test classes would suggest. Split it.
 
@@ -366,32 +367,4 @@ class MiroTransformableTransformer
 
     imageUriTemplate.format(iiifImageApiBaseUri, miroID)
   }
-
-  /** If the image has a non-empty image_use_restrictions field, choose which
-    *  license (if any) we're going to assign to the thumbnail for this work.
-    *
-    *  The mappings in this function are based on a document provided by
-    *  Christy Henshaw (MIRO drop-downs.docx).  There are still some gaps in
-    *  that, we'll have to come back and update this code later.
-    *
-    *  For now, this mapping only covers use restrictions seen in the
-    *  V collection.  We'll need to extend this for other licenses later.
-    *
-    *  TODO: Expand this mapping to cover all of MIRO.
-    *  TODO: Update these mappings based on the final version of Christy's
-    *        document.
-    */
-  private def chooseLicense(useRestrictions: String): License =
-    useRestrictions match {
-
-      // Certain strings map directly onto license types
-      case "CC-0" => License_CC0
-      case "CC-BY" => License_CCBY
-      case "CC-BY-NC" => License_CCBYNC
-      case "CC-BY-NC-ND" => License_CCBYNCND
-
-      // These mappings are defined in Christy's document
-      case "Academics" => License_CCBYNC
-    }
-
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
@@ -230,7 +230,7 @@ class MiroTransformableTransformer
     DigitalLocation(
       locationType = LocationType("thumbnail-image"),
       url = buildImageApiURL(miroId, "thumbnail"),
-      license = chooseLicense(miroData.useRestrictions.get)
+      license = chooseLicense(miroData.useRestrictions)
     )
   }
 
@@ -253,7 +253,7 @@ class MiroTransformableTransformer
             locationType = LocationType("iiif-image"),
             url = buildImageApiURL(miroId, "info"),
             credit = getCredit(miroData),
-            license = chooseLicense(miroData.useRestrictions.get)
+            license = chooseLicense(miroData.useRestrictions)
           )
         )
       ))

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
@@ -39,12 +39,14 @@ class MiroTransformableTransformer
             subjects = getSubjects(miroData),
             contributors = getContributors(miroData),
             genres = getGenres(miroData),
-            thumbnail = Some(getThumbnail(miroData, miroTransformable.sourceId)),
+            thumbnail =
+              Some(getThumbnail(miroData, miroTransformable.sourceId)),
             items = getItems(miroData, miroTransformable.sourceId)
           ))
       } catch {
         case e: ShouldNotTransformException => {
-          warn(s"Should not transform ${miroTransformable.sourceId}: ${e.getMessage}")
+          warn(
+            s"Should not transform ${miroTransformable.sourceId}: ${e.getMessage}")
           None
         }
       }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicenses.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicenses.scala
@@ -22,7 +22,9 @@ trait MiroLicenses {
     maybeUseRestrictions match {
 
       // These images need more data.
-      case None => throw new ShouldNotTransformException("No usage restriction specified!")
+      case None =>
+        throw new ShouldNotTransformException(
+          "No usage restriction specified!")
 
       case Some(useRestrictions) =>
         useRestrictions match {
@@ -40,8 +42,12 @@ trait MiroLicenses {
           // like Tandem Vault, but we have seen some of these strings in the
           // catalogue data -- for now, explicitly mark these as "do not transform"
           // so they don't end up on the DLQ.
-          case "Do not use" => throw new ShouldNotTransformException("Usage restriction is 'Do not use'")
-          case "Image withdrawn, see notes" => throw new ShouldNotTransformException("Usage restriction is 'Image withdrawn'")
+          case "Do not use" =>
+            throw new ShouldNotTransformException(
+              "Usage restriction is 'Do not use'")
+          case "Image withdrawn, see notes" =>
+            throw new ShouldNotTransformException(
+              "Usage restriction is 'Image withdrawn'")
         }
     }
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicenses.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicenses.scala
@@ -30,5 +30,12 @@ trait MiroLicenses {
       // These mappings are defined in Christy's document
       case "Academics" => License_CCBYNC
 
+      // These images should really be removed entirely and sent to something
+      // like Tandem Vault, but we have seen some of these strings in the
+      // catalogue data -- for now, explicitly mark these as "do not transform"
+      // so they don't end up on the DLQ.
+      case "Do not use" => throw new ShouldNotTransformException("Usage restriction is 'Do not use'")
+      case "Image withdrawn, see notes" => throw new ShouldNotTransformException("Usage restriction is 'Image withdrawn'")
+
     }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicenses.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicenses.scala
@@ -1,0 +1,34 @@
+package uk.ac.wellcome.platform.transformer.transformers.miro
+
+import uk.ac.wellcome.models.work.internal._
+
+trait MiroLicenses {
+
+  /** If the image has a non-empty image_use_restrictions field, choose which
+    *  license (if any) we're going to assign to the thumbnail for this work.
+    *
+    *  The mappings in this function are based on a document provided by
+    *  Christy Henshaw (MIRO drop-downs.docx).  There are still some gaps in
+    *  that, we'll have to come back and update this code later.
+    *
+    *  For now, this mapping only covers use restrictions seen in the
+    *  V collection.  We'll need to extend this for other licenses later.
+    *
+    *  TODO: Expand this mapping to cover all of MIRO.
+    *  TODO: Update these mappings based on the final version of Christy's
+    *        document.
+    */
+  def chooseLicense(useRestrictions: String): License =
+    useRestrictions match {
+
+      // Certain strings map directly onto license types
+      case "CC-0" => License_CC0
+      case "CC-BY" => License_CCBY
+      case "CC-BY-NC" => License_CCBYNC
+      case "CC-BY-NC-ND" => License_CCBYNCND
+
+      // These mappings are defined in Christy's document
+      case "Academics" => License_CCBYNC
+
+    }
+}

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicenses.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicenses.scala
@@ -18,24 +18,31 @@ trait MiroLicenses {
     *  TODO: Update these mappings based on the final version of Christy's
     *        document.
     */
-  def chooseLicense(useRestrictions: String): License =
-    useRestrictions match {
+  def chooseLicense(maybeUseRestrictions: Option[String]): License =
+    maybeUseRestrictions match {
 
-      // Certain strings map directly onto license types
-      case "CC-0" => License_CC0
-      case "CC-BY" => License_CCBY
-      case "CC-BY-NC" => License_CCBYNC
-      case "CC-BY-NC-ND" => License_CCBYNCND
+      // These images need more data.
+      case None => throw new ShouldNotTransformException("No usage restriction specified!")
 
-      // These mappings are defined in Christy's document
-      case "Academics" => License_CCBYNC
+      case Some(useRestrictions) =>
+        useRestrictions match {
 
-      // These images should really be removed entirely and sent to something
-      // like Tandem Vault, but we have seen some of these strings in the
-      // catalogue data -- for now, explicitly mark these as "do not transform"
-      // so they don't end up on the DLQ.
-      case "Do not use" => throw new ShouldNotTransformException("Usage restriction is 'Do not use'")
-      case "Image withdrawn, see notes" => throw new ShouldNotTransformException("Usage restriction is 'Image withdrawn'")
+          // Certain strings map directly onto license types
+          case "CC-0" => License_CC0
+          case "CC-BY" => License_CCBY
+          case "CC-BY-NC" => License_CCBYNC
+          case "CC-BY-NC-ND" => License_CCBYNCND
 
+          // These mappings are defined in Christy's document
+          case "Academics" => License_CCBYNC
+
+          // These images should really be removed entirely and sent to something
+          // like Tandem Vault, but we have seen some of these strings in the
+          // catalogue data -- for now, explicitly mark these as "do not transform"
+          // so they don't end up on the DLQ.
+          case "Do not use" => throw new ShouldNotTransformException("Usage restriction is 'Do not use'")
+          case "Image withdrawn, see notes" => throw new ShouldNotTransformException("Usage restriction is 'Image withdrawn'")
+        }
     }
+
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/ShouldNotTransformException.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/ShouldNotTransformException.scala
@@ -1,3 +1,4 @@
 package uk.ac.wellcome.platform.transformer.transformers.miro
 
-class ShouldNotTransformException(message: String) extends RuntimeException(message)
+class ShouldNotTransformException(message: String)
+    extends RuntimeException(message)

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/ShouldNotTransformException.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/ShouldNotTransformException.scala
@@ -1,0 +1,3 @@
+package uk.ac.wellcome.platform.transformer.transformers.miro
+
+class ShouldNotTransformException(message: String) extends RuntimeException(message)

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.transformer.transformers
 
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.transformable.MiroTransformable
 import uk.ac.wellcome.models.work.internal._
 
 class MiroTransformableTransformerTest
@@ -222,6 +223,21 @@ class MiroTransformableTransformerTest
     work.contributors shouldBe List(
       Contributor(agent = Unidentifiable(Agent("Gyokushō, a cät Ôwnêr")))
     )
+  }
+
+  it("returns None for Miro records with usage restrictions that mean we suppress the image") {
+    val miroTransformable = MiroTransformable(
+      sourceId = "P0000001",
+      MiroCollection = "TestCollection",
+      data = buildJSONForWork("""
+        "image_title": "Private pictures of perilous penguins",
+        "image_use_restrictions": "Do not use"
+      """)
+    )
+
+    val triedMaybeWork = transformer.transform(miroTransformable, version = 1)
+    triedMaybeWork.isSuccess shouldBe true
+    triedMaybeWork.get shouldBe None
   }
 
   private def transformRecordAndCheckSierraSystemNumber(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
@@ -225,11 +225,13 @@ class MiroTransformableTransformerTest
     )
   }
 
-  it("returns None for Miro records with usage restrictions that mean we suppress the image") {
+  it(
+    "returns None for Miro records with usage restrictions that mean we suppress the image") {
     val miroTransformable = MiroTransformable(
       sourceId = "P0000001",
       MiroCollection = "TestCollection",
-      data = buildJSONForWork("""
+      data = buildJSONForWork(
+        """
         "image_title": "Private pictures of perilous penguins",
         "image_use_restrictions": "Do not use"
       """)

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicensesTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicensesTest.scala
@@ -9,5 +9,17 @@ class MiroLicensesTest extends FunSpec with Matchers {
     transformer.chooseLicense(useRestrictions = "CC-0") shouldBe License_CC0
   }
 
+  it("rejects restrictions 'Do not use'") {
+    intercept[ShouldNotTransformException] {
+      transformer.chooseLicense(useRestrictions = "Do not use")
+    }
+  }
+
+  it("rejects restrictions 'Image withdrawn, see notes'") {
+    intercept[ShouldNotTransformException] {
+      transformer.chooseLicense(useRestrictions = "Image withdrawn, see notes")
+    }
+  }
+
   val transformer = new MiroLicenses {}
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicensesTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicensesTest.scala
@@ -6,18 +6,24 @@ import uk.ac.wellcome.models.work.internal.License_CC0
 class MiroLicensesTest extends FunSpec with Matchers {
 
   it("finds a recognised license") {
-    transformer.chooseLicense(useRestrictions = "CC-0") shouldBe License_CC0
+    transformer.chooseLicense(Some("CC-0")) shouldBe License_CC0
   }
 
   it("rejects restrictions 'Do not use'") {
     intercept[ShouldNotTransformException] {
-      transformer.chooseLicense(useRestrictions = "Do not use")
+      transformer.chooseLicense(Some("Do not use"))
     }
   }
 
   it("rejects restrictions 'Image withdrawn, see notes'") {
     intercept[ShouldNotTransformException] {
-      transformer.chooseLicense(useRestrictions = "Image withdrawn, see notes")
+      transformer.chooseLicense(Some("Image withdrawn, see notes"))
+    }
+  }
+
+  it("rejects the record if the usage restrictions are unspecified") {
+    intercept[ShouldNotTransformException] {
+      transformer.chooseLicense(None)
     }
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicensesTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicensesTest.scala
@@ -1,0 +1,13 @@
+package uk.ac.wellcome.platform.transformer.transformers.miro
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.internal.License_CC0
+
+class MiroLicensesTest extends FunSpec with Matchers {
+
+  it("finds a recognised license") {
+    transformer.chooseLicense(useRestrictions = "CC-0") shouldBe License_CC0
+  }
+
+  val transformer = new MiroLicenses {}
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

We have 38 records in Miro for which the image_use_restrictions field is either `Do not use` or `Image withdrawn, see notes`. Currently they end up on the DLQ every time, which makes the transformer DLQ unnecessarily noisy.

This patch modifies the transformer to explicitly drop them without sending to the DLQ.

### Who is this change for?

🗡 🏷 