### PR TITLE
Don't set an 'id' parameter on MultipleResultsRequest

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
@@ -13,7 +13,6 @@ case class MultipleResultsRequest(
   @Min(1) @QueryParam page: Int = 1,
   @Min(1) @Max(100) @QueryParam pageSize: Option[Int],
   @QueryParam includes: Option[WorksIncludes],
-  @RouteParam id: Option[String],
   @QueryParam query: Option[String],
   @QueryParam _index: Option[String],
   request: Request


### PR DESCRIPTION
If you want multiple requests, you can't have an ID!

Spotted in #2326, but I wanted to discuss it separately in case there's a good reason for it being here.