### PR TITLE
Don’t log health check requests from the ALB

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
@@ -13,6 +13,7 @@ import uk.ac.wellcome.finatra.elasticsearch.{
   ElasticClientModule,
   ElasticConfigModule
 }
+import uk.ac.wellcome.finatra.modules.AccessLoggingFilterModule
 import uk.ac.wellcome.platform.api.controllers._
 import uk.ac.wellcome.platform.api.finatra.exceptions.{
   CaseClassMappingExceptionWrapper,
@@ -26,6 +27,7 @@ object ServerMain extends Server
 class Server extends HttpServer {
   override val name = "uk.ac.wellcome.platform.api Platformapi"
   override val modules = Seq(
+    AccessLoggingFilterModule,
     ApiConfigModule,
     ElasticClientModule,
     ElasticConfigModule

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/Server.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/Server.scala
@@ -15,6 +15,7 @@ import uk.ac.wellcome.finatra.messaging.{
   SNSClientModule,
   SQSClientModule
 }
+import uk.ac.wellcome.finatra.modules.AccessLoggingFilterModule
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
 import uk.ac.wellcome.finatra.storage.S3ClientModule
 import uk.ac.wellcome.platform.idminter.modules._
@@ -24,6 +25,7 @@ object ServerMain extends Server
 class Server extends HttpServer {
   override val name = "uk.ac.wellcome.platform.id_minter IdMinter"
   override val modules = Seq(
+    AccessLoggingFilterModule,
     MysqlModule,
     IdentifiersTableConfigModule,
     AkkaModule,

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/Server.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/Server.scala
@@ -15,6 +15,7 @@ import uk.ac.wellcome.finatra.elasticsearch.{
   ElasticConfigModule
 }
 import uk.ac.wellcome.finatra.messaging.{MessageConfigModule, SQSClientModule}
+import uk.ac.wellcome.finatra.modules.AccessLoggingFilterModule
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
 import uk.ac.wellcome.finatra.storage.{S3ClientModule, S3ConfigModule}
 import uk.ac.wellcome.platform.ingestor.modules.{
@@ -29,6 +30,7 @@ object ServerMain extends Server
 class Server extends HttpServer {
   override val name = "uk.ac.wellcome.platform.ingestor Ingestor"
   override val modules = Seq(
+    AccessLoggingFilterModule,
     MetricsSenderModule,
     SQSClientModule,
     MessageConfigModule,

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/Server.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/Server.scala
@@ -16,6 +16,7 @@ import uk.ac.wellcome.finatra.messaging.{
   SQSClientModule,
   SQSConfigModule
 }
+import uk.ac.wellcome.finatra.modules.AccessLoggingFilterModule
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
 import uk.ac.wellcome.finatra.storage.{
   DynamoClientModule,
@@ -35,6 +36,7 @@ class Server extends HttpServer {
   override val name =
     "uk.ac.wellcome.platform.matcher Matcher"
   override val modules = Seq(
+    AccessLoggingFilterModule,
     MetricsSenderModule,
     SQSConfigModule,
     SQSClientModule,

--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Server.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Server.scala
@@ -11,6 +11,7 @@ import com.twitter.finatra.http.routing.HttpRouter
 import uk.ac.wellcome.finatra.akka.{AkkaModule, ExecutionContextModule}
 import uk.ac.wellcome.finatra.controllers.ManagementController
 import uk.ac.wellcome.finatra.messaging._
+import uk.ac.wellcome.finatra.modules.AccessLoggingFilterModule
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
 import uk.ac.wellcome.finatra.storage.{
   DynamoClientModule,
@@ -26,6 +27,7 @@ import uk.ac.wellcome.platform.merger.modules.{
 class Server extends HttpServer {
   override val name = "uk.ac.wellcome.platform.merger Merger"
   override val modules = Seq(
+    AccessLoggingFilterModule,
     MetricsSenderModule,
     AkkaModule,
     SQSClientModule,

--- a/catalogue_pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/Server.scala
+++ b/catalogue_pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/Server.scala
@@ -15,6 +15,7 @@ import uk.ac.wellcome.finatra.messaging.{
   SQSClientModule,
   SQSConfigModule
 }
+import uk.ac.wellcome.finatra.modules.AccessLoggingFilterModule
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
 import uk.ac.wellcome.finatra.storage.{
   DynamoClientModule,
@@ -33,6 +34,7 @@ class Server extends HttpServer {
   override val name =
     "uk.ac.wellcome.platform.recorder Recorder"
   override val modules = Seq(
+    AccessLoggingFilterModule,
     ExecutionContextModule,
     VHSConfigModule,
     MessageConfigModule,

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/Server.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/Server.scala
@@ -16,6 +16,7 @@ import uk.ac.wellcome.finatra.messaging.{
   SQSClientModule,
   SQSConfigModule
 }
+import uk.ac.wellcome.finatra.modules.AccessLoggingFilterModule
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
 import uk.ac.wellcome.finatra.storage.{S3ClientModule, S3ConfigModule}
 import uk.ac.wellcome.platform.transformer.modules.{TransformerWorkerModule, _}
@@ -25,6 +26,7 @@ object ServerMain extends Server
 class Server extends HttpServer {
   override val name = "uk.ac.wellcome.platform.transformer Transformer"
   override val modules = Seq(
+    AccessLoggingFilterModule,
     MetricsSenderModule,
     AkkaModule,
     SQSClientModule,

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/Server.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/Server.scala
@@ -21,6 +21,7 @@ import uk.ac.wellcome.finatra.messaging.{
   SQSClientModule,
   SQSConfigModule
 }
+import uk.ac.wellcome.finatra.modules.AccessLoggingFilterModule
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
 import uk.ac.wellcome.finatra.storage.S3ConfigModule
 import uk.ac.wellcome.platform.snapshot_generator.finatra.modules.{
@@ -36,6 +37,7 @@ class Server extends HttpServer {
     "uk.ac.wellcome.platform.snapshot_generator SnapshotGenerator"
 
   override val modules = Seq(
+    AccessLoggingFilterModule,
     MetricsSenderModule,
     SQSClientModule,
     SQSConfigModule,

--- a/goobi_adapter/goobi_reader/src/main/scala/uk/ac/wellcome/platform/goobi_reader/Server.scala
+++ b/goobi_adapter/goobi_reader/src/main/scala/uk/ac/wellcome/platform/goobi_reader/Server.scala
@@ -11,6 +11,7 @@ import com.twitter.finatra.http.routing.HttpRouter
 import uk.ac.wellcome.finatra.akka.AkkaModule
 import uk.ac.wellcome.finatra.messaging.{SQSClientModule, SQSConfigModule}
 import uk.ac.wellcome.finatra.controllers.ManagementController
+import uk.ac.wellcome.finatra.modules.AccessLoggingFilterModule
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
 import uk.ac.wellcome.finatra.storage.{
   DynamoClientModule,
@@ -28,6 +29,7 @@ class Server extends HttpServer {
   override val name =
     "uk.ac.wellcome.platform.goobi_reader Goobi reader"
   override val modules = Seq(
+    AccessLoggingFilterModule,
     AkkaModule,
     DynamoClientModule,
     GoobiReaderModule,

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/Server.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/Server.scala
@@ -16,6 +16,7 @@ import uk.ac.wellcome.finatra.messaging.{
   SQSClientModule,
   SQSConfigModule
 }
+import uk.ac.wellcome.finatra.modules.AccessLoggingFilterModule
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
 import uk.ac.wellcome.finatra.storage.{
   DynamoClientModule,
@@ -30,6 +31,7 @@ class Server extends HttpServer {
   override val name = "uk.ac.wellcome.platform.reindexer Reindexer"
 
   override val modules = Seq(
+    AccessLoggingFilterModule,
     MetricsSenderModule,
     DynamoClientModule,
     DynamoConfigModule,

--- a/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/filters/PlatformLoggingFilter.scala
+++ b/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/filters/PlatformLoggingFilter.scala
@@ -1,0 +1,38 @@
+package uk.ac.wellcome.finatra.filters
+
+import com.google.inject.{Inject, Singleton}
+import com.twitter.finagle.Service
+import com.twitter.finagle.filter.LogFormatter
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finatra.http.filters.AccessLoggingFilter
+import com.twitter.util.Future
+
+/** Suppress logs for healthcheck requests from the ALB.
+  *
+  * Specifically, it suppresses log messages such as the following:
+  *
+  *     10:14:09.578 [finagle/netty4-7] INFO c.t.f.h.filters.AccessLoggingFilter -
+  *         172.17.0.5 - - [14/Jun/2018:10:14:09 +0000]
+  *         "GET /management/healthcheck HTTP/1.0" 200 16 0 "ELB-HealthChecker/2.0"
+  *
+  * This helps keep our logs clean -- we know that healthchecks are working
+  * unless an application gets stopped by ECS, and then we can re-enable these
+  * logs by setting the log level to DEBUG.
+  */
+@Singleton
+class PlatformLoggingFilter @Inject()(
+  logFormatter: LogFormatter[Request, Response]
+) extends AccessLoggingFilter[Request](logFormatter = logFormatter) {
+
+  override def apply(request: Request, service: Service[Request, Response]): Future[Response] = {
+    if (
+      request.userAgent.contains("ELB-HealthChecker/2.0") &&
+      request.path == "/management/healthcheck" &&
+      !isDebugEnabled
+    ) {
+      service(request)
+    } else {
+      super.apply(request = request, service = service)
+    }
+  }
+}

--- a/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/filters/PlatformLoggingFilter.scala
+++ b/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/filters/PlatformLoggingFilter.scala
@@ -24,12 +24,11 @@ class PlatformLoggingFilter @Inject()(
   logFormatter: LogFormatter[Request, Response]
 ) extends AccessLoggingFilter[Request](logFormatter = logFormatter) {
 
-  override def apply(request: Request, service: Service[Request, Response]): Future[Response] = {
-    if (
-      request.userAgent.contains("ELB-HealthChecker/2.0") &&
-      request.path == "/management/healthcheck" &&
-      !isDebugEnabled
-    ) {
+  override def apply(request: Request,
+                     service: Service[Request, Response]): Future[Response] = {
+    if (request.userAgent.contains("ELB-HealthChecker/2.0") &&
+        request.path == "/management/healthcheck" &&
+        !isDebugEnabled) {
       service(request)
     } else {
       super.apply(request = request, service = service)

--- a/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/modules/AccessLoggingFilterModule.scala
+++ b/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/modules/AccessLoggingFilterModule.scala
@@ -7,6 +7,18 @@ import com.twitter.finatra.http.filters.AccessLoggingFilter
 import com.twitter.inject.{Injector, TwitterModule}
 import uk.ac.wellcome.finatra.filters.PlatformLoggingFilter
 
+/** Provides the [[PlatformLoggingFilter]] which doesn't log ALB healthchecks.
+  *
+  * To see where this injection is used:
+  *
+  *   - Note that all of our [[com.twitter.finatra.http.HttpServer]] instances
+  *     configure [[com.twitter.finatra.http.filters.CommonFilters]].
+  *   - The second parameter to [[com.twitter.finatra.http.filters.CommonFilters]]
+  *     is an instance of [[AccessLoggingFilter]].
+  *   - Normally that filter is provided by some builtin Finatra module --
+  *     by using this module, we can override the default filter.
+  *
+  */
 object AccessLoggingFilterModule extends TwitterModule {
 
   @Singleton

--- a/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/modules/AccessLoggingFilterModule.scala
+++ b/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/modules/AccessLoggingFilterModule.scala
@@ -1,0 +1,18 @@
+package uk.ac.wellcome.finatra.modules
+
+import com.google.inject.{Provides, Singleton}
+import com.twitter.finagle.filter.LogFormatter
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finatra.http.filters.AccessLoggingFilter
+import com.twitter.inject.{Injector, TwitterModule}
+import uk.ac.wellcome.finatra.filters.PlatformLoggingFilter
+
+object AccessLoggingFilterModule extends TwitterModule {
+
+  @Singleton
+  @Provides
+  def providesAccessLoggingFilter(injector: Injector): AccessLoggingFilter[Request] = {
+    val logFormatter = injector.instance[LogFormatter[Request, Response]]
+    new PlatformLoggingFilter(logFormatter = logFormatter)
+  }
+}

--- a/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/modules/AccessLoggingFilterModule.scala
+++ b/sbt_common/finatra_controllers/src/main/scala/uk/ac/wellcome/finatra/modules/AccessLoggingFilterModule.scala
@@ -23,7 +23,8 @@ object AccessLoggingFilterModule extends TwitterModule {
 
   @Singleton
   @Provides
-  def providesAccessLoggingFilter(injector: Injector): AccessLoggingFilter[Request] = {
+  def providesAccessLoggingFilter(
+    injector: Injector): AccessLoggingFilter[Request] = {
     val logFormatter = injector.instance[LogFormatter[Request, Response]]
     new PlatformLoggingFilter(logFormatter = logFormatter)
   }

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/Server.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/Server.scala
@@ -8,6 +8,7 @@ import uk.ac.wellcome.finatra.akka.{AkkaModule, ExecutionContextModule}
 import uk.ac.wellcome.finatra.messaging.{SQSClientModule, SQSConfigModule}
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
 import uk.ac.wellcome.finatra.controllers.ManagementController
+import uk.ac.wellcome.finatra.modules.AccessLoggingFilterModule
 import uk.ac.wellcome.finatra.storage.{DynamoClientModule, S3ClientModule, VHSConfigModule}
 import uk.ac.wellcome.platform.sierra_bib_merger.modules._
 import uk.ac.wellcome.sierra_adapter.modules.SierraTransformableModule
@@ -18,6 +19,7 @@ class Server extends HttpServer {
   override val name =
     "uk.ac.wellcome.platform.sierra_bib_merger SierraBibMerger"
   override val modules = Seq(
+    AccessLoggingFilterModule,
     VHSConfigModule,
     DynamoClientModule,
     SierraTransformableModule,

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/Server.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/Server.scala
@@ -12,6 +12,7 @@ import uk.ac.wellcome.finatra.akka.{AkkaModule, ExecutionContextModule}
 import uk.ac.wellcome.finatra.messaging.{SQSClientModule, SQSConfigModule}
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
 import uk.ac.wellcome.finatra.controllers.ManagementController
+import uk.ac.wellcome.finatra.modules.AccessLoggingFilterModule
 import uk.ac.wellcome.finatra.storage.{
   DynamoClientModule,
   S3ClientModule,
@@ -26,6 +27,7 @@ class Server extends HttpServer {
   override val name =
     "uk.ac.wellcome.platform.sierra_item_merger SierraItemMerger"
   override val modules = Seq(
+    AccessLoggingFilterModule,
     DynamoClientModule,
     VHSConfigModule,
     ExecutionContextModule,

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/Server.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/Server.scala
@@ -11,6 +11,7 @@ import com.twitter.finatra.http.routing.HttpRouter
 import uk.ac.wellcome.finatra.akka.{AkkaModule, ExecutionContextModule}
 import uk.ac.wellcome.finatra.controllers.ManagementController
 import uk.ac.wellcome.finatra.messaging.{SQSClientModule, SQSConfigModule}
+import uk.ac.wellcome.finatra.modules.AccessLoggingFilterModule
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
 import uk.ac.wellcome.finatra.storage.{DynamoClientModule, DynamoConfigModule}
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.modules.SierraItemsToDynamoModule
@@ -21,6 +22,7 @@ class Server extends HttpServer {
   override val name =
     "uk.ac.wellcome.platform.sierra_items_to_dynamo SierraItemsToDynamo"
   override val modules = Seq(
+    AccessLoggingFilterModule,
     SierraItemsToDynamoModule,
     DynamoConfigModule,
     DynamoClientModule,

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/Server.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/Server.scala
@@ -11,6 +11,7 @@ import com.twitter.finatra.http.routing.HttpRouter
 import uk.ac.wellcome.finatra.akka.{AkkaModule, ExecutionContextModule}
 import uk.ac.wellcome.finatra.messaging.{SQSClientModule, SQSConfigModule}
 import uk.ac.wellcome.finatra.controllers.ManagementController
+import uk.ac.wellcome.finatra.modules.AccessLoggingFilterModule
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
 import uk.ac.wellcome.finatra.storage.{S3ClientModule, S3ConfigModule}
 import uk.ac.wellcome.platform.sierra_reader.modules.{
@@ -25,6 +26,7 @@ class Server extends HttpServer {
   override val name =
     "uk.ac.wellcome.platform.sierra_reader SierraReader"
   override val modules = Seq(
+    AccessLoggingFilterModule,
     SierraReaderModule,
     ReaderConfigModule,
     SierraConfigModule,


### PR DESCRIPTION
Resolves #2238. We no longer get the following logs in CloudWatch unless we have debug logging enabled:

```
10:14:09.578 [finagle/netty4-7] INFO c.t.f.h.filters.AccessLoggingFilter - 172.17.0.5 - - [14/Jun/2018:10:14:09 +0000] "GET /management/healthcheck HTTP/1.0" 200 16 0 "ELB-HealthChecker/2.0"
```

The motivation isn’t cost (although it doesn’t hurt!) – it’s to keep the logs clean. We know healthchecks are succeeding, or our applications would be killed by the ALB. By the rule of “don’t log the happy path”, let’s suppress these as well. This has a dramatic improvement on the readability of CloudWatch logs.

Tested by running a container locally and using curl.