### PR TITLE
Don't test changes to top-level scripts

### DIFF
--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -154,6 +154,16 @@ def does_file_affect_build_task(path, task):
     if path == 'run_autoformat.py' and task != 'travis-format':
         raise ExclusivelyAffectsAnotherTask('travis-format')
 
+    # We have a number of scripts that live in the top of a stack, which
+    # contain useful code for that stack, but which aren't part of another
+    # task.  They should be checked by travis-format, but that's it.
+    if (
+        path.endswith('.py') and
+        path.count(os.path.sep) == 1 and
+        task != 'travis-format'
+    ):
+        raise ExclusivelyAffectsAnotherTask('travis-format')
+
     # If we can't decide if a file affects a build job, we assume it's
     # significant and run the job just-in-case.
     raise UnrecognisedFile()

--- a/travistooling/tests/test_decisionmaker.py
+++ b/travistooling/tests/test_decisionmaker.py
@@ -103,6 +103,11 @@ from travistooling.decisions import (
     # Changes to the data_science/scripts folder only trigger the format tests
     ('data_science/scripts/foo.py', 'loris-test', IgnoredPath, False),
     ('data_science/scripts/bar.py', 'travis-format', CheckedByTravisFormat, True),
+
+    # Scripts that are one deep in a stack only trigger the format tests
+    ('reindexer/trigger_reindex.py', 'travis-format', CheckedByTravisFormat, True),
+    ('reindexer/trigger_reindex.py', 'post_to_slack-publish', ExclusivelyAffectsAnotherTask, False),
+    ('reindexer/trigger_reindex.py', 'ingestor-test', ExclusivelyAffectsAnotherTask, False),
 ])
 def test_does_file_affect_build_task(path, task, exc_class, is_significant):
     with pytest.raises(exc_class) as err:

--- a/travistooling/tests/test_git_utils.py
+++ b/travistooling/tests/test_git_utils.py
@@ -31,7 +31,7 @@ def test_known_change_diff():
         #
         # In that case, we check we're seeing the expected exit code,
         # but we don't need to run this branch in the tests.
-        assert err.value.code == 128
+        assert err.code == 128
 
     assert get_changed_paths('1228fc9^', '1228fc9') == set([
         'travistooling/decisionmaker.py',


### PR DESCRIPTION
e.g. the `reindexer/trigger_reindex.py` script

That burnt a bunch of build time (and got blocked behind Sonatype flakiness) before it could be merged, and it shouldn't have affected the main tests at all.