### PR TITLE
Consolidate the helpers in WorksUtil

### DIFF
--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -23,18 +23,9 @@ class ElasticsearchServiceTest
   describe("simpleStringQueryResults") {
     it("finds results for a simpleStringQuery search") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        val work1 = workWith(
-          canonicalId = "000Z",
-          title = "Amid an Aegean"
-        )
-        val work2 = workWith(
-          canonicalId = "000Y",
-          title = "Before a Bengal"
-        )
-        val work3 = workWith(
-          canonicalId = "000X",
-          title = "Circling a Cheetah"
-        )
+        val work1 = createIdentifiedWorkWith(title = "Amid an Aegean")
+        val work2 = createIdentifiedWorkWith(title = "Before a Bengal")
+        val work3 = createIdentifiedWorkWith(title = "Circling a Cheetah")
 
         insertIntoElasticsearch(indexName, itemType, work1, work2, work3)
 
@@ -61,26 +52,21 @@ class ElasticsearchServiceTest
   describe("findResultById") {
     it("finds a result by ID") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        val canonicalId = "000Z"
+        val work = createIdentifiedWork
 
-        val expectedWork = workWith(
-          canonicalId = canonicalId,
-          title = "Amid an Aegean"
-        )
-
-        insertIntoElasticsearch(indexName, itemType, expectedWork)
+        insertIntoElasticsearch(indexName, itemType, work)
 
         withElasticSearchService(indexName = indexName, itemType = itemType) {
           searchService =>
             val searchResultFuture: Future[GetResponse] =
               searchService.findResultById(
-                canonicalId = canonicalId,
+                canonicalId = work.canonicalId,
                 indexName = indexName
               )
 
             whenReady(searchResultFuture) { result =>
               val returnedWork = jsonToIdentifiedBaseWork(result.sourceAsString)
-              returnedWork shouldBe expectedWork
+              returnedWork shouldBe work
             }
         }
       }
@@ -90,18 +76,9 @@ class ElasticsearchServiceTest
   describe("listResults") {
     it("sorts results from Elasticsearch in the correct order") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        val work1 = workWith(
-          canonicalId = "000Z",
-          title = "Amid an Aegean"
-        )
-        val work2 = workWith(
-          canonicalId = "000Y",
-          title = "Before a Bengal"
-        )
-        val work3 = workWith(
-          canonicalId = "000X",
-          title = "Circling a Cheetah"
-        )
+        val work1 = createIdentifiedWorkWith(canonicalId = "000Z")
+        val work2 = createIdentifiedWorkWith(canonicalId = "000Y")
+        val work3 = createIdentifiedWorkWith(canonicalId = "000X")
 
         insertIntoElasticsearch(indexName, itemType, work1, work2, work3)
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -182,7 +182,7 @@ class ElasticsearchServiceTest
     it("does not list works that have visible=false") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
         val visibleWorks = createWorks(count = 8)
-        val invisibleWorks = createInvisibleWorks(count = 2, start = 9)
+        val invisibleWorks = createIdentifiedInvisibleWorks(count = 2)
 
         val works = visibleWorks ++ invisibleWorks
         insertIntoElasticsearch(indexName, itemType, works: _*)

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -181,7 +181,7 @@ class ElasticsearchServiceTest
 
     it("does not list works that have visible=false") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        val visibleWorks = createWorks(count = 8)
+        val visibleWorks = createIdentifiedWorks(count = 8)
         val invisibleWorks = createIdentifiedInvisibleWorks(count = 2)
 
         val works = visibleWorks ++ invisibleWorks
@@ -198,7 +198,7 @@ class ElasticsearchServiceTest
   }
 
   private def populateElasticsearch(indexName: String): List[IdentifiedWork] = {
-    val works = createWorks(10)
+    val works = createIdentifiedWorks(count = 10)
 
     insertIntoElasticsearch(indexName, itemType, works: _*)
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -23,7 +23,7 @@ class WorksServiceTest
       withElasticSearchService(indexName = indexName, itemType = itemType) {
         searchService =>
           withWorksService(searchService) { worksService =>
-            val works = createWorks(2)
+            val works = createIdentifiedWorks(count = 2)
 
             insertIntoElasticsearch(indexName, itemType, works: _*)
 
@@ -42,19 +42,19 @@ class WorksServiceTest
       withElasticSearchService(indexName = indexName, itemType = itemType) {
         searchService =>
           withWorksService(searchService) { worksService =>
-            val works = createWorks(1)
+            val work = createIdentifiedWork
 
-            insertIntoElasticsearch(indexName, itemType, works: _*)
+            insertIntoElasticsearch(indexName, itemType, work)
 
             val recordsFuture =
               worksService.findWorkById(
-                canonicalId = works.head.canonicalId,
+                canonicalId = work.canonicalId,
                 indexName = indexName
               )
 
             whenReady(recordsFuture) { records =>
               records.isDefined shouldBe true
-              records.get shouldBe works.head
+              records.get shouldBe work
             }
           }
       }
@@ -139,7 +139,7 @@ class WorksServiceTest
       withElasticSearchService(indexName = indexName, itemType = itemType) {
         searchService =>
           withWorksService(searchService) { worksService =>
-            val works = createWorks(3)
+            val works = createIdentifiedWorks(count = 3)
 
             insertIntoElasticsearch(indexName, itemType, works: _*)
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -66,12 +66,10 @@ class WorksServiceTest
       withElasticSearchService(indexName = indexName, itemType = itemType) {
         searchService =>
           withWorksService(searchService) { worksService =>
-            val workDodo = workWith(
-              canonicalId = "1234",
+            val workDodo = createIdentifiedWorkWith(
               title = "A drawing of a dodo"
             )
-            val workMouse = workWith(
-              canonicalId = "5678",
+            val workMouse = createIdentifiedWorkWith(
               title = "A mezzotint of a mouse"
             )
 
@@ -158,13 +156,12 @@ class WorksServiceTest
   }
 
   it(
-    "throws an exception if passed an invalid query string for full-text search") {
+    "doesn't throw an exception if passed an invalid query string for full-text search") {
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
       withElasticSearchService(indexName = indexName, itemType = itemType) {
         searchService =>
           withWorksService(searchService) { worksService =>
-            val workEmu = workWith(
-              canonicalId = "1234",
+            val workEmu = createIdentifiedWorkWith(
               title = "An etching of an emu"
             )
             insertIntoElasticsearch(indexName, itemType, workEmu)

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -82,34 +82,21 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it("returns a single work when requested with id") {
     withApiFixtures(ApiVersions.v1) {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-        val work = workWith(
-          canonicalId = canonicalId,
-          title = title,
-          description = description,
-          lettering = lettering,
-          createdDate = period,
-          creator = agent,
-          items = createItems(count = 2))
+        val work = createIdentifiedWork
 
         insertIntoElasticsearch(indexNameV1, itemType, work)
 
         eventually {
           server.httpGet(
-            path = s"/$apiPrefix/works/$canonicalId",
+            path = s"/$apiPrefix/works/${work.canonicalId}",
             andExpect = Status.Ok,
             withJsonBody = s"""
                  |{
                  | "@context": "https://localhost:8888/$apiPrefix/context.json",
                  | "type": "Work",
-                 | "id": "$canonicalId",
-                 | "title": "$title",
-                 | "description": "$description",
-                 | "workType": ${workType(work.workType.get)},
-                 | "lettering": "$lettering",
-                 | "createdDate": ${period(work.createdDate.get)},
-                 | "creators": [ ${identifiedOrUnidentifiable(
-                                work.contributors(0).agent,
-                                abstractAgent)} ],
+                 | "id": "${work.canonicalId}",
+                 | "title": "${work.title}"
+                 | "creators": [ ],
                  | "subjects": [ ],
                  | "genres": [ ],
                  | "publishers": [ ],

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -10,7 +10,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it("returns a list of works") {
     withApiFixtures(ApiVersions.v1) {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-        val works = createWorks(3)
+        val works = createIdentifiedWorks(count = 3)
 
         insertIntoElasticsearch(indexNameV1, itemType, works: _*)
 
@@ -146,7 +146,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
     "returns the requested page of results when requested with page & pageSize") {
     withApiFixtures(ApiVersions.v1) {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-        val works = createWorks(3)
+        val works = createIdentifiedWorks(count = 3)
 
         insertIntoElasticsearch(indexNameV1, itemType, works: _*)
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -111,9 +111,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it("renders the items if the items include is present") {
     withApiFixtures(ApiVersions.v1) {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-        val work = workWith(
-          canonicalId = "b4heraz7",
-          title = "Inside an irate igloo",
+        val work = createIdentifiedWorkWith(
           items = createItems(count = 1)
         )
 
@@ -271,12 +269,10 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it("returns matching results if doing a full-text search") {
     withApiFixtures(ApiVersions.v1) {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-        val work1 = workWith(
-          canonicalId = "1234",
+        val work1 = createIdentifiedWorkWith(
           title = "A drawing of a dodo"
         )
-        val work2 = workWith(
-          canonicalId = "5678",
+        val work2 = createIdentifiedWorkWith(
           title = "A mezzotint of a mouse"
         )
         insertIntoElasticsearch(indexNameV1, itemType, work1, work2)
@@ -323,9 +319,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
           ontologyType = "Work",
           value = "Test1234"
         )
-        val work1 = workWith(
-          canonicalId = "1234",
-          title = "An image of an iguana",
+        val work1 = createIdentifiedWorkWith(
           otherIdentifiers = List(identifier1)
         )
 
@@ -334,9 +328,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
           ontologyType = "Work",
           value = "DTest5678"
         )
-        val work2 = workWith(
-          canonicalId = "5678",
-          title = "An impression of an igloo",
+        val work2 = createIdentifiedWorkWith(
           otherIdentifiers = List(identifier2)
         )
 
@@ -355,7 +347,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
                  |     "id": "${work1.canonicalId}",
                  |     "title": "${work1.title}",
                  |     "creators": [ ],
-                 |     "identifiers": [ ${identifier(sourceIdentifier)}, ${identifier(
+                 |     "identifiers": [ ${identifier(work1.sourceIdentifier)}, ${identifier(
                                 identifier1)} ],
                  |     "subjects": [ ],
                  |     "genres": [ ],
@@ -367,7 +359,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
                  |     "id": "${work2.canonicalId}",
                  |     "title": "${work2.title}",
                  |     "creators": [ ],
-                 |     "identifiers": [ ${identifier(sourceIdentifier)}, ${identifier(
+                 |     "identifiers": [ ${identifier(work2.sourceIdentifier)}, ${identifier(
                                 identifier2)} ],
                  |     "subjects": [ ],
                  |     "genres": [ ],
@@ -391,9 +383,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
           ontologyType = "Work",
           value = "Test1234"
         )
-        val work = workWith(
-          canonicalId = "1234",
-          title = "An insect huddled in an igloo",
+        val work = createIdentifiedWorkWith(
           otherIdentifiers = List(srcIdentifier)
         )
         insertIntoElasticsearch(indexNameV1, itemType, work)
@@ -409,7 +399,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
                  | "id": "${work.canonicalId}",
                  | "title": "${work.title}",
                  | "creators": [ ],
-                 | "identifiers": [ ${identifier(sourceIdentifier)}, ${identifier(
+                 | "identifiers": [ ${identifier(work.sourceIdentifier)}, ${identifier(
                                 srcIdentifier)} ],
                  | "subjects": [ ],
                  | "genres": [ ],
@@ -426,16 +416,10 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
     withApiFixtures(ApiVersions.v1) {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
         withLocalElasticsearchIndex(itemType = itemType) { otherIndex =>
-          val work = workWith(
-            canonicalId = "1234",
-            title = "A whale on a wave"
-          )
+          val work = createIdentifiedWork
           insertIntoElasticsearch(indexNameV1, itemType, work)
 
-          val work_alt = workWith(
-            canonicalId = "5678",
-            title = "An impostor in an igloo"
-          )
+          val work_alt = createIdentifiedWork
           insertIntoElasticsearch(
             indexName = otherIndex,
             itemType = itemType,
@@ -489,16 +473,10 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
     withApiFixtures(ApiVersions.v1) {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
         withLocalElasticsearchIndex(itemType = itemType) { otherIndex =>
-          val work = workWith(
-            canonicalId = "1234",
-            title = "A wombat wallowing under a willow"
-          )
+          val work = createIdentifiedWork
           insertIntoElasticsearch(indexNameV1, itemType, work)
 
-          val work_alt = workWith(
-            canonicalId = "5678",
-            title = "An impostor in an igloo"
-          )
+          val work_alt = createIdentifiedWork
           insertIntoElasticsearch(
             indexName = otherIndex,
             itemType = itemType,
@@ -604,18 +582,10 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
           indexNameV2,
           itemType,
           server: EmbeddedHttpServer) =>
-        val work1 = workWith(
-          canonicalId = "1234",
-          title = "A wombat wallowing under a willow"
-        )
-
+        val work1 = createIdentifiedWork
         insertIntoElasticsearch(indexNameV1, itemType, work1)
 
-        val work2 = workWith(
-          canonicalId = "5678",
-          title = "A wombat wrestling with wet weather"
-        )
-
+        val work2 = createIdentifiedWork
         insertIntoElasticsearch(indexNameV2, itemType, work2)
 
         eventually {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -559,14 +559,12 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
     "includes the thumbnail field if available and we use the thumbnail include") {
     withApiFixtures(ApiVersions.v1) {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-        val work = identifiedWorkWith(
-          canonicalId = "1234",
-          title = "A thorn in the thumb tells a traumatic tale",
-          thumbnail = DigitalLocation(
+        val work = createIdentifiedWorkWith(
+          thumbnail = Some(DigitalLocation(
             locationType = LocationType("thumbnail-image"),
             url = "https://iiif.example.org/1234/default.jpg",
             license = License_CCBY
-          )
+          ))
         )
         insertIntoElasticsearch(indexNameV1, itemType, work)
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
@@ -10,9 +10,7 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
     withApiFixtures(apiVersion = ApiVersions.v1) {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-        val work = invisibleWorkWith(
-          canonicalId = "g9dtcj2e"
-        )
+        val work = createIdentifiedInvisibleWork
 
         insertIntoElasticsearch(indexNameV1, itemType, work)
 
@@ -29,10 +27,7 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
   it("excludes works with visible=false from list results") {
     withApiFixtures(apiVersion = ApiVersions.v1) {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-        // Start by indexing a work with visible=false.
-        val deletedWork = invisibleWorkWith(
-          canonicalId = "gze7bc24"
-        )
+        val deletedWork = createIdentifiedInvisibleWork
 
         // Then we index two ordinary works into Elasticsearch.
         val works = createWorks(2)
@@ -95,9 +90,7 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
           canonicalId = "r8dx6std",
           title = "A deleted dodo"
         )
-        val deletedWork = invisibleWorkWith(
-          canonicalId = "e7rxkty8"
-        )
+        val deletedWork = createIdentifiedInvisibleWork
         insertIntoElasticsearch(indexNameV1, itemType, work, deletedWork)
 
         eventually {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
@@ -30,7 +30,7 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
         val deletedWork = createIdentifiedInvisibleWork
 
         // Then we index two ordinary works into Elasticsearch.
-        val works = createWorks(2)
+        val works = createIdentifiedWorks(count = 2)
 
         val worksToIndex = Seq[IdentifiedBaseWork](deletedWork) ++ works
         insertIntoElasticsearch(indexNameV1, itemType, worksToIndex: _*)

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
@@ -86,10 +86,7 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
   it("excludes works with visible=false from search results") {
     withApiFixtures(apiVersion = ApiVersions.v1) {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-        val work = workWith(
-          canonicalId = "r8dx6std",
-          title = "A deleted dodo"
-        )
+        val work = createIdentifiedWork
         val deletedWork = createIdentifiedInvisibleWork
         insertIntoElasticsearch(indexNameV1, itemType, work, deletedWork)
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -73,41 +73,23 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   it("returns a single work when requested with id") {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-        val work = workWith(
-          canonicalId = canonicalId,
-          title = title,
-          description = description,
-          lettering = lettering,
-          createdDate = period,
-          creator = agent,
-          subjects = List(subject),
-          genres = List(genre),
-          items = createItems(count = 2)
-        )
+        val work = createIdentifiedWork
 
         insertIntoElasticsearch(indexNameV2, itemType, work)
 
         eventually {
           server.httpGet(
-            path = s"/$apiPrefix/works/$canonicalId",
+            path = s"/$apiPrefix/works/${work.canonicalId}",
             andExpect = Status.Ok,
             withJsonBody = s"""
                |{
                | "@context": "https://localhost:8888/$apiPrefix/context.json",
                | "type": "Work",
-               | "id": "$canonicalId",
-               | "title": "$title",
-               | "description": "$description",
-               | "workType" : ${workType(work.workType.get)},
-               | "lettering": "$lettering",
-               | "createdDate": ${period(work.createdDate.get)},
-               | "contributors": [${contributor(work.contributors(0))}],
-               | "subjects": [
-               |   ${subjects(work.subjects)}
-               | ],
-               | "genres": [
-               |   ${genres(work.genres)}
-               | ],
+               | "id": "${work.canonicalId}",
+               | "title": "${work.title}",
+               | "contributors": [],
+               | "subjects": [],
+               | "genres": [],
                | "production": [ ]
                |}
           """.stripMargin

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -11,7 +11,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   it("returns a list of works") {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-        val works = createWorks(3)
+        val works = createIdentifiedWorks(count = 3)
 
         insertIntoElasticsearch(indexNameV2, itemType, works: _*)
 
@@ -135,7 +135,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
     "returns the requested page of results when requested with page & pageSize") {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-        val works = createWorks(3)
+        val works = createIdentifiedWorks(count = 3)
 
         insertIntoElasticsearch(indexNameV2, itemType, works: _*)
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -101,9 +101,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   it("renders the items if the items include is present") {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-        val work = workWith(
-          canonicalId = "b4heraz7",
-          title = "Inside an irate igloo",
+        val work = createIdentifiedWorkWith(
           items = createItems(count = 1)
         )
 
@@ -251,12 +249,10 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   it("returns matching results if doing a full-text search") {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-        val work1 = workWith(
-          canonicalId = "1234",
+        val work1 = createIdentifiedWorkWith(
           title = "A drawing of a dodo"
         )
-        val work2 = workWith(
-          canonicalId = "5678",
+        val work2 = createIdentifiedWorkWith(
           title = "A mezzotint of a mouse"
         )
         insertIntoElasticsearch(indexNameV2, itemType, work1, work2)
@@ -302,9 +298,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
           ontologyType = "Work",
           value = "Test1234"
         )
-        val work1 = workWith(
-          canonicalId = "1234",
-          title = "An image of an iguana",
+        val work1 = createIdentifiedWorkWith(
           otherIdentifiers = List(identifier1)
         )
 
@@ -313,9 +307,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
           ontologyType = "Work",
           value = "DTest5678"
         )
-        val work2 = workWith(
-          canonicalId = "5678",
-          title = "An impression of an igloo",
+        val work2 = createIdentifiedWorkWith(
           otherIdentifiers = List(identifier2)
         )
 
@@ -334,7 +326,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                |     "id": "${work1.canonicalId}",
                |     "title": "${work1.title}",
                |     "contributors": [ ],
-               |     "identifiers": [ ${identifier(sourceIdentifier)}, ${identifier(
+               |     "identifiers": [ ${identifier(work1.sourceIdentifier)}, ${identifier(
                                 identifier1)} ],
                |     "subjects": [ ],
                |     "genres": [ ],
@@ -345,7 +337,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                |     "id": "${work2.canonicalId}",
                |     "title": "${work2.title}",
                |     "contributors": [ ],
-               |     "identifiers": [ ${identifier(sourceIdentifier)}, ${identifier(
+               |     "identifiers": [ ${identifier(work2.sourceIdentifier)}, ${identifier(
                                 identifier2)} ],
                |     "subjects": [ ],
                |     "genres": [ ],
@@ -368,9 +360,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
           ontologyType = "Work",
           value = "Test1234"
         )
-        val work = workWith(
-          canonicalId = "1234",
-          title = "Idle imps ignite indigo incense",
+        val work = createIdentifiedWorkWith(
           otherIdentifiers = List(srcIdentifier)
         )
         insertIntoElasticsearch(indexNameV2, itemType, work)
@@ -386,7 +376,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                | "id": "${work.canonicalId}",
                | "title": "${work.title}",
                | "contributors": [ ],
-               | "identifiers": [ ${identifier(sourceIdentifier)}, ${identifier(
+               | "identifiers": [ ${identifier(work.sourceIdentifier)}, ${identifier(
                                 srcIdentifier)} ],
                | "subjects": [ ],
                | "genres": [ ],
@@ -402,16 +392,10 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
         withLocalElasticsearchIndex(itemType = itemType) { otherIndex =>
-          val work = workWith(
-            canonicalId = "1234",
-            title = "A whale on a wave"
-          )
+          val work = createIdentifiedWork
           insertIntoElasticsearch(indexNameV2, itemType, work)
 
-          val work_alt = workWith(
-            canonicalId = "5678",
-            title = "An impostor in an igloo"
-          )
+          val work_alt = createIdentifiedWork
           insertIntoElasticsearch(
             indexName = otherIndex,
             itemType = itemType,
@@ -463,16 +447,10 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
         withLocalElasticsearchIndex(itemType = itemType) { otherIndex =>
-          val work = workWith(
-            canonicalId = "1234",
-            title = "A wombat wallowing under a willow"
-          )
+          val work = createIdentifiedWork
           insertIntoElasticsearch(indexNameV2, itemType, work)
 
-          val work_alt = workWith(
-            canonicalId = "5678",
-            title = "An impostor in an igloo"
-          )
+          val work_alt = createIdentifiedWork
           insertIntoElasticsearch(
             indexName = otherIndex,
             itemType = itemType,
@@ -575,18 +553,10 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
           indexNameV2,
           itemType,
           server: EmbeddedHttpServer) =>
-        val work1 = workWith(
-          canonicalId = "1234",
-          title = "A wombat wallowing under a willow"
-        )
-
+        val work1 = createIdentifiedWork
         insertIntoElasticsearch(indexNameV1, itemType, work1)
 
-        val work2 = workWith(
-          canonicalId = "5678",
-          title = "A wombat wrestling with wet weather"
-        )
-
+        val work2 = createIdentifiedWork
         insertIntoElasticsearch(indexNameV2, itemType, work2)
 
         eventually {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -531,14 +531,12 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
     "includes the thumbnail field if available and we use the thumbnail include") {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-        val work = identifiedWorkWith(
-          canonicalId = "1234",
-          title = "A thorn in the thumb tells a traumatic tale",
-          thumbnail = DigitalLocation(
+        val work = createIdentifiedWorkWith(
+          thumbnail = Some(DigitalLocation(
             locationType = LocationType("thumbnail-image"),
             url = "https://iiif.example.org/1234/default.jpg",
             license = License_CCBY
-          )
+          ))
         )
         insertIntoElasticsearch(indexNameV2, itemType, work)
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
@@ -31,7 +31,7 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
         val deletedWork = createIdentifiedInvisibleWork
 
         // Then we index two ordinary works into Elasticsearch.
-        val works = createWorks(2)
+        val works = createIdentifiedWorks(count = 2)
 
         val worksToIndex = Seq[IdentifiedBaseWork](deletedWork) ++ works
         insertIntoElasticsearch(indexNameV2, itemType, worksToIndex: _*)

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
@@ -81,10 +81,7 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
   it("excludes works with visible=false from search results") {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-        val work = workWith(
-          canonicalId = "r8dx6std",
-          title = "A deleted dodo"
-        )
+        val work = createIdentifiedWork
         val deletedWork = createIdentifiedInvisibleWork
         insertIntoElasticsearch(indexNameV2, itemType, work, deletedWork)
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
@@ -11,9 +11,7 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-        val work = invisibleWorkWith(
-          canonicalId = "g9dtcj2e"
-        )
+        val work = createIdentifiedInvisibleWork
 
         insertIntoElasticsearch(indexNameV2, itemType, work)
 
@@ -30,10 +28,7 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
   it("excludes works with visible=false from list results") {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-        // Start by indexing a work with visible=false.
-        val deletedWork = invisibleWorkWith(
-          canonicalId = "gze7bc24"
-        )
+        val deletedWork = createIdentifiedInvisibleWork
 
         // Then we index two ordinary works into Elasticsearch.
         val works = createWorks(2)
@@ -90,9 +85,7 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
           canonicalId = "r8dx6std",
           title = "A deleted dodo"
         )
-        val deletedWork = invisibleWorkWith(
-          canonicalId = "e7rxkty8"
-        )
+        val deletedWork = createIdentifiedInvisibleWork
         insertIntoElasticsearch(indexNameV2, itemType, work, deletedWork)
 
         eventually {

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -46,7 +46,7 @@ class IngestorWorkerServiceTest
       value = "M000765"
     )
 
-    val work = createWork.copy(sourceIdentifier = miroSourceIdentifier)
+    val work = createIdentifiedWorkWith(sourceIdentifier = miroSourceIdentifier)
 
     withLocalElasticsearchIndex(itemType = itemType) { esIndexV1 =>
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
@@ -82,7 +82,7 @@ class IngestorWorkerServiceTest
       value = "b1027467"
     )
 
-    val work = createWork.copy(sourceIdentifier = sierraSourceIdentifier)
+    val work = createIdentifiedWorkWith(sourceIdentifier = sierraSourceIdentifier)
 
     withLocalElasticsearchIndex(itemType = itemType) { esIndexV1 =>
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
@@ -188,18 +188,18 @@ class IngestorWorkerServiceTest
   }
 
   it("inserts a mixture of miro and sierra works into the correct indices") {
-    val miroWork1 = createWork.copy(
-      sourceIdentifier = createIdentifier("miro-image-number", "M1"),
-      canonicalId = "m1")
-    val miroWork2 = createWork.copy(
-      sourceIdentifier = createIdentifier("miro-image-number", "M2"),
-      canonicalId = "m2")
-    val sierraWork1 = createWork.copy(
-      sourceIdentifier = createIdentifier("sierra-system-number", "S1"),
-      canonicalId = "s1")
-    val sierraWork2 = createWork.copy(
-      sourceIdentifier = createIdentifier("sierra-system-number", "S2"),
-      canonicalId = "s2")
+    val miroWork1 = createIdentifiedWorkWith(
+      sourceIdentifier = createIdentifier("miro-image-number", "M1")
+    )
+    val miroWork2 = createIdentifiedWorkWith(
+      sourceIdentifier = createIdentifier("miro-image-number", "M2")
+    )
+    val sierraWork1 = createIdentifiedWorkWith(
+      sourceIdentifier = createIdentifier("sierra-system-number", "S1")
+    )
+    val sierraWork2 = createIdentifiedWorkWith(
+      sourceIdentifier = createIdentifier("sierra-system-number", "S2")
+    )
 
     val works = List(miroWork1, miroWork2, sierraWork1, sierraWork2)
 
@@ -249,7 +249,7 @@ class IngestorWorkerServiceTest
       value = "MS/237"
     )
 
-    val work = createWork.copy(sourceIdentifier = calmSourceIdentifier)
+    val work = createIdentifiedWorkWith(sourceIdentifier = calmSourceIdentifier)
 
     withLocalElasticsearchIndex(itemType = itemType) { esIndexV1 =>
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
@@ -275,15 +275,15 @@ class IngestorWorkerServiceTest
 
   it(
     "inserts a mixture of miro and sierra works into the correct indices and sends invalid messages to the dlq") {
-    val miroWork = createWork.copy(
-      sourceIdentifier = createIdentifier("miro-image-number", "M"),
-      canonicalId = "m")
-    val sierraWork = createWork.copy(
-      sourceIdentifier = createIdentifier("sierra-system-number", "S2"),
-      canonicalId = "s")
-    val invalidWork = createWork.copy(
-      sourceIdentifier = createIdentifier("calm-altref-no", "C1"),
-      canonicalId = "c")
+    val miroWork = createIdentifiedWorkWith(
+      sourceIdentifier = createIdentifier("miro-image-number", "M")
+    )
+    val sierraWork = createIdentifiedWorkWith(
+      sourceIdentifier = createIdentifier("sierra-system-number", "S2")
+    )
+    val invalidWork = createIdentifiedWorkWith(
+      sourceIdentifier = createIdentifier("calm-altref-no", "C1")
+    )
 
     val works = List(miroWork, sierraWork, invalidWork)
 
@@ -329,13 +329,13 @@ class IngestorWorkerServiceTest
 
   it(
     "deletes successfully ingested works from the queue, including older versions of already ingested works") {
-    val sierraWork = createWork.copy(
+    val sierraWork = createIdentifiedWorkWith(
       sourceIdentifier = createIdentifier("sierra-system-number", "s1"),
-      canonicalId = "s1")
-    val newSierraWork = createWork.copy(
+    )
+    val newSierraWork = createIdentifiedWorkWith(
       sourceIdentifier = createIdentifier("sierra-system-number", "s2"),
-      canonicalId = "s2",
-      version = 2)
+      version = 2
+    )
     val oldSierraWork = newSierraWork.copy(version = 1)
 
     val works = List(sierraWork, oldSierraWork)
@@ -531,7 +531,7 @@ class IngestorWorkerServiceTest
                   )
 
                   val work =
-                    createWork.copy(sourceIdentifier = miroSourceIdentifier)
+                    createIdentifiedWorkWith(sourceIdentifier = miroSourceIdentifier)
 
                   val messageBody = put[IdentifiedBaseWork](
                     obj = work,

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -118,10 +118,7 @@ class IngestorWorkerServiceTest
       value = "b1027467"
     )
 
-    val work = IdentifiedInvisibleWork(
-      canonicalId = "abcdefg",
-      sourceIdentifier = sierraSourceIdentifier,
-      version = 1)
+    val work = createIdentifiedInvisibleWork
 
     withLocalElasticsearchIndex(itemType = itemType) { esIndexV1 =>
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -28,7 +28,7 @@ class WorkIndexerTest
   val esType = "work"
 
   it("inserts an identified Work into Elasticsearch") {
-    val work = createVersionedWork()
+    val work = createIdentifiedWork
 
     withLocalElasticsearchIndex(itemType = esType) { indexName =>
       withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
@@ -46,7 +46,7 @@ class WorkIndexerTest
   }
 
   it("only adds one record when the same ID is ingested multiple times") {
-    val work = createVersionedWork()
+    val work = createIdentifiedWork
 
     withLocalElasticsearchIndex(itemType = esType) { indexName =>
       withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
@@ -71,7 +71,7 @@ class WorkIndexerTest
   }
 
   it("doesn't add a Work with a lower version") {
-    val work = createVersionedWork(version = 3)
+    val work = createIdentifiedWorkWith(version = 3)
     val olderWork = work.copy(version = 1)
 
     withLocalElasticsearchIndex(itemType = esType) { indexName =>
@@ -99,8 +99,8 @@ class WorkIndexerTest
   }
 
   it("replaces a Work with the same version") {
-    val work = createVersionedWork(version = 3)
-    val updatedWork = work.copy(title = "boring title")
+    val work = createIdentifiedWorkWith(version = 3)
+    val updatedWork = work.copy(title = "a different title")
 
     withLocalElasticsearchIndex(itemType = esType) { indexName =>
       insertIntoElasticsearch(indexName = indexName, itemType = esType, work)
@@ -124,9 +124,7 @@ class WorkIndexerTest
   }
 
   it("inserts a list of works into elasticsearch and returns them") {
-    val works = (1 to 5).map { i =>
-      createVersionedWork().copy(canonicalId = s"$i-workid")
-    }
+    val works = createIdentifiedWorks(count = 5)
 
     withLocalElasticsearchIndex(itemType = esType) { indexName =>
       withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
@@ -193,8 +191,4 @@ class WorkIndexerTest
       value = value
     )
   }
-
-  def createVersionedWork(version: Int = 1): IdentifiedWork =
-    createWorks(count = 1).head
-      .copy(version = version)
 }

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
@@ -24,7 +24,7 @@ class IdentifiedWorkToVisibleDisplayWorkFlowTest
         val flow = IdentifiedWorkToVisibleDisplayWork(
           toDisplayWork = DisplayWorkV1.apply)
 
-        val works = createWorks(count = 3).toList
+        val works = createIdentifiedWorks(count = 3).toList
 
         val eventualDisplayWorks = Source(works)
           .via(flow)
@@ -46,7 +46,7 @@ class IdentifiedWorkToVisibleDisplayWorkFlowTest
         val flow = IdentifiedWorkToVisibleDisplayWork(
           toDisplayWork = DisplayWorkV2.apply)
 
-        val works = createWorks(count = 3).toList
+        val works = createIdentifiedWorks(count = 3).toList
 
         val eventualDisplayWorks = Source(works)
           .via(flow)

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -31,7 +31,6 @@ import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.Random
 
 class SnapshotServiceTest
     extends FunSpec
@@ -197,9 +196,9 @@ class SnapshotServiceTest
     withFixtures {
       case (snapshotService: SnapshotService, indexNameV1, _, publicBucket) =>
         val works = (1 to 11000).map { id =>
-          workWith(
-            canonicalId = id.toString,
-            title = Random.alphanumeric.take(1500).mkString)
+          createIdentifiedWorkWith(
+            title = randomAlphanumeric(length = 1500)
+          )
         }
 
         insertIntoElasticsearch(indexNameV1, itemType, works: _*)

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -100,8 +100,7 @@ class SnapshotServiceTest
     withFixtures {
       case (snapshotService: SnapshotService, indexNameV1, _, publicBucket) =>
         val visibleWorks = createWorks(count = 3)
-        val notVisibleWorks =
-          createInvisibleWorks(count = 1, start = 4)
+        val notVisibleWorks = createIdentifiedInvisibleWorks(count = 1)
 
         val works = visibleWorks ++ notVisibleWorks
 
@@ -149,8 +148,7 @@ class SnapshotServiceTest
     withFixtures {
       case (snapshotService: SnapshotService, _, indexNameV2, publicBucket) =>
         val visibleWorks = createWorks(count = 4)
-        val notVisibleWorks =
-          createInvisibleWorks(count = 2, start = 5)
+        val notVisibleWorks = createIdentifiedInvisibleWorks(count = 2)
 
         val works = visibleWorks ++ notVisibleWorks
 

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -99,7 +99,7 @@ class SnapshotServiceTest
   it("completes a V1 snapshot generation successfully") {
     withFixtures {
       case (snapshotService: SnapshotService, indexNameV1, _, publicBucket) =>
-        val visibleWorks = createWorks(count = 3)
+        val visibleWorks = createIdentifiedWorks(count = 3)
         val notVisibleWorks = createIdentifiedInvisibleWorks(count = 1)
 
         val works = visibleWorks ++ notVisibleWorks
@@ -147,7 +147,7 @@ class SnapshotServiceTest
   it("completes a V2 snapshot generation successfully") {
     withFixtures {
       case (snapshotService: SnapshotService, _, indexNameV2, publicBucket) =>
-        val visibleWorks = createWorks(count = 4)
+        val visibleWorks = createIdentifiedWorks(count = 4)
         val notVisibleWorks = createIdentifiedInvisibleWorks(count = 2)
 
         val works = visibleWorks ++ notVisibleWorks
@@ -244,7 +244,7 @@ class SnapshotServiceTest
   it("returns a failed future if the S3 upload fails") {
     withFixtures {
       case (snapshotService: SnapshotService, indexNameV1, _, _) =>
-        val works = createWorks(count = 3)
+        val works = createIdentifiedWorks(count = 3)
 
         insertIntoElasticsearch(indexNameV1, itemType, works: _*)
 

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElastisearchSourceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElastisearchSourceTest.scala
@@ -48,7 +48,7 @@ class ElastisearchSourceTest
       withMaterializer(actorSystem) { actorMaterialiser =>
         withLocalElasticsearchIndex(itemType = itemType) { indexName =>
           implicit val materialiser = actorMaterialiser
-          val visibleWorks = createWorks(count = 10)
+          val visibleWorks = createIdentifiedWorks(count = 10)
           val invisibleWorks = createIdentifiedInvisibleWorks(count = 3)
 
           val works = visibleWorks ++ invisibleWorks

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElastisearchSourceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElastisearchSourceTest.scala
@@ -23,11 +23,7 @@ class ElastisearchSourceTest
       withMaterializer(actorSystem) { actorMaterialiser =>
         withLocalElasticsearchIndex(itemType = itemType) { indexName =>
           implicit val materialiser = actorMaterialiser
-          val works = (1 to 10).map { i =>
-            workWith(
-              canonicalId = s"$i-id",
-              title = "woah! a wise wizard with walnuts!")
-          }
+          val works = createIdentifiedWorks(count = 10)
           insertIntoElasticsearch(indexName, itemType, works: _*)
 
           val future =

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElastisearchSourceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElastisearchSourceTest.scala
@@ -49,8 +49,7 @@ class ElastisearchSourceTest
         withLocalElasticsearchIndex(itemType = itemType) { indexName =>
           implicit val materialiser = actorMaterialiser
           val visibleWorks = createWorks(count = 10)
-          val invisibleWorks =
-            createInvisibleWorks(count = 3, start = 11)
+          val invisibleWorks = createIdentifiedInvisibleWorks(count = 3)
 
           val works = visibleWorks ++ invisibleWorks
           insertIntoElasticsearch(indexName, itemType, works: _*)

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -48,9 +48,7 @@ class DisplayWorkV1SerialisationTest
   }
 
   it("renders an item if the items include is present") {
-    val work = workWith(
-      canonicalId = "b4heraz7",
-      title = "Inside an irate igloo",
+    val work = createIdentifiedWorkWith(
       items = createItems(count = 1)
     )
 
@@ -74,9 +72,7 @@ class DisplayWorkV1SerialisationTest
   }
 
   it("includes 'items' if the items include is present, even with no items") {
-    val work = workWith(
-      canonicalId = "dgdb712",
-      title = "Without windows or wind or washing-up liquid",
+    val work = createIdentifiedWorkWith(
       items = List()
     )
     val actualJson = objectMapper.writeValueAsString(
@@ -216,9 +212,7 @@ class DisplayWorkV1SerialisationTest
       ontologyType = "Work",
       value = "Test1234"
     )
-    val work = workWith(
-      canonicalId = "1234",
-      title = "An insect huddled in an igloo",
+    val work = createIdentifiedWorkWith(
       otherIdentifiers = List(otherIdentifier)
     )
     val actualJson = objectMapper.writeValueAsString(
@@ -229,7 +223,7 @@ class DisplayWorkV1SerialisationTest
                           | "id": "${work.canonicalId}",
                           | "title": "${work.title}",
                           | "creators": [ ],
-                          | "identifiers": [ ${identifier(sourceIdentifier)}, ${identifier(
+                          | "identifiers": [ ${identifier(work.sourceIdentifier)}, ${identifier(
                             otherIdentifier)} ],
                           | "subjects": [ ],
                           | "genres": [ ],
@@ -242,9 +236,7 @@ class DisplayWorkV1SerialisationTest
 
   it(
     "always includes 'identifiers' with the identifiers include, even if there are no extra identifiers") {
-    val work = workWith(
-      canonicalId = "a87na87",
-      title = "Idling inkwells of indigo images",
+    val work = createIdentifiedWorkWith(
       otherIdentifiers = List()
     )
     val actualJson = objectMapper.writeValueAsString(
@@ -255,7 +247,7 @@ class DisplayWorkV1SerialisationTest
                           | "id": "${work.canonicalId}",
                           | "title": "${work.title}",
                           | "creators": [ ],
-                          | "identifiers": [ ${identifier(sourceIdentifier)} ],
+                          | "identifiers": [ ${identifier(work.sourceIdentifier)} ],
                           | "subjects": [ ],
                           | "genres": [ ],
                           | "publishers": [ ],

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -13,23 +13,24 @@ class DisplayWorkV1SerialisationTest
     with WorksUtil {
 
   it("serialises a DisplayWorkV1 correctly") {
-    val work = workWith(
-      canonicalId = canonicalId,
-      title = title,
-      description = description,
-      lettering = lettering,
-      createdDate = period,
-      creator = agent,
-      items = createItems(count = 2))
+    val work = createIdentifiedWorkWith(
+      workType = Some(WorkType(id = randomAlphanumeric(5), label = randomAlphanumeric(10))),
+      description = Some(randomAlphanumeric(100)),
+      lettering = Some(randomAlphanumeric(100)),
+      createdDate = Some(Period("1901")),
+      contributors = List(
+        Contributor(Unidentifiable(Agent(randomAlphanumeric(25))))
+      )
+    )
 
     val actualJsonString = objectMapper.writeValueAsString(DisplayWorkV1(work))
 
     val expectedJsonString = s"""
        |{
        | "type": "Work",
-       | "id": "$canonicalId",
-       | "title": "$title",
-       | "description": "$description",
+       | "id": "${work.canonicalId}",
+       | "title": "${work.title}",
+       | "description": "${work.description}",
        | "workType" : ${workType(work.workType.get)},
        | "lettering": "$lettering",
        | "createdDate": ${period(work.createdDate.get)},

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -267,14 +267,12 @@ class DisplayWorkV1SerialisationTest
 
   it(
     "includes the thumbnail field if available and we use the thumbnail include") {
-    val work = identifiedWorkWith(
-      canonicalId = "1234",
-      title = "A thorn in the thumb tells a traumatic tale",
-      thumbnail = DigitalLocation(
+    val work = createIdentifiedWorkWith(
+      thumbnail = Some(DigitalLocation(
         locationType = LocationType("thumbnail-image"),
         url = "https://iiif.example.org/1234/default.jpg",
         license = License_CCBY
-      )
+      ))
     )
     val actualJson = objectMapper.writeValueAsString(
       DisplayWorkV1(work, WorksIncludes(thumbnail = true)))

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -30,9 +30,9 @@ class DisplayWorkV1SerialisationTest
        | "type": "Work",
        | "id": "${work.canonicalId}",
        | "title": "${work.title}",
-       | "description": "${work.description}",
+       | "description": "${work.description.get}",
        | "workType" : ${workType(work.workType.get)},
-       | "lettering": "$lettering",
+       | "lettering": "${work.lettering.get}",
        | "createdDate": ${period(work.createdDate.get)},
        | "creators": [ ${identifiedOrUnidentifiable(
                                   work.contributors(0).agent,

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -259,14 +259,12 @@ class DisplayWorkV2SerialisationTest
 
   it(
     "includes the thumbnail field if available and we use the thumbnail include") {
-    val work = identifiedWorkWith(
-      canonicalId = "1234",
-      title = "A thorn in the thumb tells a traumatic tale",
-      thumbnail = DigitalLocation(
+    val work = createIdentifiedWorkWith(
+      thumbnail = Some(DigitalLocation(
         locationType = LocationType("thumbnail-image"),
         url = "https://iiif.example.org/1234/default.jpg",
         license = License_CCBY
-      )
+      ))
     )
     val actualJson = objectMapper.writeValueAsString(
       DisplayWorkV2(work, WorksIncludes(thumbnail = true)))

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -28,22 +28,13 @@ class DisplayWorkV2SerialisationTest
     val expectedJsonString = s"""
        |{
        | "type": "Work",
-       | "id": "$canonicalId",
-       | "title": "$title",
-       | "description": "$description",
+       | "id": "${work.canonicalId}",
+       | "title": "${work.title}",
+       | "description": "${work.description.get}",
        | "workType" : ${workType(work.workType.get)},
-       | "lettering": "$lettering",
+       | "lettering": "${work.lettering.get}",
        | "createdDate": ${period(work.createdDate.get)},
-       | "contributors": [
-       |   {
-       |     "agent": {
-       |       "label": "a person",
-       |       "type": "Agent"
-       |     },
-       |     "roles" : [ ],
-       |     "type" : "Contributor"
-       |   }
-       | ],
+       | "contributors": [ ${contributor(work.contributors.head)} ],
        | "subjects": [ ],
        | "genres": [ ],
        | "production": [ ]

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -13,15 +13,15 @@ class DisplayWorkV2SerialisationTest
     with WorksUtil {
 
   it("serialises a DisplayWorkV2 correctly") {
-
-    val work = workWith(
-      canonicalId = canonicalId,
-      title = title,
-      description = description,
-      lettering = lettering,
-      createdDate = period,
-      creator = agent,
-      items = createItems(count = 2))
+    val work = createIdentifiedWorkWith(
+      workType = Some(WorkType(id = randomAlphanumeric(5), label = randomAlphanumeric(10))),
+      description = Some(randomAlphanumeric(100)),
+      lettering = Some(randomAlphanumeric(100)),
+      createdDate = Some(Period("1901")),
+      contributors = List(
+        Contributor(Unidentifiable(Agent(randomAlphanumeric(25))))
+      )
+    )
 
     val actualJsonString = objectMapper.writeValueAsString(DisplayWorkV2(work))
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -54,9 +54,7 @@ class DisplayWorkV2SerialisationTest
   }
 
   it("renders an item if the items include is present") {
-    val work = workWith(
-      canonicalId = "b4heraz7",
-      title = "Inside an irate igloo",
+    val work = createIdentifiedWorkWith(
       items = createItems(count = 1)
     )
 
@@ -79,9 +77,7 @@ class DisplayWorkV2SerialisationTest
   }
 
   it("includes 'items' if the items include is present, even with no items") {
-    val work = workWith(
-      canonicalId = "dgdb712",
-      title = "Without windows or wind or washing-up liquid",
+    val work = createIdentifiedWorkWith(
       items = List()
     )
     val actualJson = objectMapper.writeValueAsString(
@@ -211,9 +207,7 @@ class DisplayWorkV2SerialisationTest
       ontologyType = "Work",
       value = "Test1234"
     )
-    val work = workWith(
-      canonicalId = "1234",
-      title = "An insect huddled in an igloo",
+    val work = createIdentifiedWorkWith(
       otherIdentifiers = List(otherIdentifier)
     )
     val actualJson = objectMapper.writeValueAsString(
@@ -224,7 +218,7 @@ class DisplayWorkV2SerialisationTest
                           | "id": "${work.canonicalId}",
                           | "title": "${work.title}",
                           | "contributors": [ ],
-                          | "identifiers": [ ${identifier(sourceIdentifier)}, ${identifier(
+                          | "identifiers": [ ${identifier(work.sourceIdentifier)}, ${identifier(
                             otherIdentifier)} ],
                           | "subjects": [ ],
                           | "genres": [ ],
@@ -235,9 +229,7 @@ class DisplayWorkV2SerialisationTest
   }
 
   it("always includes 'identifiers' with the identifiers include") {
-    val work = workWith(
-      canonicalId = "a87na87",
-      title = "Idling inkwells of indigo images",
+    val work = createIdentifiedWorkWith(
       otherIdentifiers = List()
     )
     val actualJson = objectMapper.writeValueAsString(
@@ -248,7 +240,7 @@ class DisplayWorkV2SerialisationTest
                           | "id": "${work.canonicalId}",
                           | "title": "${work.title}",
                           | "contributors": [ ],
-                          | "identifiers": [ ${identifier(sourceIdentifier)} ],
+                          | "identifiers": [ ${identifier(work.sourceIdentifier)} ],
                           | "subjects": [ ],
                           | "genres": [ ],
                           | "production": [ ]

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -31,7 +31,7 @@ trait WorksUtil extends ItemsUtil {
       Unidentifiable(Period("a genre period")))
   )
 
-  private def randomAlphanumeric(length: Int) =
+  def randomAlphanumeric(length: Int) =
     (Random.alphanumeric take length mkString) toLowerCase
 
   private def createCanonicalId = randomAlphanumeric(10)
@@ -56,14 +56,7 @@ trait WorksUtil extends ItemsUtil {
   def createWorks(count: Int, start: Int = 1): Seq[IdentifiedWork] =
     (start to count).map(
       (idx: Int) =>
-        workWith(
-          canonicalId = s"${idx}-${canonicalId}",
-          title = s"${idx}-${title}",
-          description = s"${idx}-${description}",
-          lettering = s"${idx}-${lettering}",
-          createdDate = Period(s"${idx}-${period.label}"),
-          creator = Agent(s"${idx}-${agent.label}"),
-          items = createItems(count = 2)
+        createIdentifiedWork
       ))
 
   def createIdentifiedInvisibleWorks(count: Int): Seq[IdentifiedInvisibleWork] =
@@ -103,34 +96,21 @@ trait WorksUtil extends ItemsUtil {
       thumbnail = Some(thumbnail)
     )
 
-  def workWith(canonicalId: String,
-               title: String,
-               description: String,
-               lettering: String,
-               createdDate: Period,
-               creator: Agent,
-               items: List[Identified[Item]]): IdentifiedWork =
-    IdentifiedWork(
-      title = title,
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = canonicalId,
-      workType = Some(workType),
-      description = Some(description),
-      lettering = Some(lettering),
-      createdDate = Some(createdDate),
-      contributors = List(
-        Contributor(agent = Unidentifiable(creator))
-      ),
-      production = List(),
-      items = items
-    )
-
-  def createIdentifiedWorkWith(): IdentifiedWork =
+  def createIdentifiedWorkWith(
+    workType: Option[WorkType] = None,
+    description: Option[String] = None,
+    lettering: Option[String] = None,
+    createdDate: Option[Period] = None,
+    contributors: List[Contributor[Displayable[AbstractAgent]]] = List()
+  ): IdentifiedWork =
     IdentifiedWork(
       canonicalId = createCanonicalId,
       sourceIdentifier = sourceIdentifier,
       title = createTitle,
+      workType = workType,
+      description = description,
+      lettering = lettering,
+      createdDate = createdDate,
       version = 1
     )
 

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -31,13 +31,18 @@ trait WorksUtil extends ItemsUtil {
       Unidentifiable(Period("a genre period")))
   )
 
-  private def createCanonicalId = (Random.alphanumeric take 10 mkString) toLowerCase
+  private def randomAlphanumeric(length: Int) =
+    (Random.alphanumeric take length mkString) toLowerCase
+
+  private def createCanonicalId = randomAlphanumeric(10)
 
   private def createSourceIdentifier = SourceIdentifier(
     identifierType = IdentifierType("miro-image-number"),
-    value = (Random.alphanumeric take 10 mkString) toLowerCase,
+    value = randomAlphanumeric(10),
     ontologyType = "Work"
   )
+
+  private def createTitle = randomAlphanumeric(100)
 
   val sourceIdentifier = SourceIdentifier(
     identifierType = IdentifierType("miro-image-number"),
@@ -121,29 +126,13 @@ trait WorksUtil extends ItemsUtil {
       items = items
     )
 
-  def workWith(canonicalId: String,
-               title: String,
-               description: String,
-               lettering: String,
-               createdDate: Period,
-               creator: Agent,
-               subjects: List[Subject[Displayable[AbstractConcept]]],
-               genres: List[Genre[Displayable[AbstractConcept]]],
-               items: List[Identified[Item]]): IdentifiedWork =
+  def createIdentifiedWorkWith(): IdentifiedWork =
     IdentifiedWork(
-      title = title,
+      canonicalId = createCanonicalId,
       sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = canonicalId,
-      workType = Some(workType),
-      description = Some(description),
-      lettering = Some(lettering),
-      createdDate = Some(createdDate),
-      contributors = List(
-        Contributor(agent = Unidentifiable(creator))
-      ),
-      subjects = subjects,
-      genres = genres,
-      items = items
+      title = createTitle,
+      version = 1
     )
+
+  def createIdentifiedWork: IdentifiedWork = createIdentifiedWorkWith()
 }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -2,6 +2,8 @@ package uk.ac.wellcome.models.work.test.util
 
 import uk.ac.wellcome.models.work.internal._
 
+import scala.util.Random
+
 trait WorksUtil extends ItemsUtil {
   val canonicalId = "1234"
   val title = "this is the first image title"
@@ -29,6 +31,14 @@ trait WorksUtil extends ItemsUtil {
       Unidentifiable(Period("a genre period")))
   )
 
+  private def createCanonicalId = (Random.alphanumeric take 10 mkString) toLowerCase
+
+  private def createSourceIdentifier = SourceIdentifier(
+    identifierType = IdentifierType("miro-image-number"),
+    value = (Random.alphanumeric take 10 mkString) toLowerCase,
+    ontologyType = "Work"
+  )
+
   val sourceIdentifier = SourceIdentifier(
     identifierType = IdentifierType("miro-image-number"),
     "Work",
@@ -51,19 +61,15 @@ trait WorksUtil extends ItemsUtil {
           items = createItems(count = 2)
       ))
 
-  def createInvisibleWorks(count: Int,
-                           start: Int = 1): Seq[IdentifiedInvisibleWork] =
-    (start to count).map(
-      (idx: Int) => invisibleWorkWith(s"$idx-$canonicalId")
-    )
+  def createIdentifiedInvisibleWorks(count: Int): Seq[IdentifiedInvisibleWork] =
+    (1 to count).map { _ => createIdentifiedInvisibleWork }
 
-  def invisibleWorkWith(canonicalId: String): IdentifiedInvisibleWork = {
+  def createIdentifiedInvisibleWork: IdentifiedInvisibleWork =
     IdentifiedInvisibleWork(
-      sourceIdentifier = sourceIdentifier,
+      sourceIdentifier = createSourceIdentifier,
       version = 1,
-      canonicalId = canonicalId
+      canonicalId = createCanonicalId
     )
-  }
 
   def workWith(canonicalId: String, title: String): IdentifiedWork =
     IdentifiedWork(

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -50,12 +50,6 @@ trait WorksUtil extends ItemsUtil {
     "sourceIdentifierFromWorksUtil"
   )
 
-  def createWorks(count: Int, start: Int = 1): Seq[IdentifiedWork] =
-    (start to count).map(
-      (idx: Int) =>
-        createIdentifiedWork
-      ))
-
   def createIdentifiedInvisibleWorks(count: Int): Seq[IdentifiedInvisibleWork] =
     (1 to count).map { _ => createIdentifiedInvisibleWork }
 
@@ -114,4 +108,7 @@ trait WorksUtil extends ItemsUtil {
     )
 
   def createIdentifiedWork: IdentifiedWork = createIdentifiedWorkWith()
+
+  def createIdentifiedWorks(count: Int): Seq[IdentifiedWork] =
+    (1 to count).map { _ => createIdentifiedWork }
 }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -60,40 +60,32 @@ trait WorksUtil extends ItemsUtil {
       canonicalId = createCanonicalId
     )
 
-  def workWith(
-    canonicalId: String,
-    title: String,
-    otherIdentifiers: List[SourceIdentifier] = List(),
-    items: List[Identified[Item]] = List()
-  ): IdentifiedWork =
-    IdentifiedWork(
-      title = title,
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      otherIdentifiers = otherIdentifiers,
-      canonicalId = canonicalId,
-      items = items)
-
   def createIdentifiedWorkWith(
+    canonicalId: String = createCanonicalId,
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
+    otherIdentifiers: List[SourceIdentifier] = List(),
+    title: String = createTitle,
     workType: Option[WorkType] = None,
     description: Option[String] = None,
     lettering: Option[String] = None,
     createdDate: Option[Period] = None,
     contributors: List[Contributor[Displayable[AbstractAgent]]] = List(),
     thumbnail: Option[Location] = None,
+    items: List[Identified[Item]] = List(),
     version: Int = 1
   ): IdentifiedWork =
     IdentifiedWork(
-      canonicalId = createCanonicalId,
+      canonicalId = canonicalId,
       sourceIdentifier = sourceIdentifier,
-      title = createTitle,
+      otherIdentifiers = otherIdentifiers,
+      title = title,
       workType = workType,
       description = description,
       lettering = lettering,
       createdDate = createdDate,
       contributors = contributors,
       thumbnail = thumbnail,
+      items = items,
       version = version
     )
 

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -104,6 +104,7 @@ trait WorksUtil extends ItemsUtil {
       description = description,
       lettering = lettering,
       createdDate = createdDate,
+      contributors = contributors,
       version = version
     )
 

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -74,19 +74,6 @@ trait WorksUtil extends ItemsUtil {
       canonicalId = canonicalId,
       items = items)
 
-  def identifiedWorkWith(
-    canonicalId: String,
-    title: String,
-    thumbnail: Location
-  ): IdentifiedWork =
-    IdentifiedWork(
-      title = title,
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = canonicalId,
-      thumbnail = Some(thumbnail)
-    )
-
   def createIdentifiedWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     workType: Option[WorkType] = None,
@@ -94,6 +81,7 @@ trait WorksUtil extends ItemsUtil {
     lettering: Option[String] = None,
     createdDate: Option[Period] = None,
     contributors: List[Contributor[Displayable[AbstractAgent]]] = List(),
+    thumbnail: Option[Location] = None,
     version: Int = 1
   ): IdentifiedWork =
     IdentifiedWork(
@@ -105,6 +93,7 @@ trait WorksUtil extends ItemsUtil {
       lettering = lettering,
       createdDate = createdDate,
       contributors = contributors,
+      thumbnail = thumbnail,
       version = version
     )
 

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -71,13 +71,6 @@ trait WorksUtil extends ItemsUtil {
       canonicalId = createCanonicalId
     )
 
-  def workWith(canonicalId: String, title: String): IdentifiedWork =
-    IdentifiedWork(
-      title = title,
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = canonicalId)
-
   def workWith(
     canonicalId: String,
     title: String,

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -50,9 +50,6 @@ trait WorksUtil extends ItemsUtil {
     "sourceIdentifierFromWorksUtil"
   )
 
-  def createWork: IdentifiedWork =
-    createWorks(count = 1).head
-
   def createWorks(count: Int, start: Int = 1): Seq[IdentifiedWork] =
     (start to count).map(
       (idx: Int) =>
@@ -97,11 +94,13 @@ trait WorksUtil extends ItemsUtil {
     )
 
   def createIdentifiedWorkWith(
+    sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     workType: Option[WorkType] = None,
     description: Option[String] = None,
     lettering: Option[String] = None,
     createdDate: Option[Period] = None,
-    contributors: List[Contributor[Displayable[AbstractAgent]]] = List()
+    contributors: List[Contributor[Displayable[AbstractAgent]]] = List(),
+    version: Int = 1
   ): IdentifiedWork =
     IdentifiedWork(
       canonicalId = createCanonicalId,
@@ -111,7 +110,7 @@ trait WorksUtil extends ItemsUtil {
       description = description,
       lettering = lettering,
       createdDate = createdDate,
-      version = 1
+      version = version
     )
 
   def createIdentifiedWork: IdentifiedWork = createIdentifiedWorkWith()


### PR DESCRIPTION
Another piece spun out from #2335.

We had a variety of methods `workWith` (with different signatures), `identifiedWorkWith`, `createWork`, and so on for creating instances of `Work` in tests.

This patch replaces all of them with a single method `createIdentifiedWorkWith`, and then adds a few helpers around it. Additionally, we default a bunch of fields we didn't before, like canonicalId and sourceIdentifier, and use genuinely unique strings on each call.