### PR TITLE
Improvements to the “trigger reindex” script

### DIFF
--- a/reindexer/trigger_reindex.py
+++ b/reindexer/trigger_reindex.py
@@ -3,11 +3,13 @@
 """
 Create/update reindex shards in the reindex shard tracker table.
 
-Usage: trigger_reindex.py --prefix=<PREFIX> [--count=<COUNT>]
+Usage: trigger_reindex.py --prefix=<PREFIX> --reason=<REASON> [--count=<COUNT>]
        trigger_reindex.py -h | --help
 
 Options:
   --prefix=<PREFIX>     Name of the reindex shard prefix, e.g. sierra, miro
+  --reason=<REASON>     An explanation of why you're running this reindex.
+                        This will be printed in the Slack alert.
   --count=<COUNT>       How many shards to create in the table
   -h --help             Print this help message
 
@@ -115,6 +117,7 @@ if __name__ == '__main__':
 
     prefix = args['--prefix']
     count = int(args['--count'] or '0')
+    reason = args['--reason']
     table_name = TABLE_NAME
 
     # We use the current timestamp for the reindex version -- this allows

--- a/reindexer/trigger_reindex.py
+++ b/reindexer/trigger_reindex.py
@@ -3,13 +3,12 @@
 """
 Create/update reindex shards in the reindex shard tracker table.
 
-Usage: trigger_reindex.py --prefix=<PREFIX> [--count=<COUNT>] [--table=<TABLE>]
+Usage: trigger_reindex.py --prefix=<PREFIX> [--count=<COUNT>]
        trigger_reindex.py -h | --help
 
 Options:
   --prefix=<PREFIX>     Name of the reindex shard prefix, e.g. sierra, miro
   --count=<COUNT>       How many shards to create in the table
-  --table=<TABLE>       Name of the reindex shard tracker DynamoDB table
   -h --help             Print this help message
 
 """
@@ -19,6 +18,9 @@ import datetime as dt
 import boto3
 import docopt
 import tqdm
+
+
+TABLE_NAME = 'ReindexShardTracker'
 
 
 # Implementation note: this code may fail if you hit the write limit on
@@ -113,7 +115,7 @@ if __name__ == '__main__':
 
     prefix = args['--prefix']
     count = int(args['--count'] or '0')
-    table_name = args['--table'] or 'ReindexShardTracker'
+    table_name = TABLE_NAME
 
     # We use the current timestamp for the reindex version -- this allows
     # us to easily trace when a reindex was triggered.

--- a/reindexer/trigger_reindex.py
+++ b/reindexer/trigger_reindex.py
@@ -152,7 +152,7 @@ def post_to_slack(prefix, reason):
     resp.raise_for_status()
 
 
-if __name__ == '__main__':
+def main():
     args = docopt.docopt(__doc__)
 
     client = boto3.client('dynamodb')
@@ -183,3 +183,11 @@ if __name__ == '__main__':
         count=count,
         table_name=table_name
     )
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        import sys
+        sys.exit(1)

--- a/reindexer/trigger_reindex.py
+++ b/reindexer/trigger_reindex.py
@@ -148,31 +148,3 @@ if __name__ == '__main__':
         count=count,
         table_name=table_name
     )
-
-    # Trigger an immediate capacity increase on the DynamoDB table.
-    #
-    # If we just start the reindexer, the autoscaling will eventually warm up
-    # the table, but only after hitting lots of ProvisionedThroughputExceeded
-    # exceptions.  This should give a smoother start to the reindexer.
-    #
-    # Note: this does not disable the autoscaling rules, and if you run this
-    # without starting the reindexer, it eventually scales back down.
-    #
-    client.update_table(
-        TableName='SourceData',
-        ProvisionedThroughput={
-            'WriteCapacityUnits': 50,
-            'ReadCapacityUnits': 5
-        },
-        GlobalSecondaryIndexUpdates=[
-            {
-                'Update': {
-                    'IndexName': 'reindexTracker',
-                    'ProvisionedThroughput': {
-                        'WriteCapacityUnits': 50,
-                        'ReadCapacityUnits': 5
-                    }
-                }
-            }
-        ]
-    )


### PR DESCRIPTION
* Don’t set SourceData capacity manually, this was an ugly hack
* Use the current timestamp as the reindex version
* Don't print a massive traceback if you only run a partial reindex
* Drop a message in Slack when the reindex starts, so we can track them:

    
<img width="334" alt="screen shot 2018-06-28 at 14 34 42" src="https://user-images.githubusercontent.com/301220/42037552-969f4de6-7ae0-11e8-9b70-4dadde06a160.png">
