### PR TITLE
Pass around stream length when PUT’ing a record

### DIFF
--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StorageBackend.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3StorageBackend.scala
@@ -1,9 +1,10 @@
 package uk.ac.wellcome.storage.s3
 
-import java.io.InputStream
+import java.io.{ByteArrayInputStream, InputStream}
 
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest}
+import com.amazonaws.util.IOUtils
 import com.google.inject.Inject
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.storage.{ObjectLocation, StorageBackend}
@@ -17,24 +18,54 @@ class S3StorageBackend @Inject()(s3Client: AmazonS3)(
     with Logging {
 
   private def generateMetadata(
-    userMetadata: Map[String, String]
+    userMetadata: Map[String, String],
+    contentLength: Int
   ): ObjectMetadata = {
     val objectMetadata = new ObjectMetadata()
     objectMetadata.setUserMetadata(userMetadata.asJava)
+    objectMetadata.setContentLength(contentLength)
     objectMetadata
   }
 
   def put(location: ObjectLocation,
           input: InputStream,
           metadata: Map[String, String]): Future[Unit] = {
+
+    // Yes, it's moderately daft that we get an InputStream which we
+    // immediately load into a ByteArray, then turn it into a different
+    // InputStream for the upload to S3.
+    //
+    // Doing it this way allows S3 to know the length of the data before
+    // we upload it.  Otherwise we get the following warning:
+    //
+    //      No content length specified for stream data. Stream
+    //      contents will be buffered in memory and could result
+    //      in out of memory errors.
+    //
+    // When we have bigger strings than fit in memory, we'll need to
+    // revisit this code anyway -- it'll be time for multipart uploads.
+    //
+    val bytes = IOUtils.toByteArray(input)
+    val byteArrayInputStream = new ByteArrayInputStream(bytes)
+
+    val generatedMetadata = generateMetadata(
+      userMetadata = metadata,
+      contentLength = bytes.length
+    )
+
     val bucketName = location.namespace
     val key = location.key
 
-    val generatedMetadata = generateMetadata(metadata)
+    val putObjectRequest = new PutObjectRequest(
+      bucketName,
+      key,
+      byteArrayInputStream,
+      generatedMetadata
+    )
 
     debug(s"Attempt: PUT object to s3://$bucketName/$key")
     val putObject = Future {
-      s3Client.putObject(bucketName, key, input, generatedMetadata)
+      s3Client.putObject(putObjectRequest)
     }
 
     putObject.map { _ =>


### PR DESCRIPTION
We have a whole heap of warnings in CloudWatch:

```
14:19:53.116 [main-actor-system-akka.actor.default-dispatcher-5] WARN c.a.services.s3.AmazonS3Client - No content length specified for stream data. Stream contents will be buffered in memory and could result in out of memory errors.
```

When we’re serialising from strings (which is always what we do, even if we’re doing it in a roundabout way), we know the length of the object we’re going to PUT to S3 – so let’s make sure S3 knows as well.