### PR TITLE
Make dynamo scaling faster

### DIFF
--- a/catalogue_pipeline/terraform/dynamo_matcher.tf
+++ b/catalogue_pipeline/terraform/dynamo_matcher.tf
@@ -39,12 +39,12 @@ module "matcher_dynamo_autoscaling" {
   table_name = "${aws_dynamodb_table.matcher_graph_table.name}"
 
   enable_read_scaling     = true
-  read_target_utilization = 70
+  read_target_utilization = 30
   read_min_capacity       = 1
   read_max_capacity       = 300
 
   enable_write_scaling     = true
-  write_target_utilization = 70
+  write_target_utilization = 30
   write_min_capacity       = 1
   write_max_capacity       = 300
 }

--- a/catalogue_pipeline/terraform/vhs/dynamo.tf
+++ b/catalogue_pipeline/terraform/vhs/dynamo.tf
@@ -47,12 +47,12 @@ module "sourcedata_dynamo_autoscaling" {
   table_name = "${aws_dynamodb_table.table.name}"
 
   enable_read_scaling     = true
-  read_target_utilization = 70
+  read_target_utilization = 30
   read_min_capacity       = 1
   read_max_capacity       = 300
 
   enable_write_scaling     = true
-  write_target_utilization = 70
+  write_target_utilization = 30
   write_min_capacity       = 1
   write_max_capacity       = 300
 }


### PR DESCRIPTION
As per discussion with @kenoir . 
We think that sqs autoscaling is faster than dynamo autoscaling which causes two main problems:
* lots of throughput exceeded errors and stuff ending up in the dlqs
* lost of exceptions logs when a reindex is run (10th of June reindex cost 78£ in logs only) 
So, lower the thresholds for scaling up dynamo, to make it scale up faster and hopefully cause fewer errors