### PR TITLE
Previously on the API… now links to the last populated page

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
@@ -43,8 +43,7 @@ object ResultListResponse {
       if (!isFirstPage) {
         val pageNumber = List(currentPage - 1, displayResultList.totalPages).min
         Some(apiLink(Map("page" -> pageNumber)))
-      }
-      else None
+      } else None
 
     val nextLink =
       if (!isLastPage && !isOutOfBounds)

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
@@ -36,10 +36,16 @@ object ResultListResponse {
 
     val apiLink = createApiLink(requestBaseUri, multipleResultsRequest) _
 
+    // We want to link to the previous *non-empty* page.
+    // e.g. if there are 5 pages and you're looking at page 10, this should
+    // link to page 5, not page 9.
     val prevLink =
-      if (!isFirstPage)
-        Some(apiLink(Map("page" -> (currentPage - 1))))
+      if (!isFirstPage) {
+        val pageNumber = List(currentPage - 1, displayResultList.totalPages).min
+        Some(apiLink(Map("page" -> pageNumber)))
+      }
       else None
+
     val nextLink =
       if (!isLastPage && !isOutOfBounds)
         Some(apiLink(Map("page" -> (currentPage + 1))))

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/responses/ResultListResponseTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/responses/ResultListResponseTest.scala
@@ -103,6 +103,15 @@ class ResultListResponseTest extends FunSpec with Matchers {
 
       resp.prevPage shouldBe Some(s"$requestBaseUri$requestUri?page=4")
     }
+
+    it("links to the last populated page if beyond the end") {
+      val resp = getResponse(
+        displayResultList = displayResultList.copy(totalPages = 5),
+        multipleResultsRequest = multipleResultsRequest.copy(page = 10)
+      )
+
+      resp.prevPage shouldBe Some(s"$requestBaseUri$requestUri?page=5")
+    }
   }
 
   private def getResponse(


### PR DESCRIPTION
Follows up #2326, closes #2325.

The "prevPage" parameter now links to the last *populated* page in the API. For example, if there are 5 pages of results and you're on page 10, the parameter links you to page 5, not page 9.