### PR TITLE
Don't default the "locations" field on our Item model

### DIFF
--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -143,13 +143,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
         val work = workWith(
           canonicalId = "b4heraz7",
           title = "Inside an irate igloo",
-          items = List(
-            itemWith(
-              canonicalId = "c3a599u5",
-              identifier = defaultItemSourceIdentifier,
-              location = defaultLocation
-            )
-          )
+          items = createItems(count = 1)
         )
 
         insertIntoElasticsearch(indexNameV1, itemType, work)

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -101,7 +101,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
           lettering = lettering,
           createdDate = period,
           creator = agent,
-          items = List(defaultItem))
+          items = createItems(count = 2))
 
         insertIntoElasticsearch(indexNameV1, itemType, work)
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -166,13 +166,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
         val work = workWith(
           canonicalId = "b4heraz7",
           title = "Inside an irate igloo",
-          items = List(
-            itemWith(
-              canonicalId = "c3a599u5",
-              identifier = defaultItemSourceIdentifier,
-              location = defaultLocation
-            )
-          )
+          items = createItems(count = 1)
         )
 
         insertIntoElasticsearch(indexNameV2, itemType, work)

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -94,7 +94,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
           creator = agent,
           subjects = List(subject),
           genres = List(genre),
-          items = List(defaultItem)
+          items = createItems(count = 2)
         )
 
         insertIntoElasticsearch(indexNameV2, itemType, work)

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -250,13 +250,14 @@ class IdEmbedderTests
         val expectedItem1 = Identified(
           sourceIdentifier = originalItem1.sourceIdentifier,
           canonicalId = newItemCanonicalId1,
-          agent = Item(
-            ))
+          agent = Item(locations = List())
+        )
 
         val expectedItem2 = Identified(
           sourceIdentifier = originalItem2.sourceIdentifier,
           canonicalId = newItemCanonicalId2,
-          agent = Item())
+          agent = Item(locations = List())
+        )
 
         whenReady(eventualWork) { json =>
           val work = fromJson[IdentifiedWork](json.toString()).get

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -6,6 +6,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.test.util.ItemsUtil
 import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 import uk.ac.wellcome.test.utils.{ExtendedPatience, JsonTestUtil}
 import uk.ac.wellcome.utils.JsonUtil._
@@ -21,7 +22,8 @@ class IdEmbedderTests
     with MockitoSugar
     with Akka
     with JsonTestUtil
-    with ExtendedPatience {
+    with ExtendedPatience
+    with ItemsUtil {
 
   private def withIdEmbedder(
     testWith: TestWith[(IdentifierGenerator, IdEmbedder), Assertion]) = {
@@ -195,9 +197,8 @@ class IdEmbedderTests
 
     val originalItem1 = Identifiable(
       sourceIdentifier = identifier,
-      agent = Item(
-        locations = List()
-      ))
+      agent = Item(locations = List())
+    )
 
     val originalItem2 = Identifiable(
       sourceIdentifier = SourceIdentifier(
@@ -205,9 +206,8 @@ class IdEmbedderTests
         ontologyType = "Item",
         value = "1235"
       ),
-      agent = Item(
-        locations = List()
-      ))
+      agent = Item(locations = List())
+    )
 
     val originalWork = UnidentifiedWork(
       title = "crap",
@@ -247,16 +247,16 @@ class IdEmbedderTests
           ).right.get
         )
 
-        val expectedItem1 = Identified(
+        val expectedItem1 = createItem(
           sourceIdentifier = originalItem1.sourceIdentifier,
           canonicalId = newItemCanonicalId1,
-          agent = Item(locations = List())
+          locations = originalItem1.agent.locations
         )
 
-        val expectedItem2 = Identified(
+        val expectedItem2 = createItem(
           sourceIdentifier = originalItem2.sourceIdentifier,
           canonicalId = newItemCanonicalId2,
-          agent = Item(locations = List())
+          locations = originalItem2.agent.locations
         )
 
         whenReady(eventualWork) { json =>

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
@@ -108,7 +108,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraData {
       transformedItem shouldBe Identifiable(
         sourceIdentifier = sourceIdentifier1,
         otherIdentifiers = List(sourceIdentifier2),
-        agent = Item())
+        agent = Item(locations = List()))
       transformedItem.identifiers shouldBe expectedIdentifiers
     }
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1Test.scala
@@ -33,9 +33,7 @@ class DisplayItemV1Test extends FunSpec with Matchers with ItemsUtil {
   }
 
   it("correctly parses an Item without any locations") {
-    val item = createItem(
-      locations = List()
-    )
+    val item = createItem(locations = List())
 
     val displayItemV1 = DisplayItemV1(
       item = item,

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1Test.scala
@@ -1,35 +1,12 @@
 package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.utils.JsonUtil._
+import uk.ac.wellcome.models.work.test.util.ItemsUtil
 
-class DisplayItemV1Test extends FunSpec with Matchers {
-
-  val location: Location = {
-    val thumbnailUrl = "https://iiif.example.org/V0000001/default.jpg"
-    val locationType = LocationType("thumbnail-image")
-
-    DigitalLocation(
-      locationType = locationType,
-      url = thumbnailUrl,
-      license = License_CCBY
-    )
-  }
-
-  val identifier: SourceIdentifier = SourceIdentifier(
-    identifierType = IdentifierType("miro-image-number"),
-    ontologyType = "Item",
-    value = "value"
-  )
+class DisplayItemV1Test extends FunSpec with Matchers with ItemsUtil {
 
   it("should read an Item as a DisplayItemV1 correctly") {
-    val item = Identified(
-      canonicalId = "foo",
-      sourceIdentifier = identifier,
-      agent = Item(
-        locations = List(location)
-      ))
+    val item = createItem()
 
     val displayItemV1 = DisplayItemV1(
       item = item,
@@ -37,24 +14,14 @@ class DisplayItemV1Test extends FunSpec with Matchers {
     )
 
     displayItemV1.id shouldBe item.canonicalId
-    displayItemV1.locations shouldBe List(DisplayLocationV1(location))
+    displayItemV1.locations shouldBe List(DisplayLocationV1(item.agent.locations.head))
     displayItemV1.identifiers shouldBe Some(
-      List(DisplayIdentifierV1(identifier)))
+      List(DisplayIdentifierV1(item.sourceIdentifier)))
     displayItemV1.ontologyType shouldBe "Item"
   }
 
   it("correctly parses an Item without any extra identifiers") {
-    val item =
-      fromJson[Identified[Item]](s"""
-        {
-          "canonicalId": "b71876a",
-          "sourceIdentifier": ${toJson(identifier).get},
-          "agent": {
-            "locations": [],
-            "type": "item"
-          }
-        }
-      """).get
+    val item = createItem()
 
     val displayItemV1 = DisplayItemV1(
       item = item,
@@ -62,29 +29,13 @@ class DisplayItemV1Test extends FunSpec with Matchers {
     )
 
     displayItemV1.identifiers shouldBe Some(
-      List(DisplayIdentifierV1(identifier)))
+      List(DisplayIdentifierV1(item.sourceIdentifier)))
   }
 
   it("correctly parses an Item without any locations") {
-    val item =
-      fromJson[Identified[Item]]("""
-        {
-          "canonicalId": "mr953zsh",
-          "sourceIdentifier": {
-            "identifierType": {
-              "id": "miro-image-number",
-              "label": "Miro image number",
-              "ontologyType": "IdentifierType"
-            },
-            "ontologyType": "Item",
-            "value": "M9530000"
-          },
-          "identifiers": [],
-          "agent": {
-            "type": "item"
-          }
-        }
-      """).get
+    val item = createItem(
+      locations = List()
+    )
 
     val displayItemV1 = DisplayItemV1(
       item = item,

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1Test.scala
@@ -14,7 +14,8 @@ class DisplayItemV1Test extends FunSpec with Matchers with ItemsUtil {
     )
 
     displayItemV1.id shouldBe item.canonicalId
-    displayItemV1.locations shouldBe List(DisplayLocationV1(item.agent.locations.head))
+    displayItemV1.locations shouldBe List(
+      DisplayLocationV1(item.agent.locations.head))
     displayItemV1.identifiers shouldBe Some(
       List(DisplayIdentifierV1(item.sourceIdentifier)))
     displayItemV1.ontologyType shouldBe "Item"

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
@@ -24,13 +24,8 @@ class DisplayLocationsV1SerialisationTest
       version = 1,
       title = "A zoo of zebras doing zumba",
       items = List(
-        Identified(
-          canonicalId = "mhberjwy7",
-          sourceIdentifier = sourceIdentifier,
-          agent = Item(
-            locations = List(physicalLocation)
-          )
-        ))
+        createItem(locations = List(physicalLocation))
+      )
     )
     val displayWork =
       DisplayWorkV1(work, includes = WorksIncludes(items = true))

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -108,12 +108,7 @@ class DisplayWorkV1SerialisationTest
       credit = Some("Wellcome Collection"),
       license = License_CCBY
     )
-    val item = Identified(
-      canonicalId = "chu27a8",
-      sourceIdentifier = sourceIdentifier,
-      agent = Item(
-        locations = List(location)
-      ))
+    val item = createItem(locations = List(location))
     val workWithCopyright = IdentifiedWork(
       title = "A scarf on a squirrel",
       sourceIdentifier = sourceIdentifier,

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -54,13 +54,7 @@ class DisplayWorkV1SerialisationTest
     val work = workWith(
       canonicalId = "b4heraz7",
       title = "Inside an irate igloo",
-      items = List(
-        itemWith(
-          canonicalId = "c3a599u5",
-          identifier = defaultItemSourceIdentifier,
-          location = defaultLocation
-        )
-      )
+      items = createItems(count = 1)
     )
 
     val actualJson = objectMapper.writeValueAsString(

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -20,7 +20,7 @@ class DisplayWorkV1SerialisationTest
       lettering = lettering,
       createdDate = period,
       creator = agent,
-      items = List(defaultItem))
+      items = createItems(count = 2))
 
     val actualJsonString = objectMapper.writeValueAsString(DisplayWorkV1(work))
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -24,11 +24,7 @@ class DisplayWorkV1Test extends FunSpec with Matchers with ItemsUtil {
   }
 
   it("correctly parses items on a work") {
-    val item = Identified(
-      canonicalId = "c3a599u5",
-      sourceIdentifier = sourceIdentifier,
-      agent = createItem(locations = List())
-    )
+    val item = createItem(locations = List())
     val work = IdentifiedWork(
       title = "Inside an irate igloo",
       sourceIdentifier = sourceIdentifier,

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -4,8 +4,9 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.test.util.ItemsUtil
 
-class DisplayWorkV1Test extends FunSpec with Matchers {
+class DisplayWorkV1Test extends FunSpec with Matchers with ItemsUtil {
 
   it("correctly parses a Work without any items") {
     val work = IdentifiedWork(
@@ -26,9 +27,8 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
     val item = Identified(
       canonicalId = "c3a599u5",
       sourceIdentifier = sourceIdentifier,
-      agent = Item(
-        locations = List()
-      ))
+      agent = createItem(locations = List())
+    )
     val work = IdentifiedWork(
       title = "Inside an irate igloo",
       sourceIdentifier = sourceIdentifier,
@@ -268,23 +268,11 @@ class DisplayWorkV1Test extends FunSpec with Matchers {
   }
 
   describe("correctly uses the WorksIncludes.identifiers include") {
-    val itemSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("miro-image-number"),
-      value = "miro/p0001",
-      ontologyType = "Item"
-    )
-
     val work = IdentifiedWork(
       canonicalId = "pt5vupg4",
       title = "Pouncing pugs play in pipes",
       sourceIdentifier = sourceIdentifier,
-      items = List(
-        Identified(
-          canonicalId = "pwaazubr",
-          sourceIdentifier = itemSourceIdentifier,
-          agent = Item()
-        )
-      ),
+      items = createItems(count = 1),
       version = 1
     )
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2Test.scala
@@ -14,7 +14,8 @@ class DisplayItemV2Test extends FunSpec with Matchers with ItemsUtil {
     )
 
     displayItemV2.id shouldBe item.canonicalId
-    displayItemV2.locations shouldBe List(DisplayLocationV2(item.agent.locations.head))
+    displayItemV2.locations shouldBe List(
+      DisplayLocationV2(item.agent.locations.head))
     displayItemV2.identifiers shouldBe Some(
       List(DisplayIdentifierV2(item.sourceIdentifier)))
     displayItemV2.ontologyType shouldBe "Item"

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2Test.scala
@@ -1,35 +1,12 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.utils.JsonUtil._
+import uk.ac.wellcome.models.work.test.util.ItemsUtil
 
-class DisplayItemV2Test extends FunSpec with Matchers {
-
-  val location: Location = {
-    val thumbnailUrl = "https://iiif.example.org/V0000001/default.jpg"
-    val locationType = LocationType("thumbnail-image")
-
-    DigitalLocation(
-      locationType = locationType,
-      url = thumbnailUrl,
-      license = License_CCBY
-    )
-  }
-
-  val identifier = SourceIdentifier(
-    identifierType = IdentifierType("miro-image-number"),
-    ontologyType = "Item",
-    value = "value"
-  )
+class DisplayItemV2Test extends FunSpec with Matchers with ItemsUtil {
 
   it("should read an Item as a DisplayItemV2 correctly") {
-    val item = Identified(
-      canonicalId = "foo",
-      sourceIdentifier = identifier,
-      agent = Item(
-        locations = List(location)
-      ))
+    val item = createItem()
 
     val displayItemV2 = DisplayItemV2(
       item = item,
@@ -37,24 +14,14 @@ class DisplayItemV2Test extends FunSpec with Matchers {
     )
 
     displayItemV2.id shouldBe item.canonicalId
-    displayItemV2.locations shouldBe List(DisplayLocationV2(location))
+    displayItemV2.locations shouldBe List(DisplayLocationV2(item.agent.locations.head))
     displayItemV2.identifiers shouldBe Some(
-      List(DisplayIdentifierV2(identifier)))
+      List(DisplayIdentifierV2(item.sourceIdentifier)))
     displayItemV2.ontologyType shouldBe "Item"
   }
 
   it("correctly parses an Item without any extra identifiers") {
-    val item =
-      fromJson[Identified[Item]](s"""
-        {
-          "canonicalId": "b71876a",
-          "sourceIdentifier": ${toJson(identifier).get},
-          "agent": {
-            "locations": [],
-            "type": "item"
-          }
-        }
-      """).get
+    val item = createItem()
 
     val displayItemV2 = DisplayItemV2(
       item = item,
@@ -62,29 +29,13 @@ class DisplayItemV2Test extends FunSpec with Matchers {
     )
 
     displayItemV2.identifiers shouldBe Some(
-      List(DisplayIdentifierV2(identifier)))
+      List(DisplayIdentifierV2(item.sourceIdentifier)))
   }
 
   it("correctly parses an Item without any locations") {
-    val item =
-      fromJson[Identified[Item]]("""
-        {
-          "canonicalId": "mr953zsh",
-          "sourceIdentifier": {
-            "identifierType": {
-              "id": "miro-image-number",
-              "label": "Miro image number",
-              "ontologyType": "IdentifierType"
-            },
-            "ontologyType": "Item",
-            "value": "M9530000"
-          },
-          "identifiers": [],
-          "agent": {
-            "type": "item"
-          }
-        }
-      """).get
+    val item = createItem(
+      locations = List()
+    )
 
     val displayItemV2 = DisplayItemV2(
       item = item,

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationsV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationsV2SerialisationTest.scala
@@ -23,15 +23,7 @@ class DisplayLocationsV2SerialisationTest
       sourceIdentifier = sourceIdentifier,
       version = 1,
       title = "A zoo of zebras doing zumba",
-      items = List(
-        Identified(
-          canonicalId = "mhberjwy7",
-          sourceIdentifier = sourceIdentifier,
-          agent = Item(
-            locations = List(physicalLocation)
-          )
-        )
-      )
+      items = List(createItem(locations = List(physicalLocation)))
     )
     val displayWork =
       DisplayWorkV2(work, includes = WorksIncludes(items = true))

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -61,13 +61,7 @@ class DisplayWorkV2SerialisationTest
     val work = workWith(
       canonicalId = "b4heraz7",
       title = "Inside an irate igloo",
-      items = List(
-        itemWith(
-          canonicalId = "c3a599u5",
-          identifier = defaultItemSourceIdentifier,
-          location = defaultLocation
-        )
-      )
+      items = createItems(count = 1)
     )
 
     val actualJson = objectMapper.writeValueAsString(

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -21,7 +21,7 @@ class DisplayWorkV2SerialisationTest
       lettering = lettering,
       createdDate = period,
       creator = agent,
-      items = List(defaultItem))
+      items = createItems(count = 2))
 
     val actualJsonString = objectMapper.writeValueAsString(DisplayWorkV2(work))
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -113,12 +113,7 @@ class DisplayWorkV2SerialisationTest
       credit = Some("Wellcome Collection"),
       license = License_CCBY
     )
-    val item = Identified(
-      canonicalId = "chu27a8",
-      sourceIdentifier = sourceIdentifier,
-      agent = Item(
-        locations = List(location)
-      ))
+    val item = createItem(locations = List(location))
     val workWithCopyright = IdentifiedWork(
       title = "A scarf on a squirrel",
       sourceIdentifier = sourceIdentifier,

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
@@ -234,12 +234,6 @@ class DisplayWorkV2Test extends FunSpec with Matchers with ItemsUtil {
       ontologyType = "Agent"
     )
 
-    val itemSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("miro-image-number"),
-      value = "miro/b0001",
-      ontologyType = "Item"
-    )
-
     val conceptSourceIdentifier = SourceIdentifier(
       identifierType = IdentifierType("lc-subjects"),
       value = "lcsh/bonds",
@@ -387,7 +381,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers with ItemsUtil {
           includes = WorksIncludes(identifiers = true, items = true))
         val item: DisplayItemV2 = displayWork.items.get.head
         item.identifiers shouldBe Some(
-          List(DisplayIdentifierV2(itemSourceIdentifier)))
+          List(DisplayIdentifierV2(work.items.head.sourceIdentifier)))
       }
 
       it("subjects") {

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
@@ -3,8 +3,9 @@ package uk.ac.wellcome.display.models.v2
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.test.util.ItemsUtil
 
-class DisplayWorkV2Test extends FunSpec with Matchers {
+class DisplayWorkV2Test extends FunSpec with Matchers with ItemsUtil {
 
   it("correctly parses a Work without any items") {
     val work = IdentifiedWork(
@@ -22,18 +23,12 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
   }
 
   it("correctly parses items on a work") {
-    val item = Identified(
-      canonicalId = "c3a599u5",
-      sourceIdentifier = sourceIdentifier,
-      agent = Item(
-        locations = List()
-      ))
     val work = IdentifiedWork(
       title = "Inside an irate igloo",
       sourceIdentifier = sourceIdentifier,
       version = 1,
       canonicalId = "b4heraz7",
-      items = List(item)
+      items = createItems(count = 1)
     )
 
     val displayWork = DisplayWorkV2(
@@ -41,7 +36,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
       includes = WorksIncludes(items = true)
     )
     val displayItem = displayWork.items.get.head
-    displayItem.id shouldBe item.canonicalId
+    displayItem.id shouldBe work.items.head.canonicalId
   }
 
   val sourceIdentifier = SourceIdentifier(
@@ -293,13 +288,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers {
           roles = List()
         )
       ),
-      items = List(
-        Identified(
-          canonicalId = "bksy8rkc",
-          sourceIdentifier = itemSourceIdentifier,
-          agent = Item()
-        )
-      ),
+      items = createItems(count = 1),
       subjects = List(
         Subject(
           label = "Beryllium-Boron Bonding",

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Item.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Item.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.models.work.internal
 
 case class Item(
-  locations: List[Location] = List(),
+  locations: List[Location],
   ontologyType: String = "Item"
 )

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/ItemsUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/ItemsUtil.scala
@@ -31,7 +31,7 @@ trait ItemsUtil {
     )
 
   def createItems(count: Int): List[Identified[Item]] =
-    (1 to count)
-      .map { _ => createItem() }
-      .toList
+    (1 to count).map { _ =>
+      createItem()
+    }.toList
 }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/ItemsUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/ItemsUtil.scala
@@ -19,7 +19,7 @@ trait ItemsUtil {
     license = License_CCBY
   )
 
-  def createItem: Identified[Item] =
+  private def createItem: Identified[Item] =
     Identified(
       canonicalId = (Random.alphanumeric take 10 mkString) toLowerCase,
       sourceIdentifier = sourceIdentifier,

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/ItemsUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/ItemsUtil.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.models.work.internal._
 import scala.util.Random
 
 trait ItemsUtil {
-  private def sourceIdentifier = {
+  private def defaultSourceIdentifier = {
     SourceIdentifier(
       identifierType = IdentifierType("miro-image-number"),
       value = (Random.alphanumeric take 10 mkString) toLowerCase,
@@ -13,17 +13,19 @@ trait ItemsUtil {
     )
   }
 
-  private def location = DigitalLocation(
+  private def defaultLocation = DigitalLocation(
     locationType = LocationType("iiif-image"),
     url = "https://iiif.wellcomecollection.org/image/M0000001.jpg/info.json",
     license = License_CCBY
   )
 
   def createItem(
-    locations: List[Location] = List(location)
+    canonicalId: String = (Random.alphanumeric take 10 mkString) toLowerCase,
+    sourceIdentifier: SourceIdentifier = defaultSourceIdentifier,
+    locations: List[Location] = List(defaultLocation)
   ): Identified[Item] =
     Identified(
-      canonicalId = (Random.alphanumeric take 10 mkString) toLowerCase,
+      canonicalId = canonicalId,
       sourceIdentifier = sourceIdentifier,
       agent = Item(locations = locations)
     )

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/ItemsUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/ItemsUtil.scala
@@ -19,15 +19,17 @@ trait ItemsUtil {
     license = License_CCBY
   )
 
-  private def createItem: Identified[Item] =
+  def createItem(
+    locations: List[Location] = List(location)
+  ): Identified[Item] =
     Identified(
       canonicalId = (Random.alphanumeric take 10 mkString) toLowerCase,
       sourceIdentifier = sourceIdentifier,
-      agent = Item(locations = List(location))
+      agent = Item(locations = locations)
     )
 
   def createItems(count: Int): List[Identified[Item]] =
     (1 to count)
-      .map { _ => createItem }
+      .map { _ => createItem() }
       .toList
 }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/ItemsUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/ItemsUtil.scala
@@ -1,0 +1,28 @@
+package uk.ac.wellcome.models.work.test.util
+
+import uk.ac.wellcome.models.work.internal._
+
+import scala.util.Random
+
+trait ItemsUtil {
+  private def sourceIdentifier = {
+    SourceIdentifier(
+      identifierType = IdentifierType("miro-image-number"),
+      value = (Random.alphanumeric take 10 mkString) toLowerCase,
+      ontologyType = "Item"
+    )
+  }
+
+  private def location = DigitalLocation(
+    locationType = LocationType("iiif-image"),
+    url = "https://iiif.wellcomecollection.org/image/M0000001.jpg/info.json",
+    license = License_CCBY
+  )
+
+  def createItem: Identified[Item] =
+    Identified(
+      canonicalId = (Random.alphanumeric take 10 mkString) toLowerCase,
+      sourceIdentifier = sourceIdentifier,
+      agent = Item(locations = List(location))
+    )
+}

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/ItemsUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/ItemsUtil.scala
@@ -25,4 +25,9 @@ trait ItemsUtil {
       sourceIdentifier = sourceIdentifier,
       agent = Item(locations = List(location))
     )
+
+  def createItems(count: Int): List[Identified[Item]] =
+    (1 to count)
+      .map { _ => createItem }
+      .toList
 }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -48,7 +48,7 @@ trait WorksUtil extends ItemsUtil {
           lettering = s"${idx}-${lettering}",
           createdDate = Period(s"${idx}-${period.label}"),
           creator = Agent(s"${idx}-${agent.label}"),
-          items = List(defaultItem)
+          items = createItems(count = 2)
       ))
 
   def createInvisibleWorks(count: Int,
@@ -147,6 +147,4 @@ trait WorksUtil extends ItemsUtil {
       genres = genres,
       items = items
     )
-
-  def defaultItem: Identified[Item] = createItem
 }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.models.work.test.util
 
 import uk.ac.wellcome.models.work.internal._
 
-trait WorksUtil {
+trait WorksUtil extends ItemsUtil {
   val canonicalId = "1234"
   val title = "this is the first image title"
   val description = "this is a description"
@@ -148,41 +148,5 @@ trait WorksUtil {
       items = items
     )
 
-  def defaultItem: Identified[Item] = itemWith(
-    "item-canonical-id",
-    defaultItemSourceIdentifier,
-    defaultLocation
-  )
-
-  def defaultItemSourceIdentifier = {
-    SourceIdentifier(
-      identifierType = IdentifierType("miro-image-number"),
-      "Item",
-      "M0000001")
-  }
-
-  def defaultLocation: Location = {
-    digitalLocationWith(
-      "https://iiif.wellcomecollection.org/image/M0000001.jpg/info.json",
-      License_CCBY)
-  }
-
-  def itemWith(
-    canonicalId: String,
-    identifier: SourceIdentifier,
-    location: Location
-  ): Identified[Item] =
-    Identified(
-      canonicalId = canonicalId,
-      sourceIdentifier = identifier,
-      agent = Item(
-        locations = List(location)
-      ))
-
-  def digitalLocationWith(url: String, license: License): DigitalLocation = {
-    DigitalLocation(
-      locationType = LocationType("iiif-image"),
-      url = url,
-      license = license)
-  }
+  def defaultItem: Identified[Item] = createItem
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

Part of #2333. Spun out from #2335.

When you create an instance of `Item`, you need to specify the locations – previously they were defaulted to an empty list. This should make Circe stricter.

This patch includes a change to the tests that adds a new `ItemsUtil` trait, which should be used to create items in tests where possible – default arguments are now in this trait, not in the main model.