### PR TITLE
Remove some unused instances of MetricsSender

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiver.scala
@@ -15,7 +15,6 @@ import uk.ac.wellcome.models.transformable.{
   Transformable
 }
 import uk.ac.wellcome.models.work.internal.UnidentifiedWork
-import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.platform.transformer.transformers.{
   CalmTransformableTransformer,
   MiroTransformableTransformer,
@@ -31,8 +30,7 @@ import scala.util.Try
 class NotificationMessageReceiver @Inject()(
   messageWriter: MessageWriter[UnidentifiedWork],
   s3Client: AmazonS3,
-  s3Config: S3Config,
-  metricsSender: MetricsSender)(
+  s3Config: S3Config)(
   implicit miroTransformableStore: ObjectStore[MiroTransformable],
   calmTransformableStore: ObjectStore[CalmTransformable],
   sierraTransformableStore: ObjectStore[SierraTransformable],

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
@@ -21,13 +21,11 @@ import uk.ac.wellcome.models.work.internal.{
   SourceIdentifier,
   UnidentifiedWork
 }
-import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.storage.s3.{S3Config, S3StorageBackend}
 import uk.ac.wellcome.platform.transformer.utils.TransformableMessageUtils
-import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
-import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
+import uk.ac.wellcome.test.fixtures.TestWith
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.utils.JsonUtil._

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
@@ -37,8 +37,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class NotificationMessageReceiverTest
     extends FunSpec
     with Matchers
-    with Akka
-    with MetricsSenderFixture
     with SQS
     with SNS
     with S3
@@ -80,18 +78,13 @@ class NotificationMessageReceiverTest
         s3Client = s3Client
       )
 
-    withActorSystem { actorSystem =>
-      withMetricsSender(actorSystem) { metricsSender =>
-        val recordReceiver = new NotificationMessageReceiver(
-          messageWriter = messageWriter,
-          s3Client = s3Client,
-          s3Config = S3Config(bucket.name),
-          metricsSender = metricsSender
-        )
+    val recordReceiver = new NotificationMessageReceiver(
+      messageWriter = messageWriter,
+      s3Client = s3Client,
+      s3Config = S3Config(bucket.name)
+    )
 
-        testWith(recordReceiver)
-      }
-    }
+    testWith(recordReceiver)
   }
 
   it("receives a message and sends it to SNS client") {

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
@@ -323,7 +323,10 @@ class GoobiReaderWorkerServiceTest
       withLocalSqsQueueAndDlq {
         case queuePair @ QueuePair(queue, dlq) =>
           withMockMetricSender { mockMetricsSender =>
-            withSQSStream[NotificationMessage, R](actorSystem, queue, mockMetricsSender) { sqsStream =>
+            withSQSStream[NotificationMessage, R](
+              actorSystem,
+              queue,
+              mockMetricsSender) { sqsStream =>
               withS3StreamStoreFixtures {
                 case (bucket, table, vhs) =>
                   new GoobiReaderWorkerService(

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
@@ -4,7 +4,6 @@ import java.io.{ByteArrayInputStream, InputStream}
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-import akka.actor.ActorSystem
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
 import com.gu.scanamo.Scanamo
 import org.mockito.Matchers.any
@@ -13,7 +12,7 @@ import org.scalatest.FunSpec
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSStream}
+import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.messaging.test.fixtures.SQS.{Queue, QueuePair}
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
@@ -24,12 +23,11 @@ import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.storage.vhs.{HybridRecord, VersionedHybridStore}
-import uk.ac.wellcome.test.fixtures.{fixture, Akka, TestWith}
+import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
 
 class GoobiReaderWorkerServiceTest
     extends FunSpec
@@ -38,7 +36,8 @@ class GoobiReaderWorkerServiceTest
     with ScalaFutures
     with ExtendedPatience
     with MockitoSugar
-    with GoobiReaderFixtures {
+    with GoobiReaderFixtures
+    with SQS {
 
   private val id = "mets-0001"
   private val goobiS3Prefix = "goobi"
@@ -311,22 +310,6 @@ class GoobiReaderWorkerServiceTest
       }
     }
 
-  private def withSqsStream[R](actorSystem: ActorSystem,
-                               queue: Queue,
-                               metricsSender: MetricsSender) =
-    fixture[SQSStream[NotificationMessage], R](
-      new SQSStream(
-        actorSystem = actorSystem,
-        sqsClient = asyncSqsClient,
-        sqsConfig = SQSConfig(
-          queueUrl = queue.url,
-          waitTime = 1.second,
-          maxMessages = 1
-        ),
-        metricsSender = metricsSender
-      )
-    )
-
   private def withGoobiReaderWorkerService[R](s3Client: AmazonS3)(
     testWith: TestWith[(Bucket,
                         QueuePair,
@@ -340,7 +323,7 @@ class GoobiReaderWorkerServiceTest
       withLocalSqsQueueAndDlq {
         case queuePair @ QueuePair(queue, dlq) =>
           withMockMetricSender { mockMetricsSender =>
-            withSqsStream(actorSystem, queue, mockMetricsSender) { sqsStream =>
+            withSQSStream[NotificationMessage, R](actorSystem, queue, mockMetricsSender) { sqsStream =>
               withS3StreamStoreFixtures {
                 case (bucket, table, vhs) =>
                   new GoobiReaderWorkerService(

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
@@ -9,7 +9,6 @@ import com.gu.scanamo.{Scanamo, _}
 import com.twitter.inject.Logging
 
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.platform.reindex_worker.GlobalExecutionContext.context
 import uk.ac.wellcome.platform.reindex_worker.models.{ReindexJob, ReindexRecord}
 import uk.ac.wellcome.storage.dynamo.{DynamoConfig, VersionedDao}

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexService.scala
@@ -18,8 +18,7 @@ import scala.concurrent.Future
 import scala.util.Try
 
 class ReindexService @Inject()(dynamoDbClient: AmazonDynamoDB,
-                               dynamoConfig: DynamoConfig,
-                               metricsSender: MetricsSender)
+                               dynamoConfig: DynamoConfig)
     extends Logging {
 
   val versionedDao = new VersionedDao(

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerService.scala
@@ -4,7 +4,6 @@ import akka.actor.ActorSystem
 import com.google.inject.Inject
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSWriter}
 import uk.ac.wellcome.messaging.sqs.SQSStream
-import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.platform.reindex_worker.GlobalExecutionContext.context
 import uk.ac.wellcome.platform.reindex_worker.models.{
   CompletedReindexJob,
@@ -18,8 +17,7 @@ class ReindexWorkerService @Inject()(
   targetService: ReindexService,
   snsWriter: SNSWriter,
   system: ActorSystem,
-  sqsStream: SQSStream[NotificationMessage],
-  metrics: MetricsSender
+  sqsStream: SQSStream[NotificationMessage]
 ) {
   sqsStream.foreach(this.getClass.getSimpleName, processMessage)
 

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -9,7 +9,6 @@ import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig, SNSWriter}
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
-import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.reindex_worker.TestRecord
 import uk.ac.wellcome.platform.reindex_worker.models.ReindexJob

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -52,8 +52,7 @@ class ReindexWorkerServiceTest
                       snsClient = snsClient,
                       snsConfig = SNSConfig(topicArn = topic.arn)
                     ),
-                    system = actorSystem,
-                    metrics = metricsSender
+                    system = actorSystem
                   )
 
                   try {
@@ -168,7 +167,6 @@ class ReindexWorkerServiceTest
 
                 new ReindexWorkerService(
                   targetService = failingReindexService,
-                  metrics = metricsSender,
                   system = actorSystem,
                   snsWriter = new SNSWriter(
                     snsClient = snsClient,

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -44,7 +44,7 @@ class ReindexWorkerServiceTest
                 actorSystem,
                 queue,
                 metricsSender) { sqsStream =>
-                withReindexService(metricsSender, table) { reindexService =>
+                withReindexService(table) { reindexService =>
                   val workerService = new ReindexWorkerService(
                     targetService = reindexService,
                     sqsStream = sqsStream,
@@ -69,12 +69,11 @@ class ReindexWorkerServiceTest
     }
   }
 
-  def withReindexService[R](metricsSender: MetricsSender, table: Table)(
+  def withReindexService[R](table: Table)(
     testWith: TestWith[ReindexService, R]) = {
     val reindexService = new ReindexService(
       dynamoDbClient = dynamoDbClient,
-      dynamoConfig = DynamoConfig(table = table.name, index = table.index),
-      metricsSender = metricsSender
+      dynamoConfig = DynamoConfig(table = table.name, index = table.index)
     )
     testWith(reindexService)
   }

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
@@ -8,7 +8,6 @@ import uk.ac.wellcome.platform.sierra_bib_merger.merger.BibMerger
 import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.vhs.{SourceMetadata, VersionedHybridStore}
 import uk.ac.wellcome.models.Sourced
-import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.storage.ObjectStore
 
 import scala.concurrent.Future
@@ -16,8 +15,7 @@ import scala.concurrent.Future
 class SierraBibMergerUpdaterService @Inject()(
   versionedHybridStore: VersionedHybridStore[SierraTransformable,
                                              SourceMetadata,
-                                             ObjectStore[SierraTransformable]],
-  metrics: MetricsSender
+                                             ObjectStore[SierraTransformable]]
 ) extends Logging {
 
   def update(bibRecord: SierraBibRecord): Future[Unit] = {

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -68,7 +68,7 @@ class SierraBibMergerWorkerServiceTest
                       storageBucket,
                       table) { vhs =>
                       val mergerUpdaterService =
-                        new SierraBibMergerUpdaterService(vhs, metricsSender)
+                        new SierraBibMergerUpdaterService(vhs)
 
                       val worker = new SierraBibMergerWorkerService(
                         system,

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
@@ -10,7 +10,6 @@ import uk.ac.wellcome.platform.sierra_item_merger.links.ItemUnlinker
 import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.vhs.{SourceMetadata, VersionedHybridStore}
 import uk.ac.wellcome.models.Sourced
-import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.storage.ObjectStore
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -18,8 +17,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class SierraItemMergerUpdaterService @Inject()(
   versionedHybridStore: VersionedHybridStore[SierraTransformable,
                                              SourceMetadata,
-                                             ObjectStore[SierraTransformable]],
-  metrics: MetricsSender
+                                             ObjectStore[SierraTransformable]]
 )(implicit ec: ExecutionContext)
     extends Logging {
 

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -1,11 +1,9 @@
 package uk.ac.wellcome.platform.sierra_item_merger.services
 
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Assertion, FunSpec}
 import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.models.transformable.SierraTransformable
-import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.platform.sierra_item_merger.utils.SierraItemMergerTestUtil
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.dynamo._
@@ -22,7 +20,6 @@ import scala.concurrent.Future
 class SierraItemMergerUpdaterServiceTest
     extends FunSpec
     with ExtendedPatience
-    with MockitoSugar
     with ScalaFutures
     with LocalVersionedHybridStore
     with SQS
@@ -34,8 +31,7 @@ class SierraItemMergerUpdaterServiceTest
                                       ObjectStore[SierraTransformable]])(
     testWith: TestWith[SierraItemMergerUpdaterService, Assertion]) = {
     val sierraUpdaterService = new SierraItemMergerUpdaterService(
-      versionedHybridStore = hybridStore,
-      mock[MetricsSender]
+      versionedHybridStore = hybridStore
     )
     testWith(sierraUpdaterService)
   }


### PR DESCRIPTION
While doing some reindexer work, I noticed that a bunch of our services have an instance of MetricsSender injected… even though they don’t use it.

This patch removes it where we can, with the corresponding cleanups and simplifications in tests.