### PR TITLE
Improve the “report Sierra adapter progress” script

### DIFF
--- a/sierra_adapter/report_adapter_progress.py
+++ b/sierra_adapter/report_adapter_progress.py
@@ -235,6 +235,6 @@ if __name__ == '__main__':
     for resource_type in ('bibs', 'items'):
         if len(final_reports[resource_type]) == 1:
             queue_url = sqs.get_queue_url(
-                QueueName=f'sierra_{resource_type}_windows'
+                QueueName=f'sierra_{resource_type}_windows_dlq'
             )['QueueUrl']
             sqs.purge_queue(QueueUrl=queue_url)

--- a/sierra_adapter/report_adapter_progress.py
+++ b/sierra_adapter/report_adapter_progress.py
@@ -163,6 +163,9 @@ def chunks(iterable, chunk_size):
 
 
 if __name__ == '__main__':
+
+    final_reports = {}
+
     for resource_type in ('bibs', 'items'):
         print('')
         print('=' * 79)
@@ -206,9 +209,18 @@ if __name__ == '__main__':
 
         print('')
 
-    print('')
-    print('-' * 79)
-    print('')
-    print('If there are gaps in the report, you can build new windows for the readers:')
-    print('')
-    print(f'$ python {sys.argv[0].replace("report_adapter_progress.py", "build_missing_windows.py")}')
+        # Now we've consolidated the markers in S3, produce a second copy
+        # of the report that "summarises" the output.
+        report = build_report(bucket=BUCKET, resource_type=resource_type)
+        final_reports[resource_type] = [iv for (iv, _) in report]
+
+    # We only need to give instructions for building missing windows if
+    # there are gaps in the run.
+    #
+    if len(final_reports['bibs']) > 1 or len(final_reports['items']) > 1:
+        print('')
+        print('-' * 79)
+        print('')
+        print('You can build new windows for the gaps:')
+        print('')
+        print(f'$ python {sys.argv[0].replace("report_adapter_progress.py", "build_missing_windows.py")}')\


### PR DESCRIPTION
In particular:

* It doesn’t tell you how to fill in the gaps if there aren’t any
* It purges the DLQs if it discovers that every window is accounted for