### PR TITLE
Tidy up direct apply of SourceIdentifier in our tests

### DIFF
--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -331,13 +331,9 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
     "includes a list of identifiers on a single work endpoint if we pass ?includes=identifiers") {
     withApiFixtures(ApiVersions.v1) {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-        val srcIdentifier = SourceIdentifier(
-          identifierType = IdentifierType("miro-image-number"),
-          ontologyType = "Work",
-          value = "Test1234"
-        )
+        val otherIdentifier = createSourceIdentifier
         val work = createIdentifiedWorkWith(
-          otherIdentifiers = List(srcIdentifier)
+          otherIdentifiers = List(otherIdentifier)
         )
         insertIntoElasticsearch(indexNameV1, itemType, work)
 
@@ -353,7 +349,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
                  | "title": "${work.title}",
                  | "creators": [ ],
                  | "identifiers": [ ${identifier(work.sourceIdentifier)}, ${identifier(
-                                srcIdentifier)} ],
+                                otherIdentifier)} ],
                  | "subjects": [ ],
                  | "genres": [ ],
                  | "publishers": [ ],

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -321,13 +321,9 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
     "includes a list of identifiers on a single work endpoint if we pass ?includes=identifiers") {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-        val srcIdentifier = SourceIdentifier(
-          identifierType = IdentifierType("miro-image-number"),
-          ontologyType = "Work",
-          value = "Test1234"
-        )
+        val otherIdentifier = createSourceIdentifier
         val work = createIdentifiedWorkWith(
-          otherIdentifiers = List(srcIdentifier)
+          otherIdentifiers = List(otherIdentifier)
         )
         insertIntoElasticsearch(indexNameV2, itemType, work)
 
@@ -343,7 +339,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                | "title": "${work.title}",
                | "contributors": [ ],
                | "identifiers": [ ${identifier(work.sourceIdentifier)}, ${identifier(
-                                srcIdentifier)} ],
+                                otherIdentifier)} ],
                | "subjects": [ ],
                | "genres": [ ],
                | "production": [ ]

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/models/Identifier.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/models/Identifier.scala
@@ -20,7 +20,8 @@ object Identifier {
       SourceId = rs.string(p.resultName.SourceId)
     )
 
-  def apply(canonicalId: String, sourceIdentifier: SourceIdentifier): Identifier =
+  def apply(canonicalId: String,
+            sourceIdentifier: SourceIdentifier): Identifier =
     Identifier(
       CanonicalId = canonicalId,
       OntologyType = sourceIdentifier.ontologyType,

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/models/Identifier.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/models/Identifier.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.idminter.models
 
 import scalikejdbc._
+import uk.ac.wellcome.models.work.internal.SourceIdentifier
 
 /** Represents a set of identifiers as stored in MySQL */
 case class Identifier(
@@ -17,5 +18,13 @@ object Identifier {
       OntologyType = rs.string(p.resultName.OntologyType),
       SourceSystem = rs.string(p.resultName.SourceSystem),
       SourceId = rs.string(p.resultName.SourceId)
+    )
+
+  def apply(canonicalId: String, sourceIdentifier: SourceIdentifier): Identifier =
+    Identifier(
+      CanonicalId = canonicalId,
+      OntologyType = sourceIdentifier.ontologyType,
+      SourceSystem = sourceIdentifier.identifierType.id,
+      SourceId = sourceIdentifier.value
     )
 }

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -95,9 +95,7 @@ class IdentifiersDaoTest
             select
               .from(identifiersTable as identifiersTable.i)
               .where
-              .eq(
-                identifiersTable.i.SourceSystem,
-                identifier.SourceSystem)
+              .eq(identifiersTable.i.SourceSystem, identifier.SourceSystem)
               .and
               .eq(identifiersTable.i.CanonicalId, identifier.CanonicalId)
           }.map(Identifier(identifiersTable.i)).single.apply()

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.idminter.database
 import org.scalatest.{FunSpec, Matchers}
 import scalikejdbc._
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier}
+import uk.ac.wellcome.models.work.test.util.IdentifiersUtil
 import uk.ac.wellcome.platform.idminter.fixtures
 import uk.ac.wellcome.platform.idminter.models.{Identifier, IdentifiersTable}
 import uk.ac.wellcome.test.fixtures.TestWith
@@ -13,7 +13,8 @@ import scala.util.{Failure, Success}
 class IdentifiersDaoTest
     extends FunSpec
     with fixtures.IdentifiersDatabase
