### PR TITLE
The Miro transformer returns an InvisibleWork if it decides not to transform something, not None

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiver.scala
@@ -75,7 +75,7 @@ class NotificationMessageReceiver @Inject()(
   private def transformTransformable(
     transformable: Transformable,
     version: Int
-  ): Try[Option[TransformedBaseWork]] = {
+  ): Try[TransformedBaseWork] = {
     val transformableTransformer = chooseTransformer(transformable)
     transformableTransformer.transform(transformable, version) map {
       transformed =>
@@ -95,11 +95,9 @@ class NotificationMessageReceiver @Inject()(
     }
   }
 
-  private def publishMessage(
-    maybeWork: Option[TransformedBaseWork]): Future[Unit] =
-    maybeWork.fold(Future.successful(())) { work =>
-      messageWriter.write(
-        work,
-        s"source: ${this.getClass.getSimpleName}.publishMessage")
-    }
+  private def publishMessage(work: TransformedBaseWork): Future[Unit] =
+    messageWriter.write(
+      message = work,
+      subject = s"source: ${this.getClass.getSimpleName}.publishMessage"
+    )
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
@@ -73,7 +73,7 @@ class MiroTransformableTransformer
         )
       }.recover {
         case e: ShouldNotTransformException =>
-          warn(s"Should not transform: ${e.getMessage}")
+          info(s"Should not transform: ${e.getMessage}")
           UnidentifiedInvisibleWork(
             sourceIdentifier = sourceIdentifier,
             version = version

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
@@ -23,7 +23,6 @@ class MiroTransformableTransformer
   override def transformForType
     : PartialFunction[(Transformable, Int), Try[TransformedBaseWork]] = {
     case (miroTransformable: MiroTransformable, version: Int) =>
-
       val sourceIdentifier = SourceIdentifier(
         identifierType = IdentifierType("miro-image-number"),
         ontologyType = "Work",

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
@@ -21,7 +21,7 @@ class MiroTransformableTransformer
   // TODO this class is too big as the different test classes would suggest. Split it.
 
   override def transformForType
-    : PartialFunction[(Transformable, Int), Try[Some[UnidentifiedWork]]] = {
+    : PartialFunction[(Transformable, Int), Try[Some[TransformedBaseWork]]] = {
     case (miroTransformable: MiroTransformable, version: Int) =>
       Try {
         val miroData = MiroTransformableData.create(miroTransformable.data)

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformer.scala
@@ -21,8 +21,15 @@ class MiroTransformableTransformer
   // TODO this class is too big as the different test classes would suggest. Split it.
 
   override def transformForType
-    : PartialFunction[(Transformable, Int), Try[Some[TransformedBaseWork]]] = {
+    : PartialFunction[(Transformable, Int), Try[TransformedBaseWork]] = {
     case (miroTransformable: MiroTransformable, version: Int) =>
+
+      val sourceIdentifier = SourceIdentifier(
+        identifierType = IdentifierType("miro-image-number"),
+        ontologyType = "Work",
+        value = miroTransformable.sourceId
+      )
+
       Try {
         val miroData = MiroTransformableData.create(miroTransformable.data)
 
@@ -38,36 +45,39 @@ class MiroTransformableTransformer
 
         val (title, description) = getTitleAndDescription(miroData)
 
-        Some(
-          UnidentifiedWork(
-            sourceIdentifier = SourceIdentifier(
-              identifierType = IdentifierType("miro-image-number"),
-              ontologyType = "Work",
-              value = miroTransformable.sourceId),
-            otherIdentifiers =
-              getOtherIdentifiers(miroData, miroTransformable.sourceId),
-            mergeCandidates = List(),
-            title = title,
-            workType = None,
-            description = description,
-            physicalDescription = None,
-            extent = None,
-            lettering = miroData.suppLettering,
-            createdDate =
-              getCreatedDate(miroData, miroTransformable.MiroCollection),
-            subjects = getSubjects(miroData),
-            genres = getGenres(miroData),
-            contributors = getContributors(
-              miroId = miroTransformable.sourceId,
-              miroData = miroData
-            ),
-            thumbnail = Some(getThumbnail(miroData, miroTransformable.sourceId)),
-            production = List(),
-            language = None,
-            dimensions = None,
-            items = getItems(miroData, miroTransformable.sourceId),
+        UnidentifiedWork(
+          sourceIdentifier = sourceIdentifier,
+          otherIdentifiers =
+            getOtherIdentifiers(miroData, miroTransformable.sourceId),
+          mergeCandidates = List(),
+          title = title,
+          workType = None,
+          description = description,
+          physicalDescription = None,
+          extent = None,
+          lettering = miroData.suppLettering,
+          createdDate =
+            getCreatedDate(miroData, miroTransformable.MiroCollection),
+          subjects = getSubjects(miroData),
+          genres = getGenres(miroData),
+          contributors = getContributors(
+            miroId = miroTransformable.sourceId,
+            miroData = miroData
+          ),
+          thumbnail = Some(getThumbnail(miroData, miroTransformable.sourceId)),
+          production = List(),
+          language = None,
+          dimensions = None,
+          items = getItems(miroData, miroTransformable.sourceId),
+          version = version
+        )
+      }.recover {
+        case e: ShouldNotTransformException =>
+          warn(s"Should not transform: ${e.getMessage}")
+          UnidentifiedInvisibleWork(
+            sourceIdentifier = sourceIdentifier,
             version = version
-          ))
+          )
       }
   }
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/ShouldNotTransformException.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/ShouldNotTransformException.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.transformer.transformers.miro
+package uk.ac.wellcome.platform.transformer.transformers
 
 class ShouldNotTransformException(message: String)
     extends RuntimeException(message)

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
@@ -75,7 +75,7 @@ class SierraTransformableTransformer
             }
             .recover {
               case e: ShouldNotTransformException =>
-                warn(s"Should not transform: ${e.getMessage}")
+                info(s"Should not transform: ${e.getMessage}")
                 UnidentifiedInvisibleWork(
                   sourceIdentifier = sourceIdentifier,
                   version = version
@@ -84,8 +84,8 @@ class SierraTransformableTransformer
         }
 
         // A merged record can have both bibs and items.  If we only have
-        // the item data so far, we don't have enough to build a Work, so we
-        // return None.
+        // the item data so far, we don't have enough to build a Work to show
+        // in the API, so we return an InvisibleWork.
         .getOrElse {
           debug(s"No bib data for ${sierraTransformable.sourceId}, so skipping")
           Success(

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.platform.transformer.source.SierraBibData
 import uk.ac.wellcome.platform.transformer.transformers.sierra._
 import uk.ac.wellcome.utils.JsonUtil._
 
-import scala.util.Try
+import scala.util.{Success, Try}
 
 class SierraTransformableTransformer
     extends TransformableTransformer[SierraTransformable]

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
@@ -84,7 +84,7 @@ class SierraTransformableTransformer
         // the item data so far, we don't have enough to build a Work, so we
         // return None.
         .getOrElse {
-          debug("No bib data on the record, so skipping")
+          debug(s"No bib data for ${sierraTransformable.sourceId}, so skipping")
           Success(
             UnidentifiedInvisibleWork(
               sourceIdentifier = sourceIdentifier,

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.transformer.transformers
 import uk.ac.wellcome.models.transformable.{SierraTransformable, Transformable}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.source.SierraBibData
-import uk.ac.wellcome.platform.transformer.transformers.miro.ShouldNotTransformException
 import uk.ac.wellcome.platform.transformer.transformers.sierra._
 import uk.ac.wellcome.utils.JsonUtil._
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
@@ -1,12 +1,13 @@
 package uk.ac.wellcome.platform.transformer.transformers
 
-import uk.ac.wellcome.models.transformable.SierraTransformable
+import uk.ac.wellcome.models.transformable.{SierraTransformable, Transformable}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.source.SierraBibData
+import uk.ac.wellcome.platform.transformer.transformers.miro.ShouldNotTransformException
 import uk.ac.wellcome.platform.transformer.transformers.sierra._
 import uk.ac.wellcome.utils.JsonUtil._
 
-import scala.util.Success
+import scala.util.Try
 
 class SierraTransformableTransformer
     extends TransformableTransformer[SierraTransformable]
@@ -27,48 +28,60 @@ class SierraTransformableTransformer
     with SierraGenres
     with SierraMergeCandidates {
 
-  override def transformForType = {
+  override def transformForType: PartialFunction[(Transformable, Int), Try[TransformedBaseWork]] = {
     case (sierraTransformable: SierraTransformable, version: Int) =>
       sierraTransformable.maybeBibData
         .map { bibData =>
           debug(s"Attempting to transform ${bibData.id}")
 
+          val sourceIdentifier = SourceIdentifier(
+            identifierType = IdentifierType("sierra-system-number"),
+            ontologyType = "Work",
+            value = addCheckDigit(
+              bibData.id,
+              recordType = SierraRecordTypes.bibs
+            )
+          )
+
           fromJson[SierraBibData](bibData.data).map { sierraBibData =>
-            val identifier = SourceIdentifier(
-              identifierType = IdentifierType("sierra-system-number"),
-              ontologyType = "Work",
-              value = addCheckDigit(
-                sierraBibData.id,
-                recordType = SierraRecordTypes.bibs
-              ))
             if (!(sierraBibData.deleted || sierraBibData.suppressed)) {
-              Some(
-                UnidentifiedWork(
-                  sourceIdentifier = identifier,
-                  otherIdentifiers = getOtherIdentifiers(sierraBibData),
-                  mergeCandidates = getMergeCandidates(sierraBibData),
-                  title = getTitle(sierraBibData),
-                  workType = getWorkType(sierraBibData),
-                  description = getDescription(sierraBibData),
-                  physicalDescription = getPhysicalDescription(sierraBibData),
-                  extent = getExtent(sierraBibData),
-                  lettering = getLettering(sierraBibData),
-                  createdDate = None,
-                  subjects = getSubjects(sierraBibData),
-                  genres = getGenres(sierraBibData),
-                  contributors = getContributors(sierraBibData),
-                  thumbnail = None,
-                  production = getProduction(sierraBibData),
-                  language = getLanguage(sierraBibData),
-                  dimensions = getDimensions(sierraBibData),
-                  items = getItems(sierraTransformable),
-                  version = version
-                ))
+              UnidentifiedWork(
+                sourceIdentifier = sourceIdentifier,
+                otherIdentifiers = getOtherIdentifiers(sierraBibData),
+                mergeCandidates = getMergeCandidates(sierraBibData),
+                title = getTitle(sierraBibData),
+                workType = getWorkType(sierraBibData),
+                description = getDescription(sierraBibData),
+                physicalDescription = getPhysicalDescription(sierraBibData),
+                extent = getExtent(sierraBibData),
+                lettering = getLettering(sierraBibData),
+                createdDate = None,
+                subjects = getSubjects(sierraBibData),
+                genres = getGenres(sierraBibData),
+                contributors = getContributors(sierraBibData),
+                thumbnail = None,
+                production = getProduction(sierraBibData),
+                language = getLanguage(sierraBibData),
+                dimensions = getDimensions(sierraBibData),
+                items = getItems(sierraTransformable),
+                version = version
+              )
             } else {
-              Some(UnidentifiedInvisibleWork(identifier, version))
+              throw new ShouldNotTransformException(
+                s"Sierra record ${bibData.id} is either deleted or suppressed!"
+              )
             }
+          }.recover {
+            case e: ShouldNotTransformException =>
+              warn(s"Should not transform: ${e.getMessage}")
+              UnidentifiedInvisibleWork(
+                sourceIdentifier = sourceIdentifier,
+                version = version
+              )
           }
         }
+
+
         // A merged record can have both bibs and items.  If we only have
         // the item data so far, we don't have enough to build a Work, so we
         // return None.

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
@@ -27,7 +27,8 @@ class SierraTransformableTransformer
     with SierraGenres
     with SierraMergeCandidates {
 
-  override def transformForType: PartialFunction[(Transformable, Int), Try[TransformedBaseWork]] = {
+  override def transformForType
+    : PartialFunction[(Transformable, Int), Try[TransformedBaseWork]] = {
     case (sierraTransformable: SierraTransformable, version: Int) =>
       val sourceIdentifier = SourceIdentifier(
         identifierType = IdentifierType("sierra-system-number"),
@@ -42,42 +43,44 @@ class SierraTransformableTransformer
         .map { bibData =>
           debug(s"Attempting to transform ${bibData.id}")
 
-          fromJson[SierraBibData](bibData.data).map { sierraBibData =>
-            if (!(sierraBibData.deleted || sierraBibData.suppressed)) {
-              UnidentifiedWork(
-                sourceIdentifier = sourceIdentifier,
-                otherIdentifiers = getOtherIdentifiers(sierraBibData),
-                mergeCandidates = getMergeCandidates(sierraBibData),
-                title = getTitle(sierraBibData),
-                workType = getWorkType(sierraBibData),
-                description = getDescription(sierraBibData),
-                physicalDescription = getPhysicalDescription(sierraBibData),
-                extent = getExtent(sierraBibData),
-                lettering = getLettering(sierraBibData),
-                createdDate = None,
-                subjects = getSubjects(sierraBibData),
-                genres = getGenres(sierraBibData),
-                contributors = getContributors(sierraBibData),
-                thumbnail = None,
-                production = getProduction(sierraBibData),
-                language = getLanguage(sierraBibData),
-                dimensions = getDimensions(sierraBibData),
-                items = getItems(sierraTransformable),
-                version = version
-              )
-            } else {
-              throw new ShouldNotTransformException(
-                s"Sierra record ${bibData.id} is either deleted or suppressed!"
-              )
+          fromJson[SierraBibData](bibData.data)
+            .map { sierraBibData =>
+              if (!(sierraBibData.deleted || sierraBibData.suppressed)) {
+                UnidentifiedWork(
+                  sourceIdentifier = sourceIdentifier,
+                  otherIdentifiers = getOtherIdentifiers(sierraBibData),
+                  mergeCandidates = getMergeCandidates(sierraBibData),
+                  title = getTitle(sierraBibData),
+                  workType = getWorkType(sierraBibData),
+                  description = getDescription(sierraBibData),
+                  physicalDescription = getPhysicalDescription(sierraBibData),
+                  extent = getExtent(sierraBibData),
+                  lettering = getLettering(sierraBibData),
+                  createdDate = None,
+                  subjects = getSubjects(sierraBibData),
+                  genres = getGenres(sierraBibData),
+                  contributors = getContributors(sierraBibData),
+                  thumbnail = None,
+                  production = getProduction(sierraBibData),
+                  language = getLanguage(sierraBibData),
+                  dimensions = getDimensions(sierraBibData),
+                  items = getItems(sierraTransformable),
+                  version = version
+                )
+              } else {
+                throw new ShouldNotTransformException(
+                  s"Sierra record ${bibData.id} is either deleted or suppressed!"
+                )
+              }
             }
-          }.recover {
-            case e: ShouldNotTransformException =>
-              warn(s"Should not transform: ${e.getMessage}")
-              UnidentifiedInvisibleWork(
-                sourceIdentifier = sourceIdentifier,
-                version = version
-              )
-          }
+            .recover {
+              case e: ShouldNotTransformException =>
+                warn(s"Should not transform: ${e.getMessage}")
+                UnidentifiedInvisibleWork(
+                  sourceIdentifier = sourceIdentifier,
+                  version = version
+                )
+            }
         }
 
         // A merged record can have both bibs and items.  If we only have

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTransformer.scala
@@ -8,18 +8,14 @@ import scala.util.Try
 
 trait TransformableTransformer[T <: Transformable] extends Logging {
   def transformForType
-    : PartialFunction[(Transformable, Int), Try[Option[TransformedBaseWork]]]
+    : PartialFunction[(Transformable, Int), Try[TransformedBaseWork]]
 
   def transform(transformable: Transformable,
-                version: Int): Try[Option[TransformedBaseWork]] =
+                version: Int): Try[TransformedBaseWork] =
     Try {
       transformable match {
-        case t if transformForType.isDefinedAt((t, version)) =>
-          transformForType((t, version)).recover {
-            case e: ShouldNotTransformException =>
-              warn(s"Should not transform: ${e.getMessage}")
-              None
-          }
+        case t if transformForType.isDefinedAt(t, version) =>
+          transformForType(t, version)
         case _ =>
           throw new RuntimeException(s"$transformable is not of the right type")
       }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTransformer.scala
@@ -14,8 +14,8 @@ trait TransformableTransformer[T <: Transformable] extends Logging {
                 version: Int): Try[TransformedBaseWork] =
     Try {
       transformable match {
-        case t if transformForType.isDefinedAt(t, version) =>
-          transformForType(t, version)
+        case t if transformForType.isDefinedAt((t, version)) =>
+          transformForType((t, version))
         case _ =>
           throw new RuntimeException(s"$transformable is not of the right type")
       }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTransformer.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.transformer.transformers
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.transformable.Transformable
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
-import uk.ac.wellcome.platform.transformer.transformers.miro.ShouldNotTransformException
 
 import scala.util.Try
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodes.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributorCodes.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.transformer.transformers.miro
 
 import java.io.InputStream
 
+import uk.ac.wellcome.platform.transformer.transformers.ShouldNotTransformException
 import uk.ac.wellcome.utils.JsonUtil.toMap
 
 import scala.io.Source

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicenses.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicenses.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.transformer.transformers.miro
 
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.platform.transformer.transformers.ShouldNotTransformException
 
 trait MiroLicenses {
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraTitle.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraTitle.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import uk.ac.wellcome.platform.transformer.source.SierraBibData
-import uk.ac.wellcome.platform.transformer.transformers.miro.ShouldNotTransformException
+import uk.ac.wellcome.platform.transformer.transformers.ShouldNotTransformException
 
 trait SierraTitle {
 

--- a/catalogue_pipeline/transformer/src/test/resources/logback-test.xml
+++ b/catalogue_pipeline/transformer/src/test/resources/logback-test.xml
@@ -1,3 +1,5 @@
 <configuration>
   <include resource="base-logback-test.xml"/>
+
+  <logger name="uk.ac.wellcome.platform.transformer" level="INFO"/>
 </configuration>

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
@@ -191,29 +191,6 @@ class NotificationMessageReceiverTest
     }
   }
 
-  it("sends no message where Transformable work is None") {
-    withLocalSnsTopic { topic =>
-      withLocalSqsQueue { _ =>
-        withLocalS3Bucket { bucket =>
-          withNotificationMessageReceiver(topic, bucket) { recordReceiver =>
-            val future = recordReceiver.receiveMessage(
-              createValidEmptySierraBibNotificationMessage(
-                id = "0101010",
-                s3Client = s3Client,
-                bucket = bucket
-              )
-            )
-
-            whenReady(future) { _ =>
-              val snsMessages = listMessagesReceivedFromSNS(topic)
-              snsMessages shouldBe empty
-            }
-          }
-        }
-      }
-    }
-  }
-
   it("fails if it's unable to perform a transformation") {
     withLocalSnsTopic { topic =>
       withLocalSqsQueue { _ =>

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
@@ -224,7 +224,8 @@ class MiroTransformableTransformerTest
     )
   }
 
-  it("returns an InvisibleWork if usage restrictions mean we suppress the image") {
+  it(
+    "returns an InvisibleWork if usage restrictions mean we suppress the image") {
     assertTransformReturnsInvisibleWork(
       data =
         buildJSONForWork("""

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/MiroTransformableTransformerTest.scala
@@ -224,9 +224,8 @@ class MiroTransformableTransformerTest
     )
   }
 
-  it(
-    "returns None for Miro records with usage restrictions that mean we suppress the image") {
-    assertTransformReturnsNone(
+  it("returns an InvisibleWork if usage restrictions mean we suppress the image") {
+    assertTransformReturnsInvisibleWork(
       data =
         buildJSONForWork("""
         "image_title": "Private pictures of perilous penguins",
@@ -235,16 +234,16 @@ class MiroTransformableTransformerTest
     )
   }
 
-  it("returns None for Miro records from contributor GUS") {
-    assertTransformReturnsNone(
+  it("returns an InvisibleWork for images from contributor GUS") {
+    assertTransformReturnsInvisibleWork(
       data = buildJSONForWork("""
         "image_source_code": "GUS"
       """)
     )
   }
 
-  it("returns None for images which don't have copyright clearance") {
-    assertTransformReturnsNone(
+  it("returns an InvisibleWork for images without copyright clearance") {
+    assertTransformReturnsInvisibleWork(
       data = """{
         "image_cleared": "Y",
         "image_copyright_cleared": "N",
@@ -273,7 +272,7 @@ class MiroTransformableTransformerTest
     work.items.head.agent.locations shouldBe List(expectedDigitalLocation)
   }
 
-  private def assertTransformReturnsNone(data: String) = {
+  private def assertTransformReturnsInvisibleWork(data: String) = {
     val miroTransformable = MiroTransformable(
       sourceId = "G0000001",
       MiroCollection = "TestCollection",
@@ -282,7 +281,15 @@ class MiroTransformableTransformerTest
 
     val triedMaybeWork = transformer.transform(miroTransformable, version = 1)
     triedMaybeWork.isSuccess shouldBe true
-    triedMaybeWork.get shouldBe None
+
+    triedMaybeWork.get shouldBe UnidentifiedInvisibleWork(
+      sourceIdentifier = SourceIdentifier(
+        identifierType = IdentifierType("miro-image-number"),
+        ontologyType = "Work",
+        value = miroTransformable.sourceId
+      ),
+      version = 1
+    )
   }
 
   private def transformRecordAndCheckSierraSystemNumber(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -15,8 +15,6 @@ import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, VarField}
 import uk.ac.wellcome.utils.JsonUtil._
 
-import scala.util.Success
-
 class SierraTransformableTransformerTest
     extends FunSpec
     with Matchers

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -642,7 +642,7 @@ class SierraTransformableTransformerTest
       sourceIdentifier = SourceIdentifier(
         identifierType = IdentifierType("sierra-system-number"),
         ontologyType = "Work",
-        value = sierraTransformable.sourceId
+        value = "b01020109"
       ),
       version = 1
     )

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformerTest.scala
@@ -53,11 +53,7 @@ class SierraTransformableTransformerTest
       )
     )
 
-    val transformedSierraRecord =
-      transformer.transform(sierraTransformable, version = 1)
-
-    transformedSierraRecord.isSuccess shouldBe true
-    val work = transformedSierraRecord.get.get
+    val work = transformToWork(sierraTransformable)
 
     val sourceIdentifier1 =
       SourceIdentifier(
@@ -115,10 +111,7 @@ class SierraTransformableTransformerTest
           version = 1))
     )
 
-    val triedMaybeWork = transformer.transform(transformable, version = 1)
-    triedMaybeWork.isSuccess shouldBe true
-    triedMaybeWork.get.isDefined shouldBe true
-    val work = triedMaybeWork.get.get
+    val work = transformToWork(transformable)
     work shouldBe a[UnidentifiedWork]
     val unidentifiedWork = work.asInstanceOf[UnidentifiedWork]
     unidentifiedWork.items should have size 1

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTestBase.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTestBase.scala
@@ -11,7 +11,8 @@ trait TransformableTestBase[T <: Transformable] extends Matchers {
   val transformer: TransformableTransformer[T]
 
   def transformToWork(transformable: T): TransformedBaseWork = {
-    val triedWork: Try[TransformedBaseWork] = transformer.transform(transformable, version = 1)
+    val triedWork: Try[TransformedBaseWork] =
+      transformer.transform(transformable, version = 1)
     if (triedWork.isFailure) triedWork.failed.get.printStackTrace()
     triedWork.isSuccess shouldBe true
     triedWork.get

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTestBase.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTestBase.scala
@@ -4,15 +4,17 @@ import org.scalatest.Matchers
 import uk.ac.wellcome.models.transformable.Transformable
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 
+import scala.util.Try
+
 trait TransformableTestBase[T <: Transformable] extends Matchers {
 
   val transformer: TransformableTransformer[T]
 
   def transformToWork(transformable: T): TransformedBaseWork = {
-    val triedMaybeWork = transformer.transform(transformable, version = 1)
-    if (triedMaybeWork.isFailure) triedMaybeWork.failed.get.printStackTrace()
-    triedMaybeWork.isSuccess shouldBe true
-    triedMaybeWork.get.get
+    val triedWork: Try[TransformedBaseWork] = transformer.transform(transformable, version = 1)
+    if (triedWork.isFailure) triedWork.failed.get.printStackTrace()
+    triedWork.isSuccess shouldBe true
+    triedWork.get
   }
 
   def assertTransformToWorkFails(transformable: T): Unit = {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicensesTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroLicensesTest.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.transformer.transformers.miro
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal.License_CC0
+import uk.ac.wellcome.platform.transformer.transformers.ShouldNotTransformException
 
 class MiroLicensesTest extends FunSpec with Matchers {
   val miroId = "V00001"

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraTitleTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraTitleTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.transformer.transformers.sierra
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraData
 import uk.ac.wellcome.platform.transformer.source.SierraBibData
-import uk.ac.wellcome.platform.transformer.transformers.miro.ShouldNotTransformException
+import uk.ac.wellcome.platform.transformer.transformers.ShouldNotTransformException
 
 class SierraTitleTest extends FunSpec with Matchers with SierraData {
 

--- a/sbt_common/common/src/test/resources/base-logback-test.xml
+++ b/sbt_common/common/src/test/resources/base-logback-test.xml
@@ -18,6 +18,7 @@
   -->
   <logger name="com.amazonaws.http.DefaultErrorResponseHandler" level="WARN"/>
 
+  <logger name="ch.qos.logback" level="WARN"/>
   <logger name="com.amazonaws" level="INFO"/>
   <logger name="com.sksamuel.elastic4s" level="INFO"/>
   <logger name="com.twitter" level="INFO"/>

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
@@ -31,7 +31,7 @@ case class SierraTransformable(
   sourceId: String,
   sourceName: String = "sierra",
   maybeBibData: Option[SierraBibRecord] = None,
-  itemData: Map[String, SierraItemRecord] = Map[String, SierraItemRecord]()
+  itemData: Map[String, SierraItemRecord] = Map()
 ) extends Transformable
 
 object SierraTransformable {


### PR DESCRIPTION
### What is this PR trying to achieve?

Per the title. We're removing a small number of works in the next reindex – they're missing copyright information, usage data, or have a bad contributor code.

The correct behaviour is for these to return a 410 when requested in the new API, whereas they would currently 404.

This also makes it easier to judge if reindexes have succeeded, because the size of the Elasticsearch index should be constant (and equal to the number of source records).