### PR TITLE
Don't run API tests for storage/messaging changes

### DIFF
--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -132,7 +132,6 @@ def does_file_affect_build_task(path, task):
     #
     if path.startswith(('sbt_common/elasticsearch', 'sbt_common/finatra_elasticsearch')):
         for project in PROJECTS:
-            print(project)
             if task.startswith(project.name) and (project.type == 'sbt_app'):
                 if project.exclusive_path.startswith((
                     'catalogue_pipeline/id_minter',
@@ -145,6 +144,31 @@ def does_file_affect_build_task(path, task):
                     'sierra_adapter/',
                 )):
                     raise ChangeToUnusedLibrary('elasticsearch')
+
+    # We have a library for messaging code.
+    #
+    # The catalogue API doesn't use this code, because it's not SQS-driven.
+    #
+    if path.startswith(('sbt_common/messaging', 'sbt_common/finatra_messaging')):
+        for project in PROJECTS:
+            if task.startswith(project.name) and (project.type == 'sbt_app'):
+                if project.exclusive_path.startswith((
+                    'catalogue_api/',
+                )):
+                    raise ChangeToUnusedLibrary('messaging')
+
+    # We have a library for storage code.
+    #
+    # The catalogue API doesn't use this code, because it only interacts
+    # with ElasticCloud.
+    #
+    if path.startswith(('sbt_common/storage', 'sbt_common/finatra_storage')):
+        for project in PROJECTS:
+            if task.startswith(project.name) and (project.type == 'sbt_app'):
+                if project.exclusive_path.startswith((
+                    'catalogue_api/',
+                )):
+                    raise ChangeToUnusedLibrary('storage')
 
     # We have a couple of sbt common libs and files scattered around the
     # repository; changes to any of these don't affect non-sbt applications.

--- a/travistooling/tests/test_decisionmaker.py
+++ b/travistooling/tests/test_decisionmaker.py
@@ -93,6 +93,18 @@ from travistooling.decisions import (
     ('sbt_common/finatra_elasticsearch/model.scala', 'sierra_reader-test', ChangeToUnusedLibrary, False),
     ('sbt_common/finatra_elasticsearch/model.scala', 'api-test', ScalaChangeAndIsScalaApp, True),
 
+    # Changes to the messaging lib don't affect all the stacks
+    ('sbt_common/messaging/model.scala', 'id_minter-test', ScalaChangeAndIsScalaApp, True),
+    ('sbt_common/messaging/model.scala', 'api-test', ChangeToUnusedLibrary, False),
+    ('sbt_common/finatra_messaging/model.scala', 'id_minter-test', ScalaChangeAndIsScalaApp, True),
+    ('sbt_common/finatra_messaging/model.scala', 'api-test', ChangeToUnusedLibrary, False),
+
+    # Changes to the storage lib don't affect all the stacks
+    ('sbt_common/storage/model.scala', 'id_minter-test', ScalaChangeAndIsScalaApp, True),
+    ('sbt_common/storage/model.scala', 'api-test', ChangeToUnusedLibrary, False),
+    ('sbt_common/finatra_storage/model.scala', 'id_minter-test', ScalaChangeAndIsScalaApp, True),
+    ('sbt_common/finatra_storage/model.scala', 'api-test', ChangeToUnusedLibrary, False),
+
     # Changes to Scala test files trigger a -test Scala task, but not
     # a -publish task.
     ('sbt_common/src/test/scala/uk/ac/wellcome/MyTest.scala', 'sierra_adapter-publish', ChangesToTestsDontGetPublished, False),


### PR DESCRIPTION
The API tests are usually 13–14 minutes long, and given the frequency with which we fiddle with either VHS or the SQS streams, this could save us quite a bit of build time.