-    with Matchers {
+    with Matchers
+    with IdentifiersUtil {
 
   def withIdentifiersDao[R](
     testWith: TestWith[(IdentifiersDao, IdentifiersTable), R]): R =
@@ -35,21 +36,15 @@ class IdentifiersDaoTest
 
   describe("lookupID") {
     it("gets an Identifier if it finds a matching SourceSystem and SourceId") {
+      val sourceIdentifier = createSourceIdentifier
+      val identifier = Identifier(
+        canonicalId = createCanonicalId,
+        sourceIdentifier = sourceIdentifier
+      )
+
       withIdentifiersDao {
         case (identifiersDao, _) =>
-          val identifier = Identifier(
-            CanonicalId = "A turtle turns to try to taste",
-            SourceId = "A tangerine",
-            SourceSystem = IdentifierType("miro-image-number").id,
-            OntologyType = "t-t-t-turtles"
-          )
           identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
-
-          val sourceIdentifier = SourceIdentifier(
-            identifierType = IdentifierType("miro-image-number"),
-            identifier.OntologyType,
-            value = identifier.SourceId
-          )
 
           val triedLookup = identifiersDao.lookupId(
             sourceIdentifier = sourceIdentifier
@@ -61,25 +56,22 @@ class IdentifiersDaoTest
 
     it(
       "does not get an identifier if there is no matching SourceSystem and SourceId") {
+      val identifier = Identifier(
+        canonicalId = createCanonicalId,
+        sourceIdentifier = createSourceIdentifier
+      )
+
       withIdentifiersDao {
         case (identifiersDao, _) =>
-          val identifier = Identifier(
-            CanonicalId = "A turtle turns to try to taste",
-            SourceId = "A tangerine",
-            SourceSystem = IdentifierType("miro-image-number").id,
-            OntologyType = "t-t-t-turtles"
-          )
-
           identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
 
-          val sourceIdentifier = SourceIdentifier(
-            identifierType = IdentifierType("miro-image-number"),
-            identifier.OntologyType,
+          val unknownSourceIdentifier = createSourceIdentifierWith(
+            ontologyType = identifier.OntologyType,
             value = "not_an_existing_value"
           )
 
           val triedLookup = identifiersDao.lookupId(
-            sourceIdentifier = sourceIdentifier
+            sourceIdentifier = unknownSourceIdentifier
           )
 
           triedLookup shouldBe Success(None)
@@ -89,16 +81,15 @@ class IdentifiersDaoTest
 
   describe("saveIdentifier") {
     it("inserts the provided identifier into the database") {
+      val identifier = Identifier(
+        canonicalId = createCanonicalId,
+        sourceIdentifier = createSourceIdentifier
+      )
+
       withIdentifiersDao {
         case (identifiersDao, identifiersTable) =>
           implicit val session = AutoSession
 
-          val identifier = Identifier(
-            CanonicalId = "A provision of porpoises",
-            OntologyType = "Work",
-            SourceSystem = IdentifierType("miro-image-number").id,
-            SourceId = "A picture of pangolins"
-          )
           identifiersDao.saveIdentifier(identifier)
           val maybeIdentifier = withSQL {
             select
@@ -106,7 +97,7 @@ class IdentifiersDaoTest
               .where
               .eq(
                 identifiersTable.i.SourceSystem,
-                IdentifierType("miro-image-number").id)
+                identifier.SourceSystem)
               .and
               .eq(identifiersTable.i.CanonicalId, identifier.CanonicalId)
           }.map(Identifier(identifiersTable.i)).single.apply()
@@ -117,21 +108,17 @@ class IdentifiersDaoTest
     }
 
     it("fails to insert a record with a duplicate CanonicalId") {
+      val identifier = Identifier(
+        canonicalId = createCanonicalId,
+        sourceIdentifier = createSourceIdentifier
+      )
+      val duplicateIdentifier = Identifier(
+        canonicalId = identifier.CanonicalId,
+        sourceIdentifier = createSourceIdentifier
+      )
+
       withIdentifiersDao {
         case (identifiersDao, _) =>
-          val identifier = new Identifier(
-            CanonicalId = "A failed field of flowers",
-            SourceId = "A farm full of fruit",
-            SourceSystem = "France",
-            OntologyType = "Fruits"
-          )
-          val duplicateIdentifier = new Identifier(
-            CanonicalId = identifier.CanonicalId,
-            SourceId = "Fuel for a factory",
-            SourceSystem = "Space",
-            OntologyType = "Fuels"
-          )
-
           identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
 
           val triedSave = identifiersDao.saveIdentifier(duplicateIdentifier)
@@ -143,69 +130,74 @@ class IdentifiersDaoTest
 
     it(
       "saves records with the same SourceSystem and SourceId but different OntologyType") {
+      val sourceIdentifier1 = createSourceIdentifierWith(
+        ontologyType = "Foo"
+      )
+      val sourceIdentifier2 = createSourceIdentifierWith(
+        ontologyType = "Bar"
+      )
+
+      val identifier1 = Identifier(
+        canonicalId = createCanonicalId,
+        sourceIdentifier = sourceIdentifier1
+      )
+
+      val identifier2 = Identifier(
+        canonicalId = createCanonicalId,
+        sourceIdentifier = sourceIdentifier2
+      )
+
       withIdentifiersDao {
         case (identifiersDao, _) =>
-          val identifier = new Identifier(
-            CanonicalId = "A mountain of muesli",
-            SourceSystem = "A maize made of maze",
-            SourceId = "A maize made of maze",
-            OntologyType = "Cereals"
-          )
-
-          val secondIdentifier = new Identifier(
-            CanonicalId = "A mere mango",
-            SourceSystem = identifier.SourceSystem,
-            SourceId = "A maize made of maze",
-            OntologyType = "Fruits"
-          )
-
-          identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
-          identifiersDao.saveIdentifier(secondIdentifier) shouldBe Success(1)
+          identifiersDao.saveIdentifier(identifier1) shouldBe Success(1)
+          identifiersDao.saveIdentifier(identifier2) shouldBe Success(1)
       }
     }
 
     it(
       "saves records with different SourceId but the same OntologyType and SourceSystem") {
+      val sourceIdentifier1 = createSourceIdentifierWith(
+        value = "1234"
+      )
+      val sourceIdentifier2 = createSourceIdentifierWith(
+        value = "5678"
+      )
+
+      val identifier1 = Identifier(
+        canonicalId = createCanonicalId,
+        sourceIdentifier = sourceIdentifier1
+      )
+
+      val identifier2 = Identifier(
+        canonicalId = createCanonicalId,
+        sourceIdentifier = sourceIdentifier2
+      )
+
       withIdentifiersDao {
         case (identifiersDao, _) =>
-          val identifier = new Identifier(
-            CanonicalId = "Overflowing with okra",
-            SourceId = "Olive oil in an orchard",
-            SourceSystem = "A hedge maze in Loughborough",
-            OntologyType = "Crops"
-          )
-          val secondIdentifier = new Identifier(
-            CanonicalId = "An order of onions",
-            SourceId = "Only orange orbs",
-            SourceSystem = "A hedge maze in Loughborough",
-            OntologyType = identifier.OntologyType
-          )
-
-          identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
-          identifiersDao.saveIdentifier(secondIdentifier) shouldBe Success(1)
+          identifiersDao.saveIdentifier(identifier1) shouldBe Success(1)
+          identifiersDao.saveIdentifier(identifier2) shouldBe Success(1)
       }
     }
 
     it(
       "does not insert records with the same SourceId, SourceSystem and OntologyType") {
+      val sourceIdentifier = createSourceIdentifier
+
+      val identifier1 = Identifier(
+        canonicalId = createCanonicalId,
+        sourceIdentifier = sourceIdentifier
+      )
+      val identifier2 = Identifier(
+        canonicalId = createCanonicalId,
+        sourceIdentifier = sourceIdentifier
+      )
+
       withIdentifiersDao {
         case (identifiersDao, _) =>
-          val identifier = new Identifier(
-            CanonicalId = "A surplus of strawberries",
-            SourceId = "Sunflower seeds in a sack",
-            SourceSystem = "The microscopic world of eyelash lice",
-            OntologyType = "Cropssss"
-          )
-          val duplicateIdentifier = new Identifier(
-            CanonicalId = "Sweeteners and sugar cane",
-            SourceId = identifier.SourceId,
-            SourceSystem = identifier.SourceSystem,
-            OntologyType = identifier.OntologyType
-          )
+          identifiersDao.saveIdentifier(identifier1) shouldBe Success(1)
 
-          identifiersDao.saveIdentifier(identifier) shouldBe Success(1)
-
-          val triedSave = identifiersDao.saveIdentifier(duplicateIdentifier)
+          val triedSave = identifiersDao.saveIdentifier(identifier2)
 
           triedSave shouldBe a[Failure[_]]
           triedSave.failed.get shouldBe a[GracefulFailureException]

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -39,23 +39,14 @@ class IdEmbedderTests
   }
 
   it("sets the canonicalId given by the IdentifierGenerator on the work") {
-    val identifier = SourceIdentifier(
-      identifierType = IdentifierType("miro-image-number"),
-      ontologyType = "Work",
-      value = "1234"
-    )
-
-    val originalWork = createUnidentifiedWorkWith(
-      sourceIdentifier = identifier
-    )
-
-    val newCanonicalId = "5467"
+    val originalWork = createUnidentifiedWork
+    val newCanonicalId = createCanonicalId
 
     withIdEmbedder {
       case (identifierGenerator, idEmbedder) =>
         setUpIdentifierGeneratorMock(
           mockIdentifierGenerator = identifierGenerator,
-          sourceIdentifier = identifier,
+          sourceIdentifier = originalWork.sourceIdentifier,
           ontologyType = originalWork.ontologyType,
           newCanonicalId = newCanonicalId
         )
@@ -83,10 +74,8 @@ class IdEmbedderTests
   }
 
   it("mints identifiers for creators in work") {
-    val creatorIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("lc-names"),
-      ontologyType = "Person",
-      value = "1234"
+    val creatorIdentifier = createSourceIdentifierWith(
+      ontologyType = "Person"
     )
 
     val person = Person(label = "The Librarian")
@@ -170,10 +159,8 @@ class IdEmbedderTests
   }
 
   it("adds canonicalIds to all items") {
-    val identifier = SourceIdentifier(
-      identifierType = IdentifierType("miro-image-number"),
-      ontologyType = "Item",
-      value = "1234"
+    val identifier = createSourceIdentifierWith(
+      ontologyType = "Item"
     )
 
     val originalItem1 = Identifiable(
@@ -182,10 +169,8 @@ class IdEmbedderTests
     )
 
     val originalItem2 = Identifiable(
-      sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("miro-image-number"),
-        ontologyType = "Item",
-        value = "1235"
+      sourceIdentifier = createSourceIdentifierWith(
+        ontologyType = "Item"
       ),
       agent = Item(locations = List())
     )
@@ -308,23 +293,17 @@ class IdEmbedderTests
   describe("identifiable objects should be updated correctly") {
 
     it("identify a document that is Identifiable") {
-
-      val ontologyType = "false capitals"
-      val sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("miro-image-number"),
-        ontologyType = ontologyType,
-        "sydney"
+      val sourceIdentifier = createSourceIdentifierWith(
+        ontologyType = "false capitals"
       )
-
-      val newCanonicalId =
-        generateMockCanonicalId(sourceIdentifier, ontologyType)
+      val newCanonicalId = createCanonicalId
 
       withIdEmbedder {
         case (identifierGenerator, idEmbedder) =>
           setUpIdentifierGeneratorMock(
             mockIdentifierGenerator = identifierGenerator,
             sourceIdentifier = sourceIdentifier,
-            ontologyType = ontologyType,
+            ontologyType = sourceIdentifier.ontologyType,
             newCanonicalId = newCanonicalId
           )
 
@@ -336,10 +315,10 @@ class IdEmbedderTests
               "label": "${sourceIdentifier.identifierType.label}",
               "ontologyType": "${sourceIdentifier.identifierType.ontologyType}"
             },
-            "ontologyType": "$ontologyType",
+            "ontologyType": "${sourceIdentifier.ontologyType}",
             "value": "${sourceIdentifier.value}"
           },
-          "ontologyType": "$ontologyType"
+          "ontologyType": "${sourceIdentifier.ontologyType}"
         }
         """
 
@@ -352,10 +331,10 @@ class IdEmbedderTests
               "label": "${sourceIdentifier.identifierType.label}",
               "ontologyType": "${sourceIdentifier.identifierType.ontologyType}"
             },
-            "ontologyType": "$ontologyType",
+            "ontologyType": "${sourceIdentifier.ontologyType}",
             "value": "${sourceIdentifier.value}"
           },
-          "ontologyType": "$ontologyType"
+          "ontologyType": "${sourceIdentifier.ontologyType}"
         }
         """
 
@@ -368,25 +347,18 @@ class IdEmbedderTests
     }
 
     it("identify a document with a key that is identifiable") {
-      val ontologyType = "fictional cities"
-
-      val sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("miro-image-number"),
-        ontologyType = ontologyType,
-        "king's landing"
+      val sourceIdentifier = createSourceIdentifierWith(
+        ontologyType = "fictional cities"
       )
 
-      val newCanonicalId = generateMockCanonicalId(
-        sourceIdentifier,
-        ontologyType
-      )
+      val newCanonicalId = createCanonicalId
 
       withIdEmbedder {
         case (identifierGenerator, idEmbedder) =>
           setUpIdentifierGeneratorMock(
             mockIdentifierGenerator = identifierGenerator,
             sourceIdentifier = sourceIdentifier,
-            ontologyType = ontologyType,
+            ontologyType = sourceIdentifier.ontologyType,
             newCanonicalId = newCanonicalId
           )
 
@@ -401,10 +373,10 @@ class IdEmbedderTests
                 "label": "${sourceIdentifier.identifierType.label}",
                 "ontologyType": "${sourceIdentifier.identifierType.ontologyType}"
               },
-              "ontologyType": "$ontologyType",
+              "ontologyType": "${sourceIdentifier.ontologyType}",
               "value": "${sourceIdentifier.value}"
             },
-            "ontologyType": "$ontologyType"
+            "ontologyType": "${sourceIdentifier.ontologyType}"
           }
         }
         """
@@ -421,10 +393,10 @@ class IdEmbedderTests
                 "label": "${sourceIdentifier.identifierType.label}",
                 "ontologyType": "${sourceIdentifier.identifierType.ontologyType}"
               },
-              "ontologyType": "$ontologyType",
+              "ontologyType": "${sourceIdentifier.ontologyType}",
               "value": "${sourceIdentifier.value}"
             },
-            "ontologyType": "$ontologyType"
+            "ontologyType": "${sourceIdentifier.ontologyType}"
           }
         }
         """
@@ -439,22 +411,18 @@ class IdEmbedderTests
   }
 
   it("sets the new type if the field identifiedType is present") {
-    val ontologyType = "false capitals"
-    val sourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("miro-image-number"),
-      ontologyType = ontologyType,
-      "sydney"
+    val sourceIdentifier = createSourceIdentifierWith(
+      ontologyType = "false capitals"
     )
 
-    val newCanonicalId =
-      generateMockCanonicalId(sourceIdentifier, ontologyType)
+    val newCanonicalId = createCanonicalId
 
     withIdEmbedder {
       case (identifierGenerator, idEmbedder) =>
         setUpIdentifierGeneratorMock(
           mockIdentifierGenerator = identifierGenerator,
           sourceIdentifier = sourceIdentifier,
-          ontologyType = ontologyType,
+          ontologyType = sourceIdentifier.ontologyType,
           newCanonicalId = newCanonicalId
         )
 
@@ -466,11 +434,11 @@ class IdEmbedderTests
               "label": "${sourceIdentifier.identifierType.label}",
               "ontologyType": "${sourceIdentifier.identifierType.ontologyType}"
             },
-            "ontologyType": "$ontologyType",
+            "ontologyType": "${sourceIdentifier.ontologyType}",
             "value": "${sourceIdentifier.value}"
           },
           "identifiedType": "NewType",
-          "ontologyType": "$ontologyType"
+          "ontologyType": "${sourceIdentifier.ontologyType}"
         }
         """
 
@@ -483,11 +451,11 @@ class IdEmbedderTests
               "label": "${sourceIdentifier.identifierType.label}",
               "ontologyType": "${sourceIdentifier.identifierType.ontologyType}"
             },
-            "ontologyType": "$ontologyType",
+            "ontologyType": "${sourceIdentifier.ontologyType}",
             "value": "${sourceIdentifier.value}"
           },
           "type": "NewType",
-          "ontologyType": "$ontologyType"
+          "ontologyType": "${sourceIdentifier.ontologyType}"
         }
         """
 
@@ -498,12 +466,6 @@ class IdEmbedderTests
         }
     }
   }
-
-  def generateMockCanonicalId(
-    sourceIdentifier: SourceIdentifier,
-    ontologyType: String
-  ): String =
-    s"${sourceIdentifier.identifierType.id}==${sourceIdentifier.value}"
 
   private def setUpIdentifierGeneratorMock(
     mockIdentifierGenerator: IdentifierGenerator,

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -98,9 +98,8 @@ class IdentifierGeneratorTest
 
         maybeIdentifier shouldBe defined
         maybeIdentifier.get shouldBe Identifier(
-          CanonicalId = id,
-          SourceSystem = sourceIdentifier.identifierType.id,
-          SourceId = sourceIdentifier.value
+          canonicalId = id,
+          sourceIdentifier = sourceIdentifier
         )
     }
   }
@@ -162,10 +161,8 @@ class IdentifierGeneratorTest
 
         maybeIdentifier shouldBe defined
         maybeIdentifier.get shouldBe Identifier(
-          CanonicalId = id,
-          SourceSystem = sourceIdentifier.identifierType.id,
-          SourceId = sourceIdentifier.value,
-          OntologyType = sourceIdentifier.ontologyType
+          canonicalId = id,
+          sourceIdentifier = sourceIdentifier
         )
     }
   }

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -6,7 +6,10 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import scalikejdbc._
 import uk.ac.wellcome.models.work.test.util.IdentifiersUtil
-import uk.ac.wellcome.platform.idminter.database.{IdentifiersDao, TableProvisioner}
+import uk.ac.wellcome.platform.idminter.database.{
+  IdentifiersDao,
+  TableProvisioner
+}
 import uk.ac.wellcome.platform.idminter.fixtures
 import uk.ac.wellcome.platform.idminter.models.{Identifier, IdentifiersTable}
 import uk.ac.wellcome.test.fixtures.TestWith

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -5,11 +5,8 @@ import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import scalikejdbc._
-import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier}
-import uk.ac.wellcome.platform.idminter.database.{
-  IdentifiersDao,
-  TableProvisioner
-}
+import uk.ac.wellcome.models.work.test.util.IdentifiersUtil
+import uk.ac.wellcome.platform.idminter.database.{IdentifiersDao, TableProvisioner}
 import uk.ac.wellcome.platform.idminter.fixtures
 import uk.ac.wellcome.platform.idminter.models.{Identifier, IdentifiersTable}
 import uk.ac.wellcome.test.fixtures.TestWith
@@ -20,7 +17,8 @@ class IdentifierGeneratorTest
     extends FunSpec
     with fixtures.IdentifiersDatabase
     with Matchers
-    with MockitoSugar {
+    with MockitoSugar
+    with IdentifiersUtil {
 
   def withIdentifierGenerator[R](maybeIdentifiersDao: Option[IdentifiersDao] =
                                    None)(
@@ -45,6 +43,9 @@ class IdentifierGeneratorTest
     }
 
   it("queries the database and return a matching canonical id") {
+    val sourceIdentifier = createSourceIdentifier
+    val canonicalId = createCanonicalId
+
     withIdentifierGenerator() {
       case (identifierGenerator, identifiersTable) =>
         implicit val session = AutoSession
@@ -53,35 +54,30 @@ class IdentifierGeneratorTest
           insert
             .into(identifiersTable)
             .namedValues(
-              identifiersTable.column.CanonicalId -> "5678",
-              identifiersTable.column.SourceSystem -> IdentifierType(
-                "miro-image-number").id,
-              identifiersTable.column.SourceId -> "1234",
-              identifiersTable.column.OntologyType -> "Work"
+              identifiersTable.column.CanonicalId -> canonicalId,
+              identifiersTable.column.SourceSystem -> sourceIdentifier.identifierType.id,
+              identifiersTable.column.SourceId -> sourceIdentifier.value,
+              identifiersTable.column.OntologyType -> sourceIdentifier.ontologyType
             )
         }.update().apply()
 
         val triedId = identifierGenerator.retrieveOrGenerateCanonicalId(
-          SourceIdentifier(
-            identifierType = IdentifierType("miro-image-number"),
-            "Work",
-            "1234")
+          sourceIdentifier
         )
 
-        triedId shouldBe Success("5678")
+        triedId shouldBe Success(canonicalId)
     }
   }
 
   it("generates and saves a new identifier") {
+    val sourceIdentifier = createSourceIdentifier
+
     withIdentifierGenerator() {
       case (identifierGenerator, identifiersTable) =>
         implicit val session = AutoSession
 
         val triedId = identifierGenerator.retrieveOrGenerateCanonicalId(
-          SourceIdentifier(
-            identifierType = IdentifierType("miro-image-number"),
-            "Work",
-            "1234")
+          sourceIdentifier
         )
 
         triedId shouldBe a[Success[_]]
@@ -96,15 +92,15 @@ class IdentifierGeneratorTest
           select
             .from(identifiersTable as i)
             .where
-            .eq(i.SourceId, "1234")
+            .eq(i.SourceId, sourceIdentifier.value)
 
         }.map(Identifier(i)).single.apply()
 
         maybeIdentifier shouldBe defined
         maybeIdentifier.get shouldBe Identifier(
           CanonicalId = id,
-          SourceSystem = IdentifierType("miro-image-number").id,
-          SourceId = "1234"
+          SourceSystem = sourceIdentifier.identifierType.id,
+          SourceId = sourceIdentifier.value
         )
     }
   }
@@ -112,11 +108,7 @@ class IdentifierGeneratorTest
   it("returns a failure if it fails registering a new identifier") {
     val identifiersDao = mock[IdentifiersDao]
 
-    val sourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("miro-image-number"),
-      "Work",
-      value = "1234"
-    )
+    val sourceIdentifier = createSourceIdentifier
 
     val triedLookup = identifiersDao.lookupId(
       sourceIdentifier = sourceIdentifier
@@ -147,14 +139,12 @@ class IdentifierGeneratorTest
       case (identifierGenerator, identifiersTable) =>
         implicit val session = AutoSession
 
-        val ontologyType = "Item"
-        val miroId = "1234"
+        val sourceIdentifier = createSourceIdentifierWith(
+          ontologyType = "Item"
+        )
 
         val triedId = identifierGenerator.retrieveOrGenerateCanonicalId(
-          SourceIdentifier(
-            identifierType = IdentifierType("miro-image-number"),
-            ontologyType,
-            miroId)
+          sourceIdentifier
         )
 
         val id = triedId.get
@@ -166,16 +156,16 @@ class IdentifierGeneratorTest
           select
             .from(identifiersTable as i)
             .where
-            .eq(i.SourceId, miroId)
+            .eq(i.SourceId, sourceIdentifier.value)
 
         }.map(Identifier(i)).single.apply()
 
         maybeIdentifier shouldBe defined
         maybeIdentifier.get shouldBe Identifier(
           CanonicalId = id,
-          SourceSystem = IdentifierType("miro-image-number").id,
-          SourceId = miroId,
-          OntologyType = ontologyType
+          SourceSystem = sourceIdentifier.identifierType.id,
+          SourceId = sourceIdentifier.value,
+          OntologyType = sourceIdentifier.ontologyType
         )
     }
   }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -6,11 +6,7 @@ import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
-import uk.ac.wellcome.models.work.internal.{
-  IdentifiedBaseWork,
-  IdentifierType,
-  SourceIdentifier
-}
+import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
@@ -34,13 +30,7 @@ class IngestorFeatureTest
 
   it(
     "reads a miro identified work from the queue and ingests it in the v1 and v2 index") {
-    val sourceIdentifier =
-      SourceIdentifier(
-        identifierType = IdentifierType("miro-image-number"),
-        "Item",
-        "5678")
-
-    val work = createIdentifiedWorkWith(sourceIdentifier = sourceIdentifier)
+    val work = createIdentifiedWork
 
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
@@ -59,13 +49,11 @@ class IngestorFeatureTest
 
   it(
     "reads a sierra identified work from the queue and ingests it in the v2 index only") {
-    val sourceIdentifier =
-      SourceIdentifier(
-        identifierType = IdentifierType("sierra-system-number"),
-        "Item",
-        "5678")
-
-    val work = createIdentifiedWorkWith(sourceIdentifier = sourceIdentifier)
+    val work = createIdentifiedWorkWith(
+      sourceIdentifier = createSourceIdentifierWith(
+        identifierType = "sierra-system-number"
+      )
+    )
 
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.elasticsearch.{ElasticConfig, ElasticCredentials}
 import uk.ac.wellcome.messaging.message.MessageStream
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
-import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, Subject}
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.platform.ingestor.IngestorConfig
 import uk.ac.wellcome.platform.ingestor.fixtures.WorkIndexerFixtures
@@ -40,11 +40,7 @@ class IngestorWorkerServiceTest
   val itemType = "work"
 
   it("inserts an Miro identified Work into v1 and v2 indices") {
-    val miroSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("miro-image-number"),
-      ontologyType = "Work",
-      value = "M000765"
-    )
+    val miroSourceIdentifier = createSourceIdentifier
 
     val work = createIdentifiedWorkWith(sourceIdentifier = miroSourceIdentifier)
 
@@ -76,14 +72,11 @@ class IngestorWorkerServiceTest
   }
 
   it("inserts an Sierra identified Work only into the v2 index") {
-    val sierraSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("sierra-system-number"),
-      ontologyType = "Work",
-      value = "b1027467"
+    val work = createIdentifiedWorkWith(
+      sourceIdentifier = createSourceIdentifierWith(
+        identifierType = "sierra-system-number"
+      )
     )
-
-    val work =
-      createIdentifiedWorkWith(sourceIdentifier = sierraSourceIdentifier)
 
     withLocalElasticsearchIndex(itemType = itemType) { esIndexV1 =>
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
@@ -113,14 +106,10 @@ class IngestorWorkerServiceTest
   }
 
   it("inserts an Sierra identified invisible Work into the v2 index") {
-    val sierraSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("sierra-system-number"),
-      ontologyType = "Work",
-      value = "b1027467"
-    )
-
     val work = createIdentifiedInvisibleWorkWith(
-      sourceIdentifier = sierraSourceIdentifier
+      sourceIdentifier = createSourceIdentifierWith(
+        identifierType = "sierra-system-number"
+      )
     )
 
     withLocalElasticsearchIndex(itemType = itemType) { esIndexV1 =>
@@ -151,14 +140,10 @@ class IngestorWorkerServiceTest
   }
 
   it("inserts an Sierra identified redirected Work into the v2 index") {
-    val sierraSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("sierra-system-number"),
-      ontologyType = "Work",
-      value = "b1027467"
-    )
-
     val work = createIdentifiedRedirectedWorkWith(
-      sourceIdentifier = sierraSourceIdentifier
+      sourceIdentifier = createSourceIdentifierWith(
+        identifierType = "sierra-system-number"
+      )
     )
 
     withLocalElasticsearchIndex(itemType = itemType) { esIndexV1 =>
@@ -244,13 +229,11 @@ class IngestorWorkerServiceTest
   }
 
   it("fails inserting a non sierra or miro identified work") {
-    val calmSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("calm-altref-no"),
-      ontologyType = "Work",
-      value = "MS/237"
+    val work = createIdentifiedWorkWith(
+      sourceIdentifier = createSourceIdentifierWith(
+        identifierType = "calm-altref-no"
+      )
     )
-
-    val work = createIdentifiedWorkWith(sourceIdentifier = calmSourceIdentifier)
 
     withLocalElasticsearchIndex(itemType = itemType) { esIndexV1 =>
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
@@ -509,15 +492,7 @@ class IngestorWorkerServiceTest
                   actorSystem,
                   brokenWorkIndexer,
                   messageStream) { _ =>
-                  val miroSourceIdentifier = SourceIdentifier(
-                    identifierType = IdentifierType("miro-image-number"),
-                    ontologyType = "Work",
-                    value = "B000675"
-                  )
-
-                  val work =
-                    createIdentifiedWorkWith(
-                      sourceIdentifier = miroSourceIdentifier)
+                  val work = createIdentifiedWork
 
                   val messageBody = put[IdentifiedBaseWork](
                     obj = work,

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -175,16 +175,20 @@ class IngestorWorkerServiceTest
 
   it("inserts a mixture of miro and sierra works into the correct indices") {
     val miroWork1 = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(identifierType = "miro-image-number")
+      sourceIdentifier =
+        createSourceIdentifierWith(identifierType = "miro-image-number")
     )
     val miroWork2 = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(identifierType = "miro-image-number")
+      sourceIdentifier =
+        createSourceIdentifierWith(identifierType = "miro-image-number")
     )
     val sierraWork1 = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(identifierType = "sierra-system-number")
+      sourceIdentifier =
+        createSourceIdentifierWith(identifierType = "sierra-system-number")
     )
     val sierraWork2 = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(identifierType = "sierra-system-number")
+      sourceIdentifier =
+        createSourceIdentifierWith(identifierType = "sierra-system-number")
     )
 
     val works = List(miroWork1, miroWork2, sierraWork1, sierraWork2)
@@ -260,13 +264,16 @@ class IngestorWorkerServiceTest
   it(
     "inserts a mixture of miro and sierra works into the correct indices and sends invalid messages to the dlq") {
     val miroWork = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(identifierType = "miro-image-number")
+      sourceIdentifier =
+        createSourceIdentifierWith(identifierType = "miro-image-number")
     )
     val sierraWork = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(identifierType = "sierra-system-number")
+      sourceIdentifier =
+        createSourceIdentifierWith(identifierType = "sierra-system-number")
     )
     val invalidWork = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(identifierType = "calm-altref-no")
+      sourceIdentifier =
+        createSourceIdentifierWith(identifierType = "calm-altref-no")
     )
 
     val works = List(miroWork, sierraWork, invalidWork)
@@ -314,10 +321,12 @@ class IngestorWorkerServiceTest
   it(
     "deletes successfully ingested works from the queue, including older versions of already ingested works") {
     val sierraWork = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(identifierType = "sierra-system-number")
+      sourceIdentifier =
+        createSourceIdentifierWith(identifierType = "sierra-system-number")
     )
     val newSierraWork = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(identifierType = "sierra-system-number"),
+      sourceIdentifier =
+        createSourceIdentifierWith(identifierType = "sierra-system-number"),
       version = 2
     )
     val oldSierraWork = newSierraWork.copy(version = 1)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -190,16 +190,16 @@ class IngestorWorkerServiceTest
 
   it("inserts a mixture of miro and sierra works into the correct indices") {
     val miroWork1 = createIdentifiedWorkWith(
-      sourceIdentifier = createIdentifier("miro-image-number", "M1")
+      sourceIdentifier = createSourceIdentifierWith(identifierType = "miro-image-number")
     )
     val miroWork2 = createIdentifiedWorkWith(
-      sourceIdentifier = createIdentifier("miro-image-number", "M2")
+      sourceIdentifier = createSourceIdentifierWith(identifierType = "miro-image-number")
     )
     val sierraWork1 = createIdentifiedWorkWith(
-      sourceIdentifier = createIdentifier("sierra-system-number", "S1")
+      sourceIdentifier = createSourceIdentifierWith(identifierType = "sierra-system-number")
     )
     val sierraWork2 = createIdentifiedWorkWith(
-      sourceIdentifier = createIdentifier("sierra-system-number", "S2")
+      sourceIdentifier = createSourceIdentifierWith(identifierType = "sierra-system-number")
     )
 
     val works = List(miroWork1, miroWork2, sierraWork1, sierraWork2)
@@ -277,13 +277,13 @@ class IngestorWorkerServiceTest
   it(
     "inserts a mixture of miro and sierra works into the correct indices and sends invalid messages to the dlq") {
     val miroWork = createIdentifiedWorkWith(
-      sourceIdentifier = createIdentifier("miro-image-number", "M")
+      sourceIdentifier = createSourceIdentifierWith(identifierType = "miro-image-number")
     )
     val sierraWork = createIdentifiedWorkWith(
-      sourceIdentifier = createIdentifier("sierra-system-number", "S2")
+      sourceIdentifier = createSourceIdentifierWith(identifierType = "sierra-system-number")
     )
     val invalidWork = createIdentifiedWorkWith(
-      sourceIdentifier = createIdentifier("calm-altref-no", "C1")
+      sourceIdentifier = createSourceIdentifierWith(identifierType = "calm-altref-no")
     )
 
     val works = List(miroWork, sierraWork, invalidWork)
@@ -331,10 +331,10 @@ class IngestorWorkerServiceTest
   it(
     "deletes successfully ingested works from the queue, including older versions of already ingested works") {
     val sierraWork = createIdentifiedWorkWith(
-      sourceIdentifier = createIdentifier("sierra-system-number", "s1"),
+      sourceIdentifier = createSourceIdentifierWith(identifierType = "sierra-system-number")
     )
     val newSierraWork = createIdentifiedWorkWith(
-      sourceIdentifier = createIdentifier("sierra-system-number", "s2"),
+      sourceIdentifier = createSourceIdentifierWith(identifierType = "sierra-system-number"),
       version = 2
     )
     val oldSierraWork = newSierraWork.copy(version = 1)
@@ -381,11 +381,8 @@ class IngestorWorkerServiceTest
     val subsetOfFieldsIndex =
       new SubsetOfFieldsWorksIndex(elasticClient, itemType)
 
-    val sierraWork = createIdentifiedWorkWith(
-      sourceIdentifier = createIdentifier("sierra-system-number", "s1")
-    )
+    val sierraWork = createIdentifiedWork
     val sierraWorkDoesNotMatchMapping = createIdentifiedWorkWith(
-      sourceIdentifier = createIdentifier("sierra-system-number", "s2"),
       subjects = List(Subject(label = "crystallography", concepts = Nil))
     )
 
@@ -433,11 +430,8 @@ class IngestorWorkerServiceTest
     val subsetOfFieldsIndex =
       new SubsetOfFieldsWorksIndex(elasticClient, itemType)
 
-    val miroWork = createIdentifiedWorkWith(
-      sourceIdentifier = createIdentifier("miro-image-number", "m1")
-    )
+    val miroWork = createIdentifiedWork
     val miroWorkDoesNotMatchV2Mapping = createIdentifiedWorkWith(
-      sourceIdentifier = createIdentifier("miro-image-number", "m2"),
       subjects = List(Subject(label = "crystallography", concepts = Nil))
     )
 
@@ -603,13 +597,5 @@ class IngestorWorkerServiceTest
     )
 
     testWith(ingestorWorkerService)
-  }
-
-  private def createIdentifier(identifierType: String, value: String) = {
-    SourceIdentifier(
-      identifierType = IdentifierType(identifierType),
-      ontologyType = "Work",
-      value = value
-    )
   }
 }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -3,11 +3,7 @@ package uk.ac.wellcome.platform.ingestor.services
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.models.work.internal.{
-  IdentifierType,
-  SourceIdentifier,
-  Subject
-}
+import uk.ac.wellcome.models.work.internal.Subject
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.platform.ingestor.fixtures.WorkIndexerFixtures
 
