### PR TITLE
Make transformer tests a bit better

### DIFF
--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
@@ -115,7 +115,8 @@ class NotificationMessageReceiverTest
               snsMessages.size should be >= 1
 
               snsMessages.map { snsMessage =>
-                get[UnidentifiedWork](snsMessage)
+                val work = get[TransformedBaseWork](snsMessage)
+                work shouldBe a[UnidentifiedWork]
                 snsMessage.subject shouldBe "source: NotificationMessageReceiver.publishMessage"
               }
             }
@@ -162,12 +163,14 @@ class NotificationMessageReceiverTest
               snsMessages.size should be >= 1
 
               snsMessages.map { snsMessage =>
-                val actualWork = get[UnidentifiedWork](snsMessage)
+                val actualWork = get[TransformedBaseWork](snsMessage)
+                actualWork shouldBe a[UnidentifiedWork]
+                val unidentifiedWork = actualWork.asInstanceOf[UnidentifiedWork]
 
-                actualWork.title shouldBe title
-                actualWork.sourceIdentifier shouldBe sourceIdentifier
-                actualWork.version shouldBe version
-                actualWork.identifiers shouldBe List(
+                unidentifiedWork.title shouldBe title
+                unidentifiedWork.sourceIdentifier shouldBe sourceIdentifier
+                unidentifiedWork.version shouldBe version
+                unidentifiedWork.identifiers shouldBe List(
                   sourceIdentifier,
                   sierraIdentifier)
 


### PR DESCRIPTION
This is the same error I had in the id minter tests which prevented me to realise the id minter would not work with the InvisibleWork change. Applications downstream always decode using the more general trait type, rather than the specific extending type, because they don't know it. This relies on the type discriminator being set correctly in the json. 
So, I think it's good practice to test the messages sent in a way that makes sure downstream apps can decode it