### PR TITLE
Dont transform Miro records with the GUS contributor code

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
@@ -23,6 +23,20 @@ class MiroTransformableTransformer
       val (title, description) = getTitleAndDescription(miroData)
 
       try {
+
+        // We had a request to remove records from contributor GUS from
+        // the API after we'd done the initial sort of the Miro data.
+        // We removed them from Elasticsearch by hand, but we don't want
+        // them to reappear on reindex.
+        //
+        // Until we can move them to Tandem Vault or Cold Store, we'll throw
+        // them away at this point.
+        if (miroData.sourceCode == Some("GUS")) {
+          throw new ShouldNotTransformException(
+            "Images from contributor GUS should not be sent to the pipeline"
+          )
+        }
+
         Some(
           UnidentifiedWork(
             title = Some(title),

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
@@ -242,6 +242,21 @@ class MiroTransformableTransformerTest
     triedMaybeWork.get shouldBe None
   }
 
+  it("returns None for Miro records from contributor GUS") {
+    val miroTransformable = MiroTransformable(
+      sourceId = "G0000001",
+      MiroCollection = "TestCollection",
+      data = buildJSONForWork(
+        """
+        "image_source_code": "GUS"
+      """)
+    )
+
+    val triedMaybeWork = transformer.transform(miroTransformable, version = 1)
+    triedMaybeWork.isSuccess shouldBe true
+    triedMaybeWork.get shouldBe None
+  }
+
   private def transformRecordAndCheckSierraSystemNumber(
     innopacId: String,
     expectedSierraNumber: String,

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
@@ -246,8 +246,7 @@ class MiroTransformableTransformerTest
     val miroTransformable = MiroTransformable(
       sourceId = "G0000001",
       MiroCollection = "TestCollection",
-      data = buildJSONForWork(
-        """
+      data = buildJSONForWork("""
         "image_source_code": "GUS"
       """)
     )


### PR DESCRIPTION
Replaces #2210.

This is better than putting a hand-coded fix in the source JSON because here the change is documented, visible, and permanent. If we ever re-run the Miro preprocessor pipeline (accidentally or on purpose), we’d lose our hand-coded fix.

Once this change is merged, I’ll go back and fix what’s in the VHS, so we have consistent data and these records don’t just land on the transformer DLQs.