### PR TITLE
[WIP] Workaround for a JSON decoding bug in the Miro transformer

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/source/MiroTransformableData.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/source/MiroTransformableData.scala
@@ -68,7 +68,7 @@ case object MiroTransformableData {
         "image_source_code":"GUS"
       """.trim
     )
-    
+
     val tryMiroTransformableData =
       createMiroTransformableData(tidiedData)
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/source/MiroTransformableData.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/source/MiroTransformableData.scala
@@ -54,8 +54,25 @@ case object MiroTransformableData {
   def create(data: String): MiroTransformableData = {
     val unescapedData = unescapeHtml(data)
 
+    // We have a very small number of records where the image_source_code
+    // field is a list, not a string.  They all contain the value
+    // ["GUS", "TO-DELETE"], which causes a JSON decoding error.  We could
+    // define a custom Circe decoder for this, but that's more complicated
+    // than it's worth!  A string substitution is a good enough workaround.
+    //
+    val tidiedData = unescapedData.replaceAllLiterally(
+      """
+        "image_source_code":["GUS","TO-DELETE"]
+      """.trim,
+      """
+        "image_source_code":"GUS"
+      """.trim
+    )
+
+    println(s"@@AWLC ||${tidiedData}||")
+
     val tryMiroTransformableData =
-      createMiroTransformableData(unescapedData)
+      createMiroTransformableData(tidiedData)
 
     val miroTransformableData: MiroTransformableData =
       tryMiroTransformableData match {

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/source/MiroTransformableData.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/source/MiroTransformableData.scala
@@ -68,9 +68,7 @@ case object MiroTransformableData {
         "image_source_code":"GUS"
       """.trim
     )
-
-    println(s"@@AWLC ||${tidiedData}||")
-
+    
     val tryMiroTransformableData =
       createMiroTransformableData(tidiedData)
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/source/MiroTransformableDataTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/source/MiroTransformableDataTest.scala
@@ -18,4 +18,32 @@ class MiroTransformableDataTest extends FunSpec with Matchers {
 
     fromJson[MiroTransformableData](jsonString).isSuccess shouldBe true
   }
+
+  // This is based on failures we've seen in the pipeline.
+  // Example: B0009887
+  it("parses a JSON string with a list in the image_source_code field") {
+    val jsonString =
+      """
+        |{
+        |   "image_source_code":["GUS","TO-DELETE"]
+        |}
+      """.stripMargin
+
+    val result = MiroTransformableData.create(jsonString)
+    result.sourceCode shouldBe Some("GUS")
+  }
+
+  // And since we're fudging with the image_source_code field, check
+  // the happy path still works as well.
+  it("parses a JSON string with a string in the image_source_code field") {
+    val jsonString =
+      """
+        |{
+        |   "image_source_code": "CGC"
+        |}
+      """.stripMargin
+
+    val result = MiroTransformableData.create(jsonString)
+    result.sourceCode shouldBe Some("CGC")
+  }
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

Nine records are falling out of the Miro transformer because we screwed up the XML-to-JSON conversion in a way that makes Circe miserable. Specifically, we have a mixture of:

    "image_source_code": "ABC"

and

    "image_source_code":["GUS","TO-DELETE"]

which appears in that exact form.

We need to address it (so we don't get stuff on the DLQs), but this may not be the final fix. I’ve emailed Christy to find out if we want to just drop these images entirely, or pass them through with GUS as the sole contributor.