### PR TITLE
Be consistent about importing Inject/Singleton

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/ContextController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/ContextController.scala
@@ -1,9 +1,9 @@
 package uk.ac.wellcome.platform.api.controllers
 
+import com.google.inject.Inject
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
-import javax.inject.{Inject, Singleton}
-
+import javax.inject.Singleton
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.platform.api.models.ApiConfig
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/ContextController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/ContextController.scala
@@ -1,9 +1,8 @@
 package uk.ac.wellcome.platform.api.controllers
 
-import com.google.inject.Inject
+import com.google.inject.{Inject, Singleton}
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
-import javax.inject.Singleton
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.platform.api.models.ApiConfig
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/DocsController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/DocsController.scala
@@ -1,10 +1,11 @@
 package uk.ac.wellcome.platform.api.controllers
 
+import com.google.inject.Inject
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
 import io.swagger.util.Json
 import io.swagger.models.{Info, Scheme, Swagger}
-import javax.inject.{Inject, Singleton}
+import javax.inject.Singleton
 
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.platform.api.models.ApiConfig

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/DocsController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/DocsController.scala
@@ -1,11 +1,10 @@
 package uk.ac.wellcome.platform.api.controllers
 
-import com.google.inject.Inject
+import com.google.inject.{Inject, Singleton}
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
 import io.swagger.util.Json
 import io.swagger.models.{Info, Scheme, Swagger}
-import javax.inject.Singleton
 
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.platform.api.models.ApiConfig

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/ManagementController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/ManagementController.scala
@@ -1,7 +1,8 @@
 package uk.ac.wellcome.platform.api.controllers
 
-import javax.inject.{Inject, Singleton}
+import javax.inject.Singleton
 
+import com.google.inject.Inject
 import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.twitter.finagle.http.Request

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/ManagementController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/ManagementController.scala
@@ -1,8 +1,6 @@
 package uk.ac.wellcome.platform.api.controllers
 
-import javax.inject.Singleton
-
-import com.google.inject.Inject
+import com.google.inject.{Inject, Singleton}
 import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.twitter.finagle.http.Request

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
@@ -1,7 +1,8 @@
 package uk.ac.wellcome.platform.api.controllers
 
-import javax.inject.{Inject, Singleton}
+import javax.inject.Singleton
 
+import com.google.inject.Inject
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.elasticsearch.ElasticConfig

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
@@ -1,8 +1,6 @@
 package uk.ac.wellcome.platform.api.controllers
 
-import javax.inject.Singleton
-
-import com.google.inject.Inject
+import com.google.inject.{Inject, Singleton}
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.elasticsearch.ElasticConfig

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
@@ -1,7 +1,8 @@
 package uk.ac.wellcome.platform.api.controllers
 
-import javax.inject.{Inject, Singleton}
+import javax.inject.Singleton
 
+import com.google.inject.Inject
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
 import uk.ac.wellcome.elasticsearch.ElasticConfig

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
@@ -1,8 +1,6 @@
 package uk.ac.wellcome.platform.api.controllers
 
-import javax.inject.Singleton
-
-import com.google.inject.Inject
+import com.google.inject.{Inject, Singleton}
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
 import uk.ac.wellcome.elasticsearch.ElasticConfig

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/CaseClassMappingExceptionWrapper.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/CaseClassMappingExceptionWrapper.scala
@@ -1,11 +1,12 @@
 package uk.ac.wellcome.platform.api.finatra.exceptions
 
+import com.google.inject.Inject
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.exceptions.ExceptionMapper
 import com.twitter.finatra.http.response.ResponseBuilder
 import com.twitter.finatra.json.internal.caseclass.exceptions.CaseClassMappingException
 import com.twitter.inject.Logging
-import javax.inject.{Inject, Singleton}
+import javax.inject.Singleton
 
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
 import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error}

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/CaseClassMappingExceptionWrapper.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/CaseClassMappingExceptionWrapper.scala
@@ -1,12 +1,11 @@
 package uk.ac.wellcome.platform.api.finatra.exceptions
 
