### PR TITLE
Add mergeCandidates to our internal Work model

### DIFF
--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/CustomElasticSearchMapping.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/CustomElasticSearchMapping.scala
@@ -39,6 +39,7 @@ trait CustomElasticSearchMapping {
         textField("title").fields(
           textField("english").analyzer(EnglishLanguageAnalyzer)),
         booleanField("visible"),
+        objectField("mergeCandidates"),
         objectField("identifiers"),
         objectField("subjects"),
         keywordField("workType"),

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -38,10 +38,10 @@ class MergerFeatureTest
                     messageBucket = messagesBucket,
                     table = table) { _ =>
                     val recorderWorkEntry = recorderWorkEntryWith(
-                      "dfmsng",
-                      "sierra-system-number",
-                      "b123456",
-                      1)
+                      title = "dfmsng",
+                      identifierType = "sierra-system-number",
+                      sourceId = "b123456",
+                      version = 1)
 
                     whenReady(storeInVHS(vhs, List(recorderWorkEntry))) { _ =>
                       val matcherResult =

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
@@ -62,7 +62,7 @@ trait MergerTestUtils { this: SQS with SNS with Messaging =>
     val recorderWorkEntry1 = RecorderWorkEntry(
       UnidentifiedWork(
         title = Some(title),
-        SourceIdentifier(IdentifierType(identifierType), "Work", sourceId),
+        sourceIdentifier = SourceIdentifier(IdentifierType(identifierType), "Work", sourceId),
         version = version))
     recorderWorkEntry1
   }

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
@@ -62,7 +62,8 @@ trait MergerTestUtils { this: SQS with SNS with Messaging =>
     val recorderWorkEntry1 = RecorderWorkEntry(
       UnidentifiedWork(
         title = Some(title),
-        sourceIdentifier = SourceIdentifier(IdentifierType(identifierType), "Work", sourceId),
+        sourceIdentifier =
+          SourceIdentifier(IdentifierType(identifierType), "Work", sourceId),
         version = version))
     recorderWorkEntry1
   }

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -138,14 +138,22 @@ class WorksIndex @Inject()(client: HttpClient, elasticConfig: ElasticConfig)
     keywordField("ontologyType")
   )
 
