### PR TITLE
Set logging level via environment variable

### DIFF
--- a/catalogue_pipeline/ingestor/src/main/resources/logback.xml
+++ b/catalogue_pipeline/ingestor/src/main/resources/logback.xml
@@ -8,7 +8,7 @@
     </encoder>
   </appender>
 
-  <root level="info">
+  <root level="${log_level:-INFO}">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/catalogue_pipeline/matcher/src/main/resources/logback.xml
+++ b/catalogue_pipeline/matcher/src/main/resources/logback.xml
@@ -8,7 +8,7 @@
     </encoder>
   </appender>
 
-  <root level="info">
+  <root level="${log_level:-INFO}">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/catalogue_pipeline/terraform/service_matcher.tf
+++ b/catalogue_pipeline/terraform/service_matcher.tf
@@ -10,13 +10,14 @@ module "matcher" {
   env_vars = {
     queue_url         = "${module.matcher_queue.id}"
     vhs_bucket_name   = "${module.vhs_recorder.bucket_name}"
-    metrics_namespace = "matcher"
     topic_arn         = "${module.linked_works_topic.arn}"
     dynamo_table      = "${aws_dynamodb_table.matcher_graph_table.id}"
     dynamo_index      = "${var.matcher_table_index}"
+    metrics_namespace = "matcher"
+    log_level         = "DEBUG"
   }
 
-  env_vars_length = 6
+  env_vars_length = 7
 
   memory = 2048
   cpu    = 512


### PR DESCRIPTION
### What is this PR trying to achieve?

Increase the flexibility of changing log levels by allowing log levels to set by environment variable.

The log level can then be set by container env variables.

This change modifies the ingestor to use an env variable but default to `INFO` and also changes the matcher to use `DEBUG` log level set via terraform, (this is in order to test both the default and override cases in services we know will log at the appropriate levels).

### Who is this change for?

🔖 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`