### PR TITLE
Give a way to specify Miro contributor credit lines on a per-record basis

### DIFF
--- a/catalogue_pipeline/transformer/src/main/resources/miro_individual_record_contributor_map.json
+++ b/catalogue_pipeline/transformer/src/main/resources/miro_individual_record_contributor_map.json
@@ -1,0 +1,35 @@
+{
+  "B0006507": {
+    "CSC": "Jenny Nichols"
+  },
+  "B0007831": {
+    "CHC": "Dr Stephen McQuaid & Stewart Church / QUB"
+  },
+  "B0007832": {
+    "CHC": "Dr Stephen McQuaid & Stewart Church / QUB"
+  },
+  "B0007833": {
+    "CHC": "Dr Stephen McQuaid & Stewart Church / QUB"
+  },
+  "B0007834": {
+    "CHC": "Dr Stephen McQuaid & Stewart Church / QUB"
+  },
+  "B0007835": {
+    "CHC": "Dr Stephen McQuaid & Stewart Church / QUB"
+  },
+  "B0007836": {
+    "CHC": "Dr Stephen McQuaid & Stewart Church / QUB"
+  },
+  "B0011303": {
+    "RHL": "Anya Suppermpool and Vera Hunnekuhl, Meyer lab, King's College London"
+  },
+  "B0011302": {
+    "RHL": "Anya Suppermpool, Rihel lab/ Wilson lab, University College London"
+  },
+  "N0038265": {
+    "QVH": "Stacey Hussell, Queen Victoria Hospital NHS FT"
+  },
+  "N0038266": {
+    "QVH": "Stacey Hussell, Queen Victoria Hospital NHS FT"
+  }
+}

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
@@ -51,7 +51,10 @@ class MiroTransformableTransformer
             createdDate =
               getCreatedDate(miroData, miroTransformable.MiroCollection),
             subjects = getSubjects(miroData),