+  val mergeCandidates = objectField("mergeCandidates").fields(
+    objectField("identifier").fields(sourceIdentifierFields),
+    keywordField("reason")
+  )
+
   val rootIndexFields: Seq[FieldDefinition with Product with Serializable] =
     Seq(
       keywordField("canonicalId"),
       booleanField("visible"),
       keywordField("ontologyType"),
       intField("version"),
+
       sourceIdentifier,
       identifiers,
+      mergeCandidates,
+
       workType,
       textField("title").fields(
         textField("english").analyzer(EnglishLanguageAnalyzer)),

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -149,11 +149,9 @@ class WorksIndex @Inject()(client: HttpClient, elasticConfig: ElasticConfig)
       booleanField("visible"),
       keywordField("ontologyType"),
       intField("version"),
-
       sourceIdentifier,
       identifiers,
       mergeCandidates,
-
       workType,
       textField("title").fields(
         textField("english").analyzer(EnglishLanguageAnalyzer)),

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/MergeCandidate.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/MergeCandidate.scala
@@ -1,0 +1,16 @@
+package uk.ac.wellcome.models.work.internal
+
+/** Indicates that it might be possible to merge this Work with another Work.
+  *
+  * @param identifier The SourceIdentifier of the other Work.
+  * @param reason A statement of _why_ the we think it might be possible to
+  *               to merge these two works.  For example, "MARC tag 776 points
+  *               to electronic resource".
+  *
+  *               Long-term, this might be replaced with an enum or a fixed
+  *               set of strings.
+  */
+case class MergeCandidate(
+  identifier: SourceIdentifier,
+  reason: Option[String] = None
+)

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -2,32 +2,35 @@ package uk.ac.wellcome.models.work.internal
 
 /** A representation of a work in our ontology */
 trait Work {
-  val title: Option[String]
   val sourceIdentifier: SourceIdentifier
-  val version: Int
   val identifiers: List[SourceIdentifier]
+
   val workType: Option[WorkType]
+  val title: Option[String]
   val description: Option[String]
   val physicalDescription: Option[String]
   val extent: Option[String]
   val lettering: Option[String]
   val createdDate: Option[Period]
   val subjects: List[Subject[IdentityState[AbstractConcept]]]
-  val contributors: List[Contributor[IdentityState[AbstractAgent]]]
   val genres: List[Genre[IdentityState[AbstractConcept]]]
+  val contributors: List[Contributor[IdentityState[AbstractAgent]]]
   val thumbnail: Option[Location]
   val production: List[ProductionEvent[IdentityState[AbstractAgent]]]
   val language: Option[Language]
   val dimensions: Option[String]
+
+  val version: Int
   val visible: Boolean
+
   val ontologyType: String
 }
 
 case class UnidentifiedWork(
-  title: Option[String],
   sourceIdentifier: SourceIdentifier,
-  version: Int,
   identifiers: List[SourceIdentifier] = List(),
+
+  title: Option[String],
   workType: Option[WorkType] = None,
   description: Option[String] = None,
   physicalDescription: Option[String] = None,
@@ -35,22 +38,24 @@ case class UnidentifiedWork(
   lettering: Option[String] = None,
   createdDate: Option[Period] = None,
   subjects: List[Subject[MaybeDisplayable[AbstractConcept]]] = Nil,
-  contributors: List[Contributor[MaybeDisplayable[AbstractAgent]]] = Nil,
   genres: List[Genre[MaybeDisplayable[AbstractConcept]]] = Nil,
+  contributors: List[Contributor[MaybeDisplayable[AbstractAgent]]] = Nil,
   thumbnail: Option[Location] = None,
   items: List[UnidentifiedItem] = Nil,
   production: List[ProductionEvent[MaybeDisplayable[AbstractAgent]]] = Nil,
   language: Option[Language] = None,
   dimensions: Option[String] = None,
+
+  version: Int,
   visible: Boolean = true,
-  ontologyType: String = "Work")
-    extends Work
+
+  ontologyType: String = "Work") extends Work
 
 case class IdentifiedWork(
   canonicalId: String,
   title: Option[String],
   sourceIdentifier: SourceIdentifier,
-  version: Int,
+
   identifiers: List[SourceIdentifier] = List(),
   workType: Option[WorkType] = None,
   description: Option[String] = None,
@@ -59,13 +64,15 @@ case class IdentifiedWork(
   lettering: Option[String] = None,
   createdDate: Option[Period] = None,
   subjects: List[Subject[Displayable[AbstractConcept]]] = Nil,
-  contributors: List[Contributor[Displayable[AbstractAgent]]] = Nil,
   genres: List[Genre[Displayable[AbstractConcept]]] = Nil,
+  contributors: List[Contributor[Displayable[AbstractAgent]]] = Nil,
   thumbnail: Option[Location] = None,
   items: List[IdentifiedItem] = Nil,
   production: List[ProductionEvent[Displayable[AbstractAgent]]] = Nil,
   language: Option[Language] = None,
   dimensions: Option[String] = None,
+
+  version: Int,
   visible: Boolean = true,
-  ontologyType: String = "Work")
-    extends Work
+
+  ontologyType: String = "Work") extends Work

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -6,8 +6,8 @@ trait Work {
   val identifiers: List[SourceIdentifier]
   val mergeCandidates: List[MergeCandidate]
 
-  val workType: Option[WorkType]
   val title: Option[String]
+  val workType: Option[WorkType]
   val description: Option[String]
   val physicalDescription: Option[String]
   val extent: Option[String]
@@ -21,6 +21,8 @@ trait Work {
   val language: Option[Language]
   val dimensions: Option[String]
 
+  val items: List[Item]
+
   val version: Int
   val visible: Boolean
 
@@ -31,6 +33,7 @@ case class UnidentifiedWork(
   sourceIdentifier: SourceIdentifier,
   identifiers: List[SourceIdentifier] = List(),
   mergeCandidates: List[MergeCandidate] = List(),
+
   title: Option[String],
   workType: Option[WorkType] = None,
   description: Option[String] = None,
@@ -42,21 +45,25 @@ case class UnidentifiedWork(
   genres: List[Genre[MaybeDisplayable[AbstractConcept]]] = Nil,
   contributors: List[Contributor[MaybeDisplayable[AbstractAgent]]] = Nil,
   thumbnail: Option[Location] = None,
-  items: List[UnidentifiedItem] = Nil,
   production: List[ProductionEvent[MaybeDisplayable[AbstractAgent]]] = Nil,
   language: Option[Language] = None,
   dimensions: Option[String] = None,
+
+  items: List[UnidentifiedItem] = Nil,
+
   version: Int,
   visible: Boolean = true,
-  ontologyType: String = "Work")
-    extends Work
+
+  ontologyType: String = "Work") extends Work
 
 case class IdentifiedWork(
   canonicalId: String,
-  title: Option[String],
+
   sourceIdentifier: SourceIdentifier,
-  mergeCandidates: List[MergeCandidate] = List(),
   identifiers: List[SourceIdentifier] = List(),
+  mergeCandidates: List[MergeCandidate] = List(),
+
+  title: Option[String],
   workType: Option[WorkType] = None,
   description: Option[String] = None,
   physicalDescription: Option[String] = None,
@@ -67,11 +74,13 @@ case class IdentifiedWork(
   genres: List[Genre[Displayable[AbstractConcept]]] = Nil,
   contributors: List[Contributor[Displayable[AbstractAgent]]] = Nil,
   thumbnail: Option[Location] = None,
-  items: List[IdentifiedItem] = Nil,
   production: List[ProductionEvent[Displayable[AbstractAgent]]] = Nil,
   language: Option[Language] = None,
   dimensions: Option[String] = None,
+
+  items: List[IdentifiedItem] = Nil,
+
   version: Int,
   visible: Boolean = true,
-  ontologyType: String = "Work")
-    extends Work
+
+  ontologyType: String = "Work") extends Work

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -31,7 +31,6 @@ case class UnidentifiedWork(
   sourceIdentifier: SourceIdentifier,
   identifiers: List[SourceIdentifier] = List(),
   mergeCandidates: List[MergeCandidate] = List(),
-
   title: Option[String],
   workType: Option[WorkType] = None,
   description: Option[String] = None,
@@ -47,18 +46,16 @@ case class UnidentifiedWork(
   production: List[ProductionEvent[MaybeDisplayable[AbstractAgent]]] = Nil,
   language: Option[Language] = None,
   dimensions: Option[String] = None,
-
   version: Int,
   visible: Boolean = true,
-
-  ontologyType: String = "Work") extends Work
+  ontologyType: String = "Work")
+    extends Work
 
 case class IdentifiedWork(
   canonicalId: String,
   title: Option[String],
   sourceIdentifier: SourceIdentifier,
   mergeCandidates: List[MergeCandidate] = List(),
-
   identifiers: List[SourceIdentifier] = List(),
   workType: Option[WorkType] = None,
   description: Option[String] = None,
@@ -74,8 +71,7 @@ case class IdentifiedWork(
   production: List[ProductionEvent[Displayable[AbstractAgent]]] = Nil,
   language: Option[Language] = None,
   dimensions: Option[String] = None,
-
   version: Int,
   visible: Boolean = true,
-
-  ontologyType: String = "Work") extends Work
+  ontologyType: String = "Work")
+    extends Work

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -33,7 +33,6 @@ case class UnidentifiedWork(
   sourceIdentifier: SourceIdentifier,
   identifiers: List[SourceIdentifier] = List(),
   mergeCandidates: List[MergeCandidate] = List(),
-
   title: Option[String],
   workType: Option[WorkType] = None,
   description: Option[String] = None,
@@ -48,21 +47,17 @@ case class UnidentifiedWork(
   production: List[ProductionEvent[MaybeDisplayable[AbstractAgent]]] = Nil,
   language: Option[Language] = None,
   dimensions: Option[String] = None,
-
   items: List[UnidentifiedItem] = Nil,
-
   version: Int,
   visible: Boolean = true,
-
-  ontologyType: String = "Work") extends Work
+  ontologyType: String = "Work")
+    extends Work
 
 case class IdentifiedWork(
   canonicalId: String,
-
   sourceIdentifier: SourceIdentifier,
   identifiers: List[SourceIdentifier] = List(),
   mergeCandidates: List[MergeCandidate] = List(),
-
   title: Option[String],
   workType: Option[WorkType] = None,
   description: Option[String] = None,
@@ -77,10 +72,8 @@ case class IdentifiedWork(
   production: List[ProductionEvent[Displayable[AbstractAgent]]] = Nil,
   language: Option[Language] = None,
   dimensions: Option[String] = None,
-
   items: List[IdentifiedItem] = Nil,
-
   version: Int,
   visible: Boolean = true,
-
-  ontologyType: String = "Work") extends Work
+  ontologyType: String = "Work")
+    extends Work

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -4,6 +4,7 @@ package uk.ac.wellcome.models.work.internal
 trait Work {
   val sourceIdentifier: SourceIdentifier
   val identifiers: List[SourceIdentifier]
+  val mergeCandidates: List[MergeCandidate]
 
   val workType: Option[WorkType]
   val title: Option[String]
@@ -29,6 +30,7 @@ trait Work {
 case class UnidentifiedWork(
   sourceIdentifier: SourceIdentifier,
   identifiers: List[SourceIdentifier] = List(),
+  mergeCandidates: List[MergeCandidate] = List(),
 
   title: Option[String],
   workType: Option[WorkType] = None,
@@ -55,6 +57,7 @@ case class IdentifiedWork(
   canonicalId: String,
   title: Option[String],
   sourceIdentifier: SourceIdentifier,
+  mergeCandidates: List[MergeCandidate] = List(),
 
   identifiers: List[SourceIdentifier] = List(),
   workType: Option[WorkType] = None,


### PR DESCRIPTION
As discussed in standup, this adds a new field "mergeCandidates" to Work. This is distinct from "identifiers" – it’s a stronger statement that these Works should eventually exist in the pipeline, and the merger should look for them.

I also added a "reason" field, so the merger can know why we thought these two works might need merging.