### PR TITLE
Move many logs from info to debug

### DIFF
--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -47,7 +47,7 @@ class MessageWriter[T] @Inject()(
       )
       pointer <- Future.fromTry(toJson(MessagePointer(location)))
       publishAttempt <- sns.writeMessage(pointer, subject)
-      _ = info(publishAttempt)
+      _ = debug(publishAttempt)
     } yield ()
 
   }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
@@ -21,7 +21,7 @@ class SNSWriter @Inject()(snsClient: AmazonSNS, snsConfig: SNSConfig)
           toPublishRequest(message = message, subject = subject))
       }
     }.map { publishResult =>
-      debug(
+        debug(
           s"Published message $message to ${snsConfig.topicArn} (${publishResult.getMessageId})")
         PublishAttempt(Right(publishResult.getMessageId))
       }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
@@ -21,7 +21,7 @@ class SNSWriter @Inject()(snsClient: AmazonSNS, snsConfig: SNSConfig)
           toPublishRequest(message = message, subject = subject))
       }
     }.map { publishResult =>
-        info(
+      debug(
           s"Published message $message to ${snsConfig.topicArn} (${publishResult.getMessageId})")
         PublishAttempt(Right(publishResult.getMessageId))
       }

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/VersionedDao.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/VersionedDao.scala
@@ -57,7 +57,7 @@ class VersionedDao @Inject()(
     updateExpressionGenerator: UpdateExpressionGenerator[T]
   ): Future[Unit] = Future {
     val id = idGetter.id(record)
-    info(s"Attempting to update Dynamo record: $id")
+    debug(s"Attempting to update Dynamo record: $id")
 
     updateBuilder(record).map { ops =>
       Scanamo.exec(dynamoDbClient)(ops) match {
@@ -69,7 +69,7 @@ class VersionedDao @Inject()(
           throw exception
         }
         case Right(_) => {
-          info(s"Successfully updated Dynamo record: $id")
+          debug(s"Successfully updated Dynamo record: $id")
         }
       }
     }
@@ -79,10 +79,10 @@ class VersionedDao @Inject()(
     implicit evidence: DynamoFormat[T]): Future[Option[T]] = Future {
     val table = Table[T](dynamoConfig.table)
 
-    info(s"Attempting to retrieve Dynamo record: $id")
+    debug(s"Attempting to retrieve Dynamo record: $id")
     Scanamo.exec(dynamoDbClient)(table.get('id -> id)) match {
       case Some(Right(record)) => {
-        info(s"Successfully retrieved Dynamo record: $id")
+        debug(s"Successfully retrieved Dynamo record: $id")
 
         Some(record)
       }
@@ -96,7 +96,7 @@ class VersionedDao @Inject()(
 
         throw exception
       case None => {
-        info(s"No Dynamo record found for id: $id")
+        debug(s"No Dynamo record found for id: $id")
 
         None
       }

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StorageBackend.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StorageBackend.scala
@@ -32,13 +32,13 @@ class S3StorageBackend @Inject()(s3Client: AmazonS3)(
 
     val generatedMetadata = generateMetadata(metadata)
 
-    info(s"Attempt: PUT object to s3://$bucketName/$key")
+    debug(s"Attempt: PUT object to s3://$bucketName/$key")
     val putObject = Future {
       s3Client.putObject(bucketName, key, input, generatedMetadata)
     }
 
     putObject.map { _ =>
-      info(s"Success: PUT object to s3://$bucketName/$key")
+      debug(s"Success: PUT object to s3://$bucketName/$key")
       ObjectLocation(bucketName, key)
     }
   }
@@ -47,7 +47,7 @@ class S3StorageBackend @Inject()(s3Client: AmazonS3)(
     val bucketName = location.namespace
     val key = location.key
 
-    info(s"Attempt: GET object from s3://$bucketName/$key")
+    debug(s"Attempt: GET object from s3://$bucketName/$key")
 
     val futureInputStream = Future {
       s3Client.getObject(bucketName, key).getObjectContent
@@ -55,7 +55,7 @@ class S3StorageBackend @Inject()(s3Client: AmazonS3)(
 
     futureInputStream.foreach {
       case _ =>
-        info(s"Success: GET object from s3://$bucketName/$key")
+        debug(s"Success: GET object from s3://$bucketName/$key")
     }
 
     futureInputStream


### PR DESCRIPTION
### What is this PR trying to achieve?

In order to reduce our CloudWatch bill, this change reduces the amount of logs sent at info level by making all [happy path](https://en.wikipedia.org/wiki/Happy_path) `info` logs `debug`.

The default log level for all our services is `info` so this change will drastically reduce the amount of logs sent.

Currently we send 14 logs per work indexed, the current size of the index is ~1M, so that's 14M messages sent! This change should result in a reduction of log events per reindex by approximately that amount.

**In the future I suggest that all "happy path" logs are by default `debug`and we simply turn up the log level of new apps until we are satisfied they are working as intended.**

### Who is this change for?

📖 🔥 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.