### PR TITLE
hash component ids in graph matcher

### DIFF
--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
@@ -4,7 +4,11 @@ import grizzled.slf4j.Logging
 import scalax.collection.Graph
 import scalax.collection.GraphPredef._
 import uk.ac.wellcome.models.matcher.WorkNode
-import uk.ac.wellcome.platform.matcher.models.{VersionConflictException, WorkGraph, WorkUpdate}
+import uk.ac.wellcome.platform.matcher.models.{
+  VersionConflictException,
+  WorkGraph,
+  WorkUpdate
+}
 
 import scala.collection.immutable.Iterable
 import scala.util.hashing.MurmurHash3

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -38,6 +38,7 @@ import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.hashing.MurmurHash3
 
 trait MatcherFixtures
     extends Akka
@@ -200,6 +201,12 @@ trait MatcherFixtures
       title = Some("WorkTitle"),
       version = 1
     )
+  }
+
+  def ciHash(str: String): String = {
+    MurmurHash3
+      .stringHash(str, MurmurHash3.stringSeed)
+      .toHexString
   }
 
   def aRowLock(id: String, contextId: String) = {

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -51,10 +51,11 @@ class WorkMatcherTest
 
                     val savedLinkedWork = Scanamo
                       .get[WorkNode](dynamoDbClient)(graphTable.name)(
-                      'id -> workId)
+                        'id -> workId)
                       .map(_.right.get)
 
-                    savedLinkedWork shouldBe Some(WorkNode(workId, 1, Nil, ciHash(workId)))
+                    savedLinkedWork shouldBe Some(
+                      WorkNode(workId, 1, Nil, ciHash(workId)))
                 }
             }
           }
@@ -159,17 +160,20 @@ class WorkMatcherTest
                       "sierra-system-number/A",
                       1,
                       List("sierra-system-number/B"),
-                      ciHash("sierra-system-number/A+sierra-system-number/B+sierra-system-number/C")),
+                      ciHash(
+                        "sierra-system-number/A+sierra-system-number/B+sierra-system-number/C")),
                     WorkNode(
                       "sierra-system-number/B",
                       2,
                       List("sierra-system-number/C"),
-                      ciHash("sierra-system-number/A+sierra-system-number/B+sierra-system-number/C")),
+                      ciHash(
+                        "sierra-system-number/A+sierra-system-number/B+sierra-system-number/C")),
                     WorkNode(
                       "sierra-system-number/C",
                       1,
                       Nil,
-                      ciHash("sierra-system-number/A+sierra-system-number/B+sierra-system-number/C"))
+                      ciHash(
+                        "sierra-system-number/A+sierra-system-number/B+sierra-system-number/C"))
                   )
                 }
             }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -51,11 +51,10 @@ class WorkMatcherTest
 
                     val savedLinkedWork = Scanamo
                       .get[WorkNode](dynamoDbClient)(graphTable.name)(
-                        'id -> workId)
+                      'id -> workId)
                       .map(_.right.get)
 
-                    savedLinkedWork shouldBe Some(
-                      WorkNode(workId, 1, Nil, workId))
+                    savedLinkedWork shouldBe Some(WorkNode(workId, 1, Nil, ciHash(workId)))
                 }
             }
           }
@@ -93,12 +92,12 @@ class WorkMatcherTest
                       "sierra-system-number/A",
                       1,
                       List("sierra-system-number/B"),
-                      "sierra-system-number/A+sierra-system-number/B"),
+                      ciHash("sierra-system-number/A+sierra-system-number/B")),
                     WorkNode(
                       "sierra-system-number/B",
                       0,
                       Nil,
-                      "sierra-system-number/A+sierra-system-number/B")
+                      ciHash("sierra-system-number/A+sierra-system-number/B"))
                   )
                 }
             }
@@ -160,17 +159,17 @@ class WorkMatcherTest
                       "sierra-system-number/A",
                       1,
                       List("sierra-system-number/B"),
