### PR TITLE
Fix the deep learning ASG, plus some minor script improvements

### DIFF
--- a/data_science/scripts/asg_utils.py
+++ b/data_science/scripts/asg_utils.py
@@ -32,15 +32,6 @@ def discover_asg(asg_client, tag_name):
     sys.exit("Can't find an ASG with name %r!" % tag_name)
 
 
-def discover_asg_name(asg_client, tag_name):
-    """
-    Returns the name of the first autoscaling group whose tags exactly match
-    the supplied input.
-    """
-    asg_data = discover_asg(asg_client=asg_client, tag_name=tag_name)
-    return asg_data['AutoScalingGroupName']
-
-
 def set_asg_size(asg_client, asg_name, desired_size):
     """
     Set the size of an ASG to ``desired_size``.

--- a/data_science/scripts/create_tunnel_to_asg.py
+++ b/data_science/scripts/create_tunnel_to_asg.py
@@ -35,7 +35,7 @@ def _wait(message, wait=5):
     time.sleep(wait)
 
 
-if __name__ == '__main__':
+def main():
     args = docopt.docopt(__doc__)
 
     key_path = args['--key'] or _default_ssh_key_path()
@@ -112,3 +112,10 @@ if __name__ == '__main__':
         ])
     except subprocess.CalledProcessError as err:
         sys.exit(err.returncode)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(1)

--- a/data_science/scripts/toggle_asg.py
+++ b/data_science/scripts/toggle_asg.py
@@ -3,11 +3,12 @@
 """
 Start/stop all the instances in an autoscaling group.
 
-Usage: toggle_asg.py (--start | --stop) [--type=(p2 | t2)]
+Usage: toggle_asg.py (--start | --stop | --status) [--type=(p2 | t2)]
 
 Actions:
   --start                 Start the autoscaling group (set the desired count to 1).
   --stop                  Stop the autoscaling group (set the desired count to 0).
+  --status                Report the current side of autoscaling group.
   --type=(p2 | t2)        AWS Instance type (valid values: p2,t2) defaults to t2
 
 """
@@ -17,28 +18,36 @@ import sys
 import boto3
 import docopt
 
-from asg_utils import discover_asg_name, set_asg_size
+from asg_utils import discover_asg, set_asg_size
 
 if __name__ == '__main__':
     args = docopt.docopt(__doc__)
-
-    if args.get('--start'):
-        desired_size = 1
-    elif args.get('--stop'):
-        desired_size = 0
-    else:
-        print('Neither --start nor --stop flags supplied?  args=%r' % args)
-        sys.exit(1)
 
     instance_type = args['--type'] or 't2'
     tag_name = 'jupyter-%s' % instance_type
 
     asg_client = boto3.client('autoscaling')
+    asg = discover_asg(asg_client=asg_client, tag_name=tag_name)
+    asg_name = asg['AutoScalingGroupName']
 
-    asg_name = discover_asg_name(asg_client=asg_client, tag_name=tag_name)
+    if args['--start'] or args['--stop']:
+        if args['--start']:
+            desired_size = 1
+        else:
+            desired_size = 0
 
-    set_asg_size(
-        asg_client=asg_client,
-        asg_name=asg_name,
-        desired_size=desired_size
-    )
+        set_asg_size(
+            asg_client=asg_client,
+            asg_name=asg_name,
+            desired_size=desired_size
+        )
+
+    elif args['--status']:
+        actual_size = asg['DesiredCapacity']
+        print('The current size of ASG group %r is %r' % (asg_name, actual_size))
+
+    else:
+        print(
+            'Neither --start, --stop nor --status flags supplied?  args=%r' %
+            args)
+        sys.exit(1)

--- a/data_science/scripts/toggle_asg.py
+++ b/data_science/scripts/toggle_asg.py
@@ -44,7 +44,19 @@ if __name__ == '__main__':
 
     elif args['--status']:
         actual_size = asg['DesiredCapacity']
-        print('The current size of ASG group %r is %r' % (asg_name, actual_size))
+        instance_count = len(asg['Instances'])
+
+        if instance_count == 1:
+            instance_str = '1 instance'
+        elif instance_count == 0:
+            instance_str = 'no instances'
+        else:
+            instance_str = '%d instances' % instance_count
+
+        print(
+            'The desired size of ASG group %r is %r, with %s running' %
+            (asg_name, actual_size, instance_str)
+        )
 
     else:
         print(

--- a/data_science/terraform/main.tf
+++ b/data_science/terraform/main.tf
@@ -1,5 +1,5 @@
 module "p2_compute" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//dlami_asg?ref=v10.2.2"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//dlami_asg?ref=fix-dlami"
   name   = "jupyter-p2"
 
   key_name    = "${var.key_name}"
@@ -15,7 +15,7 @@ module "p2_compute" {
 }
 
 module "t2_compute" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//dlami_asg?ref=v10.2.2"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//dlami_asg?ref=fix-dlami"
   name   = "jupyter-t2"
 
   key_name    = "${var.key_name}"


### PR DESCRIPTION
Requires https://github.com/wellcometrust/terraform-modules/pull/78. Resolves #1966.

This pull request:

- Fixes the version of s3contents that we install on our data science VMs
- Adds logging on the instances to detect issues with pip
- Adds a `--status` flag to the `toggle_asg.py` script, which reports the current state of the ASG:

    ```console
    $ python data_science/scripts/toggle_asg.py --status
    The desired size of ASG group 'jupyter-t2-AutoScalingGroup-BLAP9EQ7948C' is 1, with 1 instance running
    ```

- Modifies the `create_tunnel_to_asg.py` script to keep retrying until an instance comes up.