### PR TITLE
Modify work model to contain redirect information

### DIFF
--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -173,7 +173,8 @@ class WorksIndex @Inject()(client: HttpClient, elasticConfig: ElasticConfig)
       language,
       location("thumbnail"),
       textField("dimensions"),
-      objectField("redirect").fields(sourceIdentifier, keywordField("canonicalId")),
+      objectField("redirect")
+        .fields(sourceIdentifier, keywordField("canonicalId")),
       keywordField("type")
     )
 

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -172,7 +172,9 @@ class WorksIndex @Inject()(client: HttpClient, elasticConfig: ElasticConfig)
       production,
       language,
       location("thumbnail"),
-      textField("dimensions")
+      textField("dimensions"),
+      objectField("redirect").fields(sourceIdentifier, keywordField("canonicalId")),
+      keywordField("type")
     )
 
   val mappingDefinition: MappingDefinition = mapping(rootIndexType)

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexTest.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexTest.scala
@@ -8,10 +8,10 @@ import org.scalatest.prop.PropertyChecks
 import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.GlobalExecutionContext.context
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
+import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 import uk.ac.wellcome.test.utils.{ExtendedPatience, JsonTestUtil}
 import uk.ac.wellcome.utils.JsonUtil._
 import org.scalacheck.ScalacheckShapeless._
-import uk.ac.wellcome.models.work.internal.IdentifiedWork
 
 class WorksIndexTest
     extends FunSpec
@@ -26,10 +26,10 @@ class WorksIndexTest
 
   // On failure, scalacheck tries to shrink to the smallest input that causes a failure.
   // With IdentifiedWork, that means that it never actually completes.