-                      "sierra-system-number/A+sierra-system-number/B+sierra-system-number/C"),
+                      ciHash("sierra-system-number/A+sierra-system-number/B+sierra-system-number/C")),
                     WorkNode(
                       "sierra-system-number/B",
                       2,
                       List("sierra-system-number/C"),
-                      "sierra-system-number/A+sierra-system-number/B+sierra-system-number/C"),
+                      ciHash("sierra-system-number/A+sierra-system-number/B+sierra-system-number/C")),
                     WorkNode(
                       "sierra-system-number/C",
                       1,
                       Nil,
-                      "sierra-system-number/A+sierra-system-number/B+sierra-system-number/C")
+                      ciHash("sierra-system-number/A+sierra-system-number/B+sierra-system-number/C"))
                   )
                 }
             }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -2,15 +2,23 @@ package uk.ac.wellcome.platform.matcher.workgraph
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.matcher.WorkNode
+import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkUpdate}
 
-class WorkGraphUpdaterTest extends FunSpec with Matchers {
+class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
 
   // An existing graph of works is updated by changing the links of a single work.
   // The change may result in new compound works which are identified by the LinkedWorkGraphUpdater
   // works are shown by id with directed links, A->B means work with id "A" is linked to work with id "B"
   // works comprised of linked works are identified by compound id together with their linked works.
   // A+B:(A->B, B) means compound work with id "A+B" is made of work A linked to B and work B.
+
+  private val hashed_A    = "217b21f3" // ciHash("A")
+  private val hashed_B    = "4d7e95ff" // ciHash("B")
+  private val hashed_C    = "8171cb29" // ciHash("C")
+  private val hashed_AB   = "2f2f1575" // ciHash("A+B")
+  private val hashed_ABC  = "45e72cb2" // ciHash("A+B+C")
+  private val hashed_ABCD = "73200083" // ciHash("A+B+C+D")
 
   describe("Adding links without existing works") {
     it("updating nothing with A gives A:A") {
@@ -19,7 +27,7 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers {
           workUpdate = WorkUpdate("A", 1, Set.empty),
           existingGraph = WorkGraph(Set.empty)
         )
-        .nodes shouldBe Set(WorkNode("A", 1, List(), componentId = "A"))
+        .nodes shouldBe Set(WorkNode("A", 1, List(), hashed_A))
     }
 
     it("updating nothing with A->B gives A+B:A->B") {
@@ -29,8 +37,8 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers {
           existingGraph = WorkGraph(Set.empty)
         )
         .nodes shouldBe Set(
-        WorkNode("A", 1, List("B"), componentId = "A+B"),
-        WorkNode("B", 0, List(), componentId = "A+B"))
+        WorkNode("A", 1, List("B"), hashed_AB),
+        WorkNode("B", 0, List(), hashed_AB))
     }
 
     it("updating nothing with B->A gives A+B:B->A") {
@@ -40,8 +48,8 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers {
           existingGraph = WorkGraph(Set.empty)
         )
         .nodes shouldBe Set(
-        WorkNode("B", 1, List("A"), componentId = "A+B"),
-        WorkNode("A", 0, List(), componentId = "A+B"))
+        WorkNode("B", 1, List("A"), hashed_AB),
+        WorkNode("A", 0, List(), hashed_AB))
     }
   }
 
@@ -55,8 +63,8 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers {
         )
         .nodes should contain theSameElementsAs
         List(
-          WorkNode("A", 2, List("B"), componentId = "A+B"),
-          WorkNode("B", 1, List(), componentId = "A+B"))
+          WorkNode("A", 2, List("B"), hashed_AB),
+          WorkNode("B", 1, List(), hashed_AB))
     }
 
     it("updating A->B with A->B gives A+B:(A->B, B)") {
@@ -68,10 +76,10 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers {
               WorkNode("A", 1, List("B"), "A+B"),
               WorkNode("B", 1, Nil, "A+B")))
         )
