### PR TITLE
SNS notifications in dynamo_to_sns are logged as DEBUG, not INFO

### DIFF
--- a/shared_infra/dynamo_to_sns/src/dynamo_to_sns.py
+++ b/shared_infra/dynamo_to_sns/src/dynamo_to_sns.py
@@ -6,10 +6,14 @@ Receives DynamoDB events and publishes the event to an SNS topic.
 import os
 
 import boto3
+import daiquiri
 
 from wellcome_aws_utils.dynamo_event import create_dynamo_events
 from wellcome_aws_utils.lambda_utils import log_on_error
 from wellcome_aws_utils.sns_utils import publish_sns_message
+
+
+daiquiri.setup(level=os.environ.get('LOG_LEVEL', 'INFO'))
 
 
 def get_sns_messages(trigger_event, stream_view_type):

--- a/shared_infra/dynamo_to_sns/src/requirements.in
+++ b/shared_infra/dynamo_to_sns/src/requirements.in
@@ -1,1 +1,2 @@
-wellcome_aws_utils==2.1.1
+daiquiri
+wellcome_aws_utils==2.1.2

--- a/shared_infra/dynamo_to_sns/src/requirements.txt
+++ b/shared_infra/dynamo_to_sns/src/requirements.txt
@@ -6,10 +6,10 @@
 #
 boto3==1.7.31             # via wellcome-aws-utils
 botocore==1.10.31         # via boto3, s3transfer
-daiquiri==1.3.0           # via wellcome-aws-utils
+daiquiri==1.3.0
 docutils==0.14            # via botocore
 jmespath==0.9.3           # via boto3, botocore
 python-dateutil==2.7.3    # via botocore, wellcome-aws-utils
 s3transfer==0.1.13        # via boto3
 six==1.11.0               # via python-dateutil
-wellcome_aws_utils==2.1.1
+wellcome_aws_utils==2.1.2


### PR DESCRIPTION
We already do this in the S3 demultiplexers for the adapter stack; this is another chunk of pointless logging we can mostly do without.