-import com.google.inject.Inject
+import com.google.inject.{Inject, Singleton}
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.exceptions.ExceptionMapper
 import com.twitter.finatra.http.response.ResponseBuilder
 import com.twitter.finatra.json.internal.caseclass.exceptions.CaseClassMappingException
 import com.twitter.inject.Logging
-import javax.inject.Singleton
 
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
 import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error}

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
@@ -1,11 +1,12 @@
 package uk.ac.wellcome.platform.api.finatra.exceptions
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.inject.Inject
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.exceptions.ExceptionMapper
 import com.twitter.finatra.http.response.ResponseBuilder
 import com.twitter.inject.Logging
-import javax.inject.{Inject, Singleton}
+import javax.inject.Singleton
 
 import org.elasticsearch.client.ResponseException
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/ElasticsearchResponseExceptionMapper.scala
@@ -1,12 +1,11 @@
 package uk.ac.wellcome.platform.api.finatra.exceptions
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.google.inject.Inject
+import com.google.inject.{Inject, Singleton}
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.exceptions.ExceptionMapper
 import com.twitter.finatra.http.response.ResponseBuilder
 import com.twitter.inject.Logging
-import javax.inject.Singleton
 
 import org.elasticsearch.client.ResponseException
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/GeneralExceptionMapper.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/GeneralExceptionMapper.scala
@@ -1,7 +1,8 @@
 package uk.ac.wellcome.platform.api.finatra.exceptions
 
-import javax.inject.{Inject, Singleton}
+import javax.inject.Singleton
 
+import com.google.inject.Inject
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.exceptions.ExceptionMapper
 import com.twitter.finatra.http.response.ResponseBuilder

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/GeneralExceptionMapper.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/GeneralExceptionMapper.scala
@@ -1,8 +1,6 @@
 package uk.ac.wellcome.platform.api.finatra.exceptions
 
-import javax.inject.Singleton
-
-import com.google.inject.Inject
+import com.google.inject.{Inject, Singleton}
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.exceptions.ExceptionMapper
 import com.twitter.finatra.http.response.ResponseBuilder

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/modules/ApiConfigModule.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/modules/ApiConfigModule.scala
@@ -1,8 +1,6 @@
 package uk.ac.wellcome.platform.api.modules
 
-import javax.inject.Singleton
-
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.platform.api.models.ApiConfig
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchService.scala
@@ -1,11 +1,10 @@
 package uk.ac.wellcome.platform.api.services
 
-import com.google.inject.Inject
+import com.google.inject.{Inject, Singleton}
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.http.get.GetResponse
 import com.sksamuel.elastic4s.http.search.SearchResponse
-import javax.inject.Singleton
 
 import uk.ac.wellcome.elasticsearch.ElasticConfig
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchService.scala
@@ -1,10 +1,11 @@
 package uk.ac.wellcome.platform.api.services
 
+import com.google.inject.Inject
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.http.get.GetResponse
 import com.sksamuel.elastic4s.http.search.SearchResponse
-import javax.inject.{Inject, Singleton}
+import javax.inject.Singleton
 
 import uk.ac.wellcome.elasticsearch.ElasticConfig
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -1,7 +1,8 @@
 package uk.ac.wellcome.platform.api.services
 
+import com.google.inject.Inject
 import com.sksamuel.elastic4s.http.search.SearchHit
-import javax.inject.{Inject, Singleton}
+import javax.inject.Singleton
 
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.platform.api.models.{ApiConfig, ResultList}

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.platform.api.services
 
-import com.google.inject.Inject
+import com.google.inject.{Inject, Singleton}
 import com.sksamuel.elastic4s.http.search.SearchHit
-import javax.inject.Singleton
 
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.platform.api.models.{ApiConfig, ResultList}

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
@@ -2,9 +2,8 @@ package uk.ac.wellcome.platform.idminter.database
 
 import java.sql.SQLIntegrityConstraintViolationException
 
-import com.google.inject.Inject
+import com.google.inject.{Inject, Singleton}
 import com.twitter.inject.Logging
-import javax.inject.Singleton
 import scalikejdbc._
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal.SourceIdentifier

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/JsonModule.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/JsonModule.scala
@@ -1,9 +1,8 @@
 package uk.ac.wellcome.platform.idminter.modules
 
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.{Injector, TwitterModule}
 import io.circe.Json
