### PR TITLE
Apply new formatting rules

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConcepts.scala
@@ -94,13 +94,12 @@ trait SierraConcepts extends MarcUtils {
   // These are never identified.  We preserve the order from MARC.
   protected def getSubdivisions(subdivisionSubfields: List[MarcSubfield])
     : List[Unidentifiable[AbstractConcept]] = {
-    val concepts: List[AbstractConcept] = subdivisionSubfields.map {
-      subfield =>
-        subfield.tag match {
-          case "v" | "x" => Concept(label = subfield.content)
-          case "y" => Period(label = subfield.content)
-          case "z" => Place(label = subfield.content)
-        }
+    val concepts: List[AbstractConcept] = subdivisionSubfields.map { subfield =>
+      subfield.tag match {
+        case "v" | "x" => Concept(label = subfield.content)
+        case "y"       => Period(label = subfield.content)
+        case "z"       => Place(label = subfield.content)
+      }
     }
 
     concepts.map { Unidentifiable(_) }


### PR DESCRIPTION
As part of #2272, the scalafmt sbt plugin had to be updated cause the version we were using was not available for sbt 1.1.6. This has caused a slight change in formatting rules apparently wich where not applied. Checking the log for the auto formatting task on the upgrade sbt PR, I saw this ```*** Skipping format-scala as there are no affected files```. Apparently, scala format is only applied when there are changes to.scala files, not .sbt files. We might want to change that.

In the meantime, pushing the formatting changes as this is polluting all PRs