### PR TITLE
Matcher WorkNodeDao wraps ProvisionedThroughputExceeded exceptions as GracefulFailureExceptions

### DIFF
--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
@@ -1,23 +1,20 @@
 package uk.ac.wellcome.platform.matcher.storage
 
-import javax.naming.ConfigurationException
-
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.amazonaws.services.dynamodbv2.model.{
-  BatchGetItemRequest,
-  PutItemRequest,
-  QueryRequest
-}
+import com.amazonaws.services.dynamodbv2.model._
 import com.gu.scanamo.Scanamo
 import com.gu.scanamo.syntax._
+import javax.naming.ConfigurationException
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.matcher.WorkNode
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
+
 import scala.concurrent.ExecutionContext.Implicits.global
 class WorkNodeDaoTest
     extends FunSpec
@@ -73,22 +70,25 @@ class WorkNodeDaoTest
       }
     }
 
-    it("returns an error if Scanamo fails") {
+    it("returns a GracefulFailure if ProvisionedThroughputExceededException occurs during get from dynamo") {
       withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { table =>
-        withWorkNodeDao(table) { workNodeDao =>
-          case class BadRecord(id: String)
-          val badRecord: BadRecord = BadRecord(id = "A")
-          Scanamo.put(dynamoDbClient)(table.name)(badRecord)
+        val dynamoDbClient = mock[AmazonDynamoDB]
+        when(dynamoDbClient.batchGetItem(any[BatchGetItemRequest]))
+          .thenThrow(new ProvisionedThroughputExceededException("test"))
+        val workNodeDao = new WorkNodeDao(
+          dynamoDbClient,
+          DynamoConfig(table.name, table.index)
+        )
 
-          whenReady(workNodeDao.get(Set("A")).failed) { failedException =>
-            failedException shouldBe a[RuntimeException]
-          }
+        whenReady(workNodeDao.get(Set("A")).failed) {
+          failedException =>
+            failedException shouldBe a[GracefulFailureException]
         }
       }
     }
   }
 
-  describe("Get by SetIds") {
+  describe("Get by ComponentIds") {
     it("returns empty set if componentIds are not in dynamo") {
       withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { table =>
         withWorkNodeDao(table) { workNodeDao =>
@@ -100,7 +100,7 @@ class WorkNodeDaoTest
       }
     }
 
-    it("returns WorkNodes which are stored in DynamoDB") {
+    it("returns WorkNodes which are stored in DynamoDB for a given component id") {
       withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { table =>
         withWorkNodeDao(table) { matcherGraphDao =>
           val existingWorkNodeA: WorkNode = WorkNode("A", 1, List("B"), "A+B")
@@ -117,7 +117,7 @@ class WorkNodeDaoTest
       }
     }
 
-    it("returns an error if fetching from dynamo fails") {
+    it("returns an error if fetching from dynamo fails during a getByComponentIds") {
       withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { table =>
         val dynamoDbClient = mock[AmazonDynamoDB]
         val expectedException = new RuntimeException("FAILED")
@@ -135,7 +135,23 @@ class WorkNodeDaoTest
       }
     }
 
-    it("returns an error if Scanamo fails") {
+    it("returns a GracefulFailure if ProvisionedThroughputExceededException occurs during a getByComponentIds") {
+      withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { table =>
+        val dynamoDbClient = mock[AmazonDynamoDB]
+        when(dynamoDbClient.query(any[QueryRequest]))
+          .thenThrow(new ProvisionedThroughputExceededException("test"))
+        val workNodeDao = new WorkNodeDao(
+          dynamoDbClient,
+          DynamoConfig(table.name, table.index)
+        )
+
+        whenReady(workNodeDao.getByComponentIds(Set("A+B")).failed) { failedException =>
+          failedException shouldBe a[GracefulFailureException]
+        }
+      }
+    }
+
+    it("returns an error if Scanamo fails during a getByComponentIds") {
       withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { table =>
         withWorkNodeDao(table) { workNodeDao =>
           case class BadRecord(id: String, componentId: String)
@@ -165,7 +181,21 @@ class WorkNodeDaoTest
       }
     }
 
-    it("returns an error if putting to dynamo fails") {
+    it("returns an error if Scanamo fails to put a record") {
+      withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { table =>
+        withWorkNodeDao(table) { workNodeDao =>
+          case class BadRecord(id: String)
+          val badRecord: BadRecord = BadRecord(id = "A")
+          Scanamo.put(dynamoDbClient)(table.name)(badRecord)
+
+          whenReady(workNodeDao.get(Set("A")).failed) { failedException =>
+            failedException shouldBe a[RuntimeException]
+          }
+        }
+      }
+    }
+
+    it("returns an error if put to dynamo fails") {
       withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { table =>
         val dynamoDbClient = mock[AmazonDynamoDB]
         val expectedException = new RuntimeException("FAILED")
@@ -179,6 +209,23 @@ class WorkNodeDaoTest
         whenReady(workNodeDao.put(WorkNode("A", 1, List("B"), "A+B")).failed) {
           failedException =>
             failedException shouldBe expectedException
+        }
+      }
+    }
+
+    it("returns a GracefulFailure if ProvisionedThroughputExceededException occurs during put to dynamo") {
+      withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { table =>
+        val dynamoDbClient = mock[AmazonDynamoDB]
+        when(dynamoDbClient.putItem(any[PutItemRequest]))
+          .thenThrow(new ProvisionedThroughputExceededException("test"))
+        val workNodeDao = new WorkNodeDao(
+          dynamoDbClient,
+          DynamoConfig(table.name, table.index)
+        )
+
+        whenReady(workNodeDao.put(WorkNode("A", 1, List("B"), "A+B")).failed) {
+          failedException =>
+            failedException shouldBe a[GracefulFailureException]
         }
       }
     }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
@@ -70,7 +70,8 @@ class WorkNodeDaoTest
       }
     }
 
-    it("returns a GracefulFailure if ProvisionedThroughputExceededException occurs during get from dynamo") {
+    it(
+      "returns a GracefulFailure if ProvisionedThroughputExceededException occurs during get from dynamo") {
       withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { table =>
         val dynamoDbClient = mock[AmazonDynamoDB]
         when(dynamoDbClient.batchGetItem(any[BatchGetItemRequest]))
@@ -80,9 +81,8 @@ class WorkNodeDaoTest
           DynamoConfig(table.name, table.index)
         )
 
-        whenReady(workNodeDao.get(Set("A")).failed) {
-          failedException =>
-            failedException shouldBe a[GracefulFailureException]
+        whenReady(workNodeDao.get(Set("A")).failed) { failedException =>
+          failedException shouldBe a[GracefulFailureException]
         }
       }
     }
@@ -100,7 +100,8 @@ class WorkNodeDaoTest
       }
     }
 
-    it("returns WorkNodes which are stored in DynamoDB for a given component id") {
+    it(
+      "returns WorkNodes which are stored in DynamoDB for a given component id") {
       withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { table =>
         withWorkNodeDao(table) { matcherGraphDao =>
           val existingWorkNodeA: WorkNode = WorkNode("A", 1, List("B"), "A+B")
@@ -117,7 +118,8 @@ class WorkNodeDaoTest
       }
     }
 
-    it("returns an error if fetching from dynamo fails during a getByComponentIds") {
+    it(
+      "returns an error if fetching from dynamo fails during a getByComponentIds") {
       withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { table =>
         val dynamoDbClient = mock[AmazonDynamoDB]
         val expectedException = new RuntimeException("FAILED")
@@ -135,7 +137,8 @@ class WorkNodeDaoTest
       }
     }
 
-    it("returns a GracefulFailure if ProvisionedThroughputExceededException occurs during a getByComponentIds") {
+    it(
+      "returns a GracefulFailure if ProvisionedThroughputExceededException occurs during a getByComponentIds") {
       withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { table =>
         val dynamoDbClient = mock[AmazonDynamoDB]
         when(dynamoDbClient.query(any[QueryRequest]))
@@ -145,8 +148,9 @@ class WorkNodeDaoTest
           DynamoConfig(table.name, table.index)
         )
 
-        whenReady(workNodeDao.getByComponentIds(Set("A+B")).failed) { failedException =>
-          failedException shouldBe a[GracefulFailureException]
+        whenReady(workNodeDao.getByComponentIds(Set("A+B")).failed) {
+          failedException =>
+            failedException shouldBe a[GracefulFailureException]
         }
       }
     }
@@ -213,7 +217,8 @@ class WorkNodeDaoTest
       }
     }
 
-    it("returns a GracefulFailure if ProvisionedThroughputExceededException occurs during put to dynamo") {
+    it(
+      "returns a GracefulFailure if ProvisionedThroughputExceededException occurs during put to dynamo") {
       withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { table =>
         val dynamoDbClient = mock[AmazonDynamoDB]
         when(dynamoDbClient.putItem(any[PutItemRequest]))


### PR DESCRIPTION
### What is this PR trying to achieve?
wrap ProvisionedThroughputExceeded exceptions as GracefulFailureExceptions from WorkNodeDao
to prevent stacktraces being written to logs

### Who is this change for?
