### PR TITLE
Never create instances of Work directly in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,10 @@ jobs:
   include:
     - stage: quicktest
       env: TASK=travis-format
-    - env: TASK=travistooling-test
+
+    # Because this isn't under active development, and we're really squeezed
+    # for build VMs, we aren't testing this in CI right now.
+    # - env: TASK=travistooling-test
 
     - stage: sbt-common-test
       env: TASK=common-test

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -59,11 +59,11 @@ class IdMinterFeatureTest
                 val works =
                   messages.map(message => get[IdentifiedBaseWork](message))
                 works.map(_.canonicalId).distinct should have size 1
-                works.foreach { work =>
-                  work
+                works.foreach { receivedWork =>
+                  receivedWork
                     .asInstanceOf[IdentifiedWork]
                     .sourceIdentifier shouldBe work.sourceIdentifier
-                  work.asInstanceOf[IdentifiedWork].title shouldBe work.title
+                  receivedWork.asInstanceOf[IdentifiedWork].title shouldBe work.title
                 }
               }
             }
@@ -84,18 +84,7 @@ class IdMinterFeatureTest
 
             withServer(flags) { _ =>
               eventuallyTableExists(identifiersTableConfig)
-
-              val id = "id"
-              val identifier =
-                SourceIdentifier(
-                  identifierType = IdentifierType("sierra-system-number"),
-                  "Work",
-                  id)
-
-              val work = UnidentifiedInvisibleWork(
-                sourceIdentifier = identifier,
-                version = 1
-              )
+              val work = createUnidentifiedInvisibleWork
 
               val messageBody = put[UnidentifiedInvisibleWork](
                 obj = work,
@@ -110,9 +99,9 @@ class IdMinterFeatureTest
                 val messages = listMessagesReceivedFromSNS(topic)
                 messages.length shouldBe >=(1)
 
-                val work = get[IdentifiedBaseWork](messages.head)
-                val invisibleWork = work.asInstanceOf[IdentifiedInvisibleWork]
-                invisibleWork.sourceIdentifier shouldBe identifier
+                val receivedWork = get[IdentifiedBaseWork](messages.head)
+                val invisibleWork = receivedWork.asInstanceOf[IdentifiedInvisibleWork]
+                invisibleWork.sourceIdentifier shouldBe work.sourceIdentifier
                 invisibleWork.canonicalId shouldNot be(empty)
               }
             }

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -123,22 +123,7 @@ class IdMinterFeatureTest
             withServer(flags) { _ =>
               eventuallyTableExists(identifiersTableConfig)
 
-              val id = "id"
-              val identifier =
-                SourceIdentifier(
-                  identifierType = IdentifierType("sierra-system-number"),
-                  "Work",
-                  id)
-
-              val work = UnidentifiedRedirectedWork(
-                sourceIdentifier = identifier,
-                version = 1,
-                redirect = IdentifiableRedirect(
-                  sourceIdentifier = SourceIdentifier(
-                    IdentifierType("sierra-system-number"),
-                    "Work",
-                    "b1234567"))
-              )
+              val work = createUnidentifiedRedirectedWork
 
               val messageBody = put[UnidentifiedRedirectedWork](
                 obj = work,
@@ -153,9 +138,9 @@ class IdMinterFeatureTest
                 val messages = listMessagesReceivedFromSNS(topic)
                 messages.length shouldBe >=(1)
 
-                val work = get[IdentifiedBaseWork](messages.head)
+                val receivedWork = get[IdentifiedBaseWork](messages.head)
                 val redirectedWork = work.asInstanceOf[IdentifiedRedirectedWork]
-                redirectedWork.sourceIdentifier shouldBe identifier
+                redirectedWork.sourceIdentifier shouldBe work.sourceIdentifier
                 redirectedWork.canonicalId shouldNot be(empty)
                 redirectedWork.redirect.canonicalId shouldNot be(empty)
               }

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -63,7 +63,9 @@ class IdMinterFeatureTest
                   receivedWork
                     .asInstanceOf[IdentifiedWork]
                     .sourceIdentifier shouldBe work.sourceIdentifier
-                  receivedWork.asInstanceOf[IdentifiedWork].title shouldBe work.title
+                  receivedWork
+                    .asInstanceOf[IdentifiedWork]
+                    .title shouldBe work.title
                 }
               }
             }
@@ -100,7 +102,8 @@ class IdMinterFeatureTest
                 messages.length shouldBe >=(1)
 
                 val receivedWork = get[IdentifiedBaseWork](messages.head)
-                val invisibleWork = receivedWork.asInstanceOf[IdentifiedInvisibleWork]
+                val invisibleWork =
+                  receivedWork.asInstanceOf[IdentifiedInvisibleWork]
                 invisibleWork.sourceIdentifier shouldBe work.sourceIdentifier
                 invisibleWork.canonicalId shouldNot be(empty)
               }
@@ -139,7 +142,8 @@ class IdMinterFeatureTest
                 messages.length shouldBe >=(1)
 
                 val receivedWork = get[IdentifiedBaseWork](messages.head)
-                val redirectedWork = receivedWork.asInstanceOf[IdentifiedRedirectedWork]
+                val redirectedWork =
+                  receivedWork.asInstanceOf[IdentifiedRedirectedWork]
                 redirectedWork.sourceIdentifier shouldBe work.sourceIdentifier
                 redirectedWork.canonicalId shouldNot be(empty)
                 redirectedWork.redirect.canonicalId shouldNot be(empty)

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -139,7 +139,7 @@ class IdMinterFeatureTest
                 messages.length shouldBe >=(1)
 
                 val receivedWork = get[IdentifiedBaseWork](messages.head)
-                val redirectedWork = work.asInstanceOf[IdentifiedRedirectedWork]
+                val redirectedWork = receivedWork.asInstanceOf[IdentifiedRedirectedWork]
                 redirectedWork.sourceIdentifier shouldBe work.sourceIdentifier
                 redirectedWork.canonicalId shouldNot be(empty)
                 redirectedWork.redirect.canonicalId shouldNot be(empty)

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -45,10 +45,9 @@ class IdEmbedderTests
       value = "1234"
     )
 
-    val originalWork = UnidentifiedWork(
-      title = "crap",
-      sourceIdentifier = identifier,
-      version = 1)
+    val originalWork = createUnidentifiedWorkWith(
+      sourceIdentifier = identifier
+    )
 
     val newCanonicalId = "5467"
 
@@ -97,14 +96,12 @@ class IdEmbedderTests
     )
 
     val person = Person(label = "The Librarian")
-    val originalWork = UnidentifiedWork(
-      title = "crap",
-      sourceIdentifier = workIdentifier,
+    val originalWork = createUnidentifiedWorkWith(
       contributors = List(
         Contributor(
-          agent = Identifiable(person, sourceIdentifier = creatorIdentifier))
-      ),
-      version = 1
+          agent = Identifiable(person, sourceIdentifier = creatorIdentifier)
+        )
+      )
     )
 
     val newWorkCanonicalId = "5467"
@@ -156,16 +153,7 @@ class IdEmbedderTests
   }
 
   it("returns a failed future if the call to IdentifierGenerator fails") {
-    val identifier = SourceIdentifier(
-      identifierType = IdentifierType("miro-image-number"),
-      ontologyType = "Work",
-      value = "1234"
-    )
-
-    val originalWork = UnidentifiedWork(
-      title = "crap",
-      sourceIdentifier = identifier,
-      version = 1)
+    val originalWork = createUnidentifiedWork
 
     val expectedException = new Exception("Aaaaah something happened!")
 
@@ -174,7 +162,7 @@ class IdEmbedderTests
         when(
           identifierGenerator
             .retrieveOrGenerateCanonicalId(
-              identifier
+              originalWork.sourceIdentifier
             )
         ).thenReturn(Try(throw expectedException))
 
@@ -208,11 +196,9 @@ class IdEmbedderTests
       agent = Item(locations = List())
     )
 
-    val originalWork = UnidentifiedWork(
-      title = "crap",
-      sourceIdentifier = identifier,
-      version = 1,
-      items = List(originalItem1, originalItem2))
+    val originalWork = createUnidentifiedWorkWith(
+      items = List(originalItem1, originalItem2)
+    )
 
     val newItemCanonicalId1 = "item1-canonical-id"
     val newItemCanonicalId2 = "item2-canonical-id"

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -6,13 +6,12 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.ItemsUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 import uk.ac.wellcome.test.utils.{ExtendedPatience, JsonTestUtil}
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.ExecutionContext.Implicits.global
-
 import scala.util.Try
 
 class IdEmbedderTests
@@ -23,7 +22,7 @@ class IdEmbedderTests
     with Akka
     with JsonTestUtil
     with ExtendedPatience
