### PR TITLE
Expunge a bit of logging we don't actually need

### DIFF
--- a/reindexer/complete_reindex/src/complete_reindex.py
+++ b/reindexer/complete_reindex/src/complete_reindex.py
@@ -83,5 +83,3 @@ def main(event, _):
     table = dynamodb.Table(table_name)
 
     _run(table, event)
-
-    print(f'Done with {event!r}!')

--- a/reindexer/reindex_shard_generator/src/reindex_shard_generator.py
+++ b/reindexer/reindex_shard_generator/src/reindex_shard_generator.py
@@ -20,8 +20,6 @@ SHARD_SIZE = 1500
 
 @log_on_error
 def main(event, _ctxt=None, dynamodb_client=None):
-    print(f'event={event!r}')
-
     dynamodb_client = dynamodb_client or boto3.client('dynamodb')
     table_name = os.environ['TABLE_NAME']
 

--- a/shared_infra/dynamo_to_sns/src/dynamo_to_sns.py
+++ b/shared_infra/dynamo_to_sns/src/dynamo_to_sns.py
@@ -41,8 +41,6 @@ def get_sns_messages(trigger_event, stream_view_type):
 
 @log_on_error
 def main(event, _ctxt=None, sns_client=None):
-    print(f'Received event: {event!r}')
-
     topic_arn = os.environ['TOPIC_ARN']
     topic_name = topic_arn.split(":")[-1]
     stream_view_type = os.environ.get('STREAM_VIEW_TYPE', 'FULL_EVENT')

--- a/sierra_adapter/s3_demultiplexer/src/s3_demultiplexer.py
+++ b/sierra_adapter/s3_demultiplexer/src/s3_demultiplexer.py
@@ -32,8 +32,6 @@ from wellcome_aws_utils.lambda_utils import log_on_error
 
 @log_on_error
 def main(event, _ctxt=None, s3_client=None, sns_client=None):
-    print(f'event = {event!r}')
-
     topic_arn = os.environ["TOPIC_ARN"]
 
     s3_client = s3_client or boto3.client('s3')


### PR DESCRIPTION
The `@log_on_error` decorator logs the event if the Lambda fails, but otherwise we don't need it.