### PR TITLE
Fix another broken use of Miro contributor codes

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
@@ -11,6 +11,7 @@ import scala.util.Try
 class MiroTransformableTransformer
     extends TransformableTransformer[MiroTransformable]
     with MiroContributors
+    with MiroCredits
     with MiroGenres
     with MiroIdentifiers
     with MiroLicenses
@@ -215,7 +216,7 @@ class MiroTransformableTransformer
           DigitalLocation(
             locationType = LocationType("iiif-image"),
             url = buildImageApiURL(miroId, "info"),
-            credit = getCredit(miroData),
+            credit = getCredit(miroId = miroId, miroData = miroData),
             license = chooseLicense(miroData.useRestrictions)
           )
         )
@@ -231,69 +232,6 @@ class MiroTransformableTransformer
     }
 
   private def collectionIsV(c: String) = c.toLowerCase.contains("images-v")
-
-  /** Image credits in MIRO could be set in two ways:
-    *
-    *    - using the image_credit_line, which is per-image
-    *    - using the image_source_code, which falls back to a contributor-level
-    *      credit line
-    *
-    * We prefer the per-image credit line, but use the contributor-level credit
-    * if unavailable.
-    */
-  private def getCredit(miroData: MiroTransformableData): Option[String] = {
-    miroData.creditLine match {
-
-      // Some of the credit lines are inconsistent or use old names for
-      // Wellcome, so we do a bunch of replacements and trimming to tidy
-      // them up.
-      case Some(line) =>
-        Some(line
-          .replaceAll(
-            "Adrian Wressell, Heart of England NHSFT",
-            "Adrian Wressell, Heart of England NHS FT")
-          .replaceAll(
-            "Andrew Dilley,Jane Greening & Bruce Lynn",
-            "Andrew Dilley, Jane Greening & Bruce Lynn")
-          .replaceAll(
-            "Andrew Dilley,Nicola DeLeon & Bruce Lynn",
-            "Andrew Dilley, Nicola De Leon & Bruce Lynn")
-          .replaceAll(
-            "Ashley Prytherch, Royal Surrey County Hospital NHS Foundation Trust",
-            "Ashley Prytherch, Royal Surrey County Hospital NHS FT")
-          .replaceAll(
-            "David Gregory & Debbie Marshall",
-            "David Gregory and Debbie Marshall")
-          .replaceAll(
-            "David Gregory&Debbie Marshall",
-            "David Gregory and Debbie Marshall")
-          .replaceAll("Geraldine Thompson.", "Geraldine Thompson")
-          .replaceAll("John & Penny Hubley.", "John & Penny Hubley")
-          .replaceAll(
-            "oyal Army Medical Corps Muniment Collection, Wellcome Images",
-            "Royal Army Medical Corps Muniment Collection, Wellcome Collection")
-          .replaceAll("Science Museum London", "Science Museum, London")
-          .replaceAll("The Wellcome Library, London", "Wellcome Collection")
-          .replaceAll("Wellcome Library, London", "Wellcome Collection")
-          .replaceAll("Wellcome Libary, London", "Wellcome Collection")
-          .replaceAll("Wellcome LIbrary, London", "Wellcome Collection")
-          .replaceAll("Wellcome Images", "Wellcome Collection")
-          .replaceAll("The Wellcome Library", "Wellcome Collection")
-          .replaceAll("Wellcome Library", "Wellcome Collection")
-          .replaceAll("Wellcome Collection London", "Wellcome Collection")
-          .replaceAll("Wellcome Collection, Londn", "Wellcome Collection")
-          .replaceAll("Wellcome Trust", "Wellcome Collection")
-          .replaceAll("'Wellcome Collection'", "Wellcome Collection"))
-
-      // Otherwise we carry through the contributor codes, which have
-      // already been edited for consistency.
-      case None =>
-        miroData.sourceCode match {
-          case Some(code) => Some(contributorMap(code.toUpperCase))
-          case None => None
-        }
-    }
-  }
 
   private def buildImageApiURL(miroID: String, templateName: String): String = {
     val iiifImageApiBaseUri = "https://iiif.wellcomecollection.org"

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodes.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodes.scala
@@ -21,7 +21,7 @@ trait MiroContributorCodes {
   // where the fields in Miro weren't filled in correctly.
   private val stream: InputStream = getClass
     .getResourceAsStream("/miro_contributor_map.json")
-  val contributorMap: Map[String, String] =
+  private val contributorMap: Map[String, String] =
     toMap[String](Source.fromInputStream(stream).mkString).get
 
   // This JSON resource gives us contributor codes on a per-record basis.
@@ -35,7 +35,7 @@ trait MiroContributorCodes {
   // that tells us what contributor codes mean on a per-record basis.
   private val perRecordStream: InputStream = getClass
     .getResourceAsStream("/miro_individual_record_contributor_map.json")
-  val perRecordContributorMap: Map[String, Map[String, String]] =
+  private val perRecordContributorMap: Map[String, Map[String, String]] =
     toMap[Map[String, String]](
       Source.fromInputStream(perRecordStream).mkString).get
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroCredits.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroCredits.scala
@@ -1,0 +1,71 @@
+package uk.ac.wellcome.platform.transformer.transformers.miro
+
+import uk.ac.wellcome.platform.transformer.source.MiroTransformableData
+
+trait MiroCredits extends MiroContributorCodes {
+
+  /** Image credits in MIRO could be set in two ways:
+    *
+    *    - using the image_credit_line, which is per-image
+    *    - using the image_source_code, which falls back to a contributor-level
+    *      credit line
+    *
+    * We prefer the per-image credit line, but use the contributor-level credit
+    * if unavailable.
+    */
+  def getCredit(miroId: String, miroData: MiroTransformableData): Option[String] = {
+    miroData.creditLine match {
+
+      // Some of the credit lines are inconsistent or use old names for
+      // Wellcome, so we do a bunch of replacements and trimming to tidy
+      // them up.
+      case Some(line) =>
+        Some(line
+          .replaceAll(
+            "Adrian Wressell, Heart of England NHSFT",
+            "Adrian Wressell, Heart of England NHS FT")
+          .replaceAll(
+            "Andrew Dilley,Jane Greening & Bruce Lynn",
+            "Andrew Dilley, Jane Greening & Bruce Lynn")
+          .replaceAll(
+            "Andrew Dilley,Nicola DeLeon & Bruce Lynn",
+            "Andrew Dilley, Nicola De Leon & Bruce Lynn")
+          .replaceAll(
+            "Ashley Prytherch, Royal Surrey County Hospital NHS Foundation Trust",
+            "Ashley Prytherch, Royal Surrey County Hospital NHS FT")
+          .replaceAll(
+            "David Gregory & Debbie Marshall",
+            "David Gregory and Debbie Marshall")
+          .replaceAll(
+            "David Gregory&Debbie Marshall",
+            "David Gregory and Debbie Marshall")
+          .replaceAll("Geraldine Thompson.", "Geraldine Thompson")
+          .replaceAll("John & Penny Hubley.", "John & Penny Hubley")
+          .replaceAll(
+            "oyal Army Medical Corps Muniment Collection, Wellcome Images",
+            "Royal Army Medical Corps Muniment Collection, Wellcome Collection")
+          .replaceAll("Science Museum London", "Science Museum, London")
+          .replaceAll("The Wellcome Library, London", "Wellcome Collection")
+          .replaceAll("Wellcome Library, London", "Wellcome Collection")
+          .replaceAll("Wellcome Libary, London", "Wellcome Collection")
+          .replaceAll("Wellcome LIbrary, London", "Wellcome Collection")
+          .replaceAll("Wellcome Images", "Wellcome Collection")
+          .replaceAll("The Wellcome Library", "Wellcome Collection")
+          .replaceAll("Wellcome Library", "Wellcome Collection")
+          .replaceAll("Wellcome Collection London", "Wellcome Collection")
+          .replaceAll("Wellcome Collection, Londn", "Wellcome Collection")
+          .replaceAll("Wellcome Trust", "Wellcome Collection")
+          .replaceAll("'Wellcome Collection'", "Wellcome Collection"))
+
+      // Otherwise we carry through the contributor codes, which have
+      // already been edited for consistency.
+      case None =>
+
+        miroData.sourceCode match {
+          case Some(code) => lookupContributorCode(miroId = miroId, code = code)
+          case None => None
+        }
+    }
+  }
+
+}

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroCredits.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroCredits.scala
@@ -13,7 +13,8 @@ trait MiroCredits extends MiroContributorCodes {
     * We prefer the per-image credit line, but use the contributor-level credit
     * if unavailable.
     */
-  def getCredit(miroId: String, miroData: MiroTransformableData): Option[String] = {
+  def getCredit(miroId: String,
+                miroData: MiroTransformableData): Option[String] = {
     miroData.creditLine match {
 
       // Some of the credit lines are inconsistent or use old names for
@@ -60,9 +61,9 @@ trait MiroCredits extends MiroContributorCodes {
       // Otherwise we carry through the contributor codes, which have
       // already been edited for consistency.
       case None =>
-
         miroData.sourceCode match {
-          case Some(code) => lookupContributorCode(miroId = miroId, code = code)
+          case Some(code) =>
+            lookupContributorCode(miroId = miroId, code = code)
           case None => None
         }
     }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
@@ -255,6 +255,24 @@ class MiroTransformableTransformerTest
     )
   }
 
+  it("transforms an image with no credit line and an image-specific contributor code") {
+    val work = transformWork(
+      data = s"""
+        "image_credit_line": null,
+        "image_source_code": "FDN"
+      """,
+      MiroID = "B0011308"
+    )
+
+    val expectedDigitalLocation = DigitalLocation(
+      url = "https://iiif.wellcomecollection.org/image/B0011308.jpg/info.json",
+      license = License_CCBY,
+      credit = Some("Ezra Feilden"),
+      locationType = LocationType("iiif-image")
+    )
+    work.items.head.locations shouldBe List(expectedDigitalLocation)
+  }
+
   private def assertTransformReturnsNone(data: String) = {
     val miroTransformable = MiroTransformable(
       sourceId = "G0000001",

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
@@ -255,7 +255,8 @@ class MiroTransformableTransformerTest
     )
   }
 
-  it("transforms an image with no credit line and an image-specific contributor code") {
+  it(
+    "transforms an image with no credit line and an image-specific contributor code") {
     val work = transformWork(
       data = s"""
         "image_credit_line": null,

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroCreditsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroCreditsTest.scala
@@ -14,5 +14,5 @@ class MiroCreditsTest extends FunSpec with Matchers {
     ) shouldBe Some("Ezra Feilden")
   }
 
-  val transformer = new MiroCredits { }
+  val transformer = new MiroCredits {}
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroCreditsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroCreditsTest.scala
@@ -1,0 +1,18 @@
+package uk.ac.wellcome.platform.transformer.transformers.miro
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.platform.transformer.source.MiroTransformableData
+
+class MiroCreditsTest extends FunSpec with Matchers {
+  it("finds the credit line for an image-specific contributor code") {
+    transformer.getCredit(
+      miroId = "B0011308",
+      miroData = MiroTransformableData(
+        creditLine = None,
+        sourceCode = Some("FDN")
+      )
+    ) shouldBe Some("Ezra Feilden")
+  }
+
+  val transformer = new MiroCredits { }
+}


### PR DESCRIPTION
Another step towards #2213 – this was responsible for seven failures in the latest reindex.