### PR TITLE
Reduce failures in the Miro transformer – check for nulls in the image_keywords_unauth field

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/source/MiroTransformableData.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/source/MiroTransformableData.scala
@@ -19,7 +19,7 @@ case class MiroTransformableData(
   @JsonKey("image_cleared") cleared: Option[String],
   @JsonKey("image_copyright_cleared") copyrightCleared: Option[String],
   @JsonKey("image_keywords") keywords: Option[List[String]],
-  @JsonKey("image_keywords_unauth") keywordsUnauth: Option[List[String]],
+  @JsonKey("image_keywords_unauth") keywordsUnauth: Option[List[Option[String]]],
   @JsonKey("image_phys_format") physFormat: Option[String],
   @JsonKey("image_lc_genre") lcGenre: Option[String],
   @JsonKey("image_tech_file_size") techFileSize: Option[List[String]],

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroSubjects.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroSubjects.scala
@@ -20,6 +20,10 @@ trait MiroSubjects {
     val keywords: List[String] = miroData.keywords.getOrElse(List())
 
     val keywordsUnauth: List[String] =
+      miroData.keywordsUnauth match {
+        case Some(maybeKeywords) => maybeKeywords.flatten
+        case None => List()
+      }
       miroData.keywordsUnauth.getOrElse(List())
 
     (keywords ++ keywordsUnauth).map { keyword =>

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/source/MiroTransformableDataTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/source/MiroTransformableDataTest.scala
@@ -1,0 +1,49 @@
+package uk.ac.wellcome.platform.transformer.source
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.utils.JsonUtil._
+
+class MiroTransformableDataTest extends FunSpec with Matchers {
+
+  // This is a simplified example of a failure we saw in the pipeline.
+  // Examples: L0068740, V0014729.
+  it("parses a JSON string with nulls in the image_keywords_unauth field") {
+    val jsonString =
+      """
+        |{
+        |    "image_artwork_date": "1578",
+        |    "image_award": null,
+        |    "image_award_date": null,
+        |    "image_cleared": "Y",
+        |    "image_copyright_cleared": "Y",
+        |    "image_creator": null,
+        |    "image_credit_line": null,
+        |    "image_image_desc": "De morbis contagiosis libri septem / [Julien Le Paulmier].",
+        |    "image_image_desc_academic": null,
+        |    "image_innopac_id": "12062789",
+        |    "image_keywords": null,
+        |    "image_keywords_unauth": [
+        |        null
+        |    ],
+        |    "image_lc_genre": null,
+        |    "image_library_ref_department": [
+        |        "EPB"
+        |    ],
+        |    "image_library_ref_id": [
+        |        "4856/B/1"
+        |    ],
+        |    "image_phys_format": null,
+        |    "image_source_code": "WEL",
+        |    "image_supp_lettering": null,
+        |    "image_tech_file_size": [
+        |        "99854740"
+        |    ],
+        |    "image_title": "De morbis contagiosis libri septem",
+        |    "image_use_restrictions": "CC-BY"
+        |}
+        |
+      """.stripMargin
+
+    fromJson[MiroTransformableData](jsonString).isSuccess shouldBe true
+  }
+}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/source/MiroTransformableDataTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/source/MiroTransformableDataTest.scala
@@ -5,41 +5,13 @@ import uk.ac.wellcome.utils.JsonUtil._
 
 class MiroTransformableDataTest extends FunSpec with Matchers {
 
-  // This is a simplified example of a failure we saw in the pipeline.
+  // This is based on failures we've seen in the pipeline.
   // Examples: L0068740, V0014729.
   it("parses a JSON string with nulls in the image_keywords_unauth field") {
     val jsonString =
       """
         |{
-        |    "image_artwork_date": "1578",
-        |    "image_award": null,
-        |    "image_award_date": null,
-        |    "image_cleared": "Y",
-        |    "image_copyright_cleared": "Y",
-        |    "image_creator": null,
-        |    "image_credit_line": null,
-        |    "image_image_desc": "De morbis contagiosis libri septem / [Julien Le Paulmier].",
-        |    "image_image_desc_academic": null,
-        |    "image_innopac_id": "12062789",
-        |    "image_keywords": null,
-        |    "image_keywords_unauth": [
-        |        null
-        |    ],
-        |    "image_lc_genre": null,
-        |    "image_library_ref_department": [
-        |        "EPB"
-        |    ],
-        |    "image_library_ref_id": [
-        |        "4856/B/1"
-        |    ],
-        |    "image_phys_format": null,
-        |    "image_source_code": "WEL",
-        |    "image_supp_lettering": null,
-        |    "image_tech_file_size": [
-        |        "99854740"
-        |    ],
-        |    "image_title": "De morbis contagiosis libri septem",
-        |    "image_use_restrictions": "CC-BY"
+        |    "image_keywords_unauth": [null, null]
         |}
         |
       """.stripMargin


### PR DESCRIPTION
10 images are failing in the transformer because the field contains nulls, and we expect List[String]. This patch makes the transformer more resilient to these fields.