-        .nodes should contain theSameElementsAs
-        List(
-          WorkNode("A", 2, List("B"), componentId = "A+B"),
-          WorkNode("B", 1, List(), componentId = "A+B"))
+        .nodes shouldBe Set(
+          WorkNode("A", 2, List("B"), hashed_AB),
+          WorkNode("B", 1, List(), hashed_AB)
+        )
     }
 
     it("updating A->B, B, C with B->C gives A+B+C:(A->B, B->C, C)") {
@@ -85,9 +93,9 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers {
               WorkNode("C", 1, Nil, "C")))
         )
         .nodes shouldBe Set(
-        WorkNode("A", 2, List("B"), componentId = "A+B+C"),
-        WorkNode("B", 2, List("C"), componentId = "A+B+C"),
-        WorkNode("C", 1, List(), componentId = "A+B+C")
+        WorkNode("A", 2, List("B"), hashed_ABC),
+        WorkNode("B", 2, List("C"), hashed_ABC),
+        WorkNode("C", 1, List(), hashed_ABC)
       )
     }
 
@@ -103,12 +111,12 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers {
               WorkNode("D", 1, Nil, "C+D")
             ))
         )
-        .nodes should contain theSameElementsAs
-        List(
-          WorkNode("A", 1, List("B"), "A+B+C+D"),
-          WorkNode("B", 2, List("C"), "A+B+C+D"),
-          WorkNode("C", 1, List("D"), "A+B+C+D"),
-          WorkNode("D", 1, List(), "A+B+C+D"))
+        .nodes shouldBe
+        Set(
+          WorkNode("A", 1, List("B"), hashed_ABCD),
+          WorkNode("B", 2, List("C"), hashed_ABCD),
+          WorkNode("C", 1, List("D"), hashed_ABCD),
+          WorkNode("D", 1, List(), hashed_ABCD))
     }
 
     it("updating A->B with B->[C,D] gives A+B+C+D:(A->B, B->C&D, C, D") {
@@ -123,12 +131,12 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers {
               WorkNode("D", 1, Nil, "D")
             ))
         )
-        .nodes should contain theSameElementsAs
-        List(
-          WorkNode("A", 2, List("B"), componentId = "A+B+C+D"),
-          WorkNode("B", 2, List("C", "D"), componentId = "A+B+C+D"),
-          WorkNode("C", 1, List(), componentId = "A+B+C+D"),
-          WorkNode("D", 1, List(), componentId = "A+B+C+D")
+        .nodes shouldBe
+        Set(
+          WorkNode("A", 2, List("B"), hashed_ABCD),
+          WorkNode("B", 2, List("C", "D"),hashed_ABCD),
+          WorkNode("C", 1, List(), hashed_ABCD),
+          WorkNode("D", 1, List(), hashed_ABCD)
         )
     }
 
@@ -143,9 +151,9 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers {
               WorkNode("C", 1, Nil, "A+B+C")))
         )
         .nodes shouldBe Set(
-        WorkNode("A", 2, List("B"), componentId = "A+B+C"),
-        WorkNode("B", 2, List("C"), componentId = "A+B+C"),
-        WorkNode("C", 2, List("A"), componentId = "A+B+C")
+        WorkNode("A", 2, List("B"), hashed_ABC),
+        WorkNode("B", 2, List("C"), hashed_ABC),
+        WorkNode("C", 2, List("A"), hashed_ABC)
       )
     }
   }
@@ -161,8 +169,8 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers {
               WorkNode("B", 1, List(), "A+B")))
         )
         .nodes shouldBe Set(
-        WorkNode("A", 2, List(), componentId = "A"),
-        WorkNode("B", 1, List(), componentId = "B")
+        WorkNode("A", 2, List(), hashed_A),
+        WorkNode("B", 1, List(), hashed_B)
       )
     }
 
@@ -176,8 +184,8 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers {
             ))
         )
         .nodes shouldBe Set(
-        WorkNode("A", 2, Nil, componentId = "A"),
-        WorkNode("B", 0, Nil, componentId = "B")
+        WorkNode("A", 2, Nil, hashed_A),
+        WorkNode("B", 0, Nil, hashed_B)
       )
     }
 
