### PR TITLE
Tweak the size of windows in the Sierra bibs pipeline

### DIFF
--- a/sierra_adapter/terraform/pipeline_bibs.tf
+++ b/sierra_adapter/terraform/pipeline_bibs.tf
@@ -3,8 +3,8 @@ module "bibs_window_generator" {
 
   resource_type = "bibs"
 
-  window_length_minutes    = 31
-  trigger_interval_minutes = 15
+  window_length_minutes    = 16
+  trigger_interval_minutes = 7
 
   lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
   infra_bucket           = "${var.infra_bucket}"


### PR DESCRIPTION
Every so often a window ends up on the DLQ.  The data has still been fetched from Sierra, but we get alarms about windows on the DLQ. Shortening the windows should make windows less likely to fail.

Towards #2361.