-            contributors = getContributors(miroData),
+            contributors = getContributors(
+              miroId = miroTransformable.sourceId,
+              miroData = miroData
+            ),
             genres = getGenres(miroData),
             thumbnail =
               Some(getThumbnail(miroData, miroTransformable.sourceId)),

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodes.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodes.scala
@@ -1,0 +1,57 @@
+package uk.ac.wellcome.platform.transformer.transformers.miro
+
+import java.io.InputStream
+
+import uk.ac.wellcome.utils.JsonUtil.toMap
+
+import scala.io.Source
+
+trait MiroContributorCodes {
+  // This JSON resource gives us credit lines for contributor codes.
+  //
+  // It is constructed as a map with fields drawn from the `contributors.xml`
+  // export from Miro, with:
+  //
+  //     - `contributor_id` as the key
+  //     - `contributor_credit_line` as the value
+  //
+  // Note that the checked-in file has had some manual edits for consistency,
+  // and with a lot of the Wellcome-related strings replaced with
+  // "Wellcome Collection".  There are also a handful of manual edits
+  // where the fields in Miro weren't filled in correctly.
+  private val stream: InputStream = getClass
+    .getResourceAsStream("/miro_contributor_map.json")
+  val contributorMap: Map[String, String] =
+    toMap[String](Source.fromInputStream(stream).mkString).get
+
+  // This JSON resource gives us contributor codes on a per-record basis.
+  //
+  // For some contributors, the contributor code resolved to phrases like:
+  //
+  //      See notes
+  //      [Contributor name], University of X
+  //
+  // Because that's only a small number of records, we have a second map
+  // that tells us what contributor codes mean on a per-record basis.
+  private val perRecordStream: InputStream = getClass
+    .getResourceAsStream("/miro_individual_record_contributor_map.json")
+  val perRecordContributorMap: Map[String, Map[String, String]] =
+    toMap[Map[String, String]](Source.fromInputStream(stream).mkString).get
+
+  // Returns our best guess for the credit line of an image, given its
+  // Miro ID and contributor code.
+  //
+  // We look in the general contributor map first, and if that fails,
+  // we fallback to the per-record map.
+  //
+  def lookupContributorCode(miroId: String, code: String): Option[String] =
+  contributorMap.get(code) match {
+    case Some(creditLine) => Some(creditLine)
+    case None => {
+      perRecordContributorMap.get(miroId) match {
+        case Some(perRecordMap) => perRecordMap.get(code)
+        case None => None
+      }
+    }
+  }
+}

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodes.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodes.scala
@@ -45,14 +45,20 @@ trait MiroContributorCodes {
   // We look in the general contributor map first, and if that fails,
   // we fallback to the per-record map.
   //
-  def lookupContributorCode(miroId: String, code: String): Option[String] =
-    contributorMap.get(code) match {
+  def lookupContributorCode(miroId: String, code: String): Option[String] = {
+
+    // All the codes in our map are uppercase, but some of the Miro records
+    // use lowercased versions, so we cast everything to ALL CAPS just in case.
+    val creditCode = code.toUpperCase()
+
+    contributorMap.get(creditCode) match {
       case Some(creditLine) => Some(creditLine)
       case None => {
         perRecordContributorMap.get(miroId) match {
-          case Some(perRecordMap) => perRecordMap.get(code)
+          case Some(perRecordMap) => perRecordMap.get(creditCode)
           case None => None
         }
       }
     }
+  }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodes.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodes.scala
@@ -36,7 +36,7 @@ trait MiroContributorCodes {
   private val perRecordStream: InputStream = getClass
     .getResourceAsStream("/miro_individual_record_contributor_map.json")
   val perRecordContributorMap: Map[String, Map[String, String]] =
-    toMap[Map[String, String]](Source.fromInputStream(stream).mkString).get
+    toMap[Map[String, String]](Source.fromInputStream(perRecordStream).mkString).get
 
   // Returns our best guess for the credit line of an image, given its
   // Miro ID and contributor code.

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodes.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodes.scala
@@ -45,13 +45,13 @@ trait MiroContributorCodes {
   // we fallback to the per-record map.
   //
   def lookupContributorCode(miroId: String, code: String): Option[String] =
-  contributorMap.get(code) match {
-    case Some(creditLine) => Some(creditLine)
-    case None => {
-      perRecordContributorMap.get(miroId) match {
-        case Some(perRecordMap) => perRecordMap.get(code)
-        case None => None
+    contributorMap.get(code) match {
+      case Some(creditLine) => Some(creditLine)
+      case None => {
+        perRecordContributorMap.get(miroId) match {
+          case Some(perRecordMap) => perRecordMap.get(code)
+          case None => None
+        }
       }
     }
-  }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodes.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodes.scala
@@ -36,7 +36,8 @@ trait MiroContributorCodes {
   private val perRecordStream: InputStream = getClass
     .getResourceAsStream("/miro_individual_record_contributor_map.json")
   val perRecordContributorMap: Map[String, Map[String, String]] =
-    toMap[Map[String, String]](Source.fromInputStream(perRecordStream).mkString).get
+    toMap[Map[String, String]](
+      Source.fromInputStream(perRecordStream).mkString).get
 
   // Returns our best guess for the credit line of an image, given its
   // Miro ID and contributor code.

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributors.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributors.scala
@@ -34,9 +34,10 @@ trait MiroContributors extends MiroContributorCodes {
         lookupContributorCode(miroId = miroId, code = code) match {
           case Some("Wellcome Collection") => None
           case Some(s) => Some(s)
-          case None => throw GracefulFailureException(new RuntimeException(
-            s"Unable to look up contributor credit line for ${miroData.sourceCode} on ${miroId}"
-          ))
+          case None =>
+            throw GracefulFailureException(new RuntimeException(
+              s"Unable to look up contributor credit line for ${miroData.sourceCode} on ${miroId}"
+            ))
         }
       case None => None
     }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodesTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodesTest.scala
@@ -1,0 +1,19 @@
+package uk.ac.wellcome.platform.transformer.transformers.miro
+
+import org.scalatest.{FunSpec, Matchers}
+
+class MiroContributorCodesTest extends FunSpec with Matchers {
+  it("looks up a contributor code in the general map") {
+    transformer.lookupContributorCode(miroId = "B0000001", code = "CSP") shouldBe Some("Wellcome Collection")
+  }
+
+  it("looks up a contributor code in the per-record map if it's absent from the general map") {
+    transformer.lookupContributorCode(miroId = "B0006507", code = "CSC") shouldBe Some("Jenny Nichols")
+  }
+
+  it("returns None if it cannot find a contributor code") {
+    transformer.lookupContributorCode(miroId = "XXX", code = "XXX") shouldBe None
+  }
+
+  val transformer = new MiroContributorCodes { }
+}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodesTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodesTest.scala
@@ -14,6 +14,11 @@ class MiroContributorCodesTest extends FunSpec with Matchers {
       "Jenny Nichols")
   }
 
+  it("uses the uppercased version of a contributor code") {
+    transformer.lookupContributorCode(miroId = "B0000001", code = "csp") shouldBe Some(
+      "Wellcome Collection")
+  }
+
   it("returns None if it cannot find a contributor code") {
     transformer.lookupContributorCode(miroId = "XXX", code = "XXX") shouldBe None
   }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodesTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodesTest.scala
@@ -4,16 +4,19 @@ import org.scalatest.{FunSpec, Matchers}
 
 class MiroContributorCodesTest extends FunSpec with Matchers {
   it("looks up a contributor code in the general map") {
-    transformer.lookupContributorCode(miroId = "B0000001", code = "CSP") shouldBe Some("Wellcome Collection")
+    transformer.lookupContributorCode(miroId = "B0000001", code = "CSP") shouldBe Some(
+      "Wellcome Collection")
   }
 
-  it("looks up a contributor code in the per-record map if it's absent from the general map") {
-    transformer.lookupContributorCode(miroId = "B0006507", code = "CSC") shouldBe Some("Jenny Nichols")
+  it(
+    "looks up a contributor code in the per-record map if it's absent from the general map") {
+    transformer.lookupContributorCode(miroId = "B0006507", code = "CSC") shouldBe Some(
+      "Jenny Nichols")
   }
 
   it("returns None if it cannot find a contributor code") {
     transformer.lookupContributorCode(miroId = "XXX", code = "XXX") shouldBe None
   }
 
-  val transformer = new MiroContributorCodes { }
+  val transformer = new MiroContributorCodes {}
 }


### PR DESCRIPTION
Another step towards #2213. A handful of records have "see individual records" on their credit line in Miro, so we didn't include them in the contributor map – so they now fail and land in the DLQ.

This patch:

- Adds a mechanism to specify contributor lines for those records
- Starts populating the data
- Throws a GracefulFailureException so we get slightly less chatty tracebacks