### PR TITLE
Set up INFO-level logging in the S3 demultiplexer

### DIFF
--- a/sierra_adapter/s3_demultiplexer/src/requirements.in
+++ b/sierra_adapter/s3_demultiplexer/src/requirements.in
@@ -1,2 +1,2 @@
 daiquiri
-wellcome_aws_utils==2.1.1
+wellcome_aws_utils==2.1.2

--- a/sierra_adapter/s3_demultiplexer/src/requirements.in
+++ b/sierra_adapter/s3_demultiplexer/src/requirements.in
@@ -1,1 +1,2 @@
+daiquiri
 wellcome_aws_utils==2.1.1

--- a/sierra_adapter/s3_demultiplexer/src/requirements.txt
+++ b/sierra_adapter/s3_demultiplexer/src/requirements.txt
@@ -4,12 +4,12 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-boto3==1.7.31             # via wellcome-aws-utils
-botocore==1.10.31         # via boto3, s3transfer
-daiquiri==1.3.0           # via wellcome-aws-utils
+boto3==1.7.45             # via wellcome-aws-utils
+botocore==1.10.45         # via boto3, s3transfer
+daiquiri==1.3.0
 docutils==0.14            # via botocore
 jmespath==0.9.3           # via boto3, botocore
 python-dateutil==2.7.3    # via botocore, wellcome-aws-utils
 s3transfer==0.1.13        # via boto3
 six==1.11.0               # via python-dateutil
-wellcome_aws_utils==2.1.1
+wellcome_aws_utils==2.1.2

--- a/sierra_adapter/s3_demultiplexer/src/s3_demultiplexer.py
+++ b/sierra_adapter/s3_demultiplexer/src/s3_demultiplexer.py
@@ -25,9 +25,13 @@ import json
 import os
 
 import boto3
+import daiquiri
 
 from wellcome_aws_utils import s3_utils, sns_utils
 from wellcome_aws_utils.lambda_utils import log_on_error
+
+
+daiquiri.setup(level=os.environ.get('LOG_LEVEL', 'INFO'))
 
 
 @log_on_error


### PR DESCRIPTION
A cheap fix for one of our chattier Lambdas. This incorporates https://github.com/wellcometrust/aws_utils/pull/20, which means much less logging on the happy path.