### PR TITLE
Return a 302 Found response for redirected works

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -148,8 +148,7 @@ abstract class WorksController(apiConfig: ApiConfig,
   private def respondWithRedirect(originalUri: String,
                                   work: IdentifiedRedirectedWork,
                                   contextUri: String) =
-    response
-      .found
+    response.found
       .body("")
       .location(
         uri = originalUri.replaceAll(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
@@ -1,0 +1,21 @@
+package uk.ac.wellcome.platform.api.works.v1
+
+import com.twitter.finagle.http.Status
+import com.twitter.finatra.http.EmbeddedHttpServer
+
+class ApiV1RedirectsTest extends ApiV1WorksTestBase {
+  it("returns a TemporaryRedirect if looking up a redirected work") {
+    val redirectedWork = createIdentifiedRedirectedWork
+
+    withV1Api {
+      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+        insertIntoElasticsearch(indexNameV1, itemType, redirectedWork)
+        server.httpGet(
+          path = s"/$apiPrefix/works/${redirectedWork.canonicalId}",
+          andExpect = Status.TemporaryRedirect,
+          withBody = "",
+          withLocation = s"/$apiPrefix/works/${redirectedWork.redirect.canonicalId}"
+        )
+    }
+  }
+}

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
@@ -4,7 +4,7 @@ import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
 
 class ApiV1RedirectsTest extends ApiV1WorksTestBase {
-  it("returns a TemporaryRedirect if looking up a redirected work") {
+  it("returns a 302 Redirect if looking up a redirected work") {
     val redirectedWork = createIdentifiedRedirectedWork
 
     withV1Api {
@@ -15,6 +15,21 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
           andExpect = Status.Found,
           withBody = "",
           withLocation = s"/$apiPrefix/works/${redirectedWork.redirect.canonicalId}"
+        )
+    }
+  }
+
+  it("preserves query parameters on a 302 Redirect") {
+    val redirectedWork = createIdentifiedRedirectedWork
+
+    withV1Api {
+      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+        insertIntoElasticsearch(indexNameV1, itemType, redirectedWork)
+        server.httpGet(
+          path = s"/$apiPrefix/works/${redirectedWork.canonicalId}?includes=identifiers",
+          andExpect = Status.Found,
+          withBody = "",
+          withLocation = s"/$apiPrefix/works/${redirectedWork.redirect.canonicalId}?includes=identifiers"
         )
     }
   }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
@@ -12,7 +12,7 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
         insertIntoElasticsearch(indexNameV1, itemType, redirectedWork)
         server.httpGet(
           path = s"/$apiPrefix/works/${redirectedWork.canonicalId}",
-          andExpect = Status.TemporaryRedirect,
+          andExpect = Status.Found,
           withBody = "",
           withLocation = s"/$apiPrefix/works/${redirectedWork.redirect.canonicalId}"
         )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
@@ -14,7 +14,8 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
           path = s"/$apiPrefix/works/${redirectedWork.canonicalId}",
           andExpect = Status.Found,
           withBody = "",
-          withLocation = s"/$apiPrefix/works/${redirectedWork.redirect.canonicalId}"
+          withLocation =
+            s"/$apiPrefix/works/${redirectedWork.redirect.canonicalId}"
         )
     }
   }
@@ -26,10 +27,12 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
         insertIntoElasticsearch(indexNameV1, itemType, redirectedWork)
         server.httpGet(
-          path = s"/$apiPrefix/works/${redirectedWork.canonicalId}?includes=identifiers",
+          path =
+            s"/$apiPrefix/works/${redirectedWork.canonicalId}?includes=identifiers",
           andExpect = Status.Found,
           withBody = "",
-          withLocation = s"/$apiPrefix/works/${redirectedWork.redirect.canonicalId}?includes=identifiers"
+          withLocation =
+            s"/$apiPrefix/works/${redirectedWork.redirect.canonicalId}?includes=identifiers"
         )
     }
   }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -2,13 +2,12 @@ package uk.ac.wellcome.platform.api.works.v1
 
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
-import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.models.work.internal._
 
 class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("returns a list of works") {
-    withApiFixtures(ApiVersions.v1) {
+    withV1Api {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
@@ -61,7 +60,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("returns a single work when requested with id") {
-    withApiFixtures(ApiVersions.v1) {
+    withV1Api {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWork
 
@@ -90,7 +89,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("renders the items if the items include is present") {
-    withApiFixtures(ApiVersions.v1) {
+    withV1Api {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           items = createItems(count = 1)
@@ -123,7 +122,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it(
     "returns the requested page of results when requested with page & pageSize") {
-    withApiFixtures(ApiVersions.v1) {
+    withV1Api {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
@@ -219,7 +218,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("ignores parameters that are unused when making an API request") {
-    withApiFixtures(ApiVersions.v1) {
+    withV1Api {
       case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?foo=bar",
@@ -230,7 +229,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("returns matching results if doing a full-text search") {
-    withApiFixtures(ApiVersions.v1) {
+    withV1Api {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "A drawing of a dodo"
@@ -275,7 +274,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it(
     "includes a list of identifiers on a list endpoint if we pass ?includes=identifiers") {
-    withApiFixtures(ApiVersions.v1) {
+    withV1Api {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
@@ -329,7 +328,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it(
     "includes a list of identifiers on a single work endpoint if we pass ?includes=identifiers") {
-    withApiFixtures(ApiVersions.v1) {
+    withV1Api {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
         val otherIdentifier = createSourceIdentifier
         val work = createIdentifiedWorkWith(
@@ -362,7 +361,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("searches different indices with the ?_index query parameter") {
-    withApiFixtures(ApiVersions.v1) {
+    withV1Api {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
         withLocalElasticsearchIndex(itemType = itemType) { otherIndex =>
           val work = createIdentifiedWork
@@ -419,7 +418,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("looks up works in different indices with the ?_index query parameter") {
-    withApiFixtures(ApiVersions.v1) {
+    withV1Api {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
         withLocalElasticsearchIndex(itemType = itemType) { otherIndex =>
           val work = createIdentifiedWorkWith(
@@ -488,7 +487,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it(
     "includes the thumbnail field if available and we use the thumbnail include") {
-    withApiFixtures(ApiVersions.v1) {
+    withV1Api {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           thumbnail = Some(
@@ -529,7 +528,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("only returns works from the v1 index") {
-    withApiFixtures(ApiVersions.v1) {
+    withV1Api {
       case (
           apiPrefix,
           indexNameV1,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestBase.scala
@@ -1,8 +1,11 @@
 package uk.ac.wellcome.platform.api.works.v1
 
+import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.models.v1.DisplayV1SerialisationTestBase
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
 trait ApiV1WorksTestBase
     extends ApiWorksTestBase
-    with DisplayV1SerialisationTestBase
+    with DisplayV1SerialisationTestBase {
+  def withV1Api[R] = withApiFixtures[R](ApiVersions.v1)(_)
+}

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
@@ -12,7 +12,7 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
         insertIntoElasticsearch(indexNameV2, itemType, redirectedWork)
         server.httpGet(
           path = s"/$apiPrefix/works/${redirectedWork.canonicalId}",
-          andExpect = Status.TemporaryRedirect,
+          andExpect = Status.Found,
           withBody = "",
           withLocation = s"/$apiPrefix/works/${redirectedWork.redirect.canonicalId}"
         )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
@@ -14,7 +14,8 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
           path = s"/$apiPrefix/works/${redirectedWork.canonicalId}",
           andExpect = Status.Found,
           withBody = "",
-          withLocation = s"/$apiPrefix/works/${redirectedWork.redirect.canonicalId}"
+          withLocation =
+            s"/$apiPrefix/works/${redirectedWork.redirect.canonicalId}"
         )
     }
   }
@@ -26,10 +27,12 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
         insertIntoElasticsearch(indexNameV2, itemType, redirectedWork)
         server.httpGet(
-          path = s"/$apiPrefix/works/${redirectedWork.canonicalId}?includes=identifiers",
+          path =
+            s"/$apiPrefix/works/${redirectedWork.canonicalId}?includes=identifiers",
           andExpect = Status.Found,
           withBody = "",
-          withLocation = s"/$apiPrefix/works/${redirectedWork.redirect.canonicalId}?includes=identifiers"
+          withLocation =
+            s"/$apiPrefix/works/${redirectedWork.redirect.canonicalId}?includes=identifiers"
         )
     }
   }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
@@ -1,0 +1,21 @@
+package uk.ac.wellcome.platform.api.works.v2
+
+import com.twitter.finagle.http.Status
+import com.twitter.finatra.http.EmbeddedHttpServer
+
+class ApiV2RedirectsTest extends ApiV2WorksTestBase {
+  it("returns a TemporaryRedirect if looking up a redirected work") {
+    val redirectedWork = createIdentifiedRedirectedWork
+
+    withV2Api {
+      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+        insertIntoElasticsearch(indexNameV2, itemType, redirectedWork)
+        server.httpGet(
+          path = s"/$apiPrefix/works/${redirectedWork.canonicalId}",
+          andExpect = Status.TemporaryRedirect,
+          withBody = "",
+          withLocation = s"/$apiPrefix/works/${redirectedWork.redirect.canonicalId}"
+        )
+    }
+  }
+}

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
@@ -18,4 +18,19 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
         )
     }
   }
+
+  it("preserves query parameters on a 302 Redirect") {
+    val redirectedWork = createIdentifiedRedirectedWork
+
+    withV2Api {
+      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+        insertIntoElasticsearch(indexNameV2, itemType, redirectedWork)
+        server.httpGet(
+          path = s"/$apiPrefix/works/${redirectedWork.canonicalId}?includes=identifiers",
+          andExpect = Status.Found,
+          withBody = "",
+          withLocation = s"/$apiPrefix/works/${redirectedWork.redirect.canonicalId}?includes=identifiers"
+        )
+    }
+  }
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -6,8 +6,6 @@ import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.models.work.internal._
 
 class ApiV2WorksTest extends ApiV2WorksTestBase {
-  def withV2Api[R] = withApiFixtures[R](ApiVersions.v2)(_)
-
   it("returns a list of works") {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.api.works.v2
 
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
-import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.models.work.internal._
 
 class ApiV2WorksTest extends ApiV2WorksTestBase {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestBase.scala
@@ -1,8 +1,11 @@
 package uk.ac.wellcome.platform.api.works.v2
 
+import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.models.v2.DisplayV2SerialisationTestBase
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
 trait ApiV2WorksTestBase
     extends ApiWorksTestBase
-    with DisplayV2SerialisationTestBase
+    with DisplayV2SerialisationTestBase {
+  def withV2Api[R] = withApiFixtures[R](ApiVersions.v2)(_)
+}

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
@@ -6,8 +6,6 @@ import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 
 class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
-  def withV2Api[R] = withApiFixtures[R](ApiVersions.v2)(_)
-
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.api.works.v2
 
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
-import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 
 class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/WorksUtil.scala
@@ -14,6 +14,9 @@ trait WorksUtil extends ItemsUtil {
       )
     )
 
+  def createIdentifiedRedirectedWork: IdentifiedRedirectedWork =
+    createIdentifiedRedirectedWorkWith()
+
   def createIdentifiedRedirectedWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier
   ): IdentifiedRedirectedWork =


### PR DESCRIPTION
If we index a redirected work in Elasticsearch, retrieving it from the API will return a 302 Found, not a 410 Gone. Note that this preserves query parameters from the original request, because that feels like a sensible thing to do.

Closes #1010.