### PR TITLE
Tidy up helpers in the SQS + Messaging tests

### DIFF
--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -6,7 +6,6 @@ import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.test.util.WorksUtil
-import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.utils.JsonUtil._
@@ -41,15 +40,12 @@ class IdMinterFeatureTest
 
               val messageCount = 5
 
-              (1 to messageCount).foreach { i =>
-                val messageBody = put[UnidentifiedWork](
-                  obj = work,
-                  location = ObjectLocation(
-                    namespace = bucket.name,
-                    key = s"$i.json"
-                  )
+              (1 to messageCount).foreach { _ =>
+                sendMessage(
+                  bucket = bucket,
+                  queue = queue,
+                  message = work
                 )
-                sqsClient.sendMessage(queue.url, messageBody)
               }
 
               eventually {
@@ -88,14 +84,11 @@ class IdMinterFeatureTest
               eventuallyTableExists(identifiersTableConfig)
               val work = createUnidentifiedInvisibleWork
 
-              val messageBody = put[UnidentifiedInvisibleWork](
-                obj = work,
-                location = ObjectLocation(
-                  namespace = bucket.name,
-                  key = "invisible-work.json"
-                )
+              sendMessage(
+                bucket = bucket,
+                queue = queue,
+                message = work
               )
-              sqsClient.sendMessage(queue.url, messageBody)
 
               eventually {
                 val messages = listMessagesReceivedFromSNS(topic)
@@ -128,14 +121,11 @@ class IdMinterFeatureTest
 
               val work = createUnidentifiedRedirectedWork
 
-              val messageBody = put[UnidentifiedRedirectedWork](
-                obj = work,
-                location = ObjectLocation(
-                  namespace = bucket.name,
-                  key = "redirected-work.json"
-                )
+              sendMessage(
+                bucket = bucket,
+                queue = queue,
+                message = work
               )
-              sqsClient.sendMessage(queue.url, messageBody)
 
               eventually {
                 val messages = listMessagesReceivedFromSNS(topic)
@@ -171,15 +161,11 @@ class IdMinterFeatureTest
 
               val work = createUnidentifiedWork
 
-              val messageBody = put[UnidentifiedWork](
-                obj = work,
-                location = ObjectLocation(
-                  namespace = bucket.name,
-                  key = s"key.json"
-                )
+              sendMessage(
+                bucket = bucket,
+                queue = queue,
+                message = work
               )
-
-              sqsClient.sendMessage(queue.url, messageBody)
 
               eventually {
                 val snsMessages = listMessagesReceivedFromSNS(topic)

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -49,11 +49,9 @@ class IdMinterFeatureTest
               }
 
               eventually {
-                val messages = listMessagesReceivedFromSNS(topic)
-                messages.length shouldBe >=(messageCount)
+                val works = getMessages[IdentifiedBaseWork](topic)
+                works.length shouldBe >=(messageCount)
 
-                val works =
-                  messages.map(message => get[IdentifiedBaseWork](message))
                 works.map(_.canonicalId).distinct should have size 1
                 works.foreach { receivedWork =>
                   receivedWork
@@ -91,10 +89,10 @@ class IdMinterFeatureTest
               )
 
               eventually {
-                val messages = listMessagesReceivedFromSNS(topic)
-                messages.length shouldBe >=(1)
+                val works = getMessages[IdentifiedBaseWork](topic)
+                works.length shouldBe >=(1)
 
-                val receivedWork = get[IdentifiedBaseWork](messages.head)
+                val receivedWork = works.head
                 val invisibleWork =
                   receivedWork.asInstanceOf[IdentifiedInvisibleWork]
                 invisibleWork.sourceIdentifier shouldBe work.sourceIdentifier
@@ -128,10 +126,10 @@ class IdMinterFeatureTest
               )
 
               eventually {
-                val messages = listMessagesReceivedFromSNS(topic)
-                messages.length shouldBe >=(1)
+                val works = getMessages[IdentifiedBaseWork](topic)
+                works.length shouldBe >=(1)
 
-                val receivedWork = get[IdentifiedBaseWork](messages.head)
+                val receivedWork = works.head
                 val redirectedWork =
                   receivedWork.asInstanceOf[IdentifiedRedirectedWork]
                 redirectedWork.sourceIdentifier shouldBe work.sourceIdentifier

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -44,7 +44,7 @@ class IdMinterFeatureTest
                 sendMessage(
                   bucket = bucket,
                   queue = queue,
-                  message = work
+                  obj = work
                 )
               }
 
@@ -85,7 +85,7 @@ class IdMinterFeatureTest
               sendMessage(
                 bucket = bucket,
                 queue = queue,
-                message = work
+                obj = work
               )
 
               eventually {
@@ -122,7 +122,7 @@ class IdMinterFeatureTest
               sendMessage(
                 bucket = bucket,
                 queue = queue,
-                message = work
+                obj = work
               )
 
               eventually {
@@ -162,7 +162,7 @@ class IdMinterFeatureTest
               sendMessage(
                 bucket = bucket,
                 queue = queue,
-                message = work
+                obj = work
               )
 
               eventually {

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -4,6 +4,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
+import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.test.utils.JsonTestUtil
 import uk.ac.wellcome.utils.JsonUtil._
@@ -29,7 +30,7 @@ class IngestorFeatureTest
 
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        sendMessage(bucket = bucket, queue = queue, obj = work)
+        sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
         withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
           withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
             withServer(queue, bucket, indexNameV1, indexNameV2, itemType) { _ =>
@@ -52,7 +53,7 @@ class IngestorFeatureTest
 
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        sendMessage(bucket = bucket, queue = queue, obj = work)
+        sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
         withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
           withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
             withServer(queue, bucket, indexNameV1, indexNameV2, itemType) { _ =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -29,7 +29,7 @@ class IngestorFeatureTest
 
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        sendMessage(bucket = bucket, queue = queue, message = work)
+        sendMessage(bucket = bucket, queue = queue, obj = work)
         withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
           withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
             withServer(queue, bucket, indexNameV1, indexNameV2, itemType) { _ =>
@@ -52,7 +52,7 @@ class IngestorFeatureTest
 
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        sendMessage(bucket = bucket, queue = queue, message = work)
+        sendMessage(bucket = bucket, queue = queue, obj = work)
         withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
           withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
             withServer(queue, bucket, indexNameV1, indexNameV2, itemType) { _ =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -30,7 +30,10 @@ class IngestorFeatureTest
 
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
+        sendMessage[IdentifiedBaseWork](
+          bucket = bucket,
+          queue = queue,
+          obj = work)
         withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
           withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
             withServer(queue, bucket, indexNameV1, indexNameV2, itemType) { _ =>
@@ -53,7 +56,10 @@ class IngestorFeatureTest
 
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
+        sendMessage[IdentifiedBaseWork](
+          bucket = bucket,
+          queue = queue,
+          obj = work)
         withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
           withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
             withServer(queue, bucket, indexNameV1, indexNameV2, itemType) { _ =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -15,7 +15,6 @@ import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, Subject}
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.platform.ingestor.IngestorConfig
 import uk.ac.wellcome.platform.ingestor.fixtures.WorkIndexerFixtures
-import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures.TestWith
@@ -48,14 +47,7 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, _), bucket) =>
-            val messageBody = put[IdentifiedBaseWork](
-              obj = work,
-              location = ObjectLocation(
-                namespace = bucket.name,
-                key = s"work.json"
-              )
-            )
-            sqsClient.sendMessage(queue.url, messageBody)
+            sendMessage(bucket = bucket, queue = queue, message = work)
 
             assertElasticsearchEventuallyHasWork(
               indexName = esIndexV1,
@@ -82,14 +74,7 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, _), bucket) =>
-            val messageBody = put[IdentifiedBaseWork](
-              obj = work,
-              location = ObjectLocation(
-                namespace = bucket.name,
-                key = s"work.json"
-              )
-            )
-            sqsClient.sendMessage(queue.url, messageBody)
+            sendMessage(bucket = bucket, queue = queue, message = work)
 
             assertElasticsearchNeverHasWork(
               indexName = esIndexV1,
@@ -116,14 +101,7 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, _), bucket) =>
-            val messageBody = put[IdentifiedBaseWork](
-              obj = work,
-              location = ObjectLocation(
-                namespace = bucket.name,
-                key = s"work.json"
-              )
-            )
-            sqsClient.sendMessage(queue.url, messageBody)
+            sendMessage(bucket = bucket, queue = queue, message = work)
 
             assertElasticsearchNeverHasWork(
               indexName = esIndexV1,
@@ -150,14 +128,7 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, _), bucket) =>
-            val messageBody = put[IdentifiedBaseWork](
-              obj = work,
-              location = ObjectLocation(
-                namespace = bucket.name,
-                key = s"work.json"
-              )
-            )
-            sqsClient.sendMessage(queue.url, messageBody)
+            sendMessage(bucket = bucket, queue = queue, message = work)
 
             assertElasticsearchNeverHasWork(
               indexName = esIndexV1,
@@ -198,15 +169,7 @@ class IngestorWorkerServiceTest
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, dlq), bucket) =>
             works.foreach { work =>
-              val messageBody = put[IdentifiedBaseWork](
-                obj = work,
-                location = ObjectLocation(
-                  namespace = bucket.name,
-                  key = s"${work.canonicalId}.json"
-                )
-              )
-
-              sqsClient.sendMessage(queue.url, messageBody)
+              sendMessage(bucket = bucket, queue = queue, message = work)
             }
 
             assertElasticsearchNeverHasWork(
@@ -243,14 +206,7 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, dlq), bucket) =>
-            val messageBody = put[IdentifiedBaseWork](
-              obj = work,
-              location = ObjectLocation(
-                namespace = bucket.name,
-                key = s"work.json"
-              )
-            )
-            sqsClient.sendMessage(queue.url, messageBody)
+            sendMessage(bucket = bucket, queue = queue, message = work)
 
             eventually {
               assertQueueEmpty(queue)
@@ -283,15 +239,7 @@ class IngestorWorkerServiceTest
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, dlq), bucket) =>
             works.foreach { work =>
-              val messageBody = put[IdentifiedBaseWork](
-                obj = work,
-                location = ObjectLocation(
-                  namespace = bucket.name,
-                  key = s"${work.canonicalId}.json"
-                )
-              )
-
-              sqsClient.sendMessage(queue.url, messageBody)
+              sendMessage(bucket = bucket, queue = queue, message = work)
             }
 
             assertElasticsearchNeverHasWork(
@@ -342,15 +290,7 @@ class IngestorWorkerServiceTest
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, dlq), bucket) =>
             works.foreach { work =>
-              val messageBody = put[IdentifiedBaseWork](
-                obj = work,
-                location = ObjectLocation(
-                  namespace = bucket.name,
-                  key = s"${work.canonicalId}.json"
-                )
-              )
-
-              sqsClient.sendMessage(queue.url, messageBody)
+              sendMessage(bucket = bucket, queue = queue, message = work)
             }
 
             assertElasticsearchEventuallyHasWork(
@@ -388,15 +328,7 @@ class IngestorWorkerServiceTest
           withIngestorWorkerService(esIndexV1, esIndexV2) {
             case (QueuePair(queue, dlq), bucket) =>
               works.foreach { work =>
-                val messageBody = put[IdentifiedBaseWork](
-                  obj = work,
-                  location = ObjectLocation(
-                    namespace = bucket.name,
-                    key = s"${work.canonicalId}.json"
-                  )
-                )
-
-                sqsClient.sendMessage(queue.url, messageBody)
+                sendMessage(bucket = bucket, queue = queue, message = work)
               }
 
               assertElasticsearchNeverHasWork(
@@ -437,15 +369,7 @@ class IngestorWorkerServiceTest
           withIngestorWorkerService(esIndexV1, esIndexV2) {
             case (QueuePair(queue, dlq), bucket) =>
               works.foreach { work =>
-                val messageBody = put[IdentifiedBaseWork](
-                  obj = work,
-                  location = ObjectLocation(
-                    namespace = bucket.name,
-                    key = s"${work.canonicalId}.json"
-                  )
-                )
-
-                sqsClient.sendMessage(queue.url, messageBody)
+                sendMessage(bucket = bucket, queue = queue, message = work)
               }
 
               assertElasticsearchNeverHasWork(
@@ -503,14 +427,7 @@ class IngestorWorkerServiceTest
                   messageStream) { _ =>
                   val work = createIdentifiedWork
 
-                  val messageBody = put[IdentifiedBaseWork](
-                    obj = work,
-                    location = ObjectLocation(
-                      namespace = bucket.name,
-                      key = s"work.json"
-                    )
-                  )
-                  sqsClient.sendMessage(queue.url, messageBody)
+                  sendMessage(bucket = bucket, queue = queue, message = work)
 
                   eventually {
                     assertQueueEmpty(queue)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -47,7 +47,10 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, _), bucket) =>
-            sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
+            sendMessage[IdentifiedBaseWork](
+              bucket = bucket,
+              queue = queue,
+              obj = work)
 
             assertElasticsearchEventuallyHasWork(
               indexName = esIndexV1,
@@ -74,7 +77,10 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, _), bucket) =>
-            sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
+            sendMessage[IdentifiedBaseWork](
+              bucket = bucket,
+              queue = queue,
+              obj = work)
 
             assertElasticsearchNeverHasWork(
               indexName = esIndexV1,
@@ -101,7 +107,10 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, _), bucket) =>
-            sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
+            sendMessage[IdentifiedBaseWork](
+              bucket = bucket,
+              queue = queue,
+              obj = work)
 
             assertElasticsearchNeverHasWork(
               indexName = esIndexV1,
@@ -128,7 +137,10 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, _), bucket) =>
-            sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
+            sendMessage[IdentifiedBaseWork](
+              bucket = bucket,
+              queue = queue,
+              obj = work)
 
             assertElasticsearchNeverHasWork(
               indexName = esIndexV1,
@@ -169,7 +181,10 @@ class IngestorWorkerServiceTest
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, dlq), bucket) =>
             works.foreach { work =>
-              sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
+              sendMessage[IdentifiedBaseWork](
+                bucket = bucket,
+                queue = queue,
+                obj = work)
             }
 
             assertElasticsearchNeverHasWork(
@@ -206,7 +221,10 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, dlq), bucket) =>
-            sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
+            sendMessage[IdentifiedBaseWork](
+              bucket = bucket,
+              queue = queue,
+              obj = work)
 
             eventually {
               assertQueueEmpty(queue)
@@ -239,7 +257,10 @@ class IngestorWorkerServiceTest
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, dlq), bucket) =>
             works.foreach { work =>
-              sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
+              sendMessage[IdentifiedBaseWork](
+                bucket = bucket,
+                queue = queue,
+                obj = work)
             }
 
             assertElasticsearchNeverHasWork(
@@ -290,7 +311,10 @@ class IngestorWorkerServiceTest
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, dlq), bucket) =>
             works.foreach { work =>
-              sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
+              sendMessage[IdentifiedBaseWork](
+                bucket = bucket,
+                queue = queue,
+                obj = work)
             }
 
             assertElasticsearchEventuallyHasWork(
@@ -328,7 +352,10 @@ class IngestorWorkerServiceTest
           withIngestorWorkerService(esIndexV1, esIndexV2) {
             case (QueuePair(queue, dlq), bucket) =>
               works.foreach { work =>
-                sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
+                sendMessage[IdentifiedBaseWork](
+                  bucket = bucket,
+                  queue = queue,
+                  obj = work)
               }
 
               assertElasticsearchNeverHasWork(
@@ -369,7 +396,10 @@ class IngestorWorkerServiceTest
           withIngestorWorkerService(esIndexV1, esIndexV2) {
             case (QueuePair(queue, dlq), bucket) =>
               works.foreach { work =>
-                sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
+                sendMessage[IdentifiedBaseWork](
+                  bucket = bucket,
+                  queue = queue,
+                  obj = work)
               }
 
               assertElasticsearchNeverHasWork(
@@ -427,7 +457,10 @@ class IngestorWorkerServiceTest
                   messageStream) { _ =>
                   val work = createIdentifiedWork
 
-                  sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
+                  sendMessage[IdentifiedBaseWork](
+                    bucket = bucket,
+                    queue = queue,
+                    obj = work)
 
                   eventually {
                     assertQueueEmpty(queue)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -47,7 +47,7 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, _), bucket) =>
-            sendMessage(bucket = bucket, queue = queue, message = work)
+            sendMessage(bucket = bucket, queue = queue, obj = work)
 
             assertElasticsearchEventuallyHasWork(
               indexName = esIndexV1,
@@ -74,7 +74,7 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, _), bucket) =>
-            sendMessage(bucket = bucket, queue = queue, message = work)
+            sendMessage(bucket = bucket, queue = queue, obj = work)
 
             assertElasticsearchNeverHasWork(
               indexName = esIndexV1,
@@ -101,7 +101,7 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, _), bucket) =>
-            sendMessage(bucket = bucket, queue = queue, message = work)
+            sendMessage(bucket = bucket, queue = queue, obj = work)
 
             assertElasticsearchNeverHasWork(
               indexName = esIndexV1,
@@ -128,7 +128,7 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, _), bucket) =>
-            sendMessage(bucket = bucket, queue = queue, message = work)
+            sendMessage(bucket = bucket, queue = queue, obj = work)
 
             assertElasticsearchNeverHasWork(
               indexName = esIndexV1,
@@ -169,7 +169,7 @@ class IngestorWorkerServiceTest
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, dlq), bucket) =>
             works.foreach { work =>
-              sendMessage(bucket = bucket, queue = queue, message = work)
+              sendMessage(bucket = bucket, queue = queue, obj = work)
             }
 
             assertElasticsearchNeverHasWork(
@@ -206,7 +206,7 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, dlq), bucket) =>
-            sendMessage(bucket = bucket, queue = queue, message = work)
+            sendMessage(bucket = bucket, queue = queue, obj = work)
 
             eventually {
               assertQueueEmpty(queue)
@@ -239,7 +239,7 @@ class IngestorWorkerServiceTest
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, dlq), bucket) =>
             works.foreach { work =>
-              sendMessage(bucket = bucket, queue = queue, message = work)
+              sendMessage(bucket = bucket, queue = queue, obj = work)
             }
 
             assertElasticsearchNeverHasWork(
@@ -290,7 +290,7 @@ class IngestorWorkerServiceTest
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, dlq), bucket) =>
             works.foreach { work =>
-              sendMessage(bucket = bucket, queue = queue, message = work)
+              sendMessage(bucket = bucket, queue = queue, obj = work)
             }
 
             assertElasticsearchEventuallyHasWork(
@@ -328,7 +328,7 @@ class IngestorWorkerServiceTest
           withIngestorWorkerService(esIndexV1, esIndexV2) {
             case (QueuePair(queue, dlq), bucket) =>
               works.foreach { work =>
-                sendMessage(bucket = bucket, queue = queue, message = work)
+                sendMessage(bucket = bucket, queue = queue, obj = work)
               }
 
               assertElasticsearchNeverHasWork(
@@ -369,7 +369,7 @@ class IngestorWorkerServiceTest
           withIngestorWorkerService(esIndexV1, esIndexV2) {
             case (QueuePair(queue, dlq), bucket) =>
               works.foreach { work =>
-                sendMessage(bucket = bucket, queue = queue, message = work)
+                sendMessage(bucket = bucket, queue = queue, obj = work)
               }
 
               assertElasticsearchNeverHasWork(
@@ -427,7 +427,7 @@ class IngestorWorkerServiceTest
                   messageStream) { _ =>
                   val work = createIdentifiedWork
 
-                  sendMessage(bucket = bucket, queue = queue, message = work)
+                  sendMessage(bucket = bucket, queue = queue, obj = work)
 
                   eventually {
                     assertQueueEmpty(queue)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -47,7 +47,7 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, _), bucket) =>
-            sendMessage(bucket = bucket, queue = queue, obj = work)
+            sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
 
             assertElasticsearchEventuallyHasWork(
               indexName = esIndexV1,
@@ -74,7 +74,7 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, _), bucket) =>
-            sendMessage(bucket = bucket, queue = queue, obj = work)
+            sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
 
             assertElasticsearchNeverHasWork(
               indexName = esIndexV1,
@@ -101,7 +101,7 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, _), bucket) =>
-            sendMessage(bucket = bucket, queue = queue, obj = work)
+            sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
 
             assertElasticsearchNeverHasWork(
               indexName = esIndexV1,
@@ -128,7 +128,7 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, _), bucket) =>
-            sendMessage(bucket = bucket, queue = queue, obj = work)
+            sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
 
             assertElasticsearchNeverHasWork(
               indexName = esIndexV1,
@@ -169,7 +169,7 @@ class IngestorWorkerServiceTest
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, dlq), bucket) =>
             works.foreach { work =>
-              sendMessage(bucket = bucket, queue = queue, obj = work)
+              sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
             }
 
             assertElasticsearchNeverHasWork(
@@ -206,7 +206,7 @@ class IngestorWorkerServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { esIndexV2 =>
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, dlq), bucket) =>
-            sendMessage(bucket = bucket, queue = queue, obj = work)
+            sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
 
             eventually {
               assertQueueEmpty(queue)
@@ -239,7 +239,7 @@ class IngestorWorkerServiceTest
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, dlq), bucket) =>
             works.foreach { work =>
-              sendMessage(bucket = bucket, queue = queue, obj = work)
+              sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
             }
 
             assertElasticsearchNeverHasWork(
@@ -290,7 +290,7 @@ class IngestorWorkerServiceTest
         withIngestorWorkerService(esIndexV1, esIndexV2) {
           case (QueuePair(queue, dlq), bucket) =>
             works.foreach { work =>
-              sendMessage(bucket = bucket, queue = queue, obj = work)
+              sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
             }
 
             assertElasticsearchEventuallyHasWork(
@@ -328,7 +328,7 @@ class IngestorWorkerServiceTest
           withIngestorWorkerService(esIndexV1, esIndexV2) {
             case (QueuePair(queue, dlq), bucket) =>
               works.foreach { work =>
-                sendMessage(bucket = bucket, queue = queue, obj = work)
+                sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
               }
 
               assertElasticsearchNeverHasWork(
@@ -369,7 +369,7 @@ class IngestorWorkerServiceTest
           withIngestorWorkerService(esIndexV1, esIndexV2) {
             case (QueuePair(queue, dlq), bucket) =>
               works.foreach { work =>
-                sendMessage(bucket = bucket, queue = queue, obj = work)
+                sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
               }
 
               assertElasticsearchNeverHasWork(
@@ -427,7 +427,7 @@ class IngestorWorkerServiceTest
                   messageStream) { _ =>
                   val work = createIdentifiedWork
 
-                  sendMessage(bucket = bucket, queue = queue, obj = work)
+                  sendMessage[IdentifiedBaseWork](bucket = bucket, queue = queue, obj = work)
 
                   eventually {
                     assertQueueEmpty(queue)

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -146,12 +146,7 @@ class MatcherFeatureTest
       s3key = key
     )
 
-    NotificationMessage(
-      "messageId",
-      "topicArn",
-      "subject",
-      toJson(hybridRecord).get
-    )
+    createNotificationMessageWith(message = hybridRecord)
   }
 
 }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -105,7 +105,10 @@ trait MatcherFixtures
             withWorkGraphStore(graphTable) { workGraphStore =>
               withWorkMatcher(workGraphStore, lockTable, metricsSender) {
                 workMatcher =>
-                  withSQSStream[NotificationMessage, R](actorSystem, queue, metricsSender) { sqsStream =>
+                  withSQSStream[NotificationMessage, R](
+                    actorSystem,
+                    queue,
+                    metricsSender) { sqsStream =>
                     val matcherMessageReceiver = new MatcherMessageReceiver(
                       sqsStream,
                       snsWriter,

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -6,7 +6,6 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.gu.scanamo.{DynamoFormat, Scanamo}
 import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig, SNSWriter}
-import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSStream}
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
@@ -37,7 +36,6 @@ import uk.ac.wellcome.storage.test.fixtures.{LocalDynamoDb, S3}
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.hashing.MurmurHash3
 
@@ -107,20 +105,16 @@ trait MatcherFixtures
             withWorkGraphStore(graphTable) { workGraphStore =>
               withWorkMatcher(workGraphStore, lockTable, metricsSender) {
                 workMatcher =>
-                  val sqsStream = new SQSStream[NotificationMessage](
-                    actorSystem = actorSystem,
-                    sqsClient = asyncSqsClient,
-                    sqsConfig = SQSConfig(queue.url, 1 second, 1),
-                    metricsSender = metricsSender
-                  )
-                  val matcherMessageReceiver = new MatcherMessageReceiver(
-                    sqsStream,
-                    snsWriter,
-                    objectStore,
-                    storageS3Config,
-                    actorSystem,
-                    workMatcher)
-                  testWith(matcherMessageReceiver)
+                  withSQSStream[NotificationMessage, R](actorSystem, queue, metricsSender) { sqsStream =>
+                    val matcherMessageReceiver = new MatcherMessageReceiver(
+                      sqsStream,
+                      snsWriter,
+                      objectStore,
+                      storageS3Config,
+                      actorSystem,
+                      workMatcher)
+                    testWith(matcherMessageReceiver)
+                  }
               }
             }
           }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
@@ -375,11 +375,6 @@ class MatcherMessageReceiverTest
       s3key = key
     )
 
-    NotificationMessage(
-      "messageId",
-      "topicArn",
-      "subject",
-      toJson(hybridRecord).get
-    )
+    createNotificationMessageWith(message = hybridRecord)
   }
 }

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.{Assertion, FunSpec}
 import uk.ac.wellcome.messaging.test.fixtures.Messaging
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
+import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.storage.test.fixtures.LocalVersionedHybridStore
 import uk.ac.wellcome.storage.vhs.EmptyMetadata
 import uk.ac.wellcome.test.utils.ExtendedPatience
@@ -52,7 +53,7 @@ class MergerFeatureTest
                       eventually {
                         assertQueueEmpty(queue)
                         assertQueueEmpty(dlq)
-                        val worksSent = getWorksSent(topic)
+                        val worksSent = getMessages[TransformedBaseWork](topic)
                         worksSent should contain only recorderWorkEntry.work
                       }
                     }

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -44,7 +44,10 @@ class MergerFeatureTest
                       val matcherResult =
                         matcherResultWith(Set(Set(recorderWorkEntry)))
 
-                      sendSQSMessage(queue, matcherResult)
+                      sendNotificationToSQS(
+                        queue = queue,
+                        message = matcherResult
+                      )
 
                       eventually {
                         assertQueueEmpty(queue)

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.merger
 
-import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.matcher.{
@@ -30,16 +29,6 @@ trait MergerTestUtils extends WorksUtil { this: SQS with SNS with Messaging =>
               WorkIdentifier(
                 identifier = workEntry.id,
                 version = workEntry.work.version)))))
-
-  def sendSQSMessage(queue: SQS.Queue, matcherResult: MatcherResult) = {
-    val notificationMessage = NotificationMessage(
-      MessageId = "MessageId",
-      TopicArn = "topic-arn",
-      Subject = "subject",
-      Message = toJson(matcherResult).get
-    )
-    sqsClient.sendMessage(queue.url, toJson(notificationMessage).get)
-  }
 
   def storeInVHS(vhs: VersionedHybridStore[RecorderWorkEntry,
                                            EmptyMetadata,

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.merger
 
-import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.matcher.{
   MatchedIdentifiers,
@@ -8,11 +7,9 @@ import uk.ac.wellcome.models.matcher.{
   WorkIdentifier
 }
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
-import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}
-import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.storage.dynamo._
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -49,12 +46,4 @@ trait MergerTestUtils extends WorksUtil { this: SQS with SNS with Messaging =>
 
   def createRecorderWorkEntryWith(version: Int) =
     RecorderWorkEntry(createUnidentifiedWorkWith(version = version))
-
-  def getWorksSent(topic: Topic) = {
-    val messagesSent = listMessagesReceivedFromSNS(topic)
-    val worksSent = messagesSent.map { message =>
-      get[TransformedBaseWork](message)
-    }
-    worksSent
-  }
 }

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -59,7 +59,10 @@ class MergerWorkerServiceTest
             vhs,
             List(recorderWorkEntry1, recorderWorkEntry2, recorderWorkEntry3))) {
           _ =>
-            sendSQSMessage(queue, matcherResult)
+            sendNotificationToSQS(
+              queue = queue,
+              message = matcherResult
+            )
 
             eventually {
               assertQueueEmpty(queue)
@@ -85,7 +88,10 @@ class MergerWorkerServiceTest
         val matcherResult = matcherResultWith(Set(Set(recorderWorkEntry)))
 
         whenReady(storeInVHS(vhs, recorderWorkEntry)) { _ =>
-          sendSQSMessage(queue, matcherResult)
+          sendNotificationToSQS(
+            queue = queue,
+            message = matcherResult
+          )
 
           eventually {
             assertQueueEmpty(queue)
@@ -106,7 +112,10 @@ class MergerWorkerServiceTest
 
         val matcherResult = matcherResultWith(Set(Set(recorderWorkEntry)))
 
-        sendSQSMessage(queue, matcherResult)
+        sendNotificationToSQS(
+          queue = queue,
+          message = matcherResult
+        )
 
         eventually {
           assertQueueEmpty(queue)
@@ -135,7 +144,10 @@ class MergerWorkerServiceTest
           storeInVHS(
             vhs,
             List(recorderWorkEntry, newerVersionRecorderWorkEntry))) { _ =>
-          sendSQSMessage(queue, matcherResult)
+          sendNotificationToSQS(
+            queue = queue,
+            message = matcherResult
+          )
 
           eventually {
             assertQueueEmpty(queue)
@@ -162,7 +174,10 @@ class MergerWorkerServiceTest
           matcherResultWith(Set(Set(recorderWorkEntry, versionZeroWork)))
 
         whenReady(storeInVHS(vhs, recorderWorkEntry)) { _ =>
-          sendSQSMessage(queue, matcherResult)
+          sendNotificationToSQS(
+            queue = queue,
+            message = matcherResult
+          )
 
           eventually {
             assertQueueEmpty(queue)

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -193,14 +193,10 @@ class MergerWorkerServiceTest
   it("fails if the message sent is not a matcher result") {
     withMergerWorkerServiceFixtures {
       case (_, QueuePair(queue, dlq), _, metricsSender) =>
-        val testObject = TestObject("lallabalula")
-        val notificationMessage = NotificationMessage(
-          MessageId = "MessageId",
-          TopicArn = "topic-arn",
-          Subject = "subject",
-          Message = toJson(testObject).get
+        sendNotificationToSQS(
+          queue = queue,
+          message = TestObject("lallabalula")
         )
-        sqsClient.sendMessage(queue.url, toJson(notificationMessage).get)
 
         eventually {
           assertQueueEmpty(queue)

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -68,7 +68,7 @@ class MergerWorkerServiceTest
               assertQueueEmpty(queue)
               assertQueueEmpty(dlq)
 
-              val worksSent = getWorksSent(topic)
+              val worksSent = getMessages[TransformedBaseWork](topic)
               worksSent should contain only (recorderWorkEntry1.work,
               recorderWorkEntry2.work,
               recorderWorkEntry3.work)
@@ -97,7 +97,7 @@ class MergerWorkerServiceTest
             assertQueueEmpty(queue)
             assertQueueEmpty(dlq)
 
-            val worksSent = getWorksSent(topic)
+            val worksSent = getMessages[TransformedBaseWork](topic)
             worksSent should contain only recorderWorkEntry.work
           }
         }
@@ -152,7 +152,7 @@ class MergerWorkerServiceTest
           eventually {
             assertQueueEmpty(queue)
             assertQueueEmpty(dlq)
-            val worksSent = getWorksSent(topic)
+            val worksSent = getMessages[TransformedBaseWork](topic)
             worksSent should contain only recorderWorkEntry.work
           }
         }
@@ -183,7 +183,7 @@ class MergerWorkerServiceTest
             assertQueueEmpty(queue)
             assertQueueEmpty(dlq)
 
-            val worksSent = getWorksSent(topic)
+            val worksSent = getMessages[TransformedBaseWork](topic)
             worksSent should contain only recorderWorkEntry.work
           }
         }

--- a/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
+++ b/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
@@ -33,7 +33,7 @@ class RecorderFeatureTest
               bucket,
               queue)
             withServer(flags) { _ =>
-              sendMessage(bucket = bucket, queue = queue, message = work)
+              sendMessage(bucket = bucket, queue = queue, obj = work)
 
               eventually {
                 assertStored[RecorderWorkEntry](

--- a/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
+++ b/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
@@ -34,7 +34,10 @@ class RecorderFeatureTest
               bucket,
               queue)
             withServer(flags) { _ =>
-              sendMessage[TransformedBaseWork](bucket = bucket, queue = queue, obj = work)
+              sendMessage[TransformedBaseWork](
+                bucket = bucket,
+                queue = queue,
+                obj = work)
 
               eventually {
                 assertStored[RecorderWorkEntry](

--- a/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
+++ b/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
@@ -3,9 +3,7 @@ package uk.ac.wellcome.platform.recorder
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.messaging.test.fixtures.Messaging
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
-import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.models.work.test.util.WorksUtil
-import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.test.fixtures.LocalVersionedHybridStore
 import uk.ac.wellcome.storage.vhs.EmptyMetadata
 import uk.ac.wellcome.test.utils.ExtendedPatience
@@ -35,15 +33,7 @@ class RecorderFeatureTest
               bucket,
               queue)
             withServer(flags) { _ =>
-              val messageBody = put[TransformedBaseWork](
-                obj = work,
-                location = ObjectLocation(
-                  namespace = bucket.name,
-                  key = "work_message.json"
-                )
-              )
-
-              sqsClient.sendMessage(queue.url, messageBody)
+              sendMessage(bucket = bucket, queue = queue, message = work)
 
               eventually {
                 assertStored[RecorderWorkEntry](

--- a/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
+++ b/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.recorder
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.messaging.test.fixtures.Messaging
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
+import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.storage.test.fixtures.LocalVersionedHybridStore
 import uk.ac.wellcome.storage.vhs.EmptyMetadata
@@ -33,7 +34,7 @@ class RecorderFeatureTest
               bucket,
               queue)
             withServer(flags) { _ =>
-              sendMessage(bucket = bucket, queue = queue, obj = work)
+              sendMessage[TransformedBaseWork](bucket = bucket, queue = queue, obj = work)
 
               eventually {
                 assertStored[RecorderWorkEntry](

--- a/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -42,7 +42,7 @@ class RecorderWorkerServiceTest
             sendMessage(
               bucket = messagesBucket,
               queue = queue,
-              message = work
+              obj = work
             )
             withRecorderWorkerService(
               table,
@@ -73,7 +73,7 @@ class RecorderWorkerServiceTest
               sendMessage(
                 bucket = messagesBucket,
                 queue = queue,
-                message = invisibleWork
+                obj = invisibleWork
               )
               eventually {
                 assertStoredSingleWork(storageBucket, table, invisibleWork)
@@ -101,14 +101,14 @@ class RecorderWorkerServiceTest
               sendMessage(
                 bucket = messagesBucket,
                 queue = queue,
-                message = newerWork
+                obj = newerWork
               )
               eventually {
                 assertStoredSingleWork(storageBucket, table, newerWork)
                 sendMessage(
                   bucket = messagesBucket,
                   queue = queue,
-                  message = olderWork
+                  obj = olderWork
                 )
                 eventually {
                   assertStoredSingleWork(storageBucket, table, newerWork)
@@ -137,14 +137,14 @@ class RecorderWorkerServiceTest
               sendMessage(
                 bucket = messagesBucket,
                 queue = queue,
-                message = olderWork
+                obj = olderWork
               )
               eventually {
                 assertStoredSingleWork(storageBucket, table, olderWork)
                 sendMessage(
                   bucket = messagesBucket,
                   queue = queue,
-                  message = newerWork
+                  obj = newerWork
                 )
                 eventually {
                   assertStoredSingleWork(
@@ -173,7 +173,7 @@ class RecorderWorkerServiceTest
                 sendMessage(
                   bucket = messagesBucket,
                   queue = queue,
-                  message = work
+                  obj = work
                 )
                 eventually {
                   assertQueueEmpty(queue)
@@ -200,7 +200,7 @@ class RecorderWorkerServiceTest
               sendMessage(
                 bucket = messagesBucket,
                 queue = queue,
-                message = work
+                obj = work
               )
               eventually {
                 assertQueueEmpty(queue)

--- a/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -39,7 +39,7 @@ class RecorderWorkerServiceTest
         withLocalS3Bucket { messagesBucket =>
           withLocalSqsQueue { queue =>
             val work = createUnidentifiedWork
-            sendMessage(
+            sendMessage[TransformedBaseWork](
               bucket = messagesBucket,
               queue = queue,
               obj = work
@@ -70,7 +70,7 @@ class RecorderWorkerServiceTest
               messagesBucket,
               queue) { service =>
               val invisibleWork = createUnidentifiedInvisibleWork
-              sendMessage(
+              sendMessage[TransformedBaseWork](
                 bucket = messagesBucket,
                 queue = queue,
                 obj = invisibleWork
@@ -98,7 +98,7 @@ class RecorderWorkerServiceTest
               storageBucket,
               messagesBucket,
               queue) { service =>
-              sendMessage(
+              sendMessage[TransformedBaseWork](
                 bucket = messagesBucket,
                 queue = queue,
                 obj = newerWork
@@ -134,14 +134,14 @@ class RecorderWorkerServiceTest
               storageBucket,
               messagesBucket,
               queue) { service =>
-              sendMessage(
+              sendMessage[TransformedBaseWork](
                 bucket = messagesBucket,
                 queue = queue,
                 obj = olderWork
               )
               eventually {
                 assertStoredSingleWork(storageBucket, table, olderWork)
-                sendMessage(
+                sendMessage[TransformedBaseWork](
                   bucket = messagesBucket,
                   queue = queue,
                   obj = newerWork
@@ -170,7 +170,7 @@ class RecorderWorkerServiceTest
             withRecorderWorkerService(table, badBucket, messagesBucket, queue) {
               service =>
                 val work = createUnidentifiedWork
-                sendMessage(
+                sendMessage[TransformedBaseWork](
                   bucket = messagesBucket,
                   queue = queue,
                   obj = work
@@ -197,7 +197,7 @@ class RecorderWorkerServiceTest
               messagesBucket,
               queue) { service =>
               val work = createUnidentifiedWork
-              sendMessage(
+              sendMessage[TransformedBaseWork](
                 bucket = messagesBucket,
                 queue = queue,
                 obj = work

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/MiroTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/MiroTransformerFeatureTest.scala
@@ -58,12 +58,10 @@ class MiroTransformerFeatureTest
 
             withServer(flags) { _ =>
               eventually {
-                val snsMessages = listMessagesReceivedFromSNS(topic)
-                snsMessages.length shouldBe >=(1)
+                val works = getMessages[UnidentifiedWork](topic)
+                works.length shouldBe >=(1)
 
-                snsMessages.map { snsMessage =>
-                  val actualWork = get[UnidentifiedWork](snsMessage)
-
+                works.map { actualWork =>
                   actualWork.identifiers.head.value shouldBe miroID
                   actualWork.title shouldBe title
                 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/SierraTransformerFeatureTest.scala
@@ -79,9 +79,10 @@ class SierraTransformerFeatureTest
                   value = id
                 )
 
-                snsMessages.map { snsMessage =>
-                  val actualWork = get[UnidentifiedWork](snsMessage)
+                val works = getMessages[UnidentifiedWork](topic)
+                works.length shouldBe >=(1)
 
+                works.map { actualWork =>
                   actualWork.sourceIdentifier shouldBe sourceIdentifier
                   actualWork.title shouldBe title
                   actualWork.identifiers shouldBe List(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
@@ -159,8 +159,6 @@ class NotificationMessageReceiverTest
                 unidentifiedWork.identifiers shouldBe List(
                   sourceIdentifier,
                   sierraIdentifier)
-
-                snsMessage.subject shouldBe "source: NotificationMessageReceiver.publishMessage"
               }
             }
           }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
@@ -104,7 +104,6 @@ class NotificationMessageReceiverTest
 
               works.map { work =>
                 work shouldBe a[UnidentifiedWork]
-                snsMessage.subject shouldBe "source: NotificationMessageReceiver.publishMessage"
               }
             }
           }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
@@ -99,11 +99,10 @@ class NotificationMessageReceiverTest
             val future = recordReceiver.receiveMessage(sqsMessage)
 
             whenReady(future) { _ =>
-              val snsMessages = listMessagesReceivedFromSNS(topic)
-              snsMessages.size should be >= 1
+              val works = getMessages[TransformedBaseWork](topic)
+              works.size should be >= 1
 
-              snsMessages.map { snsMessage =>
-                val work = get[TransformedBaseWork](snsMessage)
+              works.map { work =>
                 work shouldBe a[UnidentifiedWork]
                 snsMessage.subject shouldBe "source: NotificationMessageReceiver.publishMessage"
               }
@@ -147,11 +146,10 @@ class NotificationMessageReceiverTest
             )
 
             whenReady(future) { _ =>
-              val snsMessages = listMessagesReceivedFromSNS(topic)
-              snsMessages.size should be >= 1
+              val works = getMessages[TransformedBaseWork](topic)
+              works.size should be >= 1
 
-              snsMessages.map { snsMessage =>
-                val actualWork = get[TransformedBaseWork](snsMessage)
+              works.map { actualWork =>
                 actualWork shouldBe a[UnidentifiedWork]
                 val unidentifiedWork = actualWork.asInstanceOf[UnidentifiedWork]
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/utils/TransformableMessageUtils.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/utils/TransformableMessageUtils.scala
@@ -4,6 +4,7 @@ import java.time.Instant
 
 import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.models.transformable.sierra.{
   SierraBibRecord,
   SierraItemRecord
@@ -17,7 +18,7 @@ import uk.ac.wellcome.storage.vhs.{HybridRecord, SourceMetadata}
 import uk.ac.wellcome.utils.JsonUtil
 import uk.ac.wellcome.utils.JsonUtil._
 
-trait TransformableMessageUtils {
+trait TransformableMessageUtils extends SQS {
   def createValidEmptySierraBibNotificationMessage(
     id: String,
     s3Client: AmazonS3,
@@ -106,13 +107,8 @@ trait TransformableMessageUtils {
       sourceName = sourceMetadata.sourceName
     )
 
-    val hListJson = JsonUtil.toJson(joinedCaseClass).get
-
-    NotificationMessage(
-      Subject = "",
-      Message = hListJson,
-      TopicArn = "test_transformer_topic",
-      MessageId = "notification"
+    createNotificationMessageWith(
+      message = joinedCaseClass
     )
   }
 }

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -9,7 +9,6 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.models.v1.DisplayV1SerialisationTestBase
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
@@ -62,14 +61,7 @@ class SnapshotGeneratorFeatureTest
           apiVersion = ApiVersions.v1
         )
 
-        val message = NotificationMessage(
-          Subject = "Sent from SnapshotGeneratorFeatureTest",
-          Message = toJson(snapshotJob).get,
-          TopicArn = topic.arn,
-          MessageId = "message-id"
-        )
-
-        sqsClient.sendMessage(queue.url, toJson(message).get)
+        sendNotificationToSQS(queue = queue, message = snapshotJob)
 
         eventually {
 

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/GoobiReaderFeatureTest.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/GoobiReaderFeatureTest.scala
@@ -29,7 +29,7 @@ class GoobiReaderFeatureTest
 
           sendNotificationToSQS(
             queue = queue,
-            message = anS3Notification(sourceKey, bucket.name, eventTime)
+            body = anS3Notification(sourceKey, bucket.name, eventTime)
           )
 
           withServer(goobiReaderLocalFlags(queue, bucket, table)) { _ =>

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/GoobiReaderFeatureTest.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/GoobiReaderFeatureTest.scala
@@ -7,7 +7,6 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.goobi_reader.fixtures.GoobiReaderFixtures
 import uk.ac.wellcome.storage.vhs.HybridRecord
 import uk.ac.wellcome.test.utils.ExtendedPatience
-import uk.ac.wellcome.utils.JsonUtil._
 
 class GoobiReaderFeatureTest
     extends FunSpec
@@ -25,13 +24,13 @@ class GoobiReaderFeatureTest
           val id = "mets-0001"
           val sourceKey = s"$id.xml"
           val contents = "muddling the machinations of morose METS"
-          val notificationMessage =
-            aNotificationMessage(
-              queue.arn,
-              anS3Notification(sourceKey, bucket.name, eventTime))
 
           s3Client.putObject(bucket.name, sourceKey, contents)
-          sqsClient.sendMessage(queue.url, toJson(notificationMessage).get)
+
+          sendNotificationToSQS(
+            queue = queue,
+            message = anS3Notification(sourceKey, bucket.name, eventTime)
+          )
 
           withServer(goobiReaderLocalFlags(queue, bucket, table)) { _ =>
             eventually {

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/fixtures/GoobiReaderFixtures.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/fixtures/GoobiReaderFixtures.scala
@@ -3,24 +3,13 @@ package uk.ac.wellcome.platform.goobi_reader.fixtures
 import java.time.{Instant, ZoneOffset}
 import java.time.format.DateTimeFormatter
 
-import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.storage.test.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.test.fixtures.LocalVersionedHybridStore
 import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 
-import scala.util.Random
-
 trait GoobiReaderFixtures extends SQS with LocalVersionedHybridStore {
-
-  def aNotificationMessage(topicArn: String, message: String) =
-    NotificationMessage(
-      MessageId = Random.alphanumeric take 5 mkString,
-      TopicArn = topicArn,
-      Subject = "Test notification in GoobiReaderFeatureTest",
-      Message = message
-    )
 
   private val dateTimeFormatter: DateTimeFormatter =
     DateTimeFormatter

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
@@ -243,7 +243,7 @@ class GoobiReaderWorkerServiceTest
         val sourceKey = "any.xml"
         sendNotificationToSQS(
           queue = queue,
-          message = anS3Notification(sourceKey, bucket.name, eventTime)
+          body = anS3Notification(sourceKey, bucket.name, eventTime)
         )
 
         eventually {

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
@@ -25,7 +25,6 @@ import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 import uk.ac.wellcome.storage.vhs.{HybridRecord, VersionedHybridStore}
 import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 import uk.ac.wellcome.test.utils.ExtendedPatience
-import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -85,7 +84,7 @@ class GoobiReaderWorkerServiceTest
 
         sendNotificationToSQS(
           queue = queue,
-          message = anS3Notification(sourceKey, bucket.name, eventTime)
+          message = anS3Notification(urlEncodedSourceKey, bucket.name, eventTime)
         )
 
         eventually {

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
@@ -183,8 +183,6 @@ class GoobiReaderWorkerServiceTest
           message = anS3Notification(sourceKey, bucket.name, newerEventTime)
         )
 
-        sqsClient.sendMessage(queue.url, toJson(message).get)
-
         eventually {
           val expectedRecord = HybridRecord(
             id = id,

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.FunSpec
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.messaging.test.fixtures.SQS
+import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
 import uk.ac.wellcome.messaging.test.fixtures.SQS.{Queue, QueuePair}
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
@@ -37,6 +37,7 @@ class GoobiReaderWorkerServiceTest
     with ExtendedPatience
     with MockitoSugar
     with GoobiReaderFixtures
+    with Messaging
     with SQS {
 
   private val id = "mets-0001"
@@ -53,11 +54,10 @@ class GoobiReaderWorkerServiceTest
       case (bucket, QueuePair(queue, _), _, table, _) =>
         s3Client.putObject(bucket.name, sourceKey, contents)
 
-        val message = aNotificationMessage(
-          topicArn = queue.arn,
+        sendNotificationToSQS(
+          queue = queue,
           message = anS3Notification(sourceKey, bucket.name, eventTime)
         )
-        sqsClient.sendMessage(queue.url, toJson(message).get)
 
         eventually {
           val expectedRecord = HybridRecord(
@@ -83,12 +83,10 @@ class GoobiReaderWorkerServiceTest
           java.net.URLEncoder.encode(sourceKey, "utf-8")
         s3Client.putObject(bucket.name, sourceKey, contents)
 
-        val message = aNotificationMessage(
-          topicArn = queue.arn,
-          message =
-            anS3Notification(urlEncodedSourceKey, bucket.name, eventTime)
+        sendNotificationToSQS(
+          queue = queue,
+          message = anS3Notification(sourceKey, bucket.name, eventTime)
         )
-        sqsClient.sendMessage(queue.url, toJson(message).get)
 
         eventually {
           val contentsStorageKey = s"$goobiS3Prefix/kr/$id work/cd92f8d3"
@@ -133,11 +131,11 @@ class GoobiReaderWorkerServiceTest
         s3Client.putObject(bucket.name, sourceKey, contents)
 
         val olderEventTime = eventTime.minus(1, ChronoUnit.HOURS)
-        val message = aNotificationMessage(
-          topicArn = queue.arn,
-          message = anS3Notification(sourceKey, bucket.name, olderEventTime))
 
-        sqsClient.sendMessage(queue.url, toJson(message).get)
+        sendNotificationToSQS(
+          queue = queue,
+          message = anS3Notification(sourceKey, bucket.name, olderEventTime)
+        )
 
         eventually {
           val expectedRecord = HybridRecord(
@@ -179,9 +177,11 @@ class GoobiReaderWorkerServiceTest
 
         s3Client.putObject(bucket.name, sourceKey, updatedContents)
         val newerEventTime = eventTime.plus(1, ChronoUnit.HOURS)
-        val message = aNotificationMessage(
-          topicArn = queue.arn,
-          message = anS3Notification(sourceKey, bucket.name, newerEventTime))
+
+        sendNotificationToSQS(
+          queue = queue,
+          message = anS3Notification(sourceKey, bucket.name, newerEventTime)
+        )
 
         sqsClient.sendMessage(queue.url, toJson(message).get)
 
@@ -205,12 +205,10 @@ class GoobiReaderWorkerServiceTest
   it("fails gracefully if Json cannot be parsed") {
     withGoobiReaderWorkerService(s3Client) {
       case (bucket, QueuePair(queue, dlq), mockMetricsSender, table, _) =>
-        val notificationMessage = aNotificationMessage(
-          topicArn = queue.arn,
-          message = "NotJson"
+        sendNotificationToSQS(
+          queue = queue,
+          body = "NotJson"
         )
-
-        sqsClient.sendMessage(queue.url, toJson(notificationMessage).get)
 
         eventually {
           assertMessageSentToDlq(queue, dlq)
@@ -225,12 +223,10 @@ class GoobiReaderWorkerServiceTest
       case (bucket, QueuePair(queue, dlq), mockMetricsSender, table, _) =>
         val sourceKey = "NotThere.xml"
 
-        val notificationMessage = aNotificationMessage(
-          topicArn = queue.arn,
+        sendNotificationToSQS(
+          queue = queue,
           message = anS3Notification(sourceKey, bucket.name, eventTime)
         )
-
-        sqsClient.sendMessage(queue.url, toJson(notificationMessage).get)
 
         eventually {
           assertMessageSentToDlq(queue, dlq)
@@ -248,12 +244,10 @@ class GoobiReaderWorkerServiceTest
     withGoobiReaderWorkerService(mockClient) {
       case (bucket, QueuePair(queue, dlq), mockMetricsSender, table, _) =>
         val sourceKey = "any.xml"
-        val notificationMessage = aNotificationMessage(
-          topicArn = queue.arn,
+        sendNotificationToSQS(
+          queue = queue,
           message = anS3Notification(sourceKey, bucket.name, eventTime)
         )
-
-        sqsClient.sendMessage(queue.url, toJson(notificationMessage).get)
 
         eventually {
           assertMessageSentToDlq(queue, dlq)

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
@@ -55,7 +55,7 @@ class GoobiReaderWorkerServiceTest
 
         sendNotificationToSQS(
           queue = queue,
-          message = anS3Notification(sourceKey, bucket.name, eventTime)
+          body = anS3Notification(sourceKey, bucket.name, eventTime)
         )
 
         eventually {
@@ -84,8 +84,7 @@ class GoobiReaderWorkerServiceTest
 
         sendNotificationToSQS(
           queue = queue,
-          message =
-            anS3Notification(urlEncodedSourceKey, bucket.name, eventTime)
+          body = anS3Notification(urlEncodedSourceKey, bucket.name, eventTime)
         )
 
         eventually {
@@ -134,7 +133,7 @@ class GoobiReaderWorkerServiceTest
 
         sendNotificationToSQS(
           queue = queue,
-          message = anS3Notification(sourceKey, bucket.name, olderEventTime)
+          body = anS3Notification(sourceKey, bucket.name, olderEventTime)
         )
 
         eventually {
@@ -180,7 +179,7 @@ class GoobiReaderWorkerServiceTest
 
         sendNotificationToSQS(
           queue = queue,
-          message = anS3Notification(sourceKey, bucket.name, newerEventTime)
+          body = anS3Notification(sourceKey, bucket.name, newerEventTime)
         )
 
         eventually {
@@ -223,7 +222,7 @@ class GoobiReaderWorkerServiceTest
 
         sendNotificationToSQS(
           queue = queue,
-          message = anS3Notification(sourceKey, bucket.name, eventTime)
+          body = anS3Notification(sourceKey, bucket.name, eventTime)
         )
 
         eventually {

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
@@ -84,7 +84,8 @@ class GoobiReaderWorkerServiceTest
 
         sendNotificationToSQS(
           queue = queue,
-          message = anS3Notification(urlEncodedSourceKey, bucket.name, eventTime)
+          message =
+            anS3Notification(urlEncodedSourceKey, bucket.name, eventTime)
         )
 
         eventually {

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
@@ -8,7 +8,6 @@ import org.mockito.Matchers.{any, endsWith, eq => equalTo}
 import org.mockito.Mockito.{never, times, verify}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Assertion, FunSpec, Matchers}
-import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.Messaging
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.monitoring.test.fixtures.MetricsSenderFixture
@@ -116,20 +115,10 @@ class MessageStreamTest
 
         val examplePointer =
           MessagePointer(ObjectLocation(bucket.name, key))
-        val serialisedExamplePointer = toJson(examplePointer).get
 
-        val exampleNotification = NotificationMessage(
-          MessageId = "MessageId",
-          TopicArn = "TopicArn",
-          Subject = "Subject",
-          Message = serialisedExamplePointer
-        )
-
-        val serialisedExampleNotification = toJson(exampleNotification).get
-
-        sqsClient.sendMessage(
-          queue.url,
-          serialisedExampleNotification
+        sendNotificationToSQS(
+          queue = queue,
+          message = examplePointer
         )
 
         val received = new ConcurrentLinkedQueue[ExampleObject]()

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -197,7 +197,7 @@ trait Messaging
   def sendMessage[T](bucket: Bucket, queue: Queue, obj: T)(
     implicit encoder: Encoder[T]): SendMessageResult = {
     val s3key = Random.alphanumeric take 10 mkString
-    val notificationJson = put(
+    val notificationJson = put[T](
       obj = obj,
       location = ObjectLocation(namespace = bucket.name, key = s3key)
     )

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -144,7 +144,8 @@ trait Messaging
     }
   }
 
-  private def put[T](obj: T, location: ObjectLocation)(implicit encoder: Encoder[T]) = {
+  private def put[T](obj: T, location: ObjectLocation)(
+    implicit encoder: Encoder[T]) = {
     val serialisedExampleObject = toJson[T](obj).get
 
     s3Client.putObject(
@@ -163,7 +164,8 @@ trait Messaging
     toJson(exampleNotification).get
   }
 
-  private def get[T](snsMessage: MessageInfo)(implicit decoder: Decoder[T]): T = {
+  private def get[T](snsMessage: MessageInfo)(
+    implicit decoder: Decoder[T]): T = {
     val tryMessagePointer = fromJson[MessagePointer](snsMessage.message)
     tryMessagePointer shouldBe a[Success[_]]
 
@@ -182,9 +184,9 @@ trait Messaging
     * to objects in S3, return the unpacked objects.
     */
   def getMessages[T](topic: Topic): List[T] =
-    listMessagesReceivedFromSNS(topic)
-      .map { snsMessage => get[T](snsMessage)}
-      .toList
+    listMessagesReceivedFromSNS(topic).map { snsMessage =>
+      get[T](snsMessage)
+    }.toList
 
   /** Store an object in S3 and send the notification to SQS.
     *
@@ -192,7 +194,8 @@ trait Messaging
     * to an SNS topic, which was forwarded to the queue.  We don't use a
     * MessageWriter instance because that sends to SNS, not SQS.
     */
-  def sendMessage[T](bucket: Bucket, queue: Queue, message: T)(implicit encoder: Encoder[T]): SendMessageResult = {
+  def sendMessage[T](bucket: Bucket, queue: Queue, message: T)(
+    implicit encoder: Encoder[T]): SendMessageResult = {
     val s3key = Random.alphanumeric take 10 mkString
     val notificationJson = put(
       obj = message,

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -144,7 +144,7 @@ trait Messaging
     }
   }
 
-  def put[T](obj: T, location: ObjectLocation)(implicit encoder: Encoder[T]) = {
+  private def put[T](obj: T, location: ObjectLocation)(implicit encoder: Encoder[T]) = {
     val serialisedExampleObject = toJson[T](obj).get
 
     s3Client.putObject(
@@ -163,7 +163,7 @@ trait Messaging
     toJson(exampleNotification).get
   }
 
-  def get[T](snsMessage: MessageInfo)(implicit decoder: Decoder[T]): T = {
+  private def get[T](snsMessage: MessageInfo)(implicit decoder: Decoder[T]): T = {
     val tryMessagePointer = fromJson[MessagePointer](snsMessage.message)
     tryMessagePointer shouldBe a[Success[_]]
 
@@ -188,8 +188,9 @@ trait Messaging
 
   /** Store an object in S3 and send the notification to SQS.
     *
-    * As if another application had used a MessageWriter to send the message.
-    * TODO: Why not use the MessageWriter directly?
+    * As if another application had used a MessageWriter to send the message
+    * to an SNS topic, which was forwarded to the queue.  We don't use a
+    * MessageWriter instance because that sends to SNS, not SQS.
     */
   def sendMessage[T](bucket: Bucket, queue: Queue, message: T)(implicit encoder: Encoder[T]): SendMessageResult = {
     val s3key = Random.alphanumeric take 10 mkString

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -11,7 +11,7 @@ import com.amazonaws.services.sqs.model.SendMessageResult
 import io.circe.{Decoder, Encoder}
 import org.scalatest.Matchers
 import uk.ac.wellcome.messaging.message._
-import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
+import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.sqs.SQSConfig
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.{Queue, QueuePair}
@@ -183,7 +183,7 @@ trait Messaging
   /** Given a topic ARN which has received notifications containing pointers
     * to objects in S3, return the unpacked objects.
     */
-  def getMessages[T](topic: Topic): List[T] =
+  def getMessages[T](topic: Topic)(implicit decoder: Decoder[T]): List[T] =
     listMessagesReceivedFromSNS(topic).map { snsMessage =>
       get[T](snsMessage)
     }.toList

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -178,6 +178,19 @@ trait Messaging
     tryT.get
   }
 
+  /** Given a topic ARN which has received notifications containing pointers
+    * to objects in S3, return the unpacked objects.
+    */
+  def getMessages[T](topic: Topic): List[T] =
+    listMessagesReceivedFromSNS(topic)
+      .map { snsMessage => get[T](snsMessage)}
+      .toList
+
+  /** Store an object in S3 and send the notification to SQS.
+    *
+    * As if another application had used a MessageWriter to send the message.
+    * TODO: Why not use the MessageWriter directly?
+    */
   def sendMessage[T](bucket: Bucket, queue: Queue, message: T)(implicit encoder: Encoder[T]): SendMessageResult = {
     val s3key = Random.alphanumeric take 10 mkString
     val notificationJson = put(

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -155,13 +155,8 @@ trait Messaging
     val examplePointer =
       MessagePointer(ObjectLocation(location.namespace, location.key))
 
-    val serialisedExamplePointer = toJson(examplePointer).get
-
-    val exampleNotification = NotificationMessage(
-      MessageId = "MessageId",
-      TopicArn = "TopicArn",
-      Subject = "Subject",
-      Message = serialisedExamplePointer
+    val exampleNotification = createNotificationMessageWith(
+      message = examplePointer
     )
 
     toJson(exampleNotification).get

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -146,12 +146,12 @@ trait Messaging
 
   private def put[T](obj: T, location: ObjectLocation)(
     implicit encoder: Encoder[T]) = {
-    val serialisedExampleObject = toJson[T](obj).get
+    val serialisedObj = toJson[T](obj).get
 
     s3Client.putObject(
       location.namespace,
       location.key,
-      serialisedExampleObject
+      serialisedObj
     )
 
     val examplePointer =
@@ -194,11 +194,11 @@ trait Messaging
     * to an SNS topic, which was forwarded to the queue.  We don't use a
     * MessageWriter instance because that sends to SNS, not SQS.
     */
-  def sendMessage[T](bucket: Bucket, queue: Queue, message: T)(
+  def sendMessage[T](bucket: Bucket, queue: Queue, obj: T)(
     implicit encoder: Encoder[T]): SendMessageResult = {
     val s3key = Random.alphanumeric take 10 mkString
     val notificationJson = put(
-      obj = message,
+      obj = obj,
       location = ObjectLocation(namespace = bucket.name, key = s3key)
     )
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
@@ -26,8 +26,7 @@ trait SNS {
 
   import SNS._
 
-  protected val snsInternalEndpointUrl = "http://sns:9292"
-  protected val localSNSEndpointUrl = "http://localhost:9292"
+  private val localSNSEndpointUrl = "http://localhost:9292"
 
   private val regionName = "localhost"
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -165,7 +165,8 @@ trait SQS extends Matchers {
       Message = body
     )
 
-  def createNotificationMessageWith[T](message: T)(implicit encoder: Encoder[T]): NotificationMessage =
+  def createNotificationMessageWith[T](message: T)(
+    implicit encoder: Encoder[T]): NotificationMessage =
     createNotificationMessageWith(body = toJson(message).get)
 
   def sendNotificationToSQS(queue: Queue, body: String): SendMessageResult = {
@@ -173,7 +174,8 @@ trait SQS extends Matchers {
     sqsClient.sendMessage(queue.url, toJson(message).get)
   }
 
-  def sendNotificationToSQS[T](queue: Queue, message: T)(implicit encoder: Encoder[T]): SendMessageResult =
+  def sendNotificationToSQS[T](queue: Queue, message: T)(
+    implicit encoder: Encoder[T]): SendMessageResult =
     sendNotificationToSQS(queue = queue, body = toJson(message).get)
 
   def noMessagesAreWaitingIn(queue: Queue) = {

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -157,6 +157,19 @@ trait SQS extends Matchers {
     testwith(stream)
   }
 
+  def sendNotificationToSQS(queue: Queue, body: String): SendMessageResult = {
+    val message = NotificationMessage(
+      MessageId = Random.alphanumeric take 10 mkString,
+      TopicArn = Random.alphanumeric take 10 mkString,
+      Subject = Random.alphanumeric take 10 mkString,
+      Message = body
+    )
+    sqsClient.sendMessage(queue.url, toJson(message).get)
+  }
+
+  def sendNotificationToSQS[T](queue: Queue, message: T)(implicit encoder: Encoder[T]): SendMessageResult =
+    sendNotificationToSQS(queue = queue, body = toJson(message).get)
+
   object TestNotificationMessage {
     def apply(messageBody: String) =
       NotificationMessage(

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -29,8 +29,8 @@ trait SQS extends Matchers {
 
   import SQS._
 
-  protected val sqsInternalEndpointUrl = "http://sqs:9324"
-  protected val sqsEndpointUrl = "http://localhost:9324"
+  private val sqsInternalEndpointUrl = "http://sqs:9324"
+  private val sqsEndpointUrl = "http://localhost:9324"
 
   private val regionName = "localhost"
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -165,7 +165,7 @@ trait SQS extends Matchers {
       Message = body
     )
 
-  def createNotificationMessageWith[T](message: T)(implicit encoder: Encoder[T]: NotificationMessage =
+  def createNotificationMessageWith[T](message: T)(implicit encoder: Encoder[T]): NotificationMessage =
     createNotificationMessageWith(body = toJson(message).get)
 
   def sendNotificationToSQS(queue: Queue, body: String): SendMessageResult = {

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -170,20 +170,6 @@ trait SQS extends Matchers {
   def sendNotificationToSQS[T](queue: Queue, message: T)(implicit encoder: Encoder[T]): SendMessageResult =
     sendNotificationToSQS(queue = queue, body = toJson(message).get)
 
-  object TestNotificationMessage {
-    def apply(messageBody: String) =
-      NotificationMessage(
-        MessageId = "message-id",
-        TopicArn = "topic",
-        Subject = "subject",
-        Message = messageBody
-      )
-
-    def apply[T](testObject: T)(
-      implicit encoder: Encoder[T]): NotificationMessage =
-      TestNotificationMessage(toJson(testObject).get)
-  }
-
   def noMessagesAreWaitingIn(queue: Queue) = {
     // No messages in flight
     sqsClient

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -157,13 +157,19 @@ trait SQS extends Matchers {
     testwith(stream)
   }
 
-  def sendNotificationToSQS(queue: Queue, body: String): SendMessageResult = {
-    val message = NotificationMessage(
+  def createNotificationMessageWith(body: String): NotificationMessage =
+    NotificationMessage(
       MessageId = Random.alphanumeric take 10 mkString,
       TopicArn = Random.alphanumeric take 10 mkString,
       Subject = Random.alphanumeric take 10 mkString,
       Message = body
     )
+
+  def createNotificationMessageWith[T](message: T)(implicit encoder: Encoder[T]: NotificationMessage =
+    createNotificationMessageWith(body = toJson(message).get)
+
+  def sendNotificationToSQS(queue: Queue, body: String): SendMessageResult = {
+    val message = createNotificationMessageWith(body = body)
     sqsClient.sendMessage(queue.url, toJson(message).get)
   }
 

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -4,9 +4,7 @@ import io.circe.Encoder
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Assertion, FunSpec, Matchers}
-import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SQS
-import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord
 import uk.ac.wellcome.storage.dynamo._
@@ -83,7 +81,7 @@ class SierraBibMergerFeatureTest
                 modifiedDate = "2001-01-01T01:01:01Z"
               )
 
-              sendMessageToSQS(toJson(record).get, queue)
+              sendNotificationToSQS(queue = queue, message = record)
 
               val expectedSierraTransformable =
                 SierraTransformable(bibRecord = record)
@@ -121,7 +119,7 @@ class SierraBibMergerFeatureTest
                 modifiedDate = "2001-01-01T01:01:01Z"
               )
 
-              sendMessageToSQS(toJson(record1).get, queue)
+              sendNotificationToSQS(queue = queue, message = record1)
 
               val expectedSierraTransformable1 =
                 SierraTransformable(bibRecord = record1)
@@ -137,7 +135,7 @@ class SierraBibMergerFeatureTest
                 modifiedDate = "2002-02-02T02:02:02Z"
               )
 
-              sendMessageToSQS(toJson(record2).get, queue)
+              sendNotificationToSQS(queue = queue, message = record2)
 
               val expectedSierraTransformable2 =
                 SierraTransformable(bibRecord = record2)
@@ -198,7 +196,7 @@ class SierraBibMergerFeatureTest
                   (oldRecord, SourceMetadata(oldRecord.sourceName)))((t, m) =>
                   (t, m))
                 .map { _ =>
-                  sendMessageToSQS(toJson(record).get, queue)
+                  sendNotificationToSQS(queue = queue, message = record)
                 }
 
               val expectedSierraTransformable =
@@ -258,7 +256,7 @@ class SierraBibMergerFeatureTest
                   SourceMetadata(expectedSierraTransformable.sourceName)))(
                   (t, m) => (t, m))
                 .map { _ =>
-                  sendMessageToSQS(toJson(record).get, queue)
+                  sendNotificationToSQS(queue = queue, message = record)
                 }
 
               // Blocking in Scala is generally a bad idea; we do it here so there's
@@ -306,7 +304,7 @@ class SierraBibMergerFeatureTest
                   (t, m))
 
               future.map { _ =>
-                sendMessageToSQS(toJson(record).get, queue)
+                sendNotificationToSQS(queue = queue, message = record)
               }
 
               val expectedSierraTransformable =
@@ -323,15 +321,5 @@ class SierraBibMergerFeatureTest
         }
       }
     }
-  }
-
-  private def sendMessageToSQS(body: String, queue: Queue) = {
-    val message = NotificationMessage(
-      MessageId = "message-id",
-      TopicArn = "topic",
-      Subject = "Test message sent by SierraBibMergerWorkerServiceTest",
-      Message = body
-    )
-    sqsClient.sendMessage(queue.url, toJson(message).get)
   }
 }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -35,14 +35,10 @@ class SierraBibMergerWorkerServiceTest
 
     withWorkerServiceFixtures {
       case (metricsSender, QueuePair(queue, dlq), _) =>
-        sqsClient.sendMessage(
-          queue.url,
-          toJson(
-            NotificationMessage(
-              Subject = "default-subject",
-              Message = "null",
-              TopicArn = "",
-              MessageId = "")).get)
+        sendNotificationToSQS(
+          queue = queue,
+          body = "null"
+        )
 
         eventually {
           assertQueueEmpty(queue)

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
@@ -2,11 +2,8 @@ package uk.ac.wellcome.platform.sierra_item_merger
 
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{Assertion, FunSpec, Matchers}
-import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SQS
-import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.models.transformable.SierraTransformable
-import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 import uk.ac.wellcome.platform.sierra_item_merger.utils.SierraItemMergerTestUtil
 import uk.ac.wellcome.storage.test.fixtures.{LocalVersionedHybridStore, S3}
 import uk.ac.wellcome.storage.vhs.SourceMetadata
@@ -44,7 +41,7 @@ class SierraItemMergerFeatureTest
                 bibIds = List(bibId)
               )
 
-              sendItemRecordToSQS(record, queue)
+              sendNotificationToSQS(queue = queue, message = record)
 
               val expectedSierraTransformable = SierraTransformable(
                 sourceId = bibId,
@@ -83,7 +80,7 @@ class SierraItemMergerFeatureTest
                 bibIds = List(bibId1)
               )
 
-              sendItemRecordToSQS(record1, queue)
+              sendNotificationToSQS(queue = queue, message = record1)
 
               val bibId2 = "b2000002"
               val id2 = "2000002"
@@ -94,7 +91,7 @@ class SierraItemMergerFeatureTest
                 bibIds = List(bibId2)
               )
 
-              sendItemRecordToSQS(record2, queue)
+              sendNotificationToSQS(queue = queue, message = record2)
 
               eventually {
                 val expectedSierraTransformable1 = SierraTransformable(
@@ -121,16 +118,5 @@ class SierraItemMergerFeatureTest
         }
       }
     }
-  }
-
-  private def sendItemRecordToSQS(itemRecord: SierraItemRecord,
-                                  queue: Queue) = {
-    val message = NotificationMessage(
-      MessageId = "message-id",
-      TopicArn = "topic",
-      Subject = "Test message sent by SierraItemMergerWorkerServiceTest",
-      Message = toJson(itemRecord).get
-    )
-    sqsClient.sendMessage(queue.url, toJson(message).get)
   }
 }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
@@ -6,7 +6,6 @@ import com.gu.scanamo.Scanamo
 import com.gu.scanamo.syntax._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 import uk.ac.wellcome.sierra_adapter.models.SierraRecord
@@ -34,16 +33,11 @@ class SierraItemsToDynamoFeatureTest
           val bibId = "b54321"
           val data = s"""{"id": "$id", "bibIds": ["$bibId"]}"""
           val modifiedDate = Instant.ofEpochSecond(Instant.now.getEpochSecond)
-          val message = SierraRecord(id, data, modifiedDate)
 
-          val sqsMessage = NotificationMessage(
-            MessageId = "message-id",
-            TopicArn = "topic",
-            Subject = "subject",
-            Message = toJson(message).get
+          sendNotificationToSQS(
+            queue = queue,
+            message = SierraRecord(id, data, modifiedDate)
           )
-
-          sqsClient.sendMessage(queue.url, toJson(sqsMessage).get)
 
           eventually {
             Scanamo.scan[SierraItemRecord](dynamoDbClient)(table.name) should have size 1

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -104,14 +104,7 @@ class SierraItemsToDynamoWorkerServiceTest
           modifiedDate = modifiedDate2
         )
 
-        val sqsMessage = NotificationMessage(
-          MessageId = "message-id",
-          TopicArn = "topic",
-          Subject = "subject",
-          Message = toJson(record2).get
-        )
-
-        sqsClient.sendMessage(queue.url, toJson(sqsMessage).get)
+        sendNotificationToSQS(queue = queue, message = record2)
 
         val expectedBibIds = List("3", "4", "5")
         val expectedUnlinkedBibIds = List("1", "2")
@@ -145,21 +138,14 @@ class SierraItemsToDynamoWorkerServiceTest
   it("returns a GracefulFailureException if it receives an invalid message") {
     withSierraWorkerService {
       case (_, QueuePair(queue, dlq), _, metricsSender) =>
-        val message =
+        val body =
           """
           |{
           | "something": "something"
           |}
         """.stripMargin
 
-        val sqsMessage = NotificationMessage(
-          MessageId = "message-id",
-          TopicArn = "topic",
-          Subject = "subject",
-          Message = message
-        )
-
-        sqsClient.sendMessage(queue.url, toJson(sqsMessage).get)
+        sendNotificationToSQS(queue = queue, body = body)
 
         eventually {
           assertQueueEmpty(queue)

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/SierraReaderFeatureTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/SierraReaderFeatureTest.scala
@@ -2,11 +2,9 @@ package uk.ac.wellcome.platform.sierra_reader
 
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.storage.test.fixtures.S3
 import uk.ac.wellcome.test.utils.ExtendedPatience
-import uk.ac.wellcome.utils.JsonUtil._
 
 class SierraReaderFeatureTest
     extends FunSpec

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/SierraReaderFeatureTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/SierraReaderFeatureTest.scala
@@ -28,22 +28,16 @@ class SierraReaderFeatureTest
           "sierra.fields" -> "updatedDate,deletedDate,deleted,suppressed,author,title"
         )
 
-        withServer(flags) { _ =>
-          val message =
-            """
+        val body =
+          """
             |{
             | "start": "2013-12-10T17:16:35Z",
             | "end": "2013-12-13T21:34:35Z"
             |}
-            """.stripMargin
+          """.stripMargin
 
-          val notificationMessage = NotificationMessage(
-            Subject = "subject",
-            Message = message,
-            TopicArn = "topic",
-            MessageId = "message-id"
-          )
-          sqsClient.sendMessage(queue.url, toJson(notificationMessage).get)
+        withServer(flags) { _ =>
+          sendNotificationToSQS(queue = queue, body = body)
 
           eventually {
             // This comes from the wiremock recordings for Sierra API response

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -17,7 +17,6 @@ import uk.ac.wellcome.storage.test.fixtures.S3.Bucket
 
 import scala.concurrent.duration._
 import org.scalatest.compatible.Assertion
-import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.platform.sierra_reader.models.{

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -60,7 +60,10 @@ class SierraReaderWorkerServiceTest
               fields = fields
             )
 
-            withSQSStream[NotificationMessage, Assertion](actorSystem, queue, metricsSender) { sqsStream =>
+            withSQSStream[NotificationMessage, Assertion](
+              actorSystem,
+              queue,
+              metricsSender) { sqsStream =>
               val worker = new SierraReaderWorkerService(
                 system = actorSystem,
                 sqsStream = sqsStream,

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -233,20 +233,14 @@ class SierraReaderWorkerServiceTest
   it(
     "returns a GracefulFailureException if it receives a message that doesn't contain start or end values") {
     withSierraReaderWorkerService(fields = "") { fixtures =>
-      val message =
+      val body =
         """
           |{
           | "start": "2013-12-10T17:16:35Z"
           |}
         """.stripMargin
 
-      val notificationMessage =
-        NotificationMessage(
-          Subject = "subject",
-          Message = message,
-          TopicArn = "topic",
-          MessageId = "message-id"
-        )
+      val notificationMessage = createNotificationMessageWith(body = body)
       whenReady(fixtures.worker.processMessage(notificationMessage).failed) {
         ex =>
           ex shouldBe a[GracefulFailureException]
@@ -260,7 +254,7 @@ class SierraReaderWorkerServiceTest
     "does not return a GracefulFailureException if it cannot reach the Sierra API") {
     withSierraReaderWorkerService(fields = "", apiUrl = "http://localhost:5050") {
       fixtures =>
-        val message =
+        val body =
           """
           |{
           | "start": "2013-12-10T17:16:35Z",
@@ -268,13 +262,7 @@ class SierraReaderWorkerServiceTest
           |}
         """.stripMargin
 
-        val notificationMessage =
-          NotificationMessage(
-            Subject = "subject",
-            Message = message,
-            TopicArn = "topic",
-            MessageId = "message-id"
-          )
+        val notificationMessage = createNotificationMessageWith(body = body)
 
         whenReady(fixtures.worker.processMessage(notificationMessage).failed) {
           ex =>

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -95,28 +95,20 @@ class SierraReaderWorkerServiceTest
 
   it(
     "reads a window message from SQS, retrieves the bibs from Sierra and writes them to S3") {
+    val body =
+      """
+        |{
+        | "start": "2013-12-10T17:16:35Z",
+        | "end": "2013-12-13T21:34:35Z"
+        |}
+      """.stripMargin
+
     withSierraReaderWorkerService(
       fields = "updatedDate,deletedDate,deleted,suppressed,author,title",
       batchSize = 10,
       resourceType = SierraResourceTypes.bibs
     ) { fixtures =>
-      val message =
-        """
-          |{
-          | "start": "2013-12-10T17:16:35Z",
-          | "end": "2013-12-13T21:34:35Z"
-          |}
-        """.stripMargin
-
-      val notificationMessage =
-        NotificationMessage(
-          Subject = "subject",
-          Message = message,
-          TopicArn = "topic",
-          MessageId = "message-id"
-        )
-
-      sqsClient.sendMessage(fixtures.queue.url, toJson(notificationMessage).get)
+      sendNotificationToSQS(queue = fixtures.queue, body = body)
 
       val pageNames = List("0000.json", "0001.json", "0002.json").map { label =>
         s"records_bibs/2013-12-10T17-16-35Z__2013-12-13T21-34-35Z/$label"
@@ -139,27 +131,20 @@ class SierraReaderWorkerServiceTest
 
   it(
     "reads a window message from SQS, retrieves the items from Sierra and writes them to S3") {
+    val body =
+      """
+        |{
+        | "start": "2013-12-10T17:16:35Z",
+        | "end": "2013-12-13T21:34:35Z"
+        |}
+      """.stripMargin
+
     withSierraReaderWorkerService(
       fields = "updatedDate,deleted,deletedDate,bibIds,fixedFields,varFields",
       batchSize = 50,
       resourceType = SierraResourceTypes.items
     ) { fixtures =>
-      val message =
-        """
-          |{
-          | "start": "2013-12-10T17:16:35Z",
-          | "end": "2013-12-13T21:34:35Z"
-          |}
-        """.stripMargin
-
-      val notificationMessage =
-        NotificationMessage(
-          Subject = "subject",
-          Message = message,
-          TopicArn = "topic",
-          MessageId = "message-id"
-        )
-      sqsClient.sendMessage(fixtures.queue.url, toJson(notificationMessage).get)
+      sendNotificationToSQS(queue = fixtures.queue, body = body)
 
       val pageNames = List("0000.json", "0001.json", "0002.json", "0003.json")
         .map { label =>
@@ -207,7 +192,7 @@ class SierraReaderWorkerServiceTest
       )
 
       // Then we trigger the reader, and we expect it to fill in the rest.
-      val message =
+      val body =
         """
           |{
           | "start": "2013-12-10T17:16:35Z",
@@ -215,14 +200,7 @@ class SierraReaderWorkerServiceTest
           |}
         """.stripMargin
 
-      val notificationMessage =
-        NotificationMessage(
-          Subject = "subject",
-          Message = message,
-          TopicArn = "topic",
-          MessageId = "message-id"
-        )
-      sqsClient.sendMessage(fixtures.queue.url, toJson(notificationMessage).get)
+      sendNotificationToSQS(queue = fixtures.queue, body = body)
 
       val pageNames = List("0000.json", "0001.json", "0002.json", "0003.json")
         .map { label =>


### PR DESCRIPTION
Did I say I was done with the big test refactors? Oops. I started pulling on a thread I noticed with @mklander yesterday, and kept pulling:

* We only care about the Message field of `NotificationMessage`, the others can be defaulted. So let’s add a `createNotificationMessageWith` method.
* Most uses of NotificationMessage are followed by `sqsClient.sendMessage(queue.url, message)`, so let's roll that up into its own helper.
* And some of those are accompanied by a `putObject`, because we're mimicking a MessageWriter action – there's already a helper for that, we just need to use it
* And then analogously, add a helper for getting those objects back down from SNS

I would split it into four PRs, but Travis build times are what they are and I don’t think this is a substantial change.