### PR TITLE
Remove the Id model

### DIFF
--- a/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex_request_creator/ReindexRequestCreatorFeatureTest.scala
+++ b/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex_request_creator/ReindexRequestCreatorFeatureTest.scala
@@ -6,7 +6,6 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
-import uk.ac.wellcome.models.Id
 import uk.ac.wellcome.platform.reindex_request_creator.models.{
   ReindexJob,
   ReindexRequest
@@ -22,7 +21,7 @@ case class TestRecord(
   version: Int,
   reindexShard: String,
   reindexVersion: Int
-) extends Id
+)
 
 class ReindexRequestCreatorFeatureTest
     extends FunSpec

--- a/sbt_common/common/src/main/scala/uk/ac/wellcome/models/Id.scala
+++ b/sbt_common/common/src/main/scala/uk/ac/wellcome/models/Id.scala
@@ -1,5 +1,0 @@
-package uk.ac.wellcome.models
-
-trait Id {
-  val id: String
-}

--- a/sbt_common/common/src/main/scala/uk/ac/wellcome/models/Sourced.scala
+++ b/sbt_common/common/src/main/scala/uk/ac/wellcome/models/Sourced.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.models
 
-trait Sourced extends Id {
+trait Sourced {
   val sourceId: String
   val sourceName: String
   val id: String = Sourced.id(sourceName, sourceId)

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraItemRecord.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraItemRecord.scala
@@ -2,8 +2,6 @@ package uk.ac.wellcome.models.transformable.sierra
 
 import java.time.Instant
 
-import uk.ac.wellcome.models.Id
-
 case class SierraItemRecord(
   id: String,
   data: String,
@@ -11,7 +9,7 @@ case class SierraItemRecord(
   bibIds: List[String],
   unlinkedBibIds: List[String] = List(),
   version: Int = 0
-) extends Id
+)
 
 object SierraItemRecord {
   def apply(id: String,

--- a/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/HybridRecord.scala
+++ b/sbt_common/storage/src/main/scala/uk/ac/wellcome/storage/vhs/HybridRecord.scala
@@ -1,9 +1,7 @@
 package uk.ac.wellcome.storage.vhs
 
-import uk.ac.wellcome.models.Id
-
 case class HybridRecord(
   id: String,
   version: Int,
   s3key: String
-) extends Id
+)

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
@@ -15,7 +15,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import shapeless._
-import uk.ac.wellcome.models.{Id => Identified}
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDbVersioned
 import uk.ac.wellcome.test.fixtures._
@@ -23,8 +22,7 @@ import uk.ac.wellcome.test.utils.ExtendedPatience
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-case class TestVersioned(override val id: String, data: String, version: Int)
-    extends Identified
+case class TestVersioned(id: String, data: String, version: Int)
 
 class VersionedDaoTest
     extends FunSpec
@@ -238,10 +236,8 @@ class VersionedDaoTest
                                 data: String,
                                 moreData: Int,
                                 version: Int)
-              extends Identified
 
           case class PartialRecord(id: String, moreData: Int, version: Int)
-              extends Identified
 
           val fullRecord = FullRecord(
             id = id,

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
@@ -4,7 +4,7 @@ import com.gu.scanamo._
 import com.gu.scanamo.syntax._
 import io.circe.Encoder
 import org.scalatest.Matchers
-import uk.ac.wellcome.models.Id
+import uk.ac.wellcome.models.Sourced
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.s3._
@@ -61,7 +61,7 @@ trait LocalVersionedHybridStore
     testWith(store)
   }
 
-  def assertStored[T <: Id](bucket: Bucket, table: Table, record: T)(
+  def assertStored[T <: Sourced](bucket: Bucket, table: Table, record: T)(
     implicit encoder: Encoder[T]) =
     assertJsonStringsAreEqual(
       getJsonFor(bucket, table, record.id),

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/LocalVersionedHybridStore.scala
@@ -64,12 +64,12 @@ trait LocalVersionedHybridStore
   def assertStored[T <: Id](bucket: Bucket, table: Table, record: T)(
     implicit encoder: Encoder[T]) =
     assertJsonStringsAreEqual(
-      getJsonFor[T](bucket, table, record),
+      getJsonFor(bucket, table, record.id),
       toJson(record).get
     )
 
-  def getJsonFor[T <: Id](bucket: Bucket, table: Table, record: T) = {
-    val hybridRecord = getHybridRecord(table, record.id)
+  def getJsonFor(bucket: Bucket, table: Table, id: String) = {
+    val hybridRecord = getHybridRecord(table, id)
 
     getJsonFromS3(bucket, hybridRecord.s3key).noSpaces
   }

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/vhs/TypeStoreVersionedHybridStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/vhs/TypeStoreVersionedHybridStoreTest.scala
@@ -57,7 +57,7 @@ class TypeStoreVersionedHybridStoreTest
             (record, EmptyMetadata()))(ifExisting = (t, m) => (t, m))
 
           whenReady(future) { _ =>
-            getJsonFor(bucket, table, record) shouldBe toJson(record).get
+            getJsonFor(bucket, table, id = record.id) shouldBe toJson(record).get
           }
       }
     }

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/vhs/TypeStoreVersionedHybridStoreTest.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/vhs/TypeStoreVersionedHybridStoreTest.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.storage.vhs
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.Id
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.test.fixtures.LocalVersionedHybridStore
@@ -15,9 +14,9 @@ import scala.util.Random
 import scala.concurrent.ExecutionContext.Implicits.global
 
 case class ExampleRecord(
-  override val id: String,
+  id: String,
   content: String
-) extends Id
+)
 
 class TypeStoreVersionedHybridStoreTest
     extends FunSpec


### PR DESCRIPTION
We were only using it as a type parameter in a pair of test methods – and in the latter, we could do away with it entirely *and* be more consistent.

The two uses of the remaining method were with `RecorderWorkEntry` and `SierraTransformable`, both of which inherit from `Sourced` – so inherit from that instead, and get rid of this model.

Snip, snip, common lib…