@@ -145,13 +141,8 @@ class WorkIndexerTest
     val subsetOfFieldsIndex =
       new SubsetOfFieldsWorksIndex(elasticClient, esType)
 
-    val validWorks = (1 to 5).map { _ =>
-      createIdentifiedWorkWith(
-        sourceIdentifier = createIdentifier("sierra-system-number", "s1")
-      )
-    }
+    val validWorks = createIdentifiedWorks(count = 5)
     val notMatchingMappingWork = createIdentifiedWorkWith(
-      sourceIdentifier = createIdentifier("miro-image-number", "not-matching"),
       subjects = List(Subject(label = "crystallography", concepts = Nil))
     )
 
@@ -177,13 +168,5 @@ class WorkIndexerTest
           }
         }
     }
-  }
-
-  private def createIdentifier(identifierType: String, value: String) = {
-    SourceIdentifier(
-      identifierType = IdentifierType(identifierType),
-      ontologyType = "Work",
-      value = value
-    )
   }
 }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -47,9 +47,9 @@ class MatcherFeatureTest
                   topic,
                   graphTable,
                   lockTable) { _ =>
-                  val work = createUnidentifiedWorkWith(
-                    sourceIdentifier = sourceIdentifierA
-                  )
+                  val work = createUnidentifiedWork
+                  val workId = s"${work.sourceIdentifier.identifierType.id}/${work.sourceIdentifier.value}"
+
                   val workSqsMessage: NotificationMessage =
                     hybridRecordNotificationMessage(
                       message = toJson(RecorderWorkEntry(work = work)).get,
@@ -72,7 +72,8 @@ class MatcherFeatureTest
 
                       identifiersList shouldBe
                         MatcherResult(Set(MatchedIdentifiers(
-                          Set(WorkIdentifier("sierra-system-number/A", 1)))))
+                          Set(WorkIdentifier(identifier = workId, version = 1))
+                        )))
                     }
                   }
                 }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -43,7 +43,8 @@ class MatcherFeatureTest
                   graphTable,
                   lockTable) { _ =>
                   val work = createUnidentifiedWork
-                  val workId = s"${work.sourceIdentifier.identifierType.id}/${work.sourceIdentifier.value}"
+                  val workId =
+                    s"${work.sourceIdentifier.identifierType.id}/${work.sourceIdentifier.value}"
 
                   val workSqsMessage: NotificationMessage =
                     hybridRecordNotificationMessage(
@@ -99,7 +100,8 @@ class MatcherFeatureTest
                   val workAv1 = createUnidentifiedWorkWith(
                     version = updatedWorkVersion
                   )
-                  val workId = s"${workAv1.sourceIdentifier.identifierType.id}/${workAv1.sourceIdentifier.value}"
+                  val workId =
+                    s"${workAv1.sourceIdentifier.identifierType.id}/${workAv1.sourceIdentifier.value}"
 
                   val existingWorkAv2 = WorkNode(
                     id = workId,

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -12,9 +12,7 @@ import uk.ac.wellcome.models.matcher.{
   WorkNode
 }
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
-import uk.ac.wellcome.models.work.internal.IdentifierType
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
-import uk.ac.wellcome.models.work.internal.SourceIdentifier
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.storage.vhs.HybridRecord

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -29,11 +29,6 @@ class MatcherFeatureTest
     with MatcherFixtures
     with WorksUtil {
 
-  val sourceIdentifierA = SourceIdentifier(
-    identifierType = IdentifierType("sierra-system-number"),
-    ontologyType = "Work",
-    value = "A")
-
   it("processes a message with a simple UnidentifiedWork with no linked works") {
     withLocalSnsTopic { topic =>
       withLocalSqsQueue { queue =>
@@ -101,18 +96,18 @@ class MatcherFeatureTest
                   val existingWorkVersion = 2
                   val updatedWorkVersion = 1
 
-                  val existingWorkAv2 = WorkNode(
-                    id = "sierra-system-number/A",
-                    version = existingWorkVersion,
-                    linkedIds = Nil,
-                    componentId = "sierra-system-number/A"
-                  )
-                  Scanamo.put(dynamoDbClient)(graphTable.name)(existingWorkAv2)
-
                   val workAv1 = createUnidentifiedWorkWith(
-                    sourceIdentifier = sourceIdentifierA,
                     version = updatedWorkVersion
                   )
+                  val workId = s"${workAv1.sourceIdentifier.identifierType.id}/${workAv1.sourceIdentifier.value}"
+
+                  val existingWorkAv2 = WorkNode(
+                    id = workId,
+                    version = existingWorkVersion,
+                    linkedIds = Nil,
+                    componentId = workId
+                  )
+                  Scanamo.put(dynamoDbClient)(graphTable.name)(existingWorkAv2)
 
                   val workSqsMessage: NotificationMessage =
                     hybridRecordNotificationMessage(

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -14,11 +14,7 @@ import uk.ac.wellcome.models.matcher.{
   WorkIdentifier,
   WorkNode
 }
-import uk.ac.wellcome.models.work.internal.{
-  IdentifierType,
-  MergeCandidate,
-  SourceIdentifier
-}
+import uk.ac.wellcome.models.work.internal.MergeCandidate
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.platform.matcher.locking.{
   DynamoRowLockDao,

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -77,7 +77,8 @@ class WorkMatcherTest
             withWorkMatcher(workGraphStore, lockTable, mockMetricsSender) {
               workMatcher =>
                 val invisibleWork = createUnidentifiedInvisibleWork
-                val workId = s"${invisibleWork.sourceIdentifier.identifierType.id}/${invisibleWork.sourceIdentifier.value}"
+                val workId =
+                  s"${invisibleWork.sourceIdentifier.identifierType.id}/${invisibleWork.sourceIdentifier.value}"
                 whenReady(workMatcher.matchWork(invisibleWork)) {
                   matcherResult =>
                     matcherResult shouldBe

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -76,16 +76,10 @@ class WorkMatcherTest
           withWorkGraphStore(graphTable) { workGraphStore =>
             withWorkMatcher(workGraphStore, lockTable, mockMetricsSender) {
               workMatcher =>
-                val invisibleWork = createUnidentifiedInvisibleWorkWith(
-                  sourceIdentifier = SourceIdentifier(
-                    IdentifierType("sierra-system-number"),
-                    "Work",
-                    "id")
-                )
+                val invisibleWork = createUnidentifiedInvisibleWork
+                val workId = s"${invisibleWork.sourceIdentifier.identifierType.id}/${invisibleWork.sourceIdentifier.value}"
                 whenReady(workMatcher.matchWork(invisibleWork)) {
                   matcherResult =>
-                    val workId = "sierra-system-number/id"
-
                     matcherResult shouldBe
                       MatcherResult(
                         Set(MatchedIdentifiers(Set(WorkIdentifier(workId, 1)))))

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
@@ -63,12 +63,14 @@ class MatcherMessageReceiverTest
         withLocalS3Bucket { storageBucket =>
           withMatcherMessageReceiver(queue, storageBucket, topic) { _ =>
             val invisibleWork = createUnidentifiedInvisibleWork
-            val workId = s"${invisibleWork.sourceIdentifier.identifierType.id}/${invisibleWork.sourceIdentifier.value}"
+            val workId =
+              s"${invisibleWork.sourceIdentifier.identifierType.id}/${invisibleWork.sourceIdentifier.value}"
             val expectedMatchedWorks =
               MatcherResult(
-                Set(MatchedIdentifiers(
-                  Set(WorkIdentifier(identifier = workId, version = 1))
-                ))
+                Set(
+                  MatchedIdentifiers(
+                    Set(WorkIdentifier(identifier = workId, version = 1))
+                  ))
               )
 
             sendSQS(queue, storageBucket, invisibleWork)

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
@@ -62,16 +62,14 @@ class MatcherMessageReceiverTest
       withLocalSqsQueue { queue =>
         withLocalS3Bucket { storageBucket =>
           withMatcherMessageReceiver(queue, storageBucket, topic) { _ =>
-            val invisibleWork = createUnidentifiedInvisibleWorkWith(
-              sourceIdentifier = SourceIdentifier(
-                IdentifierType("sierra-system-number"),
-                "Work",
-                "id")
-            )
+            val invisibleWork = createUnidentifiedInvisibleWork
+            val workId = s"${invisibleWork.sourceIdentifier.identifierType.id}/${invisibleWork.sourceIdentifier.value}"
             val expectedMatchedWorks =
               MatcherResult(
                 Set(MatchedIdentifiers(
-                  Set(WorkIdentifier("sierra-system-number/id", 1)))))
+                  Set(WorkIdentifier(identifier = workId, version = 1))
+                ))
+              )
 
             sendSQS(queue, storageBucket, invisibleWork)
             eventually {

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayAgentV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayAgentV1Test.scala
@@ -2,21 +2,15 @@ package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.models.work.internal.{
-  Agent,
-  Identified,
-  IdentifierType,
-  SourceIdentifier
-}
+import uk.ac.wellcome.models.work.internal.{Agent, Identified}
+import uk.ac.wellcome.models.work.test.util.IdentifiersUtil
 
-class DisplayAgentV1Test extends FunSpec with Matchers {
+class DisplayAgentV1Test extends FunSpec with Matchers with IdentifiersUtil {
   it("errors if you try to serialise from an identified Agent") {
     val agent = Identified(
       agent = Agent(label = "Henry Wellcome"),
-      canonicalId = "hw1234",
-      sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("lc-names"),
-        value = "lc-wellcome",
+      canonicalId = createCanonicalId,
+      sourceIdentifier = createSourceIdentifierWith(
         ontologyType = "Agent"
       ),
       otherIdentifiers = List()

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -197,11 +197,7 @@ class DisplayWorkV1SerialisationTest
   }
 
   it("includes a list of identifiers on DisplayWorkV1") {
-    val otherIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("miro-image-number"),
-      ontologyType = "Work",
-      value = "Test1234"
-    )
+    val otherIdentifier = createSourceIdentifier
     val work = createIdentifiedWorkWith(
       otherIdentifiers = List(otherIdentifier)
     )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
@@ -3,11 +3,13 @@ package uk.ac.wellcome.display.models.v2
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.test.util.IdentifiersUtil
 
 class DisplayAbstractConceptSerialisationTest
     extends FunSpec
     with DisplayV2SerialisationTestBase
-    with JsonMapperTestUtil {
+    with JsonMapperTestUtil
+    with IdentifiersUtil {
 
   it("serialises an unidentified DisplayConcept") {
     assertObjectMapsToJson(

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
@@ -60,10 +60,8 @@ class DisplayAbstractConceptSerialisationTest
   it("constructs a DisplayConcept from an identified Concept") {
     val concept = Identified(
       canonicalId = "uq4bt5us",
-      sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("lc-names"),
-        ontologyType = "Concept",
-        value = "lcsh/uq4"
+      sourceIdentifier = createSourceIdentifierWith(
+        ontologyType = "Concept"
       ),
       agent = Concept("conceptLabel")
     )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
@@ -2,8 +2,9 @@ package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.test.util.IdentifiersUtil
 
-class DisplayConceptTest extends FunSpec with Matchers {
+class DisplayConceptTest extends FunSpec with Matchers with IdentifiersUtil {
 
   it("reads an unidentified generic Concept as a DisplayConcept") {
     assertDisplayConceptIsCorrect(
@@ -39,10 +40,8 @@ class DisplayConceptTest extends FunSpec with Matchers {
   }
 
   it("reads an identified Concept as a DisplayConcept with identifiers") {
-    val sourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("lc-names"),
-      ontologyType = "Concept",
-      value = "lcsh/ehw"
+    val sourceIdentifier = createSourceIdentifierWith(
+      ontologyType = "Concept"
     )
 
     assertDisplayConceptIsCorrect(
@@ -60,10 +59,8 @@ class DisplayConceptTest extends FunSpec with Matchers {
   }
 
   it("reads an identified Period as a DisplayPeriod with identifiers") {
-    val sourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("lc-names"),
-      ontologyType = "Period",
-      value = "lcsh/zbm"
+    val sourceIdentifier = createSourceIdentifierWith(
+      ontologyType = "Period"
     )
 
     assertDisplayConceptIsCorrect(
@@ -81,10 +78,8 @@ class DisplayConceptTest extends FunSpec with Matchers {
   }
 
   it("reads an identified Place as a DisplayPlace with identifiers") {
-    val sourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("lc-names"),
-      ontologyType = "Place",
-      value = "lcsh/axt"
+    val sourceIdentifier = createSourceIdentifierWith(
+      ontologyType = "Place"
     )
 
     assertDisplayConceptIsCorrect(

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
@@ -3,20 +3,20 @@ package uk.ac.wellcome.display.models.v2
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.test.util.IdentifiersUtil
 
 class DisplayGenreV2SerialisationTest
     extends FunSpec
     with DisplayV2SerialisationTestBase
-    with JsonMapperTestUtil {
+    with JsonMapperTestUtil
+    with IdentifiersUtil {
 
   it("serialises a DisplayGenre constructed from a Genre correctly") {
     val concept0 = Unidentifiable(Concept("conceptLabel"))
     val concept1 = Unidentifiable(Place("placeLabel"))
     val concept2 = Identified(
-      canonicalId = "sqwyavpj",
-      sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("lc-names"),
-        value = "lcsh/sqw",
+      canonicalId = createCanonicalId,
+      sourceIdentifier = createSourceIdentifierWith(
         ontologyType = "Period"
       ),
       agent = Period("periodLabel")

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
@@ -3,20 +3,20 @@ package uk.ac.wellcome.display.models.v2
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.test.util.IdentifiersUtil
 
 class DisplaySubjectV2SerialisationTest
     extends FunSpec
     with DisplayV2SerialisationTestBase
-    with JsonMapperTestUtil {
+    with JsonMapperTestUtil
+    with IdentifiersUtil {
 
   it("serialises a DisplaySubject constructed from a Subject correctly") {
     val concept0 = Unidentifiable(Concept("conceptLabel"))
     val concept1 = Unidentifiable(Period("periodLabel"))
     val concept2 = Identified(
-      canonicalId = "p4xe8u22",
-      sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("lc-names"),
-        value = "lcsh/p4x",
+      canonicalId = createCanonicalId,
+      sourceIdentifier = createSourceIdentifierWith(
         ontologyType = "Place"
       ),
       agent = Place("placeLabel")

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -185,11 +185,7 @@ class DisplayWorkV2SerialisationTest
   }
 
   it("includes a list of identifiers on DisplayWorkV2") {
-    val otherIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("miro-image-number"),
-      ontologyType = "Work",
-      value = "Test1234"
-    )
+    val otherIdentifier = createSourceIdentifier
     val work = createIdentifiedWorkWith(
       otherIdentifiers = List(otherIdentifier)
     )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
@@ -108,11 +108,9 @@ class DisplayWorkV2Test extends FunSpec with Matchers with WorksUtil {
         Contributor(
           agent = Identified(
             Person(label = "Vlad the Vanquished"),
-            canonicalId = "vs7jd5dx",
-            sourceIdentifier = SourceIdentifier(
-              identifierType = IdentifierType("lc-names"),
-              ontologyType = "Person",
-              value = "v1"
+            canonicalId = createCanonicalId,
+            sourceIdentifier = createSourceIdentifierWith(
+              ontologyType = "Person"
             )
           )
         ),
@@ -133,15 +131,13 @@ class DisplayWorkV2Test extends FunSpec with Matchers with WorksUtil {
     displayWork.contributors shouldBe List(
       DisplayContributor(
         agent = DisplayPersonV2(
-          id = Some("vs7jd5dx"),
+          id = Some(createCanonicalId),
           label = "Vlad the Vanquished",
           identifiers = Some(
             List(
               DisplayIdentifierV2(
-                SourceIdentifier(
-                  identifierType = IdentifierType("lc-names"),
-                  ontologyType = "Person",
-                  value = "v1"
+                createSourceIdentifierWith(
+                  ontologyType = "Person"
                 )
               )
             ))
@@ -177,39 +173,27 @@ class DisplayWorkV2Test extends FunSpec with Matchers with WorksUtil {
   }
 
   describe("correctly uses the WorksIncludes.identifiers include") {
-    val contributorAgentSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("lc-names"),
-      value = "lcnames/007",
+    val contributorAgentSourceIdentifier = createSourceIdentifierWith(
       ontologyType = "Agent"
     )
 
-    val contributorPersonSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("lc-names"),
-      value = "lcnames/bla",
+    val contributorPersonSourceIdentifier = createSourceIdentifierWith(
       ontologyType = "Agent"
     )
 
-    val contributorOrganisationSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("lc-names"),
-      value = "lcnames/bus",
+    val contributorOrganisationSourceIdentifier = createSourceIdentifierWith(
       ontologyType = "Agent"
     )
 
-    val conceptSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("lc-subjects"),
-      value = "lcsh/bonds",
+    val conceptSourceIdentifier = createSourceIdentifierWith(
       ontologyType = "Concept"
     )
 
-    val periodSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("lc-subjects"),
-      value = "lcsh/before",
+    val periodSourceIdentifier = createSourceIdentifierWith(
       ontologyType = "Concept"
     )
 
-    val placeSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("lc-subjects"),
-      value = "lcsh/bul",
+    val placeSourceIdentifier = createSourceIdentifierWith(
       ontologyType = "Concept"
     )
 
@@ -218,7 +202,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers with WorksUtil {
         Contributor(
           agent = Identified(
             Agent(label = "Bond"),
-            canonicalId = "bcwth7yg",
+            canonicalId = createCanonicalId,
             sourceIdentifier = contributorAgentSourceIdentifier
           ),
           roles = List()
@@ -226,7 +210,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers with WorksUtil {
         Contributor(
           agent = Identified(
             Organisation(label = "Big Business"),
-            canonicalId = "bsf3kfwm",
+            canonicalId = createCanonicalId,
             sourceIdentifier = contributorOrganisationSourceIdentifier
           ),
           roles = List()
@@ -234,7 +218,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers with WorksUtil {
         Contributor(
           agent = Identified(
             Person(label = "Blue Blaise"),
-            canonicalId = "b5szcu3c",
+            canonicalId = createCanonicalId,
             sourceIdentifier = contributorPersonSourceIdentifier
           ),
           roles = List()
@@ -247,17 +231,17 @@ class DisplayWorkV2Test extends FunSpec with Matchers with WorksUtil {
           concepts = List(
             Identified(
               Concept("Bonding"),
-              canonicalId = "b5qsqkyh",
+              canonicalId = createCanonicalId,
               sourceIdentifier = conceptSourceIdentifier
             ),
             Identified(
               Period("Before"),
-              canonicalId = "bwn894hk",
+              canonicalId = createCanonicalId,
               sourceIdentifier = periodSourceIdentifier
             ),
             Identified(
               Place("Bulgaria"),
-              canonicalId = "bf42vqst",
+              canonicalId = createCanonicalId,
               sourceIdentifier = placeSourceIdentifier
             )
           )
@@ -269,7 +253,7 @@ class DisplayWorkV2Test extends FunSpec with Matchers with WorksUtil {
           concepts = List(
             Identified(
               Concept("Colours"),
-              canonicalId = "chzwu4ea",
+              canonicalId = createCanonicalId,
               sourceIdentifier = conceptSourceIdentifier
             )
           )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
@@ -103,15 +103,18 @@ class DisplayWorkV2Test extends FunSpec with Matchers with WorksUtil {
   }
 
   it("extracts contributors from a Work") {
+    val canonicalId = createCanonicalId
+    val sourceIdentifier = createSourceIdentifierWith(
+      ontologyType = "Person"
+    )
+
     val work = createIdentifiedWorkWith(
       contributors = List(
         Contributor(
           agent = Identified(
             Person(label = "Vlad the Vanquished"),
-            canonicalId = createCanonicalId,
-            sourceIdentifier = createSourceIdentifierWith(
-              ontologyType = "Person"
-            )
+            canonicalId = canonicalId,
+            sourceIdentifier = sourceIdentifier
           )
         ),
         Contributor(
@@ -131,16 +134,11 @@ class DisplayWorkV2Test extends FunSpec with Matchers with WorksUtil {
     displayWork.contributors shouldBe List(
       DisplayContributor(
         agent = DisplayPersonV2(
-          id = Some(createCanonicalId),
+          id = Some(canonicalId),
           label = "Vlad the Vanquished",
           identifiers = Some(
-            List(
-              DisplayIdentifierV2(
-                createSourceIdentifierWith(
-                  ontologyType = "Person"
-                )
-              )
-            ))
+            List(DisplayIdentifierV2(sourceIdentifier))
+          )
         ),
         roles = List()
       ),

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/IdentifiersUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/IdentifiersUtil.scala
@@ -12,10 +12,10 @@ trait IdentifiersUtil {
 
   def createSourceIdentifier: SourceIdentifier = createSourceIdentifierWith()
 
-  def createSourceIdentifierWith(identifierType: String = "miro-image-number", ontologyType: String = "Work"): SourceIdentifier =
+  def createSourceIdentifierWith(identifierType: String = "miro-image-number", value: String = randomAlphanumeric(length = 10), ontologyType: String = "Work"): SourceIdentifier =
     SourceIdentifier(
       identifierType = IdentifierType(identifierType),
-      value = randomAlphanumeric(length = 10),
+      value = value,
       ontologyType = ontologyType
     )
 }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/IdentifiersUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/IdentifiersUtil.scala
@@ -12,7 +12,10 @@ trait IdentifiersUtil {
 
   def createSourceIdentifier: SourceIdentifier = createSourceIdentifierWith()
 
-  def createSourceIdentifierWith(identifierType: String = "miro-image-number", value: String = randomAlphanumeric(length = 10), ontologyType: String = "Work"): SourceIdentifier =
+  def createSourceIdentifierWith(
+    identifierType: String = "miro-image-number",
+    value: String = randomAlphanumeric(length = 10),
+    ontologyType: String = "Work"): SourceIdentifier =
     SourceIdentifier(
       identifierType = IdentifierType(identifierType),
       value = value,

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/IdentifiersUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/IdentifiersUtil.scala
@@ -12,10 +12,10 @@ trait IdentifiersUtil {
 
   def createSourceIdentifier: SourceIdentifier = createSourceIdentifierWith()
 
-  def createSourceIdentifierWith(identifierType: String = "miro-image-number"): SourceIdentifier =
+  def createSourceIdentifierWith(identifierType: String = "miro-image-number", ontologyType: String = "Work"): SourceIdentifier =
     SourceIdentifier(
       identifierType = IdentifierType(identifierType),
       value = randomAlphanumeric(length = 10),
-      ontologyType = "Work"
+      ontologyType = ontologyType
     )
 }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/IdentifiersUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/IdentifiersUtil.scala
@@ -10,9 +10,12 @@ trait IdentifiersUtil {
 
   def createCanonicalId: String = randomAlphanumeric(length = 10)
 
-  def createSourceIdentifier: SourceIdentifier = SourceIdentifier(
-    identifierType = IdentifierType("miro-image-number"),
-    value = randomAlphanumeric(length = 10),
-    ontologyType = "Work"
-  )
+  def createSourceIdentifier: SourceIdentifier = createSourceIdentifierWith()
+
+  def createSourceIdentifierWith(identifierType: String = "miro-image-number"): SourceIdentifier =
+    SourceIdentifier(
+      identifierType = IdentifierType(identifierType),
+      value = randomAlphanumeric(length = 10),
+      ontologyType = "Work"
+    )
 }


### PR DESCRIPTION
Probably the last of my big test refactor PRs for now.

Somewhere in my stack of PRs, I added methods `createSourceIdentifier[With]` and `createCanonicalId`, which auto-populate the models with random data if the exact value isn't important. We already use these in a bunch of places (behind the `createWork` methods); this just pushes them out a bit further so we don't create hard-coded values unless they're actually important.

This makes our tests quite a bit simpler.