@@ -192,9 +200,9 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers {
               WorkNode("C", 1, Nil, "A+B+C")))
         )
         .nodes shouldBe Set(
-        WorkNode("A", 2, List("B"), "A+B"),
-        WorkNode("B", 3, Nil, "A+B"),
-        WorkNode("C", 1, Nil, "C")
+        WorkNode("A", 2, List("B"),hashed_AB),
+        WorkNode("B", 3, Nil, hashed_AB),
+        WorkNode("C", 1, Nil, hashed_C)
       )
     }
 
@@ -209,9 +217,9 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers {
               WorkNode("C", 1, Nil, "A+B+C")))
         )
         .nodes shouldBe Set(
-        WorkNode("A", 2, List("B"), "A+B+C"),
-        WorkNode("B", 3, List("C"), "A+B+C"),
-        WorkNode("C", 1, Nil, "A+B+C")
+        WorkNode("A", 2, List("B"),hashed_ABC),
+        WorkNode("B", 3, List("C"), hashed_ABC),
+        WorkNode("C", 1, Nil, hashed_ABC)
       )
     }
   }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -13,11 +13,11 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
   // works comprised of linked works are identified by compound id together with their linked works.
   // A+B:(A->B, B) means compound work with id "A+B" is made of work A linked to B and work B.
 
-  private val hashed_A    = "217b21f3" // ciHash("A")
-  private val hashed_B    = "4d7e95ff" // ciHash("B")
-  private val hashed_C    = "8171cb29" // ciHash("C")
-  private val hashed_AB   = "2f2f1575" // ciHash("A+B")
-  private val hashed_ABC  = "45e72cb2" // ciHash("A+B+C")
+  private val hashed_A = "217b21f3" // ciHash("A")
+  private val hashed_B = "4d7e95ff" // ciHash("B")
+  private val hashed_C = "8171cb29" // ciHash("C")
+  private val hashed_AB = "2f2f1575" // ciHash("A+B")
+  private val hashed_ABC = "45e72cb2" // ciHash("A+B+C")
   private val hashed_ABCD = "73200083" // ciHash("A+B+C+D")
 
   describe("Adding links without existing works") {
@@ -77,9 +77,9 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
               WorkNode("B", 1, Nil, "A+B")))
         )
         .nodes shouldBe Set(
-          WorkNode("A", 2, List("B"), hashed_AB),
-          WorkNode("B", 1, List(), hashed_AB)
-        )
+        WorkNode("A", 2, List("B"), hashed_AB),
+        WorkNode("B", 1, List(), hashed_AB)
+      )
     }
 
     it("updating A->B, B, C with B->C gives A+B+C:(A->B, B->C, C)") {
@@ -134,7 +134,7 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
         .nodes shouldBe
         Set(
           WorkNode("A", 2, List("B"), hashed_ABCD),
-          WorkNode("B", 2, List("C", "D"),hashed_ABCD),
+          WorkNode("B", 2, List("C", "D"), hashed_ABCD),
           WorkNode("C", 1, List(), hashed_ABCD),
           WorkNode("D", 1, List(), hashed_ABCD)
         )
@@ -200,7 +200,7 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
               WorkNode("C", 1, Nil, "A+B+C")))
         )
         .nodes shouldBe Set(
-        WorkNode("A", 2, List("B"),hashed_AB),
+        WorkNode("A", 2, List("B"), hashed_AB),
         WorkNode("B", 3, Nil, hashed_AB),
         WorkNode("C", 1, Nil, hashed_C)
       )
@@ -217,7 +217,7 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
               WorkNode("C", 1, Nil, "A+B+C")))
         )
         .nodes shouldBe Set(
-        WorkNode("A", 2, List("B"),hashed_ABC),
+        WorkNode("A", 2, List("B"), hashed_ABC),
         WorkNode("B", 3, List("C"), hashed_ABC),
         WorkNode("C", 1, Nil, hashed_ABC)
       )


### PR DESCRIPTION
### What is this PR trying to achieve?
The component ids are generated from the work source identifiers, however these can be too long for DynamoDb to store in the `componentId` key.  So this change will store hashed values.

### Who is this change for?
