### PR TITLE
Move the one common test into internal_model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,8 +93,7 @@ jobs:
     # - env: TASK=travistooling-test
 
     - stage: sbt-common-test
-      env: TASK=common-test
-    - env: TASK=elasticsearch-test
+      env: TASK=elasticsearch-test
     - env: TASK=messaging-test
     - env: TASK=storage-test
     - env: TASK=monitoring-test

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/JsonUtilTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/JsonUtilTest.scala
@@ -1,8 +1,9 @@
-package uk.ac.wellcome.utils
-import JsonUtil._
+package uk.ac.wellcome.models
+
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.test.utils.JsonTestUtil
+import uk.ac.wellcome.utils.JsonUtil._
 
 class JsonUtilTest extends FunSpec with Matchers with JsonTestUtil {
   case class A(id: String, b: B)


### PR DESCRIPTION
Because burning 2 minutes and a build VM for these three tests is silly, and JsonUtil is arguably related to internal models anyway.