### PR TITLE
Don’t include copyright-related stuff in the production events field

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
@@ -121,7 +121,9 @@ trait SierraProduction {
   //
   private def getProductionFrom264Fields(varFields: List[VarField]) =
     varFields
-      .filterNot { vf => vf.indicator2 == Some("4") }
+      .filterNot { vf =>
+        vf.indicator2 == Some("4")
+      }
       .map { vf =>
         val places = placesFromSubfields(vf, subfieldTag = "a")
         val agents = agentsFromSubfields(vf, subfieldTag = "b")

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
@@ -108,36 +108,45 @@ trait SierraProduction {
   //  - 2 = Distribution
   //  - 3 = Manufacture
   //
+  // The MARC spec specifies another value for the production function:
+  //
+  //  - 4 = Copyright notice date
+  //
+  // We'll be putting copyright information in a separate part of the domain
+  // model, so we drop any fields with indicator 4 for production events.
+  //
   // Note that a, b and c are repeatable fields.
   //
   // https://www.loc.gov/marc/bibliographic/bd264.html
   //
   private def getProductionFrom264Fields(varFields: List[VarField]) =
-    varFields.map { vf =>
-      val places = placesFromSubfields(vf, subfieldTag = "a")
-      val agents = agentsFromSubfields(vf, subfieldTag = "b")
-      val dates = datesFromSubfields(vf, subfieldTag = "c")
+    varFields
+      .filterNot { vf => vf.indicator2 == Some("4") }
+      .map { vf =>
+        val places = placesFromSubfields(vf, subfieldTag = "a")
+        val agents = agentsFromSubfields(vf, subfieldTag = "b")
+        val dates = datesFromSubfields(vf, subfieldTag = "c")
 
-      val productionFunctionLabel = vf.indicator2 match {
-        case Some("0") => "Production"
-        case Some("1") => "Publication"
-        case Some("2") => "Distribution"
-        case Some("3") => "Manufacture"
-        case other =>
-          throw GracefulFailureException(new RuntimeException(
-            s"Unrecognised second indicator for production function: [$other]"
-          ))
+        val productionFunctionLabel = vf.indicator2 match {
+          case Some("0") => "Production"
+          case Some("1") => "Publication"
+          case Some("2") => "Distribution"
+          case Some("3") => "Manufacture"
+          case other =>
+            throw GracefulFailureException(new RuntimeException(
+              s"Unrecognised second indicator for production function: [$other]"
+            ))
+        }
+
+        val productionFunction = Some(Concept(label = productionFunctionLabel))
+
+        ProductionEvent(
+          places = places,
+          agents = agents,
+          dates = dates,
+          function = productionFunction
+        )
       }
-
-      val productionFunction = Some(Concept(label = productionFunctionLabel))
-
-      ProductionEvent(
-        places = places,
-        agents = agents,
-        dates = dates,
-        function = productionFunction
-      )
-    }
 
   private def placesFromSubfields(vf: VarField,
                                   subfieldTag: String): List[Place] =

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProductionTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProductionTest.scala
@@ -248,6 +248,39 @@ class SierraProductionTest extends FunSpec with Matchers {
       }
     }
 
+    it("ignores instances of the 264 field related to copyright (2nd indicator 4)") {
+      val varFields = List(
+        VarField(
+          marcTag = Some("264"),
+          fieldTag = "a",
+          indicator2 = Some("4"),
+          subfields = List(
+            MarcSubfield(tag = "c", content = "copyright 2005")
+          )
+        ),
+        VarField(
+          marcTag = Some("264"),
+          fieldTag = "a",
+          indicator2 = Some("3"),
+          subfields = List(
+            MarcSubfield(tag = "a", content = "Cambridge"),
+            MarcSubfield(tag = "b", content = "Kinsey Printing Company")
+          )
+        )
+      )
+
+      val expectedProductions = List(
+        ProductionEvent(
+          places = List(Place("Cambridge")),
+          agents = List(Unidentifiable(Agent("Kinsey Printing Company"))),
+          dates = List(),
+          function = Some(Concept("Manufacture"))
+        )
+      )
+
+      transformToProduction(varFields) shouldBe expectedProductions
+    }
+
     it("picks up multiple instances of the 264 field") {
       val varFields = List(
         VarField(


### PR DESCRIPTION
Fixes part 2 of #2252. Talking to Silver – we’ll put this stuff in a separate field on Work, so we don’t need to include them here.

This was causing an error in the transformer (it didn’t recognise 2nd indicator 4) which should now be resolved.