-    with ItemsUtil {
+    with WorksUtil {
 
   private def withIdEmbedder(
     testWith: TestWith[(IdentifierGenerator, IdEmbedder), Assertion]) = {
@@ -68,7 +67,7 @@ class IdEmbedderTests
           ).right.get
         )
 
-        val expectedWork = IdentifiedWork(
+        val expectedWork = createIdentifiedWorkWith(
           canonicalId = newCanonicalId,
           title = originalWork.title,
           sourceIdentifier = originalWork.sourceIdentifier,
@@ -133,7 +132,7 @@ class IdEmbedderTests
           ).right.get
         )
 
-        val expectedWork = IdentifiedWork(
+        val expectedWork = createIdentifiedWorkWith(
           canonicalId = newWorkCanonicalId,
           title = originalWork.title,
           sourceIdentifier = originalWork.sourceIdentifier,

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -83,12 +83,6 @@ class IdEmbedderTests
   }
 
   it("mints identifiers for creators in work") {
-    val workIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("miro-image-number"),
-      ontologyType = "Work",
-      value = "1234"
-    )
-
     val creatorIdentifier = SourceIdentifier(
       identifierType = IdentifierType("lc-names"),
       ontologyType = "Person",
@@ -111,7 +105,7 @@ class IdEmbedderTests
       case (identifierGenerator, idEmbedder) =>
         setUpIdentifierGeneratorMock(
           mockIdentifierGenerator = identifierGenerator,
-          sourceIdentifier = workIdentifier,
+          sourceIdentifier = originalWork.sourceIdentifier,
           ontologyType = originalWork.ontologyType,
           newCanonicalId = newWorkCanonicalId
         )
@@ -119,7 +113,7 @@ class IdEmbedderTests
         setUpIdentifierGeneratorMock(
           mockIdentifierGenerator = identifierGenerator,
           sourceIdentifier = creatorIdentifier,
-          ontologyType = "Person",
+          ontologyType = creatorIdentifier.ontologyType,
           newCanonicalId = newCreatorCanonicalId
         )
 
@@ -207,7 +201,7 @@ class IdEmbedderTests
       case (identifierGenerator, idEmbedder) =>
         setUpIdentifierGeneratorMock(
           mockIdentifierGenerator = identifierGenerator,
-          sourceIdentifier = identifier,
+          sourceIdentifier = originalWork.sourceIdentifier,
           ontologyType = originalWork.ontologyType,
           newCanonicalId = "work-canonical-id"
         )

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -8,10 +8,10 @@ import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
 import uk.ac.wellcome.models.work.internal.{
   IdentifiedBaseWork,
-  IdentifiedWork,
   IdentifierType,
   SourceIdentifier
 }
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.test.utils.JsonTestUtil
@@ -27,7 +27,8 @@ class IngestorFeatureTest
     with fixtures.Server
     with ElasticsearchFixtures
     with Messaging
-    with SQS {
+    with SQS
+    with WorksUtil {
 
   val itemType = "work"
 
@@ -39,11 +40,7 @@ class IngestorFeatureTest
         "Item",
         "5678")
 
-    val work = IdentifiedWork(
-      title = "A type of a tame turtle",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = "1234")
+    val work = createIdentifiedWorkWith(sourceIdentifier = sourceIdentifier)
 
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
@@ -68,11 +65,7 @@ class IngestorFeatureTest
         "Item",
         "5678")
 
-    val work = IdentifiedWork(
-      title = "A type of a tame turtle",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = "1234")
+    val work = createIdentifiedWorkWith(sourceIdentifier = sourceIdentifier)
 
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -157,11 +157,9 @@ class IngestorWorkerServiceTest
       value = "b1027467"
     )
 
-    val work = IdentifiedRedirectedWork(
-      canonicalId = "abcdefg",
-      sourceIdentifier = sierraSourceIdentifier,
-      version = 1,
-      redirect = IdentifiedRedirect(canonicalId = "defghijlk"))
+    val work = createIdentifiedRedirectedWorkWith(
+      sourceIdentifier = sierraSourceIdentifier
+    )
 
     withLocalElasticsearchIndex(itemType = itemType) { esIndexV1 =>
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -383,16 +383,11 @@ class IngestorWorkerServiceTest
     val subsetOfFieldsIndex =
       new SubsetOfFieldsWorksIndex(elasticClient, itemType)
 
-    val sierraWork = IdentifiedWork(
-      canonicalId = "s1",
-      sourceIdentifier = createIdentifier("sierra-system-number", "s1"),
-      title = "s1 title",
-      version = 1)
-    val sierraWorkDoesNotMatchMapping = IdentifiedWork(
-      canonicalId = "s2",
+    val sierraWork = createIdentifiedWorkWith(
+      sourceIdentifier = createIdentifier("sierra-system-number", "s1")
+    )
+    val sierraWorkDoesNotMatchMapping = createIdentifiedWorkWith(
       sourceIdentifier = createIdentifier("sierra-system-number", "s2"),
-      title = "s2 title",
-      version = 1,
       subjects = List(Subject(label = "crystallography", concepts = Nil))
     )
 
@@ -440,16 +435,11 @@ class IngestorWorkerServiceTest
     val subsetOfFieldsIndex =
       new SubsetOfFieldsWorksIndex(elasticClient, itemType)
 
-    val miroWork = IdentifiedWork(
-      canonicalId = "s1",
-      sourceIdentifier = createIdentifier("miro-image-number", "m1"),
-      title = "s1 title",
-      version = 1)
-    val miroWorkDoesNotMatchV2Mapping = IdentifiedWork(
-      canonicalId = "s2",
+    val miroWork = createIdentifiedWorkWith(
+      sourceIdentifier = createIdentifier("miro-image-number", "m1")
+    )
+    val miroWorkDoesNotMatchV2Mapping = createIdentifiedWorkWith(
       sourceIdentifier = createIdentifier("miro-image-number", "m2"),
-      title = "s2 title",
-      version = 1,
       subjects = List(Subject(label = "crystallography", concepts = Nil))
     )
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -4,7 +4,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.internal.{
-  IdentifiedWork,
   IdentifierType,
   SourceIdentifier,
   Subject
@@ -145,18 +144,14 @@ class WorkIndexerTest
     "inserts a list of works into elasticsearch and return the list of works that failed inserting") {
     val subsetOfFieldsIndex =
       new SubsetOfFieldsWorksIndex(elasticClient, esType)
-    val validWorks = (1 to 5).map { i =>
-      IdentifiedWork(
-        canonicalId = s"s$i",
-        sourceIdentifier = createIdentifier("sierra-system-number", "s1"),
-        title = "s1 title",
-        version = 1)
+
+    val validWorks = (1 to 5).map { _ =>
+      createIdentifiedWorkWith(
+        sourceIdentifier = createIdentifier("sierra-system-number", "s1")
+      )
     }
-    val notMatchingMappingWork = IdentifiedWork(
-      canonicalId = "not-matching",
+    val notMatchingMappingWork = createIdentifiedWorkWith(
       sourceIdentifier = createIdentifier("miro-image-number", "not-matching"),
-      title = "title",
-      version = 1,
       subjects = List(Subject(label = "crystallography", concepts = Nil))
     )
 

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -14,7 +14,8 @@ import uk.ac.wellcome.models.matcher.{
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
 import uk.ac.wellcome.models.work.internal.IdentifierType
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
-import uk.ac.wellcome.models.work.internal.{SourceIdentifier, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.SourceIdentifier
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.storage.vhs.HybridRecord
 import uk.ac.wellcome.test.utils.ExtendedPatience
@@ -25,7 +26,8 @@ class MatcherFeatureTest
     with Matchers
     with ExtendedPatience
     with Eventually
-    with MatcherFixtures {
+    with MatcherFixtures
+    with WorksUtil {
 
   val sourceIdentifierA = SourceIdentifier(
     identifierType = IdentifierType("sierra-system-number"),
@@ -45,10 +47,8 @@ class MatcherFeatureTest
                   topic,
                   graphTable,
                   lockTable) { _ =>
-                  val work = UnidentifiedWork(
-                    sourceIdentifier = sourceIdentifierA,
-                    title = "Work",
-                    version = 1
+                  val work = createUnidentifiedWorkWith(
+                    sourceIdentifier = sourceIdentifierA
                   )
                   val workSqsMessage: NotificationMessage =
                     hybridRecordNotificationMessage(
@@ -108,9 +108,8 @@ class MatcherFeatureTest
                   )
                   Scanamo.put(dynamoDbClient)(graphTable.name)(existingWorkAv2)
 
-                  val workAv1 = UnidentifiedWork(
+                  val workAv1 = createUnidentifiedWorkWith(
                     sourceIdentifier = sourceIdentifierA,
-                    title = "Work",
                     version = updatedWorkVersion
                   )
 

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -16,6 +16,7 @@ import uk.ac.wellcome.models.work.internal.{
   SourceIdentifier,
   UnidentifiedWork
 }
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.matcher.Server

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -47,7 +47,8 @@ trait MatcherFixtures
     with SNS
     with LocalWorkGraphDynamoDb
     with MetricsSenderFixture
-    with S3 {
+    with S3
+    with WorksUtil {
 
   implicit val instantLongFormat: AnyRef with DynamoFormat[Instant] =
     DynamoFormat.coercedXmap[Instant, Long, IllegalArgumentException](
@@ -195,14 +196,10 @@ trait MatcherFixtures
       "Work",
       id)
 
-  def anUnidentifiedSierraWork: UnidentifiedWork = {
-    val sourceIdentifier = aSierraSourceIdentifier("id")
-    UnidentifiedWork(
-      sourceIdentifier = sourceIdentifier,
-      title = "WorkTitle",
-      version = 1
+  def anUnidentifiedSierraWork: UnidentifiedWork =
+    createUnidentifiedWorkWith(
+      sourceIdentifier = aSierraSourceIdentifier("id")
     )
-  }
 
   def ciHash(str: String): String = {
     MurmurHash3

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
@@ -32,12 +32,12 @@ class WorkMatcherConcurrencyTest
                     val identifierA = aSierraSourceIdentifier("A")
                     val identifierB = aSierraSourceIdentifier("B")
 
-                    val workA = anUnidentifiedSierraWork.copy(
+                    val workA = createUnidentifiedWorkWith(
                       sourceIdentifier = identifierA,
                       mergeCandidates = List(MergeCandidate(identifierB))
                     )
 
-                    val workB = anUnidentifiedSierraWork.copy(
+                    val workB = createUnidentifiedWorkWith(
                       sourceIdentifier = identifierB
                     )
 

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -112,9 +112,10 @@ class WorkMatcherTest
               workMatcher =>
                 val identifierA = aSierraSourceIdentifier("A")
                 val identifierB = aSierraSourceIdentifier("B")
-                val work = anUnidentifiedSierraWork.copy(
+                val work = createUnidentifiedWorkWith(
                   sourceIdentifier = identifierA,
-                  mergeCandidates = List(MergeCandidate(identifierB)))
+                  mergeCandidates = List(MergeCandidate(identifierB))
+                )
                 whenReady(workMatcher.matchWork(work)) { identifiersList =>
                   identifiersList shouldBe
                     MatcherResult(
@@ -175,7 +176,7 @@ class WorkMatcherTest
 
                 val bIdentifier = aSierraSourceIdentifier("B")
                 val cIdentifier = aSierraSourceIdentifier("C")
-                val work = anUnidentifiedSierraWork.copy(
+                val work = createUnidentifiedWorkWith(
                   sourceIdentifier = bIdentifier,
                   version = 2,
                   mergeCandidates = List(MergeCandidate(cIdentifier)))
@@ -282,7 +283,7 @@ class WorkMatcherTest
                       WorkNode("sierra-system-number/C", 0, Nil, "sierra-system-number/A+sierra-system-number/B+sierra-system-number/C")
                     )))
 
-                    val work = anUnidentifiedSierraWork.copy(
+                    val work = createUnidentifiedWorkWith(
                       sourceIdentifier = identifierA,
                       mergeCandidates = List(MergeCandidate(identifierB))
                     )

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -17,8 +17,7 @@ import uk.ac.wellcome.models.matcher.{
 import uk.ac.wellcome.models.work.internal.{
   IdentifierType,
   MergeCandidate,
-  SourceIdentifier,
-  UnidentifiedInvisibleWork
+  SourceIdentifier
 }
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.platform.matcher.locking.{
@@ -77,12 +76,12 @@ class WorkMatcherTest
           withWorkGraphStore(graphTable) { workGraphStore =>
             withWorkMatcher(workGraphStore, lockTable, mockMetricsSender) {
               workMatcher =>
-                val invisibleWork = UnidentifiedInvisibleWork(
-                  SourceIdentifier(
+                val invisibleWork = createUnidentifiedInvisibleWorkWith(
+                  sourceIdentifier = SourceIdentifier(
                     IdentifierType("sierra-system-number"),
                     "Work",
-                    "id"),
-                  1)
+                    "id")
+                )
                 whenReady(workMatcher.matchWork(invisibleWork)) {
                   matcherResult =>
                     val workId = "sierra-system-number/id"

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
@@ -62,12 +62,12 @@ class MatcherMessageReceiverTest
       withLocalSqsQueue { queue =>
         withLocalS3Bucket { storageBucket =>
           withMatcherMessageReceiver(queue, storageBucket, topic) { _ =>
-            val invisibleWork = UnidentifiedInvisibleWork(
-              SourceIdentifier(
+            val invisibleWork = createUnidentifiedInvisibleWorkWith(
+              sourceIdentifier = SourceIdentifier(
                 IdentifierType("sierra-system-number"),
                 "Work",
-                "id"),
-              1)
+                "id")
+            )
             val expectedMatchedWorks =
               MatcherResult(
                 Set(MatchedIdentifiers(

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
@@ -94,7 +94,7 @@ class MatcherMessageReceiverTest
           withMatcherMessageReceiver(queue, storageBucket, topic) { _ =>
             // Work Av1
             val workAv1 =
-              anUnidentifiedSierraWork.copy(
+              createUnidentifiedWorkWith(
                 sourceIdentifier = aIdentifier,
                 mergeCandidates = List(MergeCandidate(bIdentifier)))
             // Work Av1 matched to B (before B exists hence version 0)
@@ -126,7 +126,7 @@ class MatcherMessageReceiverTest
           withMatcherMessageReceiver(queue, storageBucket, topic) { _ =>
             // Work Av1
             val workAv1 =
-              anUnidentifiedSierraWork.copy(sourceIdentifier = aIdentifier)
+              createUnidentifiedWorkWith(sourceIdentifier = aIdentifier)
 
             val expectedMatchedWorks = MatcherResult(
               Set(
@@ -143,7 +143,7 @@ class MatcherMessageReceiverTest
 
             // Work Bv1
             val workBv1 =
-              anUnidentifiedSierraWork.copy(sourceIdentifier = bIdentifier)
+              createUnidentifiedWorkWith(sourceIdentifier = bIdentifier)
 
             processAndAssertMatchedWorkIs(
               workBv1,
@@ -154,7 +154,7 @@ class MatcherMessageReceiverTest
               topic)
 
             // Work Av1 matched to B
-            val workAv2 = anUnidentifiedSierraWork.copy(
+            val workAv2 = createUnidentifiedWorkWith(
               sourceIdentifier = aIdentifier,
               version = 2,
               mergeCandidates = List(MergeCandidate(bIdentifier)))
@@ -173,7 +173,7 @@ class MatcherMessageReceiverTest
 
             // Work Cv1
             val workCv1 =
-              anUnidentifiedSierraWork.copy(sourceIdentifier = cIdentifier)
+              createUnidentifiedWorkWith(sourceIdentifier = cIdentifier)
 
             processAndAssertMatchedWorkIs(
               workCv1,
@@ -184,7 +184,7 @@ class MatcherMessageReceiverTest
               topic)
 
             // Work Bv2 matched to C
-            val workBv2 = anUnidentifiedSierraWork.copy(
+            val workBv2 = createUnidentifiedWorkWith(
               sourceIdentifier = bIdentifier,
               version = 2,
               mergeCandidates = List(MergeCandidate(cIdentifier)))
@@ -214,7 +214,7 @@ class MatcherMessageReceiverTest
         withLocalS3Bucket { storageBucket =>
           withMatcherMessageReceiver(queue, storageBucket, topic) { _ =>
             // Work Av1
-            val workAv1 = anUnidentifiedSierraWork.copy(
+            val workAv1 = createUnidentifiedWorkWith(
               sourceIdentifier = aIdentifier,
               version = 1)
 
@@ -227,7 +227,7 @@ class MatcherMessageReceiverTest
               topic)
 
             // Work Bv1
-            val workBv1 = anUnidentifiedSierraWork.copy(
+            val workBv1 = createUnidentifiedWorkWith(
               sourceIdentifier = bIdentifier,
               version = 1)
 
@@ -240,7 +240,7 @@ class MatcherMessageReceiverTest
               topic)
 
             // Match Work A to Work B
-            val workAv2MatchedToB = anUnidentifiedSierraWork.copy(
+            val workAv2MatchedToB = createUnidentifiedWorkWith(
               sourceIdentifier = aIdentifier,
               version = 2,
               mergeCandidates = List(MergeCandidate(bIdentifier)))
@@ -258,7 +258,7 @@ class MatcherMessageReceiverTest
             )
 
             // A no longer matches B
-            val workAv3WithNoMatchingWorks = anUnidentifiedSierraWork.copy(
+            val workAv3WithNoMatchingWorks = createUnidentifiedWorkWith(
               sourceIdentifier = aIdentifier,
               version = 3)
 
@@ -287,7 +287,7 @@ class MatcherMessageReceiverTest
           withMatcherMessageReceiver(queuePair.queue, storageBucket, topic) {
             _ =>
               // process Work V2
-              val workAv2 = anUnidentifiedSierraWork.copy(
+              val workAv2 = createUnidentifiedWorkWith(
                 sourceIdentifier = aIdentifier,
                 version = 2
               )
@@ -304,7 +304,7 @@ class MatcherMessageReceiverTest
                 topic)
 
               // Work V1 is sent but not matched
-              val workAv1 = anUnidentifiedSierraWork.copy(
+              val workAv1 = createUnidentifiedWorkWith(
                 sourceIdentifier = aIdentifier,
                 version = 1)
 

--- a/catalogue_pipeline/merger/src/test/resources/logback-test.xml
+++ b/catalogue_pipeline/merger/src/test/resources/logback-test.xml
@@ -21,6 +21,9 @@
 
   <logger name="org.apache.http" level="INFO"/>
   <logger name="com.amazonaws" level="INFO"/>
+  <logger name="com.twitter" level="INFO"/>
+  <logger name="io.netty" level="INFO"/>
+  <logger name="uk.ac.wellcome.platform.merger.Server" level="INFO"/>
   <root level="debug">
     <appender-ref ref="STDOUT" />
   </root>

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -38,9 +38,6 @@ class MergerFeatureTest
                     messageBucket = messagesBucket,
                     table = table) { _ =>
                     val recorderWorkEntry = createRecorderWorkEntryWith(
-                      title = "dfmsng",
-                      identifierType = "sierra-system-number",
-                      sourceId = "b123456",
                       version = 1)
 
                     whenReady(storeInVHS(vhs, recorderWorkEntry)) { _ =>

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -37,7 +37,7 @@ class MergerFeatureTest
                     storageBucket = storageBucket,
                     messageBucket = messagesBucket,
                     table = table) { _ =>
-                    val recorderWorkEntry = recorderWorkEntryWith(
+                    val recorderWorkEntry = createRecorderWorkEntryWith(
                       title = "dfmsng",
                       identifierType = "sierra-system-number",
                       sourceId = "b123456",

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -37,8 +37,8 @@ class MergerFeatureTest
                     storageBucket = storageBucket,
                     messageBucket = messagesBucket,
                     table = table) { _ =>
-                    val recorderWorkEntry = createRecorderWorkEntryWith(
-                      version = 1)
+                    val recorderWorkEntry =
+                      createRecorderWorkEntryWith(version = 1)
 
                     whenReady(storeInVHS(vhs, recorderWorkEntry)) { _ =>
                       val matcherResult =

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -43,7 +43,7 @@ class MergerFeatureTest
                       sourceId = "b123456",
                       version = 1)
 
-                    whenReady(storeInVHS(vhs, List(recorderWorkEntry))) { _ =>
+                    whenReady(storeInVHS(vhs, recorderWorkEntry)) { _ =>
                       val matcherResult =
                         matcherResultWith(Set(Set(recorderWorkEntry)))
 

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
@@ -10,6 +10,7 @@ import uk.ac.wellcome.models.matcher.{
 }
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}
 import uk.ac.wellcome.utils.JsonUtil._
@@ -18,7 +19,7 @@ import uk.ac.wellcome.storage.dynamo._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-trait MergerTestUtils { this: SQS with SNS with Messaging =>
+trait MergerTestUtils extends WorksUtil { this: SQS with SNS with Messaging =>
 
   def matcherResultWith(matchedEntries: Set[Set[RecorderWorkEntry]]) =
     MatcherResult(
@@ -51,16 +52,8 @@ trait MergerTestUtils { this: SQS with SNS with Messaging =>
     })
   }
 
-  def recorderWorkEntryWith(title: String,
-                            identifierType: String,
-                            sourceId: String,
-                            version: Int) =
-    RecorderWorkEntry(
-      UnidentifiedWork(
-        title = title,
-        sourceIdentifier =
-          SourceIdentifier(IdentifierType(identifierType), "Work", sourceId),
-        version = version))
+  def recorderWorkEntryWith(version: Int) =
+    RecorderWorkEntry(createUnidentifiedWorkWith(version = version))
 
   def recorderInvisibleWorkEntryWith(identifierType: String,
                                      sourceId: String,

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
@@ -41,14 +41,19 @@ trait MergerTestUtils extends WorksUtil { this: SQS with SNS with Messaging =>
     sqsClient.sendMessage(queue.url, toJson(notificationMessage).get)
   }
 
+  def storeInVHS(vhs: VersionedHybridStore[RecorderWorkEntry, EmptyMetadata, ObjectStore[RecorderWorkEntry]],
+                 recorderWorkEntry: RecorderWorkEntry): Future[Unit] =
+    vhs.updateRecord(recorderWorkEntry.id)(
+      ifNotExisting = (recorderWorkEntry, EmptyMetadata()))((_, _) =>
+      throw new RuntimeException("Not possible, VHS is empty!")
+    )
+
   def storeInVHS(vhs: VersionedHybridStore[RecorderWorkEntry,
                                            EmptyMetadata,
                                            ObjectStore[RecorderWorkEntry]],
                  entries: List[RecorderWorkEntry]) = {
     Future.sequence(entries.map { recorderWorkEntry =>
-      vhs.updateRecord(recorderWorkEntry.id)(
-        ifNotExisting = (recorderWorkEntry, EmptyMetadata()))((_, _) =>
-        throw new RuntimeException("Not possible, VHS is empty!"))
+      storeInVHS(vhs = vhs, recorderWorkEntry = recorderWorkEntry)
     })
   }
 

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
@@ -52,7 +52,7 @@ trait MergerTestUtils extends WorksUtil { this: SQS with SNS with Messaging =>
   def storeInVHS(vhs: VersionedHybridStore[RecorderWorkEntry,
                                            EmptyMetadata,
                                            ObjectStore[RecorderWorkEntry]],
-                 entries: List[RecorderWorkEntry]) = {
+                 entries: List[RecorderWorkEntry]): Future[List[Unit]] = {
     Future.sequence(entries.map { recorderWorkEntry =>
       storeInVHS(vhs = vhs, recorderWorkEntry = recorderWorkEntry)
     })

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
@@ -52,7 +52,7 @@ trait MergerTestUtils extends WorksUtil { this: SQS with SNS with Messaging =>
     })
   }
 
-  def recorderWorkEntryWith(version: Int) =
+  def createRecorderWorkEntryWith(version: Int) =
     RecorderWorkEntry(createUnidentifiedWorkWith(version = version))
 
   def getWorksSent(topic: Topic) = {

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
@@ -55,15 +55,6 @@ trait MergerTestUtils extends WorksUtil { this: SQS with SNS with Messaging =>
   def recorderWorkEntryWith(version: Int) =
     RecorderWorkEntry(createUnidentifiedWorkWith(version = version))
 
-  def recorderInvisibleWorkEntryWith(identifierType: String,
-                                     sourceId: String,
-                                     version: Int) =
-    RecorderWorkEntry(
-      UnidentifiedInvisibleWork(
-        sourceIdentifier =
-          SourceIdentifier(IdentifierType(identifierType), "Work", sourceId),
-        version = version))
-
   def getWorksSent(topic: Topic) = {
     val messagesSent = listMessagesReceivedFromSNS(topic)
     val worksSent = messagesSent.map { message =>

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
@@ -41,12 +41,13 @@ trait MergerTestUtils extends WorksUtil { this: SQS with SNS with Messaging =>
     sqsClient.sendMessage(queue.url, toJson(notificationMessage).get)
   }
 
-  def storeInVHS(vhs: VersionedHybridStore[RecorderWorkEntry, EmptyMetadata, ObjectStore[RecorderWorkEntry]],
+  def storeInVHS(vhs: VersionedHybridStore[RecorderWorkEntry,
+                                           EmptyMetadata,
+                                           ObjectStore[RecorderWorkEntry]],
                  recorderWorkEntry: RecorderWorkEntry): Future[Unit] =
     vhs.updateRecord(recorderWorkEntry.id)(
       ifNotExisting = (recorderWorkEntry, EmptyMetadata()))((_, _) =>
-      throw new RuntimeException("Not possible, VHS is empty!")
-    )
+      throw new RuntimeException("Not possible, VHS is empty!"))
 
   def storeInVHS(vhs: VersionedHybridStore[RecorderWorkEntry,
                                            EmptyMetadata,

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -11,7 +11,10 @@ import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
-import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  TransformedBaseWork,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.merger.MergerTestUtils
@@ -120,8 +123,10 @@ class MergerWorkerServiceTest
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, _) =>
         val recorderWorkEntry = createRecorderWorkEntryWith(version = 1)
-        val olderVersionRecorderWorkEntry = createRecorderWorkEntryWith(version = 1)
-        val newerVersionRecorderWorkEntry = createRecorderWorkEntryWith(version = 2)
+        val olderVersionRecorderWorkEntry =
+          createRecorderWorkEntryWith(version = 1)
+        val newerVersionRecorderWorkEntry =
+          createRecorderWorkEntryWith(version = 2)
 
         val matcherResult = matcherResultWith(
           Set(Set(recorderWorkEntry, olderVersionRecorderWorkEntry)))
@@ -145,9 +150,12 @@ class MergerWorkerServiceTest
   it("discards works with version 0 and sends along the others") {
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, _) =>
-        val versionZeroWork: RecorderWorkEntry = createRecorderWorkEntryWith(version = 0)
+        val versionZeroWork: RecorderWorkEntry =
+          createRecorderWorkEntryWith(version = 0)
         val recorderWorkEntry = versionZeroWork.copy(
-          work = versionZeroWork.work.asInstanceOf[UnidentifiedWork].copy(version = 1)
+          work = versionZeroWork.work
+            .asInstanceOf[UnidentifiedWork]
+            .copy(version = 1)
         )
 
         val matcherResult =

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
-import uk.ac.wellcome.models.work.internal.TransformedBaseWork
+import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWork}
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.merger.MergerTestUtils
@@ -145,8 +145,10 @@ class MergerWorkerServiceTest
   it("discards works with version 0 and sends along the others") {
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, _) =>
-        val versionZeroWork = createRecorderWorkEntryWith(version = 0)
-        val recorderWorkEntry = createRecorderWorkEntryWith(version = 1)
+        val versionZeroWork: RecorderWorkEntry = createRecorderWorkEntryWith(version = 0)
+        val recorderWorkEntry = versionZeroWork.copy(
+          work = versionZeroWork.work.asInstanceOf[UnidentifiedWork].copy(version = 1)
+        )
 
         val matcherResult =
           matcherResultWith(Set(Set(recorderWorkEntry, versionZeroWork)))

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -81,7 +81,7 @@ class MergerWorkerServiceTest
 
         val matcherResult = matcherResultWith(Set(Set(recorderWorkEntry)))
 
-        whenReady(storeInVHS(vhs, List(recorderWorkEntry))) { _ =>
+        whenReady(storeInVHS(vhs, recorderWorkEntry)) { _ =>
           sendSQSMessage(queue, matcherResult)
 
           eventually {
@@ -151,7 +151,7 @@ class MergerWorkerServiceTest
         val matcherResult =
           matcherResultWith(Set(Set(recorderWorkEntry, versionZeroWork)))
 
-        whenReady(storeInVHS(vhs, List(recorderWorkEntry))) { _ =>
+        whenReady(storeInVHS(vhs, recorderWorkEntry)) { _ =>
           sendSQSMessage(queue, matcherResult)
 
           eventually {

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -42,14 +42,9 @@ class MergerWorkerServiceTest
 
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, _) =>
-        val recorderWorkEntry1 =
-          recorderWorkEntryWith("dfmsng", "sierra-system-number", "b123456", 1)
-
-        val recorderWorkEntry2 =
-          recorderWorkEntryWith("dfmsng", "sierra-system-number", "b987654", 1)
-
-        val recorderWorkEntry3 =
-          recorderWorkEntryWith("dfmsng", "sierra-system-number", "b678910", 1)
+        val recorderWorkEntry1 = recorderWorkEntryWith(version = 1)
+        val recorderWorkEntry2 = recorderWorkEntryWith(version = 1)
+        val recorderWorkEntry3 = recorderWorkEntryWith(version = 1)
 
         val matcherResult = matcherResultWith(
           Set(
@@ -103,8 +98,7 @@ class MergerWorkerServiceTest
 
     withMergerWorkerServiceFixtures {
       case (_, QueuePair(queue, dlq), topic, metricsSender) =>
-        val recorderWorkEntry: RecorderWorkEntry =
-          recorderWorkEntryWith("dfmsng", "sierra-system-number", "b123456", 1)
+        val recorderWorkEntry = recorderWorkEntryWith(version = 1)
 
         val matcherResult = matcherResultWith(Set(Set(recorderWorkEntry)))
 
@@ -124,12 +118,9 @@ class MergerWorkerServiceTest
 
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, _) =>
-        val recorderWorkEntry: RecorderWorkEntry =
-          recorderWorkEntryWith("dfmsng", "sierra-system-number", "b123456", 1)
-        val olderVersionRecorderWorkEntry: RecorderWorkEntry =
-          recorderWorkEntryWith("dfmsng", "sierra-system-number", "b987654", 1)
-        val newerVersionRecorderWorkEntry =
-          recorderWorkEntryWith("dfmsng", "sierra-system-number", "b987654", 2)
+        val recorderWorkEntry = recorderWorkEntryWith(version = 1)
+        val olderVersionRecorderWorkEntry = recorderWorkEntryWith(version = 1)
+        val newerVersionRecorderWorkEntry = recorderWorkEntryWith(version = 2)
 
         val matcherResult = matcherResultWith(
           Set(Set(recorderWorkEntry, olderVersionRecorderWorkEntry)))
@@ -153,10 +144,8 @@ class MergerWorkerServiceTest
   it("discards works with version 0 and sends along the others") {
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, _) =>
-        val versionZeroWork: RecorderWorkEntry =
-          recorderWorkEntryWith("dfmsng", "sierra-system-number", "b123456", 0)
-        val recorderWorkEntry: RecorderWorkEntry =
-          recorderWorkEntryWith("dfmsng", "sierra-system-number", "b987654", 1)
+        val versionZeroWork = recorderWorkEntryWith(version = 0)
+        val recorderWorkEntry = recorderWorkEntryWith(version = 1)
 
         val matcherResult =
           matcherResultWith(Set(Set(recorderWorkEntry, versionZeroWork)))

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -75,8 +75,9 @@ class MergerWorkerServiceTest
 
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, _) =>
-        val recorderWorkEntry =
-          recorderInvisibleWorkEntryWith("sierra-system-number", "b123456", 1)
+        val recorderWorkEntry = RecorderWorkEntry(
+          work = createUnidentifiedInvisibleWork
+        )
 
         val matcherResult = matcherResultWith(Set(Set(recorderWorkEntry)))
 

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -123,10 +123,10 @@ class MergerWorkerServiceTest
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, _) =>
         val recorderWorkEntry = createRecorderWorkEntryWith(version = 1)
-        val olderVersionRecorderWorkEntry =
-          createRecorderWorkEntryWith(version = 1)
-        val newerVersionRecorderWorkEntry =
-          createRecorderWorkEntryWith(version = 2)
+        val olderVersionRecorderWorkEntry =createRecorderWorkEntryWith(version = 1)
+        val newerVersionRecorderWorkEntry = olderVersionRecorderWorkEntry.copy(
+          work = recorderWorkEntry.work.copy(version = 2)
+        )
 
         val matcherResult = matcherResultWith(
           Set(Set(recorderWorkEntry, olderVersionRecorderWorkEntry)))

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -42,9 +42,9 @@ class MergerWorkerServiceTest
 
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, _) =>
-        val recorderWorkEntry1 = recorderWorkEntryWith(version = 1)
-        val recorderWorkEntry2 = recorderWorkEntryWith(version = 1)
-        val recorderWorkEntry3 = recorderWorkEntryWith(version = 1)
+        val recorderWorkEntry1 = createRecorderWorkEntryWith(version = 1)
+        val recorderWorkEntry2 = createRecorderWorkEntryWith(version = 1)
+        val recorderWorkEntry3 = createRecorderWorkEntryWith(version = 1)
 
         val matcherResult = matcherResultWith(
           Set(
@@ -99,7 +99,7 @@ class MergerWorkerServiceTest
 
     withMergerWorkerServiceFixtures {
       case (_, QueuePair(queue, dlq), topic, metricsSender) =>
-        val recorderWorkEntry = recorderWorkEntryWith(version = 1)
+        val recorderWorkEntry = createRecorderWorkEntryWith(version = 1)
 
         val matcherResult = matcherResultWith(Set(Set(recorderWorkEntry)))
 
@@ -119,9 +119,9 @@ class MergerWorkerServiceTest
 
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, _) =>
-        val recorderWorkEntry = recorderWorkEntryWith(version = 1)
-        val olderVersionRecorderWorkEntry = recorderWorkEntryWith(version = 1)
-        val newerVersionRecorderWorkEntry = recorderWorkEntryWith(version = 2)
+        val recorderWorkEntry = createRecorderWorkEntryWith(version = 1)
+        val olderVersionRecorderWorkEntry = createRecorderWorkEntryWith(version = 1)
+        val newerVersionRecorderWorkEntry = createRecorderWorkEntryWith(version = 2)
 
         val matcherResult = matcherResultWith(
           Set(Set(recorderWorkEntry, olderVersionRecorderWorkEntry)))
@@ -145,8 +145,8 @@ class MergerWorkerServiceTest
   it("discards works with version 0 and sends along the others") {
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, _) =>
-        val versionZeroWork = recorderWorkEntryWith(version = 0)
-        val recorderWorkEntry = recorderWorkEntryWith(version = 1)
+        val versionZeroWork = createRecorderWorkEntryWith(version = 0)
+        val recorderWorkEntry = createRecorderWorkEntryWith(version = 1)
 
         val matcherResult =
           matcherResultWith(Set(Set(recorderWorkEntry, versionZeroWork)))

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -123,7 +123,8 @@ class MergerWorkerServiceTest
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, _) =>
         val recorderWorkEntry = createRecorderWorkEntryWith(version = 1)
-        val olderVersionRecorderWorkEntry =createRecorderWorkEntryWith(version = 1)
+        val olderVersionRecorderWorkEntry =
+          createRecorderWorkEntryWith(version = 1)
         val newerVersionRecorderWorkEntry = olderVersionRecorderWorkEntry.copy(
           work = recorderWorkEntry.work.copy(version = 2)
         )

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -125,7 +125,8 @@ class MergerWorkerServiceTest
         val recorderWorkEntry = createRecorderWorkEntryWith(version = 1)
         val work = createUnidentifiedWorkWith(version = 1)
         val olderVersionRecorderWorkEntry = RecorderWorkEntry(work = work)
-        val newerVersionRecorderWorkEntry = RecorderWorkEntry(work = work.copy(version = 2))
+        val newerVersionRecorderWorkEntry =
+          RecorderWorkEntry(work = work.copy(version = 2))
 
         val matcherResult = matcherResultWith(
           Set(Set(recorderWorkEntry, olderVersionRecorderWorkEntry)))

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -123,11 +123,9 @@ class MergerWorkerServiceTest
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, _) =>
         val recorderWorkEntry = createRecorderWorkEntryWith(version = 1)
-        val olderVersionRecorderWorkEntry =
-          createRecorderWorkEntryWith(version = 1)
-        val newerVersionRecorderWorkEntry = olderVersionRecorderWorkEntry.copy(
-          work = recorderWorkEntry.work.copy(version = 2)
-        )
+        val work = createUnidentifiedWorkWith(version = 1)
+        val olderVersionRecorderWorkEntry = RecorderWorkEntry(work = work)
+        val newerVersionRecorderWorkEntry = RecorderWorkEntry(work = work.copy(version = 2))
 
         val matcherResult = matcherResultWith(
           Set(Set(recorderWorkEntry, olderVersionRecorderWorkEntry)))

--- a/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
+++ b/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
@@ -3,12 +3,8 @@ package uk.ac.wellcome.platform.recorder
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.messaging.test.fixtures.Messaging
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
-import uk.ac.wellcome.models.work.internal.{
-  IdentifierType,
-  SourceIdentifier,
-  TransformedBaseWork,
-  UnidentifiedWork
-}
+import uk.ac.wellcome.models.work.internal.TransformedBaseWork
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.test.fixtures.LocalVersionedHybridStore
 import uk.ac.wellcome.storage.vhs.EmptyMetadata

--- a/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
+++ b/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
@@ -23,22 +23,11 @@ class RecorderFeatureTest
     with ExtendedPatience
     with fixtures.Server
     with LocalVersionedHybridStore
-    with Messaging {
+    with Messaging
+    with WorksUtil {
 
   it("receives a transformed Work, and saves it to the VHS") {
-    val title = "Not from Guildford after all"
-
-    val sourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("miro-image-number"),
-      value = "V0237865",
-      ontologyType = "Work"
-    )
-
-    val work = UnidentifiedWork(
-      title = title,
-      sourceIdentifier = sourceIdentifier,
-      version = 1
-    )
+    val work = createUnidentifiedWork
 
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>

--- a/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -66,9 +66,7 @@ class RecorderWorkerServiceTest
               storageBucket,
               messagesBucket,
               queue) { service =>
-              val invisibleWork = UnidentifiedInvisibleWork(
-                sourceIdentifier = sourceIdentifier,
-                version = 2)
+              val invisibleWork = createUnidentifiedInvisibleWork
               sendMessage(queue, messagesBucket, invisibleWork)
               eventually {
                 assertStoredSingleWork(storageBucket, table, invisibleWork)

--- a/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -8,6 +8,7 @@ import uk.ac.wellcome.messaging.test.fixtures.SQS.{Queue, QueuePair}
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
@@ -30,27 +31,15 @@ class RecorderWorkerServiceTest
     with ScalaFutures
     with Messaging
     with MetricsSenderFixture
-    with ExtendedPatience {
-
-  val title = "Whose umbrella did I find?"
-
-  val sourceIdentifier = SourceIdentifier(
-    identifierType = IdentifierType("miro-image-number"),
-    value = "U8634924",
-    ontologyType = "Work"
-  )
-
-  val work = UnidentifiedWork(
-    title = title,
-    sourceIdentifier = sourceIdentifier,
-    version = 2
-  )
+    with ExtendedPatience
+    with WorksUtil {
 
   it("successfully records a UnidentifiedWork") {
     withLocalDynamoDbTable { table =>
       withLocalS3Bucket { storageBucket =>
         withLocalS3Bucket { messagesBucket =>
           withLocalSqsQueue { queue =>
+            val work = createUnidentifiedWork
             sendMessage(queue, messagesBucket, work)
             withRecorderWorkerService(
               table,
@@ -92,8 +81,8 @@ class RecorderWorkerServiceTest
   }
 
   it("doesn't overwrite a newer work with an older work") {
-    val olderWork = work
-    val newerWork = work.copy(version = 10, title = "A nice new thing")
+    val olderWork = createUnidentifiedWork
+    val newerWork = olderWork.copy(version = 10, title = "A nice new thing")
 
     withLocalDynamoDbTable { table =>
       withLocalS3Bucket { storageBucket =>
@@ -120,8 +109,8 @@ class RecorderWorkerServiceTest
   }
 
   it("overwrites an older work with an newer work") {
-    val olderWork = work
-    val newerWork = work.copy(version = 10, title = "A nice new thing")
+    val olderWork = createUnidentifiedWork
+    val newerWork = olderWork.copy(version = 10, title = "A nice new thing")
 
     withLocalDynamoDbTable { table =>
       withLocalS3Bucket { storageBucket =>
@@ -159,6 +148,7 @@ class RecorderWorkerServiceTest
           case QueuePair(queue, dlq) =>
             withRecorderWorkerService(table, badBucket, messagesBucket, queue) {
               service =>
+                val work = createUnidentifiedWork
                 sendMessage(queue, messagesBucket, work)
                 eventually {
                   assertQueueEmpty(queue)
@@ -181,6 +171,7 @@ class RecorderWorkerServiceTest
               storageBucket,
               messagesBucket,
               queue) { service =>
+              val work = createUnidentifiedWork
               sendMessage(queue, messagesBucket, work)
               eventually {
                 assertQueueEmpty(queue)

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
@@ -50,18 +50,6 @@ class NotificationMessageReceiverTest
     with ScalaFutures
     with TransformableMessageUtils {
 
-  val sourceIdentifier =
-    SourceIdentifier(
-      identifierType = IdentifierType("calm-altref-no"),
-      ontologyType = "Work",
-      value = "value")
-
-  val work = UnidentifiedWork(
-    title = "placeholder title",
-    sourceIdentifier = sourceIdentifier,
-    version = 1
-  )
-
   def withNotificationMessageReceiver[R](
     topic: Topic,
     bucket: Bucket,

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -11,6 +11,7 @@ import uk.ac.wellcome.models.transformable.sierra.{
 }
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraData
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, VarField}
 import uk.ac.wellcome.utils.JsonUtil._
 
@@ -18,7 +19,8 @@ class SierraTransformableTransformerTest
     extends FunSpec
     with Matchers
     with SierraData
-    with TransformableTestBase[SierraTransformable] {
+    with TransformableTestBase[SierraTransformable]
+    with WorksUtil {
   val transformer = new SierraTransformableTransformer
 
   it("performs a transformation on a work with items") {
@@ -245,10 +247,9 @@ class SierraTransformableTransformerTest
 
     val work = transformDataToWork(id = id, data = data)
 
-    work shouldBe UnidentifiedWork(
+    work shouldBe createUnidentifiedWorkWith(
       title = title,
       sourceIdentifier = sourceIdentifier,
-      version = 1,
       otherIdentifiers = List(sierraIdentifier),
       description = Some("A delightful description of a dead daisy."),
       production = List(

--- a/data_api/snapshot_generator/src/test/resources/logback-test.xml
+++ b/data_api/snapshot_generator/src/test/resources/logback-test.xml
@@ -22,6 +22,7 @@
   <logger name="org.apache.http" level="WARN"/>
   <logger name="com.amazonaws" level="INFO"/>
   <logger name="com.sksamuel.elastic4s" level="INFO"/>
+  <logger name="org.elasticsearch.client.RestClient" level="INFO"/>
   <root level="debug">
     <appender-ref ref="STDOUT" />
   </root>

--- a/data_api/snapshot_generator/src/test/resources/logback-test.xml
+++ b/data_api/snapshot_generator/src/test/resources/logback-test.xml
@@ -23,6 +23,7 @@
   <logger name="com.amazonaws" level="INFO"/>
   <logger name="com.sksamuel.elastic4s" level="INFO"/>
   <logger name="org.elasticsearch.client.RestClient" level="INFO"/>
+  <logger name="uk.ac.wellcome.platform.snapshot_generator.Server" level="INFO"/>
   <root level="debug">
     <appender-ref ref="STDOUT" />
   </root>

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -98,7 +98,7 @@ class SnapshotGeneratorFeatureTest
                    }""".stripMargin
           }
 
-          actualJsonLines.zip(expectedJsonLines).foreach {
+          actualJsonLines.sorted.zip(expectedJsonLines).foreach {
             case (actualLine, expectedLine) =>
               assertJsonStringsAreEqual(actualLine, expectedLine)
           }

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -83,7 +83,7 @@ class SnapshotGeneratorFeatureTest
           val actualJsonLines: List[String] =
             readGzipFile(downloadFile.getPath).split("\n").toList
 
-          val expectedJsonLines = works.map { work =>
+          val expectedJsonLines = works.sortBy { _.canonicalId }.map { work =>
             s"""{
                  |  "id": "${work.canonicalId}",
                  |  "title": "${work.title}",

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -13,11 +13,7 @@ import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
-import uk.ac.wellcome.models.work.internal.{
-  IdentifiedWork,
-  IdentifierType,
-  SourceIdentifier
-}
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.monitoring.test.fixtures.CloudWatch
 import uk.ac.wellcome.platform.snapshot_generator.fixtures.AkkaS3
 import uk.ac.wellcome.platform.snapshot_generator.models.{
@@ -46,27 +42,15 @@ class SnapshotGeneratorFeatureTest
     with JsonTestUtil
     with ExtendedPatience
     with ElasticsearchFixtures
-    with DisplayV1SerialisationTestBase {
+    with DisplayV1SerialisationTestBase
+    with WorksUtil {
 
   val itemType = "work"
 
   it("completes a snapshot generation successfully") {
     withFixtures {
       case (_, queue, topic, indexNameV1, indexNameV2, publicBucket) =>
-        // Create a collection of works.  These three differ by version,
-        // if not anything more interesting!
-        val works = (1 to 3).map { version =>
-          IdentifiedWork(
-            canonicalId = s"rbfhv6b4$version",
-            title = "Rumblings from a rambunctious rodent",
-            sourceIdentifier = SourceIdentifier(
-              identifierType = IdentifierType("miro-image-number"),
-              ontologyType = "work",
-              value = "R0060400"
-            ),
-            version = version
-          )
-        }
+        val works = createIdentifiedWorks(count = 3)
 
         insertIntoElasticsearch(indexNameV1, itemType, works: _*)
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
@@ -12,11 +12,7 @@ class DisplayCreatorsV1SerialisationTest
     with WorksUtil {
 
   it("serialises creators") {
-    val work = IdentifiedWork(
-      canonicalId = "v9w6cz66",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      title = "Vultures vying for victory",
+    val work = createIdentifiedWorkWith(
       contributors = List(
         Contributor(agent = Unidentifiable(Agent("Vivian Violet"))),
         Contributor(agent = Unidentifiable(Agent("Verily Volumes"))),

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
@@ -18,11 +18,7 @@ class DisplayLocationsV1SerialisationTest
       label = "a stack of slick slimes"
     )
 
-    val work = IdentifiedWork(
-      canonicalId = "zm9q6c6h",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      title = "A zoo of zebras doing zumba",
+    val work = createIdentifiedWorkWith(
       items = List(
         createItem(locations = List(physicalLocation))
       )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -103,12 +103,9 @@ class DisplayWorkV1SerialisationTest
       license = License_CCBY
     )
     val item = createItem(locations = List(location))
-    val workWithCopyright = IdentifiedWork(
-      title = "A scarf on a squirrel",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = "yxh928a",
-      items = List(item))
+    val workWithCopyright = createIdentifiedWorkWith(
+      items = List(item)
+    )
 
     val actualJson = objectMapper.writeValueAsString(
       DisplayWorkV1(workWithCopyright, WorksIncludes(items = true)))
@@ -146,11 +143,7 @@ class DisplayWorkV1SerialisationTest
     val concept0 = Unidentifiable(Concept("fish"))
     val concept1 = Unidentifiable(Concept("gardening"))
 
-    val workWithSubjects = IdentifiedWork(
-      title = "A seal selling seaweed sandwiches in Scotland",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = "test_subject1",
+    val workWithSubjects = createIdentifiedWorkWith(
       subjects = List(
         Subject("label", List(concept0)),
         Subject("label", List(concept1))
@@ -178,11 +171,7 @@ class DisplayWorkV1SerialisationTest
     val concept0 = Unidentifiable(Concept("woodwork"))
     val concept1 = Unidentifiable(Concept("etching"))
 
-    val wotkWithGenres = IdentifiedWork(
-      title = "A guppy in a greenhouse",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = "test_subject1",
+    val wotkWithGenres = createIdentifiedWorkWith(
       genres = List(
         Genre("label", List(concept0)),
         Genre("label", List(concept1))

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -4,16 +4,13 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.ItemsUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 
-class DisplayWorkV1Test extends FunSpec with Matchers with ItemsUtil {
+class DisplayWorkV1Test extends FunSpec with Matchers with WorksUtil {
 
   it("correctly parses a Work without any items") {
-    val work = IdentifiedWork(
-      title = "An irritating imp is immune from items",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = "abcdef12"
+    val work = createIdentifiedWorkWith(
+      items = List()
     )
 
     val displayWork = DisplayWorkV1(
@@ -25,11 +22,7 @@ class DisplayWorkV1Test extends FunSpec with Matchers with ItemsUtil {
 
   it("correctly parses items on a work") {
     val item = createItem(locations = List())
-    val work = IdentifiedWork(
-      title = "Inside an irate igloo",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = "b4heraz7",
+    val work = createIdentifiedWorkWith(
       items = List(item)
     )
 
@@ -41,33 +34,21 @@ class DisplayWorkV1Test extends FunSpec with Matchers with ItemsUtil {
     displayItem.id shouldBe item.canonicalId
   }
 
-  val sourceIdentifier = SourceIdentifier(
-    identifierType = IdentifierType("sierra-system-number"),
-    ontologyType = "Work",
-    value = "b1234567"
-  )
-
   it("correctly parses a work without any extra identifiers") {
-    val work = IdentifiedWork(
-      title = "An irascible iguana invites impudence",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = "xtsx8hwk")
+    val work = createIdentifiedWorkWith(
+      otherIdentifiers = List()
+    )
 
     val displayWork = DisplayWorkV1(
       work = work,
       includes = WorksIncludes(identifiers = true)
     )
     displayWork.identifiers shouldBe Some(
-      List(DisplayIdentifierV1(sourceIdentifier)))
+      List(DisplayIdentifierV1(work.sourceIdentifier)))
   }
 
   it("extracts creators from a Work with Unidentifiable Contributors") {
-    val work = IdentifiedWork(
-      title = "Jumping over jackals in Japan",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = "j7tw9jv3",
+    val work = createIdentifiedWorkWith(
       contributors = List(
         Contributor(
           agent = Unidentifiable(Agent(label = "Esmerelda Weatherwax"))
@@ -88,12 +69,8 @@ class DisplayWorkV1Test extends FunSpec with Matchers with ItemsUtil {
   it("gets the physicalDescription from a Work") {
     val physicalDescription = "A magnificent mural of magpies"
 
-    val work = IdentifiedWork(
-      title = "Moving a mighty mouse to Madagascar",
-      canonicalId = "mtc2wvrg",
-      sourceIdentifier = sourceIdentifier,
-      physicalDescription = Some(physicalDescription),
-      version = 1
+    val work = createIdentifiedWorkWith(
+      physicalDescription = Some(physicalDescription)
     )
 
     val displayWork = DisplayWorkV1(work)
@@ -106,32 +83,24 @@ class DisplayWorkV1Test extends FunSpec with Matchers with ItemsUtil {
       label = "Proud pooch pavement plops"
     )
 
-    val expectedDisplayWorkV1 = DisplayWorkType(
+    val expectedDisplayWorkType = DisplayWorkType(
       id = workType.id,
       label = workType.label
     )
 
-    val work = IdentifiedWork(
-      title = "Moving a mighty mouse to Madagascar",
-      canonicalId = "mtc2wvrg",
-      sourceIdentifier = sourceIdentifier,
-      workType = Some(workType),
-      version = 1
+    val work = createIdentifiedWorkWith(
+      workType = Some(workType)
     )
 
     val displayWork = DisplayWorkV1(work)
-    displayWork.workType shouldBe Some(expectedDisplayWorkV1)
+    displayWork.workType shouldBe Some(expectedDisplayWorkType)
   }
 
   it("gets the extent from a Work") {
     val extent = "Bound in boxes of bark"
 
-    val work = IdentifiedWork(
-      title = "Brilliant beeches in Bucharest",
-      canonicalId = "bmnppscn",
-      sourceIdentifier = sourceIdentifier,
-      extent = Some(extent),
-      version = 1
+    val work = createIdentifiedWorkWith(
+      extent = Some(extent)
     )
 
     val displayWork = DisplayWorkV1(work)
@@ -144,12 +113,8 @@ class DisplayWorkV1Test extends FunSpec with Matchers with ItemsUtil {
       label = "British Sign Language"
     )
 
-    val work = IdentifiedWork(
-      title = "A largesse of leaping Libyan lions",
-      canonicalId = "lfk6nkje",
-      sourceIdentifier = sourceIdentifier,
-      language = Some(language),
-      version = 1
+    val work = createIdentifiedWorkWith(
+      language = Some(language)
     )
 
     val displayWork = DisplayWorkV1(work)
@@ -183,12 +148,8 @@ class DisplayWorkV1Test extends FunSpec with Matchers with ItemsUtil {
       )
     )
 
-    val work = IdentifiedWork(
-      title = "A work with genres",
-      canonicalId = "b225839r",
-      sourceIdentifier = sourceIdentifier,
-      genres = genres,
-      version = 1
+    val work = createIdentifiedWorkWith(
+      genres = genres
     )
 
     val displayWork = DisplayWorkV1(work)
@@ -224,12 +185,8 @@ class DisplayWorkV1Test extends FunSpec with Matchers with ItemsUtil {
       )
     )
 
-    val work = IdentifiedWork(
-      title = "A work with subjects",
-      canonicalId = "nznaj8p5",
-      sourceIdentifier = sourceIdentifier,
-      subjects = subjects,
-      version = 1
+    val work = createIdentifiedWorkWith(
+      subjects = subjects
     )
 
     val displayWork = DisplayWorkV1(work)
@@ -241,10 +198,7 @@ class DisplayWorkV1Test extends FunSpec with Matchers with ItemsUtil {
   }
 
   it("errors if you try to convert a work with non-empty production field") {
-    val work = IdentifiedWork(
-      canonicalId = "pejk5skd",
-      title = "Perhaps production of pasta is perfunctory?",
-      sourceIdentifier = sourceIdentifier,
+    val work = createIdentifiedWorkWith(
       production = List(
         ProductionEvent(
           places = List(),
@@ -252,8 +206,7 @@ class DisplayWorkV1Test extends FunSpec with Matchers with ItemsUtil {
           dates = List(),
           function = Some(Concept("Manufacture"))
         )
-      ),
-      version = 1
+      )
     )
 
     val caught = intercept[GracefulFailureException] {
@@ -264,12 +217,8 @@ class DisplayWorkV1Test extends FunSpec with Matchers with ItemsUtil {
   }
 
   describe("correctly uses the WorksIncludes.identifiers include") {
-    val work = IdentifiedWork(
-      canonicalId = "pt5vupg4",
-      title = "Pouncing pugs play in pipes",
-      sourceIdentifier = sourceIdentifier,
-      items = createItems(count = 1),
-      version = 1
+    val work = createIdentifiedWorkWith(
+      items = createItems(count = 1)
     )
 
     describe("omits identifiers if WorksIncludes.identifiers is false") {
@@ -293,7 +242,7 @@ class DisplayWorkV1Test extends FunSpec with Matchers with ItemsUtil {
 
       it("on the top-level Work") {
         displayWork.identifiers shouldBe Some(
-          List(DisplayIdentifierV1(sourceIdentifier)))
+          List(DisplayIdentifierV1(work.sourceIdentifier)))
       }
 
       it("items") {

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -247,7 +247,9 @@ class DisplayWorkV1Test extends FunSpec with Matchers with WorksUtil {
 
       it("items") {
         val displayWork =
-          DisplayWorkV1(work, includes = WorksIncludes(identifiers = true, items = true))
+          DisplayWorkV1(
+            work,
+            includes = WorksIncludes(identifiers = true, items = true))
         val item: DisplayItemV1 = displayWork.items.get.head
         item.identifiers shouldBe Some(
           List(DisplayIdentifierV1(work.items.head.sourceIdentifier)))

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -295,6 +295,14 @@ class DisplayWorkV1Test extends FunSpec with Matchers with ItemsUtil {
         displayWork.identifiers shouldBe Some(
           List(DisplayIdentifierV1(sourceIdentifier)))
       }
+
+      it("items") {
+        val displayWork =
+          DisplayWorkV1(work, includes = WorksIncludes(identifiers = true, items = true))
+        val item: DisplayItemV1 = displayWork.items.get.head
+        item.identifiers shouldBe Some(
+          List(DisplayIdentifierV1(work.items.head.sourceIdentifier)))
+      }
     }
   }
 }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationsV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationsV2SerialisationTest.scala
@@ -18,11 +18,7 @@ class DisplayLocationsV2SerialisationTest
       label = "a stack of slick slimes"
     )
 
-    val work = IdentifiedWork(
-      canonicalId = "zm9q6c6h",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      title = "A zoo of zebras doing zumba",
+    val work = createIdentifiedWorkWith(
       items = List(createItem(locations = List(physicalLocation)))
     )
     val displayWork =

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -98,12 +98,9 @@ class DisplayWorkV2SerialisationTest
       license = License_CCBY
     )
     val item = createItem(locations = List(location))
-    val workWithCopyright = IdentifiedWork(
-      title = "A scarf on a squirrel",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = "yxh928a",
-      items = List(item))
+    val workWithCopyright = createIdentifiedWorkWith(
+      items = List(item)
+    )
 
     val actualJson = objectMapper.writeValueAsString(
       DisplayWorkV2(workWithCopyright, WorksIncludes(items = true)))
@@ -137,14 +134,11 @@ class DisplayWorkV2SerialisationTest
   }
 
   it("includes subject information in DisplayWorkV2 serialisation") {
-    val workWithSubjects = IdentifiedWork(
-      title = "A seal selling seaweed sandwiches in Scotland",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = "test_subject1",
+    val workWithSubjects = createIdentifiedWorkWith(
       subjects = List(
         Subject("label", List(Unidentifiable(Concept("fish")))),
-        Subject("label", List(Unidentifiable(Concept("gardening")))))
+        Subject("label", List(Unidentifiable(Concept("gardening"))))
+      )
     )
     val actualJson =
       objectMapper.writeValueAsString(DisplayWorkV2(workWithSubjects))
@@ -163,11 +157,7 @@ class DisplayWorkV2SerialisationTest
   }
 
   it("includes genre information in DisplayWorkV2 serialisation") {
-    val workWithSubjects = IdentifiedWork(
-      title = "A guppy in a greenhouse",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = "test_subject1",
+    val workWithSubjects = createIdentifiedWorkWith(
       genres = List(
         Genre(
           label = "genre",
@@ -175,7 +165,8 @@ class DisplayWorkV2SerialisationTest
             Unidentifiable(Concept("woodwork")),
             Unidentifiable(Concept("etching"))
           )
-        ))
+        )
+      )
     )
     val actualJson =
       objectMapper.writeValueAsString(DisplayWorkV2(workWithSubjects))

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
@@ -3,16 +3,13 @@ package uk.ac.wellcome.display.models.v2
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.ItemsUtil
+import uk.ac.wellcome.models.work.test.util.WorksUtil
 
-class DisplayWorkV2Test extends FunSpec with Matchers with ItemsUtil {
+class DisplayWorkV2Test extends FunSpec with Matchers with WorksUtil {
 
   it("correctly parses a Work without any items") {
-    val work = IdentifiedWork(
-      title = "An irritating imp is immune from items",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = "abcdef12"
+    val work = createIdentifiedWorkWith(
+      items = List()
     )
 
     val displayWork = DisplayWorkV2(
@@ -23,11 +20,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers with ItemsUtil {
   }
 
   it("correctly parses items on a work") {
-    val work = IdentifiedWork(
-      title = "Inside an irate igloo",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = "b4heraz7",
+    val work = createIdentifiedWorkWith(
       items = createItems(count = 1)
     )
 
@@ -39,18 +32,10 @@ class DisplayWorkV2Test extends FunSpec with Matchers with ItemsUtil {
     displayItem.id shouldBe work.items.head.canonicalId
   }
 
-  val sourceIdentifier = SourceIdentifier(
-    identifierType = IdentifierType("sierra-system-number"),
-    ontologyType = "Work",
-    value = "b1234567"
-  )
-
   it("correctly parses a work without any extra identifiers") {
-    val work = IdentifiedWork(
-      title = "An irascible iguana invites impudence",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
-      canonicalId = "xtsx8hwk")
+    val work = createIdentifiedWorkWith(
+      otherIdentifiers = List()
+    )
 
     val displayWork = DisplayWorkV2(
       work = work,
@@ -63,12 +48,8 @@ class DisplayWorkV2Test extends FunSpec with Matchers with ItemsUtil {
   it("gets the physicalDescription from a Work") {
     val physicalDescription = "A magnificent mural of magpies"
 
-    val work = IdentifiedWork(
-      title = "Moving a mighty mouse to Madagascar",
-      canonicalId = "mtc2wvrg",
-      sourceIdentifier = sourceIdentifier,
-      physicalDescription = Some(physicalDescription),
-      version = 1
+    val work = createIdentifiedWorkWith(
+      physicalDescription = Some(physicalDescription)
     )
 
     val displayWork = DisplayWorkV2(work)
@@ -86,12 +67,8 @@ class DisplayWorkV2Test extends FunSpec with Matchers with ItemsUtil {
       label = workType.label
     )
 
-    val work = IdentifiedWork(
-      title = "Moving a mighty mouse to Madagascar",
-      canonicalId = "mtc2wvrg",
-      sourceIdentifier = sourceIdentifier,
-      workType = Some(workType),
-      version = 1
+    val work = createIdentifiedWorkWith(
+      workType = Some(workType)
     )
 
     val displayWork = DisplayWorkV2(work)
@@ -101,12 +78,8 @@ class DisplayWorkV2Test extends FunSpec with Matchers with ItemsUtil {
   it("gets the extent from a Work") {
     val extent = "Bound in boxes of bark"
 
-    val work = IdentifiedWork(
-      title = "Brilliant beeches in Bucharest",
-      canonicalId = "bmnppscn",
-      sourceIdentifier = sourceIdentifier,
-      extent = Some(extent),
-      version = 1
+    val work = createIdentifiedWorkWith(
+      extent = Some(extent)
     )
 
     val displayWork = DisplayWorkV2(work)
@@ -119,12 +92,8 @@ class DisplayWorkV2Test extends FunSpec with Matchers with ItemsUtil {
       label = "British Sign Language"
     )
 
-    val work = IdentifiedWork(
-      title = "A largesse of leaping Libyan lions",
-      canonicalId = "lfk6nkje",
-      sourceIdentifier = sourceIdentifier,
-      language = Some(language),
-      version = 1
+    val work = createIdentifiedWorkWith(
+      language = Some(language)
     )
 
     val displayWork = DisplayWorkV2(work)
@@ -134,10 +103,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers with ItemsUtil {
   }
 
   it("extracts contributors from a Work") {
-    val work = IdentifiedWork(
-      canonicalId = "vc6zww4f",
-      title = "Vicarious victory for violet vampires",
-      sourceIdentifier = sourceIdentifier,
+    val work = createIdentifiedWorkWith(
       contributors = List(
         Contributor(
           agent = Identified(
@@ -158,8 +124,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers with ItemsUtil {
             ContributionRole(label = "Background location")
           )
         )
-      ),
-      version = 1
+      )
     )
 
     val displayWork =
@@ -202,11 +167,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers with ItemsUtil {
       function = Some(Concept("Manufacture"))
     )
 
-    val work = IdentifiedWork(
-      canonicalId = "ecgxstzd",
-      title = "Events entailing the exegesis of empires",
-      sourceIdentifier = sourceIdentifier,
-      version = 1,
+    val work = createIdentifiedWorkWith(
       production = List(productionEvent)
     )
 
@@ -252,10 +213,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers with ItemsUtil {
       ontologyType = "Concept"
     )
 
-    val work = IdentifiedWork(
-      canonicalId = "bmzwdx3t",
-      title = "Bizarre bees bounce below a basketball",
-      sourceIdentifier = sourceIdentifier,
+    val work = createIdentifiedWorkWith(
       contributors = List(
         Contributor(
           agent = Identified(
@@ -316,8 +274,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers with ItemsUtil {
             )
           )
         )
-      ),
-      version = 1
+      )
     )
 
     describe("omits identifiers if WorksIncludes.identifiers is false") {
@@ -356,7 +313,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers with ItemsUtil {
 
       it("on the top-level Work") {
         displayWork.identifiers shouldBe Some(
-          List(DisplayIdentifierV2(sourceIdentifier)))
+          List(DisplayIdentifierV2(work.sourceIdentifier)))
       }
 
       it("contributors") {

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
@@ -42,7 +42,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers with WorksUtil {
       includes = WorksIncludes(identifiers = true)
     )
     displayWork.identifiers shouldBe Some(
-      List(DisplayIdentifierV2(sourceIdentifier)))
+      List(DisplayIdentifierV2(work.sourceIdentifier)))
   }
 
   it("gets the physicalDescription from a Work") {

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -67,11 +67,18 @@ trait WorksUtil extends ItemsUtil {
       createIdentifiedInvisibleWork
     }
 
-  def createUnidentifiedWorkWith(): UnidentifiedWork =
+  def createUnidentifiedWorkWith(
+    sourceIdentifier: SourceIdentifier = createSourceIdentifier,
+    version: Int = 1,
+    contributors: List[Contributor[MaybeDisplayable[AbstractAgent]]] = List(),
+    items: List[Identifiable[Item]] = List()
+  ): UnidentifiedWork =
     UnidentifiedWork(
-      sourceIdentifier = createSourceIdentifier,
-      version = 1,
-      title = createTitle
+      sourceIdentifier = sourceIdentifier,
+      version = version,
+      title = createTitle,
+      contributors = contributors,
+      items = items
     )
 
   def createUnidentifiedWork: UnidentifiedWork = createUnidentifiedWorkWith()

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -79,7 +79,8 @@ trait WorksUtil extends ItemsUtil {
       version = 1
     )
 
-  def createUnidentifiedInvisibleWork: UnidentifiedInvisibleWork = createUnidentifiedInvisibleWorkWith()
+  def createUnidentifiedInvisibleWork: UnidentifiedInvisibleWork =
+    createUnidentifiedInvisibleWorkWith()
 
   def createIdentifiedInvisibleWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier
@@ -94,7 +95,9 @@ trait WorksUtil extends ItemsUtil {
     createIdentifiedInvisibleWorkWith()
 
   def createIdentifiedInvisibleWorks(count: Int): Seq[IdentifiedInvisibleWork] =
-    (1 to count).map { _ => createIdentifiedInvisibleWork }
+    (1 to count).map { _ =>
+      createIdentifiedInvisibleWork
+    }
 
   def createUnidentifiedWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -74,10 +74,16 @@ trait WorksUtil extends ItemsUtil {
     title: String = createTitle,
     workType: Option[WorkType] = None,
     description: Option[String] = None,
+    physicalDescription: Option[String] = None,
+    extent: Option[String] = None,
     lettering: Option[String] = None,
     createdDate: Option[Period] = None,
+    subjects: List[Subject[Displayable[AbstractConcept]]] = List(),
+    genres: List[Genre[Displayable[AbstractConcept]]] = List(),
     contributors: List[Contributor[Displayable[AbstractAgent]]] = List(),
     thumbnail: Option[Location] = None,
+    production: List[ProductionEvent[Displayable[AbstractAgent]]] = List(),
+    language: Option[Language] = None,
     items: List[Identified[Item]] = List(),
     version: Int = 1
   ): IdentifiedWork =
@@ -88,10 +94,16 @@ trait WorksUtil extends ItemsUtil {
       title = title,
       workType = workType,
       description = description,
+      physicalDescription = physicalDescription,
+      extent = extent,
       lettering = lettering,
       createdDate = createdDate,
+      subjects = subjects,
+      genres = genres,
       contributors = contributors,
       thumbnail = thumbnail,
+      production = production,
+      language = language,
       items = items,
       version = version
     )

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -69,12 +69,14 @@ trait WorksUtil extends ItemsUtil {
 
   def createUnidentifiedWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
+    mergeCandidates: List[MergeCandidate] = List(),
     version: Int = 1,
     contributors: List[Contributor[MaybeDisplayable[AbstractAgent]]] = List(),
     items: List[Identifiable[Item]] = List()
   ): UnidentifiedWork =
     UnidentifiedWork(
       sourceIdentifier = sourceIdentifier,
+      mergeCandidates = mergeCandidates,
       version = version,
       title = createTitle,
       contributors = contributors,

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -84,15 +84,6 @@ trait WorksUtil extends ItemsUtil {
   def createIdentifiedInvisibleWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier
   ): IdentifiedInvisibleWork =
-    UnidentifiedInvisibleWork(
-      sourceIdentifier = sourceIdentifier,
-      version = 1
-    )
-
-  def createIdentifiedInvisibleWorks(count: Int): Seq[IdentifiedInvisibleWork] =
-    (1 to count).map { _ => createIdentifiedInvisibleWork }
-
-  def createIdentifiedInvisibleWork: IdentifiedInvisibleWork =
     IdentifiedInvisibleWork(
       sourceIdentifier = sourceIdentifier,
       version = 1,
@@ -103,9 +94,7 @@ trait WorksUtil extends ItemsUtil {
     createIdentifiedInvisibleWorkWith()
 
   def createIdentifiedInvisibleWorks(count: Int): Seq[IdentifiedInvisibleWork] =
-    (1 to count).map { _ =>
-      createIdentifiedInvisibleWork
-    }
+    (1 to count).map { _ => createIdentifiedInvisibleWork }
 
   def createUnidentifiedWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -67,6 +67,15 @@ trait WorksUtil extends ItemsUtil {
       createIdentifiedInvisibleWork
     }
 
+  def createUnidentifiedWorkWith(): UnidentifiedWork =
+    UnidentifiedWork(
+      sourceIdentifier = createSourceIdentifier,
+      version = 1,
+      title = createTitle
+    )
+
+  def createUnidentifiedWork: UnidentifiedWork = createUnidentifiedWorkWith()
+
   def createIdentifiedWorkWith(
     canonicalId: String = createCanonicalId,
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -59,6 +59,18 @@ trait WorksUtil extends ItemsUtil {
       )
     )
 
+  def createIdentifiedRedirectedWorkWith(
+    sourceIdentifier: SourceIdentifier = createSourceIdentifier
+  ): IdentifiedRedirectedWork =
+    IdentifiedRedirectedWork(
+      canonicalId = createCanonicalId,
+      sourceIdentifier = sourceIdentifier,
+      version = 1,
+      redirect = IdentifiedRedirect(
+        canonicalId = createCanonicalId
+      )
+    )
+
   def createUnidentifiedInvisibleWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier
   ): UnidentifiedInvisibleWork =

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -50,9 +50,24 @@ trait WorksUtil extends ItemsUtil {
     "sourceIdentifierFromWorksUtil"
   )
 
+  def createUnidentifiedInvisibleWorkWith(
+    sourceIdentifier: SourceIdentifier = createSourceIdentifier
+  ): UnidentifiedInvisibleWork =
+    UnidentifiedInvisibleWork(
+      sourceIdentifier = sourceIdentifier,
+      version = 1
+    )
+
+  def createUnidentifiedInvisibleWork: UnidentifiedInvisibleWork = createUnidentifiedInvisibleWorkWith()
+
   def createIdentifiedInvisibleWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier
   ): IdentifiedInvisibleWork =
+
+  def createIdentifiedInvisibleWorks(count: Int): Seq[IdentifiedInvisibleWork] =
+    (1 to count).map { _ => createIdentifiedInvisibleWork }
+
+  def createIdentifiedInvisibleWork: IdentifiedInvisibleWork =
     IdentifiedInvisibleWork(
       sourceIdentifier = sourceIdentifier,
       version = 1,
@@ -69,17 +84,26 @@ trait WorksUtil extends ItemsUtil {
 
   def createUnidentifiedWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    mergeCandidates: List[MergeCandidate] = List(),
     version: Int = 1,
+    title: String = createTitle,
+    otherIdentifiers: List[SourceIdentifier] = List(),
+    mergeCandidates: List[MergeCandidate] = List(),
+    description: Option[String] = None,
+    lettering: Option[String] = None,
     contributors: List[Contributor[MaybeDisplayable[AbstractAgent]]] = List(),
+    production: List[ProductionEvent[MaybeDisplayable[AbstractAgent]]] = List(),
     items: List[Identifiable[Item]] = List()
   ): UnidentifiedWork =
     UnidentifiedWork(
       sourceIdentifier = sourceIdentifier,
-      mergeCandidates = mergeCandidates,
       version = version,
-      title = createTitle,
+      title = title,
+      otherIdentifiers = otherIdentifiers,
+      mergeCandidates = mergeCandidates,
+      description = description,
+      lettering = lettering,
       contributors = contributors,
+      production = production,
       items = items
     )
 

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -84,6 +84,10 @@ trait WorksUtil extends ItemsUtil {
   def createIdentifiedInvisibleWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier
   ): IdentifiedInvisibleWork =
+    UnidentifiedInvisibleWork(
+      sourceIdentifier = sourceIdentifier,
+      version = 1
+    )
 
   def createIdentifiedInvisibleWorks(count: Int): Seq[IdentifiedInvisibleWork] =
     (1 to count).map { _ => createIdentifiedInvisibleWork }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -50,6 +50,15 @@ trait WorksUtil extends ItemsUtil {
     "sourceIdentifierFromWorksUtil"
   )
 
+  def createUnidentifiedRedirectedWork: UnidentifiedRedirectedWork =
+    UnidentifiedRedirectedWork(
+      sourceIdentifier = createSourceIdentifier,
+      version = 1,
+      redirect = IdentifiableRedirect(
+        sourceIdentifier = createSourceIdentifier
+      )
+    )
+
   def createUnidentifiedInvisibleWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier
   ): UnidentifiedInvisibleWork =


### PR DESCRIPTION
Another pieces sound out from #2335, and follows #2349.

If we’re going to remove all the defaults from the Work/UnidentifiedWork/… constructors, we need to use them in as few places as possible – hence the helpers on `WorksUtil`.

This patch gets all (?) the places where we construct an instance of a Work subclass in the tests, and replaces them with helpers in WorksUtil.