### PR TITLE
Switch the prod and staging APIs to expose the new location types

### DIFF
--- a/catalogue_api/terraform/variables.tf
+++ b/catalogue_api/terraform/variables.tf
@@ -26,6 +26,21 @@ variable "release_ids" {
   type        = "map"
 }
 
+variable "api_prod_host" {
+  description = "Hostname to use for the production API"
+  default     = "api.wellcomecollection.org"
+}
+
+variable "api_stage_host" {
+  description = "Hostname to use for the production API"
+  default     = "api-stage.wellcomecollection.org"
+}
+
+variable "es_cluster_credentials" {
+  description = "Credentials for the Elasticsearch cluster"
+  type        = "map"
+}
+
 # These variables will change fairly regularly, whenever we want to swap the
 # staging and production APIs.
 
@@ -52,24 +67,6 @@ variable "pinned_remus_api" {
 variable "pinned_remus_api_nginx" {
   description = "Which version of the nginx API image to pin remus to, if any"
   default     = ""
-}
-
-# These variables change less frequently -- the service blocks in services.tf
-# will choose which variable to use based on the value of `production_api`.
-
-variable "api_prod_host" {
-  description = "Hostname to use for the production API"
-  default     = "api.wellcomecollection.org"
-}
-
-variable "api_stage_host" {
-  description = "Hostname to use for the production API"
-  default     = "api-stage.wellcomecollection.org"
-}
-
-variable "es_cluster_credentials" {
-  description = "Credentials for the Elasticsearch cluster"
-  type        = "map"
 }
 
 variable "es_config_romulus" {

--- a/catalogue_api/terraform/variables.tf
+++ b/catalogue_api/terraform/variables.tf
@@ -46,27 +46,27 @@ variable "es_cluster_credentials" {
 
 variable "production_api" {
   description = "Which version of the API is production? (romulus | remus)"
-  default     = "romulus"
+  default     = "remus"
 }
 
 variable "pinned_romulus_api" {
   description = "Which version of the API image to pin romulus to, if any"
-  default     = "3709fe4bc8d54c07709f8b11e995f40ad6ca39f7"
+  default     = ""
 }
 
 variable "pinned_romulus_api_nginx" {
   description = "Which version of the nginx API image to pin romulus to, if any"
-  default     = "4d0b58c7cd5feefbe77637f7fcda0d93b645e11b"
+  default     = ""
 }
 
 variable "pinned_remus_api" {
   description = "Which version of the API image to pin remus to, if any"
-  default     = ""
+  default     = "58d71745bc3b50ef0bde45be7e27a63e1dee4b1a"
 }
 
 variable "pinned_remus_api_nginx" {
   description = "Which version of the nginx API image to pin remus to, if any"
-  default     = ""
+  default     = "4d0b58c7cd5feefbe77637f7fcda0d93b645e11b"
 }
 
 variable "es_config_romulus" {

--- a/catalogue_api/terraform/variables.tf
+++ b/catalogue_api/terraform/variables.tf
@@ -85,8 +85,8 @@ variable "es_config_remus" {
   type        = "map"
 
   default = {
-    index_v1 = "v1-20180530-new-identifier-schemes"
-    index_v2 = "v2-20180530-new-identifier-schemes"
+    index_v1 = "v1-2018-06-05-new-location-types"
+    index_v2 = "v2-2018-06-05-new-location-types"
     doc_type = "work"
   }
 }


### PR DESCRIPTION
This change is already applied, so I’m going to merge it almost immediately.