-  implicit val noShrink = Shrink.shrinkAny[IdentifiedWork]
+  implicit val noShrink = Shrink.shrinkAny[IdentifiedBaseWork]
 
   it("puts a valid work") {
-    forAll { sampleWork: IdentifiedWork =>
+    forAll { sampleWork: IdentifiedBaseWork =>
       withLocalElasticsearchIndex(itemType = "work") { indexName =>
         val sampleWorkJson = toJson(sampleWork).get
 

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Redirect.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Redirect.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.models.work.internal
 
 sealed trait Redirect
-case class IdentifiableRedirect(sourceIdentifier: SourceIdentifier) extends Redirect
+case class IdentifiableRedirect(sourceIdentifier: SourceIdentifier)
+    extends Redirect
 case class IdentifiedRedirect(canonicalId: String) extends Redirect

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Redirect.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Redirect.scala
@@ -1,0 +1,5 @@
+package uk.ac.wellcome.models.work.internal
+
+sealed trait Redirect
+case class IdentifiableRedirect(sourceIdentifier: SourceIdentifier) extends Redirect
+case class IdentifiedRedirect(canonicalId: String) extends Redirect

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -57,7 +57,7 @@ case class UnidentifiedWork(
   items: List[UnidentifiedItem] = Nil,
   visible: Boolean = true,
   ontologyType: String = "Work")
-    extends Work with IdentifiedBaseWork
+    extends Work
 
 case class IdentifiedWork(
   canonicalId: String,
@@ -82,7 +82,7 @@ case class IdentifiedWork(
   version: Int,
   visible: Boolean = true,
   ontologyType: String = "Work")
-    extends Work
+    extends Work with IdentifiedBaseWork
 
 trait RedirectedWork extends BaseWork {
   val sourceIdentifier: SourceIdentifier

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -1,12 +1,9 @@
 package uk.ac.wellcome.models.work.internal
 
-object Work {
-  type Redirect = IdentityState[Nothing]
-  type IdentifiedRedirect = Identified[Nothing]
-  type IdentifiableRedirect = Identifiable[Nothing]
-}
+sealed trait Redirect
+case class IdentifiableRedirect(sourceIdentifier: SourceIdentifier) extends Redirect
+case class IdentifiedRedirect(canonicalId: String) extends Redirect
 
-import Work._
 /** A representation of a work in our ontology */
 trait Work extends MultipleSourceIdentifiers {
   val sourceIdentifier: SourceIdentifier

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -27,13 +27,15 @@ trait Work extends MultipleSourceIdentifiers {
   val visible: Boolean
 
   val ontologyType: String
+  val redirect: Option[IdentityState[None.type]]
 }
 
 case class UnidentifiedWork(
   sourceIdentifier: SourceIdentifier,
+  version: Int,
+  title: Option[String],
   otherIdentifiers: List[SourceIdentifier] = List(),
   mergeCandidates: List[MergeCandidate] = List(),
-  title: Option[String],
   workType: Option[WorkType] = None,
   description: Option[String] = None,
   physicalDescription: Option[String] = None,
@@ -48,9 +50,9 @@ case class UnidentifiedWork(
   language: Option[Language] = None,
   dimensions: Option[String] = None,
   items: List[UnidentifiedItem] = Nil,
-  version: Int,
   visible: Boolean = true,
-  ontologyType: String = "Work")
+  ontologyType: String = "Work",
+  redirect: Option[Identifiable[None.type]] = None)
     extends Work
 
 case class IdentifiedWork(
@@ -75,5 +77,6 @@ case class IdentifiedWork(
   items: List[IdentifiedItem] = Nil,
   version: Int,
   visible: Boolean = true,
-  ontologyType: String = "Work")
+  ontologyType: String = "Work",
+  redirect: Option[Identified[None.type]] = None)
     extends Work

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -4,6 +4,8 @@ sealed trait BaseWork {
   val version: Int
   val sourceIdentifier: SourceIdentifier
 }
+
+sealed trait IdentifiedBaseWork extends BaseWork
 /** A representation of a work in our ontology */
 trait Work extends BaseWork with MultipleSourceIdentifiers {
   val sourceIdentifier: SourceIdentifier
@@ -55,7 +57,7 @@ case class UnidentifiedWork(
   items: List[UnidentifiedItem] = Nil,
   visible: Boolean = true,
   ontologyType: String = "Work")
-    extends Work
+    extends Work with IdentifiedBaseWork
 
 case class IdentifiedWork(
   canonicalId: String,
@@ -99,4 +101,4 @@ case class IdentifiedRedirectedWork(
                                      sourceIdentifier: SourceIdentifier,
                                      version: Int,
                                      redirect: IdentifiedRedirect
-                                     ) extends RedirectedWork
+                                     ) extends RedirectedWork with IdentifiedBaseWork

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -1,5 +1,12 @@
 package uk.ac.wellcome.models.work.internal
 
+object Work {
+  type Redirect = IdentityState[Nothing]
+  type IdentifiedRedirect = Identified[Nothing]
+  type IdentifiableRedirect = Identifiable[Nothing]
+}
+
+import Work._
 /** A representation of a work in our ontology */
 trait Work extends MultipleSourceIdentifiers {
   val sourceIdentifier: SourceIdentifier
@@ -27,7 +34,7 @@ trait Work extends MultipleSourceIdentifiers {
   val visible: Boolean
 
   val ontologyType: String
-  val redirect: Option[IdentityState[Nothing]]
+  val redirect: Option[Redirect]
 }
 
 case class UnidentifiedWork(
@@ -52,7 +59,7 @@ case class UnidentifiedWork(
   items: List[UnidentifiedItem] = Nil,
   visible: Boolean = true,
   ontologyType: String = "Work",
-  redirect: Option[Identifiable[Nothing]] = None)
+  redirect: Option[IdentifiableRedirect] = None)
     extends Work
 
 case class IdentifiedWork(
@@ -78,5 +85,5 @@ case class IdentifiedWork(
   version: Int,
   visible: Boolean = true,
   ontologyType: String = "Work",
-  redirect: Option[Identified[Nothing]] = None)
+  redirect: Option[IdentifiedRedirect] = None)
     extends Work

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -6,6 +6,7 @@ sealed trait BaseWork {
 }
 
 sealed trait IdentifiedBaseWork extends BaseWork
+
 /** A representation of a work in our ontology */
 trait Work extends BaseWork with MultipleSourceIdentifiers {
   val sourceIdentifier: SourceIdentifier
@@ -82,7 +83,8 @@ case class IdentifiedWork(
   version: Int,
   visible: Boolean = true,
   ontologyType: String = "Work")
-    extends Work with IdentifiedBaseWork
+    extends Work
+    with IdentifiedBaseWork
 
 trait RedirectedWork extends BaseWork {
   val sourceIdentifier: SourceIdentifier
@@ -91,14 +93,15 @@ trait RedirectedWork extends BaseWork {
 }
 
 case class UnidentifiedRedirectedWork(
-                                     sourceIdentifier: SourceIdentifier,
-                                     version: Int,
-                                     redirect: IdentifiableRedirect
-                                     ) extends RedirectedWork
+  sourceIdentifier: SourceIdentifier,
+  version: Int,
+  redirect: IdentifiableRedirect
+) extends RedirectedWork
 
 case class IdentifiedRedirectedWork(
-                                   canonicalId: String,
-                                     sourceIdentifier: SourceIdentifier,
-                                     version: Int,
-                                     redirect: IdentifiedRedirect
-                                     ) extends RedirectedWork with IdentifiedBaseWork
+  canonicalId: String,
+  sourceIdentifier: SourceIdentifier,
+  version: Int,
+  redirect: IdentifiedRedirect
+) extends RedirectedWork
+    with IdentifiedBaseWork

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -27,7 +27,7 @@ trait Work extends MultipleSourceIdentifiers {
   val visible: Boolean
 
   val ontologyType: String
-  val redirect: Option[IdentityState[None.type]]
+  val redirect: Option[IdentityState[Nothing]]
 }
 
 case class UnidentifiedWork(
@@ -52,7 +52,7 @@ case class UnidentifiedWork(
   items: List[UnidentifiedItem] = Nil,
   visible: Boolean = true,
   ontologyType: String = "Work",
-  redirect: Option[Identifiable[None.type]] = None)
+  redirect: Option[Identifiable[Nothing]] = None)
     extends Work
 
 case class IdentifiedWork(
@@ -78,5 +78,5 @@ case class IdentifiedWork(
   version: Int,
   visible: Boolean = true,
   ontologyType: String = "Work",
-  redirect: Option[Identified[None.type]] = None)
+  redirect: Option[Identified[Nothing]] = None)
     extends Work

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.models.work.internal
 
-sealed trait Redirect
-case class IdentifiableRedirect(sourceIdentifier: SourceIdentifier) extends Redirect
-case class IdentifiedRedirect(canonicalId: String) extends Redirect
-
+sealed trait BaseWork {
+  val version: Int
+  val sourceIdentifier: SourceIdentifier
+}
 /** A representation of a work in our ontology */
-trait Work extends MultipleSourceIdentifiers {
+trait Work extends BaseWork with MultipleSourceIdentifiers {
   val sourceIdentifier: SourceIdentifier
   val otherIdentifiers: List[SourceIdentifier]
   val mergeCandidates: List[MergeCandidate]
@@ -31,7 +31,6 @@ trait Work extends MultipleSourceIdentifiers {
   val visible: Boolean
 
   val ontologyType: String
-  val redirect: Option[Redirect]
 }
 
 case class UnidentifiedWork(
@@ -55,8 +54,7 @@ case class UnidentifiedWork(
   dimensions: Option[String] = None,
   items: List[UnidentifiedItem] = Nil,
   visible: Boolean = true,
-  ontologyType: String = "Work",
-  redirect: Option[IdentifiableRedirect] = None)
+  ontologyType: String = "Work")
     extends Work
 
 case class IdentifiedWork(
@@ -81,6 +79,24 @@ case class IdentifiedWork(
   items: List[IdentifiedItem] = Nil,
   version: Int,
   visible: Boolean = true,
-  ontologyType: String = "Work",
-  redirect: Option[IdentifiedRedirect] = None)
+  ontologyType: String = "Work")
     extends Work
+
+trait RedirectedWork extends BaseWork {
+  val sourceIdentifier: SourceIdentifier
+  val version: Int
+  val redirect: Redirect
+}
+
+case class UnidentifiedRedirectedWork(
+                                     sourceIdentifier: SourceIdentifier,
+                                     version: Int,
+                                     redirect: IdentifiableRedirect
+                                     ) extends RedirectedWork
+
+case class IdentifiedRedirectedWork(
+                                   canonicalId: String,
+                                     sourceIdentifier: SourceIdentifier,
+                                     version: Int,
+                                     redirect: IdentifiedRedirect
+                                     ) extends RedirectedWork


### PR DESCRIPTION
In a way that allows the idminter to add an identifier for it that can be used by the API
