### PR TITLE
Get a few more Miro images passing through the transformer cleanly

### DIFF
--- a/catalogue_pipeline/transformer/src/main/resources/miro_individual_record_contributor_map.json
+++ b/catalogue_pipeline/transformer/src/main/resources/miro_individual_record_contributor_map.json
@@ -1,6 +1,9 @@
 {
   "B0006507": {
-    "CSC": "Jenny Nichols"
+    "CSC": "Jenny Nichols, Wellcome Trust Centre for Stem Cell Research"
+  },
+  "B0006714": {
+    "CSC": "Jose Silva, Wellcome Trust Centre for Stem Cell Research"
   },
   "B0007831": {
     "CHC": "Dr Stephen McQuaid & Stewart Church / QUB"
@@ -20,11 +23,41 @@
   "B0007836": {
     "CHC": "Dr Stephen McQuaid & Stewart Church / QUB"
   },
+  "B0011004": {
+    "JAC": "Queen's University Belfast"
+  },
   "B0011303": {
     "RHL": "Anya Suppermpool and Vera Hunnekuhl, Meyer lab, King's College London"
   },
   "B0011302": {
     "RHL": "Anya Suppermpool, Rihel lab/ Wilson lab, University College London"
+  },
+  "B0011149": {
+    "RSM": "Dr Patrice Rassam, University of Oxford"
+  },
+  "B0011276": {
+    "MKK": "Sophie McKay Knight"
+  },
+  "B0011277": {
+    "MKK": "Sophie McKay Knight"
+  },
+  "B0011278": {
+    "MKK": "Sophie McKay Knight"
+  },
+  "B0011306": {
+    "FDN": "Ezra Feilden"
+  },
+  "B0011307": {
+    "FDN": "Ezra Feilden"
+  },
+  "B0011308": {
+    "FDN": "Ezra Feilden"
+  },
+  "B0011321": {
+    "ZGS": "Magdalena Zernicka-Goetz and Hanna Sidorowicz, University of Cambridge"
+  },
+  "B0011322": {
+    "ZGS": "Magdalena Zernicka-Goetz and Hanna Sidorowicz, University of Cambridge"
   },
   "N0038265": {
     "QVH": "Stacey Hussell, Queen Victoria Hospital NHS FT"

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
@@ -40,6 +40,16 @@ class MiroTransformableTransformer
           )
         }
 
+        // These images should really have been removed from the pipeline
+        // already, but we have at least one instance (B0010525).  It was
+        // throwing a MatchError when we tried to pick a license, so handle
+        // it properly here.
+        if (miroData.copyrightCleared != Some("Y")) {
+          throw new ShouldNotTransformException(
+            s"Image ${miroTransformable.sourceId} does not have copyright clearance!"
+          )
+        }
+
         Some(
           UnidentifiedWork(
             title = Some(title),

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/MiroTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/MiroTransformerFeatureTest.scala
@@ -37,7 +37,7 @@ class MiroTransformerFeatureTest
                 message = createValidMiroTransformableJson(
                   MiroID = miroID,
                   MiroCollection = "foo",
-                  data = buildJSONForWork(""""image_title": "$title"""")
+                  data = buildJSONForWork(s""""image_title": "$title"""")
                 ),
                 sourceName = "miro",
                 s3Client = s3Client,

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/MiroTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/MiroTransformerFeatureTest.scala
@@ -37,13 +37,7 @@ class MiroTransformerFeatureTest
                 message = createValidMiroTransformableJson(
                   MiroID = miroID,
                   MiroCollection = "foo",
-                  data = s"""{
-                  "image_title": "$title",
-                  "image_cleared": "N",
-                  "image_use_restrictions": "CC-0",
-                  "image_copyright_cleared": "N",
-                  "image_tech_file_size": ["100000"]
-                }"""
+                  data = buildJSONForWork(""""image_title": "$title"""")
                 ),
                 sourceName = "miro",
                 s3Client = s3Client,

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
@@ -227,28 +227,29 @@ class MiroTransformableTransformerTest
 
   it(
     "returns None for Miro records with usage restrictions that mean we suppress the image") {
-    val miroTransformable = MiroTransformable(
-      sourceId = "P0000001",
-      MiroCollection = "TestCollection",
+    assertTransformReturnsNone(
       data = buildJSONForWork(
         """
         "image_title": "Private pictures of perilous penguins",
         "image_use_restrictions": "Do not use"
       """)
     )
-
-    val triedMaybeWork = transformer.transform(miroTransformable, version = 1)
-    triedMaybeWork.isSuccess shouldBe true
-    triedMaybeWork.get shouldBe None
   }
 
   it("returns None for Miro records from contributor GUS") {
-    val miroTransformable = MiroTransformable(
-      sourceId = "G0000001",
-      MiroCollection = "TestCollection",
+    assertTransformReturnsNone(
       data = buildJSONForWork("""
         "image_source_code": "GUS"
       """)
+    )
+  }
+
+
+  private def assertTransformReturnsNone(data: String) = {
+    val miroTransformable = MiroTransformable(
+      sourceId = "G0000001",
+      MiroCollection = "TestCollection",
+      data = data
     )
 
     val triedMaybeWork = transformer.transform(miroTransformable, version = 1)

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
@@ -244,6 +244,16 @@ class MiroTransformableTransformerTest
     )
   }
 
+  it("returns None for images which don't have copyright clearance") {
+    assertTransformReturnsNone(
+      data = """{
+        "image_cleared": "Y",
+        "image_copyright_cleared": "N",
+        "image_tech_file_size": ["1000000"],
+        "image_use_restrictions": "CC-BY"
+      }"""
+    )
+  }
 
   private def assertTransformReturnsNone(data: String) = {
     val miroTransformable = MiroTransformable(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodesTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodesTest.scala
@@ -11,7 +11,7 @@ class MiroContributorCodesTest extends FunSpec with Matchers {
   it(
     "looks up a contributor code in the per-record map if it's absent from the general map") {
     transformer.lookupContributorCode(miroId = "B0006507", code = "CSC") shouldBe Some(
-      "Jenny Nichols")
+      "Jenny Nichols, Wellcome Trust Centre for Stem Cell Research")
   }
 
   it("uses the uppercased version of a contributor code") {


### PR DESCRIPTION
Another piece of #2213. Mostly contributor code fixes, and the discovery that we have one image which isn't copyright cleared in the pipeline!

This should fix all the Miro images that fell out of the pipeline last night.