### PR TITLE
A few Sierra transformer improvements

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocation.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocation.scala
@@ -10,11 +10,11 @@ trait SierraLocation {
   def getLocation(itemData: SierraItemData): Option[PhysicalLocation] =
     itemData.location match {
       // We've seen records where the "location" field is populated in
-      // the JSON, but the code and name are both empty strings.  We can't
-      // do anything useful with this, so don't return a location.
-      // TODO: Find out if we can populate location from other fields in
-      // those cases.
+      // the JSON, but the code and name are both empty strings or "none".
+      // We can't do anything useful with this, so don't return a location.
+      // TODO: Find out if we can populate location from other fields.
       case Some(SierraItemLocation("", "")) => None
+      case Some(SierraItemLocation("none", "none")) => None
 
       case Some(loc: SierraItemLocation) =>
         Some(

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocation.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocation.scala
@@ -13,7 +13,7 @@ trait SierraLocation {
       // the JSON, but the code and name are both empty strings or "none".
       // We can't do anything useful with this, so don't return a location.
       // TODO: Find out if we can populate location from other fields.
-      case Some(SierraItemLocation("", "")) => None
+      case Some(SierraItemLocation("", ""))         => None
       case Some(SierraItemLocation("none", "none")) => None
 
       case Some(loc: SierraItemLocation) =>

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableWrapper.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableWrapper.scala
@@ -11,7 +11,9 @@ import uk.ac.wellcome.models.work.internal.UnidentifiedWork
   *  fields before transformation, allowing tests to focus on only the fields
   *  that are interesting for that test.
   */
-trait MiroTransformableWrapper extends Matchers with TransformableTestBase[MiroTransformable] { this: Suite =>
+trait MiroTransformableWrapper
+    extends Matchers
+    with TransformableTestBase[MiroTransformable] { this: Suite =>
 
   val transformer = new MiroTransformableTransformer
   def buildJSONForWork(extraData: String): String =

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableWrapper.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableWrapper.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.models.work.internal.UnidentifiedWork
   *  fields before transformation, allowing tests to focus on only the fields
   *  that are interesting for that test.
   */
-trait MiroTransformableWrapper extends Matchers { this: Suite =>
+trait MiroTransformableWrapper extends Matchers with TransformableTestBase[MiroTransformable] { this: Suite =>
 
   val transformer = new MiroTransformableTransformer
   def buildJSONForWork(extraData: String): String =
@@ -34,10 +34,7 @@ trait MiroTransformableWrapper extends Matchers { this: Suite =>
       data = buildJSONForWork(data)
     )
 
-    val triedMaybeWork = transformer.transform(miroTransformable, version = 1)
-    if (triedMaybeWork.isFailure) triedMaybeWork.failed.get.printStackTrace()
-    triedMaybeWork.isSuccess shouldBe true
-    triedMaybeWork.get.get
+    transformToWork(miroTransformable)
   }
 
   def assertTransformWorkFails(
@@ -50,8 +47,7 @@ trait MiroTransformableWrapper extends Matchers { this: Suite =>
       MiroCollection = MiroCollection,
       data = buildJSONForWork(data)
     )
-    transformer
-      .transform(miroTransformable, version = 1)
-      .isSuccess shouldBe false
+
+    assertTransformToWorkFails(miroTransformable)
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -17,7 +17,8 @@ import uk.ac.wellcome.utils.JsonUtil._
 class SierraTransformableTransformerTest
     extends FunSpec
     with Matchers
-    with SierraData {
+    with SierraData
+    with TransformableTestBase[SierraTransformable] {
   val transformer = new SierraTransformableTransformer
 
   it("performs a transformation on a work with items") {
@@ -576,13 +577,6 @@ class SierraTransformableTransformerTest
       maybeBibData = Some(bibRecord)
     )
 
-    val triedMaybeWork = transformer.transform(
-      transformable = sierraTransformable,
-      version = 1
-    )
-
-    if (triedMaybeWork.isFailure) triedMaybeWork.failed.get.printStackTrace()
-    triedMaybeWork.isSuccess shouldBe true
-    triedMaybeWork.get.get
+    transformToWork(sierraTransformable)
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTestBase.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTestBase.scala
@@ -22,14 +22,16 @@ trait TransformableTestBase[T <: Transformable] extends Matchers {
 
   val transformer: TransformableTransformer[T]
 
-  def transformToWork(transformable: T)(implicit c: ClassTag[T]): UnidentifiedWork = {
+  def transformToWork(transformable: T)(
+    implicit c: ClassTag[T]): UnidentifiedWork = {
     val triedMaybeWork = transformer.transform(transformable, version = 1)
     if (triedMaybeWork.isFailure) triedMaybeWork.failed.get.printStackTrace()
     triedMaybeWork.isSuccess shouldBe true
     triedMaybeWork.get.get
   }
 
-  def assertTransformToWorkFails(transformable: T)(implicit c: ClassTag[T]): Unit = {
+  def assertTransformToWorkFails(transformable: T)(
+    implicit c: ClassTag[T]): Unit = {
     transformer
       .transform(transformable, version = 1)
       .isSuccess shouldBe false

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTestBase.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTestBase.scala
@@ -4,18 +4,32 @@ import org.scalatest.Matchers
 import uk.ac.wellcome.models.transformable.Transformable
 import uk.ac.wellcome.models.work.internal.UnidentifiedWork
 
+import scala.reflect.ClassTag
+
+/** Utilities for transformer tests.
+  *
+  * @@AWLC: when I first wrote this code, I got the following error:
+  *
+  *     TransformableTestBase.scala:12:47: No ClassTag available for T
+  *         val triedMaybeWork = transformer.transform(transformable, version = 1)
+  *                                                    ↑
+  *
+  * The addition of the implicit ClassTag[T] is working around this error.
+  * In general reflection is icky, but it's only in tests so I think this
+  * is okay.
+  */
 trait TransformableTestBase[T <: Transformable] extends Matchers {
 
   val transformer: TransformableTransformer[T]
 
-  def transformToWork(transformable: T): UnidentifiedWork = {
+  def transformToWork(transformable: T)(implicit c: ClassTag[T]): UnidentifiedWork = {
     val triedMaybeWork = transformer.transform(transformable, version = 1)
     if (triedMaybeWork.isFailure) triedMaybeWork.failed.get.printStackTrace()
     triedMaybeWork.isSuccess shouldBe true
     triedMaybeWork.get.get
   }
 
-  def assertTransformToWorkFails(transformable: T): Unit = {
+  def assertTransformToWorkFails(transformable: T)(implicit c: ClassTag[T]): Unit = {
     transformer
       .transform(transformable, version = 1)
       .isSuccess shouldBe false

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTestBase.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTestBase.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.platform.transformer.transformers
+
+import org.scalatest.Matchers
+import uk.ac.wellcome.models.transformable.Transformable
+import uk.ac.wellcome.models.work.internal.UnidentifiedWork
+
+trait TransformableTestBase[T <: Transformable] extends Matchers {
+
+  val transformer: TransformableTransformer[T]
+
+  def transformToWork(transformable: T): UnidentifiedWork = {
+    val triedMaybeWork = transformer.transform(transformable, version = 1)
+    if (triedMaybeWork.isFailure) triedMaybeWork.failed.get.printStackTrace()
+    triedMaybeWork.isSuccess shouldBe true
+    triedMaybeWork.get.get
+  }
+
+  def assertTransformToWorkFails(transformable: T): Unit = {
+    transformer
+      .transform(transformable, version = 1)
+      .isSuccess shouldBe false
+  }
+}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocationTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocationTest.scala
@@ -34,6 +34,15 @@ class SierraLocationTest extends FunSpec with Matchers {
     transformer.getLocation(itemData = itemData) shouldBe None
   }
 
+  it("returns None if the location field only contains the string 'none'") {
+    val itemData = SierraItemData(
+      id = "i1234567",
+      location = Some(SierraItemLocation("none", "none"))
+    )
+
+    transformer.getLocation(itemData = itemData) shouldBe None
+  }
+
   it("returns None if there is no location in the item data") {
     val itemData = SierraItemData(
       id = "i1234567"

--- a/misc/get_transformer_objects.py
+++ b/misc/get_transformer_objects.py
@@ -1,0 +1,58 @@
+# -*- encoding: utf-8
+"""
+Snippet.
+
+AWLC: When I'm trying to diagnose failures on the transformer queue,
+I save the queue contents with sqs_freezeray [1], and then I want to
+go through them to analyse the failures.
+
+Our transformer messages contain pointers to S3, not the records themselves.
+This snippet gets messages from the frozen SQS output, extracts the
+S3 pointers, and yields the contents of the resulting objects.
+
+Copy + paste this into a Jupyter notebook/script to use.
+
+Usage:
+
+    >>> for obj in get_transformer_objects():
+    ...    print(obj)
+    {"sourceId": "123", "sourceName": "sierra", ...}
+    {"sourceId": "456", "sourceName": "sierra", ...}
+    {"sourceId": "789", "sourceName": "sierra", ...}
+
+[1]: https://github.com/wellcometrust/dockerfiles/tree/master/sqs_freezeray
+
+"""
+
+
+def get_transformer_objects(key=None):
+    import json
+    import boto3
+
+    s3 = boto3.client('s3')
+
+    if key is None:
+        resp = s3.list_objects_v2(
+            Bucket='wellcomecollection-platform-infra',
+            Prefix='sqs'
+        )
+        possible_keys = [r['Key'] for r in resp['Contents']]
+        key = max(possible_keys)
+
+    if not key.startswith('sqs/'):
+        key = f'sqs/{key}'
+
+    data = s3.get_object(
+        Bucket='wellcomecollection-platform-infra',
+        Key=key
+    )['Body'].read()
+
+    jl = json.loads
+
+    for line in data.splitlines():
+        s3key = jl(jl(jl(line)['Body'])['Message'])['s3key']
+        s3obj = s3.get_object(
+            Bucket='wellcomecollection-vhs-sourcedata',
+            Key=s3key
+        )
+        yield s3obj['Body'].read()

--- a/misc/get_transformer_objects.py
+++ b/misc/get_transformer_objects.py
@@ -28,14 +28,16 @@ Usage:
 
 """
 
+import json
+
+import boto3
+
+
+s3 = boto3.client('s3')
+jl = json.loads
+
 
 class GetTransformerObjects(object):
-
-    import json
-    import boto3
-
-    s3 = boto3.client('s3')
-    jl = json.loads
 
     def __init__(self, key=None):
         if key is None:
@@ -57,7 +59,7 @@ class GetTransformerObjects(object):
         self.cached_s3_records = {}
 
     def __iter__(self):
-        for line in data.splitlines():
+        for line in self.data.splitlines():
             s3key = jl(jl(jl(line)['Body'])['Message'])['s3key']
 
             try:

--- a/misc/get_transformer_objects.py
+++ b/misc/get_transformer_objects.py
@@ -14,45 +14,55 @@ Copy + paste this into a Jupyter notebook/script to use.
 
 Usage:
 
-    >>> for obj in get_transformer_objects():
+    >>> gto = GetTransformerObjects()
+    >>> for obj in gto
     ...    print(obj)
-    {"sourceId": "123", "sourceName": "sierra", ...}
-    {"sourceId": "456", "sourceName": "sierra", ...}
-    {"sourceId": "789", "sourceName": "sierra", ...}
+    '{"sourceId": "123", "sourceName": "sierra", ...}'
+    '{"sourceId": "456", "sourceName": "sierra", ...}'
+    '{"sourceId": "789", "sourceName": "sierra", ...}'
 
 [1]: https://github.com/wellcometrust/dockerfiles/tree/master/sqs_freezeray
 
 """
 
 
-def get_transformer_objects(key=None):
+class GetTransformerObjects(object):
+
     import json
     import boto3
 
     s3 = boto3.client('s3')
-
-    if key is None:
-        resp = s3.list_objects_v2(
-            Bucket='wellcomecollection-platform-infra',
-            Prefix='sqs'
-        )
-        possible_keys = [r['Key'] for r in resp['Contents']]
-        key = max(possible_keys)
-
-    if not key.startswith('sqs/'):
-        key = f'sqs/{key}'
-
-    data = s3.get_object(
-        Bucket='wellcomecollection-platform-infra',
-        Key=key
-    )['Body'].read()
-
     jl = json.loads
 
-    for line in data.splitlines():
-        s3key = jl(jl(jl(line)['Body'])['Message'])['s3key']
-        s3obj = s3.get_object(
-            Bucket='wellcomecollection-vhs-sourcedata',
-            Key=s3key
-        )
-        yield s3obj['Body'].read()
+    def __init__(self, key=None):
+        if key is None:
+            resp = s3.list_objects_v2(
+                Bucket='wellcomecollection-platform-infra',
+                Prefix='sqs'
+            )
+            possible_keys = [r['Key'] for r in resp['Contents']]
+            key = max(possible_keys)
+
+        if not key.startswith('sqs/'):
+            key = f'sqs/{key}'
+
+        self.data = s3.get_object(
+            Bucket='wellcomecollection-platform-infra',
+            Key=key
+        )['Body'].read()
+
+        self.cached_s3_records = {}
+
+    def __iter__(self):
+        for line in data.splitlines():
+            s3key = jl(jl(jl(line)['Body'])['Message'])['s3key']
+
+            try:
+                self.cached_s3_records[s3key]
+            except KeyError:
+                self.cached_s3_records[s3key] = s3.get_object(
+                    Bucket='wellcomecollection-vhs-sourcedata',
+                    Key=s3key
+                )['Body'].read()
+
+            yield self.cached_s3_records[s3key]

--- a/misc/get_transformer_objects.py
+++ b/misc/get_transformer_objects.py
@@ -10,6 +10,9 @@ Our transformer messages contain pointers to S3, not the records themselves.
 This snippet gets messages from the frozen SQS output, extracts the
 S3 pointers, and yields the contents of the resulting objects.
 
+I kept rewriting this snippet from scratch, so I figured checking it in
+would save me a bit of time later.
+
 Copy + paste this into a Jupyter notebook/script to use.
 
 Usage:

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayConceptV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayConceptV1.scala
@@ -25,7 +25,7 @@ case object DisplayConceptV1 {
   def apply(concept: Displayable[AbstractConcept]): DisplayConceptV1 = {
     val label = concept match {
       case Identified(c: AbstractConcept, _, _, _) => c.label
-      case Unidentifiable(c: AbstractConcept)      => c.label
+      case Unidentifiable(c: AbstractConcept)   => c.label
     }
     DisplayConceptV1(label = label)
   }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayConceptV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayConceptV1.scala
@@ -25,7 +25,7 @@ case object DisplayConceptV1 {
   def apply(concept: Displayable[AbstractConcept]): DisplayConceptV1 = {
     val label = concept match {
       case Identified(c: AbstractConcept, _, _, _) => c.label
-      case Unidentifiable(c: AbstractConcept)   => c.label
+      case Unidentifiable(c: AbstractConcept)      => c.label
     }
     DisplayConceptV1(label = label)
   }


### PR DESCRIPTION
Some fixes in the direction of #2252 and #2282:

* Add a snippet to make it easier to diagnose transformer failures
* Add some tracing to the TransformableTransformer tests, so if a Sierra transform fails we get a traceback, not just "false was not equal to true"
* Handle the case where the location on an item is `{"code": "none", "name": "none"}`