### PR TITLE
If we get empty strings for location from Sierra, don't try to turn it into a Location

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocation.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocation.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import uk.ac.wellcome.models.work.internal.{LocationType, PhysicalLocation}
-import uk.ac.wellcome.platform.transformer.source.{SierraItemData, SierraItemLocation}
+import uk.ac.wellcome.platform.transformer.source.{
+  SierraItemData,
+  SierraItemLocation
+}
 
 trait SierraLocation {
   def getLocation(itemData: SierraItemData): Option[PhysicalLocation] =
@@ -13,12 +16,13 @@ trait SierraLocation {
       // those cases.
       case Some(SierraItemLocation("", "")) => None
 
-      case Some(loc: SierraItemLocation) => Some(
-        PhysicalLocation(
-          locationType = LocationType(loc.code),
-          label = loc.name
+      case Some(loc: SierraItemLocation) =>
+        Some(
+          PhysicalLocation(
+            locationType = LocationType(loc.code),
+            label = loc.name
+          )
         )
-      )
       case None => None
     }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocation.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocation.scala
@@ -1,11 +1,24 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import uk.ac.wellcome.models.work.internal.{LocationType, PhysicalLocation}
-import uk.ac.wellcome.platform.transformer.source.SierraItemData
+import uk.ac.wellcome.platform.transformer.source.{SierraItemData, SierraItemLocation}
 
 trait SierraLocation {
   def getLocation(itemData: SierraItemData): Option[PhysicalLocation] =
-    itemData.location.map { l =>
-      PhysicalLocation(locationType = LocationType(l.code), label = l.name)
+    itemData.location match {
+      // We've seen records where the "location" field is populated in
+      // the JSON, but the code and name are both empty strings.  We can't
+      // do anything useful with this, so don't return a location.
+      // TODO: Find out if we can populate location from other fields in
+      // those cases.
+      case Some(SierraItemLocation("", "")) => None
+
+      case Some(loc: SierraItemLocation) => Some(
+        PhysicalLocation(
+          locationType = LocationType(loc.code),
+          label = loc.name
+        )
+      )
+      case None => None
     }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocationTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocationTest.scala
@@ -11,7 +11,7 @@ class SierraLocationTest extends FunSpec with Matchers {
 
   val transformer = new SierraLocation {}
 
-  it("should extract location from item data") {
+  it("extracts location from item data") {
     val locationTypeCode = "sgmed"
     val locationType = LocationType("sgmed")
     val label = "A museum of mermaids"
@@ -26,7 +26,7 @@ class SierraLocationTest extends FunSpec with Matchers {
       expectedLocation)
   }
 
-  it("should return none if there is no location in the item data") {
+  it("returns None if there is no location in the item data") {
     val itemData = SierraItemData(
       id = "i1234567"
     )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocationTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocationTest.scala
@@ -26,6 +26,15 @@ class SierraLocationTest extends FunSpec with Matchers {
       expectedLocation)
   }
 
+  it("returns None if the location field only contains empty strings") {
+    val itemData = SierraItemData(
+      id = "i1234567",
+      location = Some(SierraItemLocation("", ""))
+    )
+
+    transformer.getLocation(itemData = itemData) shouldBe None
+  }
+
   it("returns None if there is no location in the item data") {
     val itemData = SierraItemData(
       id = "i1234567"


### PR DESCRIPTION
Resolves #2224. This was a major cause of failures in the transformer last time I checked, it would be nice to patch this leak!