-import javax.inject.Singleton
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.s3.S3StorageBackend
 

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/IdentifiedWorkModule.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/IdentifiedWorkModule.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.ingestor.modules
 
-import javax.inject.Singleton
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.{Injector, TwitterModule}
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.storage.ObjectStore

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -1,11 +1,12 @@
 package uk.ac.wellcome.platform.ingestor.services
 
+import com.google.inject.Inject
 import com.sksamuel.elastic4s.Indexable
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.http.bulk.BulkResponse
 import com.twitter.inject.Logging
-import javax.inject.{Inject, Singleton}
+import javax.inject.Singleton
 import org.elasticsearch.index.VersionType
 import uk.ac.wellcome.elasticsearch.ElasticsearchExceptionManager
 import uk.ac.wellcome.models.work.internal.IdentifiedWork

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -1,12 +1,11 @@
 package uk.ac.wellcome.platform.ingestor.services
 
-import com.google.inject.Inject
+import com.google.inject.{Inject, Singleton}
 import com.sksamuel.elastic4s.Indexable
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.http.bulk.BulkResponse
 import com.twitter.inject.Logging
-import javax.inject.Singleton
 import org.elasticsearch.index.VersionType
 import uk.ac.wellcome.elasticsearch.ElasticsearchExceptionManager
 import uk.ac.wellcome.models.work.internal.IdentifiedWork

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/modules/RecorderWorkEntryModule.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/modules/RecorderWorkEntryModule.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.platform.matcher.modules
 
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.{Injector, TwitterModule}
-import javax.inject.Singleton
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.s3.S3StorageBackend

--- a/catalogue_pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/modules/RecorderWorkEntryModule.scala
+++ b/catalogue_pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/modules/RecorderWorkEntryModule.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.recorder.modules
 
-import javax.inject.Singleton
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.{Injector, TwitterModule}
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
 import uk.ac.wellcome.storage.ObjectStore

