### PR TITLE
Don't show a "nextPage" parameter in API responses if we're beyond the last page

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
@@ -32,16 +32,15 @@ object ResultListResponse {
     val currentPage = multipleResultsRequest.page
     val isLastPage = displayResultList.totalPages == currentPage
     val isFirstPage = currentPage == 1
-    val isOnlyPage = displayResultList.totalPages <= 1
 
     val apiLink = createApiLink(requestBaseUri, multipleResultsRequest) _
 
     val prevLink =
-      if (!isFirstPage && !isOnlyPage)
+      if (!isFirstPage)
         Some(apiLink(Map("page" -> (currentPage - 1))))
       else None
     val nextLink =
-      if (!isLastPage && !isOnlyPage)
+      if (!isLastPage)
         Some(apiLink(Map("page" -> (currentPage + 1))))
       else None
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
@@ -31,6 +31,7 @@ object ResultListResponse {
 
     val currentPage = multipleResultsRequest.page
     val isLastPage = displayResultList.totalPages == currentPage
+    val isOutOfBounds = displayResultList.totalPages < currentPage
     val isFirstPage = currentPage == 1
 
     val apiLink = createApiLink(requestBaseUri, multipleResultsRequest) _
@@ -40,7 +41,7 @@ object ResultListResponse {
         Some(apiLink(Map("page" -> (currentPage - 1))))
       else None
     val nextLink =
-      if (!isLastPage)
+      if (!isLastPage && !isOutOfBounds)
         Some(apiLink(Map("page" -> (currentPage + 1))))
       else None
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/responses/ResultListResponseTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/responses/ResultListResponseTest.scala
@@ -30,6 +30,16 @@ class ResultListResponseTest extends FunSpec with Matchers {
     request = Request(method = Method.Get, uri = requestUri)
   )
 
+  it("inclues a nextPage and prevPage parameter where appropriate") {
+    val resp = getResponse(
+      displayResultList = displayResultList.copy(totalPages = 5),
+      multipleResultsRequest = multipleResultsRequest.copy(page = 3)
+    )
+
+    resp.prevPage shouldBe Some(s"$requestBaseUri$requestUri?page=2")
+    resp.nextPage shouldBe Some(s"$requestBaseUri$requestUri?page=4")
+  }
+
   describe("nextPage") {
     it("omits the parameter if this is the only page") {
       val resp = getResponse(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/responses/ResultListResponseTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/responses/ResultListResponseTest.scala
@@ -68,6 +68,34 @@ class ResultListResponseTest extends FunSpec with Matchers {
     }
   }
 
+  describe("prevPage") {
+    it("omits the parameter if this is the only page") {
+      val resp = getResponse(
+        displayResultList = displayResultList.copy(totalPages = 1)
+      )
+
+      resp.prevPage shouldBe None
+    }
+
+    it("omits the parameter if this is the first page") {
+      val resp = getResponse(
+        displayResultList = displayResultList.copy(totalPages = 5),
+        multipleResultsRequest = multipleResultsRequest.copy(page = 1)
+      )
+
+      resp.prevPage shouldBe None
+    }
+
+    it("includes the parameter if there's a previous page to view") {
+      val resp = getResponse(
+        displayResultList = displayResultList.copy(totalPages = 10),
+        multipleResultsRequest = multipleResultsRequest.copy(page = 5)
+      )
+
+      resp.prevPage shouldBe Some(s"$requestBaseUri$requestUri?page=4")
+    }
+  }
+
   private def getResponse(
     contextUri: String = contextUri,
     displayResultList: DisplayResultList[DisplayWorkV1],

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/responses/ResultListResponseTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/responses/ResultListResponseTest.scala
@@ -16,7 +16,6 @@ class ResultListResponseTest extends FunSpec with Matchers {
     pageSize = 10,
     totalPages = 5,
     totalResults = 45,
-
     // Nothing checks that results is populated correctly!
     results = List()
   )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/responses/ResultListResponseTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/responses/ResultListResponseTest.scala
@@ -1,0 +1,83 @@
+package uk.ac.wellcome.platform.api.responses
+
+import com.twitter.finagle.http.Request
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.display.models.v1.DisplayWorkV1
+import uk.ac.wellcome.platform.api.models.DisplayResultList
+import uk.ac.wellcome.platform.api.requests.MultipleResultsRequest
+
+class ResultListResponseTest extends FunSpec with Matchers with MockitoSugar {
+  val contextUri = "https://example.org/context.json"
+
+  val requestBaseUri = "https://api.example.org/works"
+
+  val displayResultList = DisplayResultList[DisplayWorkV1](
+    pageSize = 10,
+    totalPages = 5,
+    totalResults = 45,
+
+    // Nothing checks that results is populated correctly!
+    results = List()
+  )
+
+  val multipleResultsRequest = MultipleResultsRequest(
+    page = 1,
+    pageSize = Some(displayResultList.pageSize),
+    includes = None,
+    id = None,
+    query = None,
+    _index = None,
+    request = mock[Request]
+  )
+
+  describe("nextPage") {
+    it("omits the parameter if this is the only page") {
+      val resp = getResponse(
+        displayResultList = displayResultList.copy(totalPages = 1)
+      )
+
+      resp.nextPage shouldBe None
+    }
+
+    it("omits the parameter if this is the last page") {
+      val resp = getResponse(
+        displayResultList = displayResultList.copy(totalPages = 5),
+        multipleResultsRequest = multipleResultsRequest.copy(page = 5)
+      )
+
+      resp.nextPage shouldBe None
+    }
+
+    it("omits the parameter if the request is beyond the last page") {
+      val resp = getResponse(
+        displayResultList = displayResultList.copy(totalPages = 5),
+        multipleResultsRequest = multipleResultsRequest.copy(page = 10)
+      )
+
+      resp.nextPage shouldBe None
+    }
+
+    it("includes the parameter if there's a next page to view") {
+      val resp = getResponse(
+        displayResultList = displayResultList.copy(totalPages = 10),
+        multipleResultsRequest = multipleResultsRequest.copy(page = 5)
+      )
+
+      resp.nextPage shouldBe Some(s"$requestBaseUri?page=6")
+    }
+  }
+
+  private def getResponse(
+    contextUri: String = contextUri,
+    displayResultList: DisplayResultList[DisplayWorkV1],
+    multipleResultsRequest: MultipleResultsRequest = multipleResultsRequest,
+    requestBaseUri: String = requestBaseUri
+  ): ResultListResponse =
+    ResultListResponse.create(
+      contextUri = contextUri,
+      displayResultList = displayResultList,
+      multipleResultsRequest = multipleResultsRequest,
+      requestBaseUri = requestBaseUri
+    )
+}

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/responses/ResultListResponseTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/responses/ResultListResponseTest.scala
@@ -1,16 +1,16 @@
 package uk.ac.wellcome.platform.api.responses
 
-import com.twitter.finagle.http.Request
-import org.scalatest.mockito.MockitoSugar
+import com.twitter.finagle.http.{Method, Request}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.platform.api.models.DisplayResultList
 import uk.ac.wellcome.platform.api.requests.MultipleResultsRequest
 
-class ResultListResponseTest extends FunSpec with Matchers with MockitoSugar {
+class ResultListResponseTest extends FunSpec with Matchers {
   val contextUri = "https://example.org/context.json"
 
-  val requestBaseUri = "https://api.example.org/works"
+  val requestBaseUri = "https://api.example.org"
+  val requestUri = "/works"
 
   val displayResultList = DisplayResultList[DisplayWorkV1](
     pageSize = 10,
@@ -28,7 +28,7 @@ class ResultListResponseTest extends FunSpec with Matchers with MockitoSugar {
     id = None,
     query = None,
     _index = None,
-    request = mock[Request]
+    request = Request(method = Method.Get, uri = requestUri)
   )
 
   describe("nextPage") {
@@ -64,7 +64,7 @@ class ResultListResponseTest extends FunSpec with Matchers with MockitoSugar {
         multipleResultsRequest = multipleResultsRequest.copy(page = 5)
       )
 
-      resp.nextPage shouldBe Some(s"$requestBaseUri?page=6")
+      resp.nextPage shouldBe Some(s"$requestBaseUri$requestUri?page=6")
     }
   }
 


### PR DESCRIPTION
First part of #2325 – this makes our API responses a bit more sensible.

Additionally add a bunch of testing around this code, and simplifies a bit of the existing logic.

I’m not sure what to do with prevPage, and @jtweed is away from their desk, so let’s do that in a separate patch.