### PR TITLE
Use more of the display serialisation helpers in tests

### DIFF
--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -28,11 +28,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
                  |     "id": "${works(0).canonicalId}",
                  |     "title": "${works(0).title}",
                  |     "description": "${works(0).description.get}",
-                 |     "workType": {
-                 |       "id": "${works(0).workType.get.id}",
-                 |       "label": "${works(0).workType.get.label}",
-                 |       "type": "WorkType"
-                 |     },
+                 |     "workType" : ${workType(works(0).workType.get)},
                  |     "lettering": "${works(0).lettering.get}",
                  |     "createdDate": ${period(works(0).createdDate.get)},
                  |     "creators": [ ${identifiedOrUnidentifiable(
@@ -48,11 +44,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
                  |     "id": "${works(1).canonicalId}",
                  |     "title": "${works(1).title}",
                  |     "description": "${works(1).description.get}",
-                 |     "workType": {
-                 |       "id": "${works(1).workType.get.id}",
-                 |       "label": "${works(1).workType.get.label}",
-                 |       "type": "WorkType"
-                 |     },
+                 |     "workType" : ${workType(works(1).workType.get)},
                  |     "lettering": "${works(1).lettering.get}",
                  |     "createdDate": ${period(works(1).createdDate.get)},
                  |     "creators": [ ${identifiedOrUnidentifiable(
@@ -68,11 +60,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
                  |     "id": "${works(2).canonicalId}",
                  |     "title": "${works(2).title}",
                  |     "description": "${works(2).description.get}",
-                 |     "workType": {
-                 |       "id": "${works(2).workType.get.id}",
-                 |       "label": "${works(2).workType.get.label}",
-                 |       "type": "WorkType"
-                 |     },
+                 |     "workType" : ${workType(works(2).workType.get)},
                  |     "lettering": "${works(2).lettering.get}",
                  |     "createdDate": ${period(works(2).createdDate.get)},
                  |     "creators": [ ${identifiedOrUnidentifiable(
@@ -116,11 +104,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
                  | "id": "$canonicalId",
                  | "title": "$title",
                  | "description": "$description",
-                 | "workType": {
-                 |       "id": "${workType.id}",
-                 |       "label": "${workType.label}",
-                 |       "type": "WorkType"
-                 | },
+                 | "workType": ${workType(work.workType.get)},
                  | "lettering": "$lettering",
                  | "createdDate": ${period(work.createdDate.get)},
                  | "creators": [ ${identifiedOrUnidentifiable(
@@ -198,11 +182,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
                  |     "id": "${works(1).canonicalId}",
                  |     "title": "${works(1).title}",
                  |     "description": "${works(1).description.get}",
-                 |     "workType" : {
-                 |        "id" : "${works(1).workType.get.id}",
-                 |        "label" : "${works(1).workType.get.label}",
-                 |        "type" : "WorkType"
-                 |      },
+                 |     "workType" : ${workType(works(1).workType.get)},
                  |     "lettering": "${works(1).lettering.get}",
                  |     "createdDate": ${period(works(1).createdDate.get)},
                  |     "creators": [ ${identifiedOrUnidentifiable(
@@ -236,11 +216,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
                  |     "id": "${works(0).canonicalId}",
                  |     "title": "${works(0).title}",
                  |     "description": "${works(0).description.get}",
-                 |     "workType" : {
-                 |        "id" : "${works(0).workType.get.id}",
-                 |        "label" : "${works(0).workType.get.label}",
-                 |        "type" : "WorkType"
-                 |      },
+                 |     "workType" : ${workType(works(0).workType.get)},
                  |     "lettering": "${works(0).lettering.get}",
                  |     "createdDate": ${period(works(0).createdDate.get)},
                  |     "creators": [ ${identifiedOrUnidentifiable(
@@ -274,11 +250,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
                  |     "id": "${works(2).canonicalId}",
                  |     "title": "${works(2).title}",
                  |     "description": "${works(2).description.get}",
-                 |     "workType" : {
-                 |        "id" : "${works(2).workType.get.id}",
-                 |        "label" : "${works(2).workType.get.label}",
-                 |        "type" : "WorkType"
-                 |      },
+                 |     "workType" : ${workType(works(2).workType.get)},
                  |     "lettering": "${works(2).lettering.get}",
                  |     "createdDate": ${period(works(2).createdDate.get)},
                  |     "creators": [ ${identifiedOrUnidentifiable(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
@@ -53,11 +53,7 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
                |     "id": "${works(0).canonicalId}",
                |     "title": "${works(0).title}",
                |     "description": "${works(0).description.get}",
-               |     "workType": {
-               |       "id": "${works(0).workType.get.id}",
-               |       "label": "${works(0).workType.get.label}",
-               |       "type": "WorkType"
-               |     },
+               |     "workType" : ${workType(works(0).workType.get)},
                |     "lettering": "${works(0).lettering.get}",
                |     "createdDate": ${period(works(0).createdDate.get)},
                |     "creators": [ ${identifiedOrUnidentifiable(
@@ -73,11 +69,7 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
                |     "id": "${works(1).canonicalId}",
                |     "title": "${works(1).title}",
                |     "description": "${works(1).description.get}",
-               |     "workType": {
-               |       "id": "${works(1).workType.get.id}",
-               |       "label": "${works(1).workType.get.label}",
-               |       "type": "WorkType"
-               |     },
+               |     "workType" : ${workType(works(1).workType.get)},
                |     "lettering": "${works(1).lettering.get}",
                |     "createdDate": ${period(works(1).createdDate.get)},
                |     "creators": [ ${identifiedOrUnidentifiable(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -119,38 +119,10 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                | "createdDate": ${period(work.createdDate.get)},
                | "contributors": [${contributor(work.contributors(0))}],
                | "subjects": [
-               |   { "label": "${subject.label}",
-               |     "type": "${subject.ontologyType}",
-               |     "concepts":[
-               |       {
-               |         "label": "${subject.concepts(0).agent.label}",
-               |         "type":  "${subject.concepts(0).agent.ontologyType}"
-               |       },
-               |       {
-               |         "label": "${subject.concepts(1).agent.label}",
-               |         "type":  "${subject.concepts(1).agent.ontologyType}"
-               |       },
-               |       {
-               |         "label": "${subject.concepts(2).agent.label}",
-               |         "type":  "${subject.concepts(2).agent.ontologyType}"
-               |       }]}
+               |   ${subjects(work.subjects)}
                | ],
                | "genres": [
-               |   { "label": "${genre.label}",
-               |     "type": "${genre.ontologyType}",
-               |     "concepts":[
-               |       {
-               |         "label": "${genre.concepts(0).agent.label}",
-               |         "type":  "${genre.concepts(0).agent.ontologyType}"
-               |       },
-               |       {
-               |         "label": "${genre.concepts(1).agent.label}",
-               |         "type":  "${genre.concepts(1).agent.ontologyType}"
-               |       },
-               |       {
-               |         "label": "${genre.concepts(2).agent.label}",
-               |         "type":  "${genre.concepts(2).agent.ontologyType}"
-               |       }]}
+               |   ${genres(work.genres)}
                | ],
                | "production": [ ]
                |}

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -28,11 +28,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                |     "id": "${works(0).canonicalId}",
                |     "title": "${works(0).title}",
                |     "description": "${works(0).description.get}",
-               |     "workType": {
-               |       "id": "${works(0).workType.get.id}",
-               |       "label": "${works(0).workType.get.label}",
-               |       "type": "WorkType"
-               |     },
+               |     "workType" : ${workType(works(0).workType.get)},
                |     "lettering": "${works(0).lettering.get}",
                |     "createdDate": ${period(works(0).createdDate.get)},
                |     "contributors": [${contributor(works(0).contributors(0))}],
@@ -45,11 +41,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                |     "id": "${works(1).canonicalId}",
                |     "title": "${works(1).title}",
                |     "description": "${works(1).description.get}",
-               |     "workType": {
-               |       "id": "${works(1).workType.get.id}",
-               |       "label": "${works(1).workType.get.label}",
-               |       "type": "WorkType"
-               |     },
+               |     "workType" : ${workType(works(1).workType.get)},
                |     "lettering": "${works(1).lettering.get}",
                |     "createdDate": ${period(works(1).createdDate.get)},
                |     "contributors": [${contributor(works(1).contributors(0))}],
@@ -62,11 +54,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                |     "id": "${works(2).canonicalId}",
                |     "title": "${works(2).title}",
                |     "description": "${works(2).description.get}",
-               |     "workType": {
-               |       "id": "${works(2).workType.get.id}",
-               |       "label": "${works(2).workType.get.label}",
-               |       "type": "WorkType"
-               |     },
+               |     "workType" : ${workType(works(2).workType.get)},
                |     "lettering": "${works(2).lettering.get}",
                |     "createdDate": ${period(works(2).createdDate.get)},
                |     "contributors": [${contributor(works(2).contributors(0))}],
@@ -110,11 +98,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                | "id": "$canonicalId",
                | "title": "$title",
                | "description": "$description",
-               | "workType": {
-               |       "id": "${workType.id}",
-               |       "label": "${workType.label}",
-               |       "type": "WorkType"
-               | },
+               | "workType" : ${workType(work.workType.get)},
                | "lettering": "$lettering",
                | "createdDate": ${period(work.createdDate.get)},
                | "contributors": [${contributor(work.contributors(0))}],
@@ -192,11 +176,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                |     "id": "${works(1).canonicalId}",
                |     "title": "${works(1).title}",
                |     "description": "${works(1).description.get}",
-               |     "workType" : {
-               |        "id" : "${works(1).workType.get.id}",
-               |        "label" : "${works(1).workType.get.label}",
-               |        "type" : "WorkType"
-               |      },
+               |     "workType" : ${workType(works(1).workType.get)},
                |     "lettering": "${works(1).lettering.get}",
                |     "createdDate": ${period(works(1).createdDate.get)},
                |     "contributors": [${contributor(works(1).contributors(0))}],
@@ -227,11 +207,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                |     "id": "${works(0).canonicalId}",
                |     "title": "${works(0).title}",
                |     "description": "${works(0).description.get}",
-               |     "workType" : {
-               |        "id" : "${works(0).workType.get.id}",
-               |        "label" : "${works(0).workType.get.label}",
-               |        "type" : "WorkType"
-               |      },
+               |     "workType" : ${workType(works(0).workType.get)},
                |     "lettering": "${works(0).lettering.get}",
                |     "createdDate": ${period(works(0).createdDate.get)},
                |     "contributors": [${contributor(works(0).contributors(0))}],
@@ -262,11 +238,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                |     "id": "${works(2).canonicalId}",
                |     "title": "${works(2).title}",
                |     "description": "${works(2).description.get}",
-               |     "workType" : {
-               |        "id" : "${works(2).workType.get.id}",
-               |        "label" : "${works(2).workType.get.label}",
-               |        "type" : "WorkType"
-               |      },
+               |     "workType" : ${workType(works(2).workType.get)},
                |     "lettering": "${works(2).lettering.get}",
                |     "createdDate": ${period(works(2).createdDate.get)},
                |     "contributors": [${contributor(works(2).contributors(0))}],

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
@@ -54,11 +54,7 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
                |     "id": "${works(0).canonicalId}",
                |     "title": "${works(0).title}",
                |     "description": "${works(0).description.get}",
-               |     "workType": {
-               |       "id": "${works(0).workType.get.id}",
-               |       "label": "${works(0).workType.get.label}",
-               |       "type": "WorkType"
-               |     },
+               |     "workType" : ${workType(works(0).workType.get)},
                |     "lettering": "${works(0).lettering.get}",
                |     "createdDate": ${period(works(0).createdDate.get)},
                |     "contributors": [${contributor(works(0).contributors(0))}],
@@ -71,11 +67,7 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
                |     "id": "${works(1).canonicalId}",
                |     "title": "${works(1).title}",
                |     "description": "${works(1).description.get}",
-               |     "workType": {
-               |       "id": "${works(1).workType.get.id}",
-               |       "label": "${works(1).workType.get.label}",
-               |       "type": "WorkType"
-               |     },
+               |     "workType" : ${workType(works(1).workType.get)},
                |     "lettering": "${works(1).lettering.get}",
                |     "createdDate": ${period(works(1).createdDate.get)},
                |     "contributors": [${contributor(works(1).contributors(0))}],

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -175,4 +175,12 @@ trait DisplaySerialisationTestBase { this: Suite =>
        |}
      """.stripMargin
 
+  def workType(w: WorkType) =
+    s"""
+       |{
+       |  "id": "${w.id}",
+       |  "label": "${w.label}",
+       |  "type": "WorkType"
+       |}
+     """.stripMargin
 }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -30,11 +30,7 @@ class DisplayWorkV1SerialisationTest
        | "id": "$canonicalId",
        | "title": "$title",
        | "description": "$description",
-       | "workType": {
-       |       "id": "${workType.id}",
-       |       "label": "${workType.label}",
-       |       "type": "WorkType"
-       | },
+       | "workType" : ${workType(work.workType.get)},
        | "lettering": "$lettering",
        | "createdDate": ${period(work.createdDate.get)},
        | "creators": [ ${identifiedOrUnidentifiable(

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -31,11 +31,7 @@ class DisplayWorkV2SerialisationTest
        | "id": "$canonicalId",
        | "title": "$title",
        | "description": "$description",
-       | "workType": {
-       |       "id": "${workType.id}",
-       |       "label": "${workType.label}",
-       |       "type": "WorkType"
-       | },
+       | "workType" : ${workType(work.workType.get)},
        | "lettering": "$lettering",
        | "createdDate": ${period(work.createdDate.get)},
        | "contributors": [


### PR DESCRIPTION
A tidy pulled out of #2235. Makes the tests cleaner.

Ready for immediate review/merging.