--- a/catalogue_pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/modules/UnidentifiedWorkModule.scala
+++ b/catalogue_pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/modules/UnidentifiedWorkModule.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.platform.recorder.modules
 
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.{Injector, TwitterModule}
-import javax.inject.Singleton
 import uk.ac.wellcome.models.work.internal.UnidentifiedWork
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.s3.S3StorageBackend

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/modules/TransformablesModule.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/modules/TransformablesModule.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.platform.transformer.modules
 
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.{Injector, TwitterModule}
-import javax.inject.Singleton
 import uk.ac.wellcome.models.transformable.{
   CalmTransformable,
   MiroTransformable,

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/modules/UnidentifiedWorkModule.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/modules/UnidentifiedWorkModule.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.platform.transformer.modules
 
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.{Injector, TwitterModule}
-import javax.inject.Singleton
 import uk.ac.wellcome.models.work.internal.UnidentifiedWork
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.s3.S3StorageBackend

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/finatra/modules/AkkaS3ClientModule.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/finatra/modules/AkkaS3ClientModule.scala
@@ -11,9 +11,8 @@ import com.amazonaws.auth.{
   DefaultAWSCredentialsProviderChain
 }
 import com.amazonaws.regions.AwsRegionProvider
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
-import javax.inject.Singleton
 
 object AkkaS3ClientModule extends TwitterModule {
   private val endpoint = flag[String](

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
@@ -7,9 +7,9 @@ import akka.stream.alpakka.s3.scaladsl.{MultipartUploadResult, S3Client}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.inject.Inject
 import com.sksamuel.elastic4s.http.HttpClient
 import com.twitter.inject.Logging
-import javax.inject.Inject
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
 import uk.ac.wellcome.display.models.{ApiVersions, DisplayWork, WorksIncludes}

--- a/goobi_adapter/goobi_reader/src/main/scala/uk/ac/wellcome/platform/goobi_reader/modules/ExecutionContextModule.scala
+++ b/goobi_adapter/goobi_reader/src/main/scala/uk/ac/wellcome/platform/goobi_reader/modules/ExecutionContextModule.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.platform.goobi_reader.modules
 
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.{Injector, TwitterModule}
-import javax.inject.Singleton
 import uk.ac.wellcome.platform.goobi_reader.GlobalExecutionContext
 
 import scala.concurrent.ExecutionContext

--- a/goobi_adapter/goobi_reader/src/main/scala/uk/ac/wellcome/platform/goobi_reader/modules/GoobiReaderStorageModule.scala
+++ b/goobi_adapter/goobi_reader/src/main/scala/uk/ac/wellcome/platform/goobi_reader/modules/GoobiReaderStorageModule.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.platform.goobi_reader.modules
 
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.{Injector, TwitterModule}
-import javax.inject.Singleton
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.s3.S3StorageBackend
 

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
@@ -1,12 +1,12 @@
 package uk.ac.wellcome.platform.reindex_worker.services
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.google.inject.Inject
 import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo.query._
 import com.gu.scanamo.syntax._
 import com.gu.scanamo.{Scanamo, _}
 import com.twitter.inject.Logging
-import javax.inject.Inject
 
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.monitoring.MetricsSender

--- a/sbt_common/finatra_akka/src/main/scala/uk/ac/wellcome/finatra/akka/AkkaModule.scala
+++ b/sbt_common/finatra_akka/src/main/scala/uk/ac/wellcome/finatra/akka/AkkaModule.scala
@@ -1,9 +1,7 @@
 package uk.ac.wellcome.finatra.akka
 
-import javax.inject.Singleton
 import akka.actor.ActorSystem
-import com.google.inject.Provides
-import com.google.inject.Injector
+import com.google.inject.{Injector, Provides, Singleton}
 import com.twitter.inject.{InjectorModule, TwitterModule}
 
 object AkkaModule extends TwitterModule {

--- a/sbt_common/finatra_akka/src/main/scala/uk/ac/wellcome/finatra/akka/ExecutionContextModule.scala
+++ b/sbt_common/finatra_akka/src/main/scala/uk/ac/wellcome/finatra/akka/ExecutionContextModule.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.finatra.akka
 
-import javax.inject.Singleton
 import akka.actor.ActorSystem
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
 
 import scala.concurrent.ExecutionContext

--- a/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/controllers/ManagementController.scala
+++ b/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/controllers/ManagementController.scala
@@ -1,8 +1,6 @@
 package uk.ac.wellcome.finatra.controllers
 
-import javax.inject.Singleton
-
-import com.google.inject.Inject
+import com.google.inject.{Inject, Singleton}
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
 

--- a/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/controllers/ManagementController.scala
+++ b/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/controllers/ManagementController.scala
@@ -1,7 +1,8 @@
 package uk.ac.wellcome.finatra.controllers
 
-import javax.inject.{Inject, Singleton}
+import javax.inject.Singleton
 
+import com.google.inject.Inject
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
 

--- a/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
+++ b/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.finatra.messaging
 
-import com.google.inject.{Inject, Singleton}
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.messaging.message.{
   MessageReaderConfig,

--- a/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
+++ b/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageConfigModule.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.finatra.messaging
 
-import com.google.inject.Provides
+import com.google.inject.{Inject, Singleton}
 import com.twitter.inject.TwitterModule
-import javax.inject.Singleton
 import uk.ac.wellcome.messaging.message.{
   MessageReaderConfig,
   MessageWriterConfig

--- a/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/SNSClientModule.scala
+++ b/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/SNSClientModule.scala
@@ -1,9 +1,8 @@
 package uk.ac.wellcome.finatra.messaging
 
 import com.amazonaws.services.sns.AmazonSNS
-import com.google.inject.Provides
+import com.google.inject.{Inject, Singleton}
 import com.twitter.inject.TwitterModule
-import javax.inject.Singleton
 import uk.ac.wellcome.messaging.sns.SNSClientFactory
 
 object SNSClientModule extends TwitterModule {

--- a/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/SNSClientModule.scala
+++ b/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/SNSClientModule.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.finatra.messaging
 
 import com.amazonaws.services.sns.AmazonSNS
-import com.google.inject.{Inject, Singleton}
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.messaging.sns.SNSClientFactory
 

--- a/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/SNSConfigModule.scala
+++ b/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/SNSConfigModule.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.finatra.messaging
 
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
-import javax.inject.Singleton
 import uk.ac.wellcome.messaging.sns.SNSConfig
 
 object SNSConfigModule extends TwitterModule {

--- a/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/SQSClientModule.scala
+++ b/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/SQSClientModule.scala
@@ -1,9 +1,8 @@
 package uk.ac.wellcome.finatra.messaging
 
 import com.amazonaws.services.sqs.{AmazonSQS, AmazonSQSAsync}
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
-import javax.inject.Singleton
 import uk.ac.wellcome.messaging.sqs.SQSClientFactory
 
 object SQSClientModule extends TwitterModule {

--- a/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/SQSConfigModule.scala
+++ b/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/SQSConfigModule.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.finatra.messaging
 
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
-import javax.inject.Singleton
 import uk.ac.wellcome.messaging.sqs.SQSConfig
 
 import scala.concurrent.duration._

--- a/sbt_common/finatra_storage/src/main/scala/uk/ac/wellcome/finatra/storage/DynamoClientModule.scala
+++ b/sbt_common/finatra_storage/src/main/scala/uk/ac/wellcome/finatra/storage/DynamoClientModule.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.finatra.storage
 
-import javax.inject.Singleton
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.storage.dynamo.DynamoClientFactory
 

--- a/sbt_common/finatra_storage/src/main/scala/uk/ac/wellcome/finatra/storage/DynamoConfigModule.scala
+++ b/sbt_common/finatra_storage/src/main/scala/uk/ac/wellcome/finatra/storage/DynamoConfigModule.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.finatra.storage
 
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
-import javax.inject.Singleton
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
 object DynamoConfigModule extends TwitterModule {

--- a/sbt_common/finatra_storage/src/main/scala/uk/ac/wellcome/finatra/storage/S3ClientModule.scala
+++ b/sbt_common/finatra_storage/src/main/scala/uk/ac/wellcome/finatra/storage/S3ClientModule.scala
@@ -1,9 +1,8 @@
 package uk.ac.wellcome.finatra.storage
 
 import com.amazonaws.services.s3.AmazonS3
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
-import javax.inject.Singleton
 import uk.ac.wellcome.storage.s3.S3ClientFactory
 
 object S3ClientModule extends TwitterModule {

--- a/sbt_common/finatra_storage/src/main/scala/uk/ac/wellcome/finatra/storage/S3ConfigModule.scala
+++ b/sbt_common/finatra_storage/src/main/scala/uk/ac/wellcome/finatra/storage/S3ConfigModule.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.finatra.storage
 
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
-import javax.inject.Singleton
 import uk.ac.wellcome.storage.s3.S3Config
 
 object S3ConfigModule extends TwitterModule {

--- a/sbt_common/finatra_storage/src/main/scala/uk/ac/wellcome/finatra/storage/VHSConfigModule.scala
+++ b/sbt_common/finatra_storage/src/main/scala/uk/ac/wellcome/finatra/storage/VHSConfigModule.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.finatra.storage
 
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
-import javax.inject.Singleton
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.vhs.VHSConfig

--- a/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/modules/SierraTransformableModule.scala
+++ b/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/modules/SierraTransformableModule.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.sierra_adapter.modules
 
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.{Injector, TwitterModule}
-import javax.inject.Singleton
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.s3.S3StorageBackend

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/ReaderConfigModule.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/ReaderConfigModule.scala
@@ -1,8 +1,6 @@
 package uk.ac.wellcome.platform.sierra_reader.modules
 
-import javax.inject.Singleton
-
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.platform.sierra_reader.models.ReaderConfig
 

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/SierraConfigModule.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/SierraConfigModule.scala
@@ -1,8 +1,6 @@
 package uk.ac.wellcome.platform.sierra_reader.modules
 
-import javax.inject.Singleton
-
-import com.google.inject.Provides
+import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.platform.sierra_reader.models.SierraConfig
 import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes.{


### PR DESCRIPTION
We had a mixture of imports from javax.inject and com.google.inject. I don’t know what the differences are – we should be consistent to reduce the risk of hard-to-spot bugs.