### PR TITLE
Max the capacity of SourceData when triggering a reindex

### DIFF
--- a/reindexer/dynamodb_capacity_helpers.py
+++ b/reindexer/dynamodb_capacity_helpers.py
@@ -1,0 +1,101 @@
+# -*- encoding: utf-8
+
+import attr
+import boto3
+from botocore.exceptions import ClientError
+
+
+@attr.s
+class DynamoDBCapacity(object):
+    write = attr.ib()
+    read = attr.ib()
+
+    def __str__(self):
+        return f'{self.write} write and {self.read} read'
+
+
+def _get_max_dynamodb_capacity(resource_id, dimension):
+    autoscaling = boto3.client('application-autoscaling')
+
+    resp = autoscaling.describe_scalable_targets(
+        ServiceNamespace='dynamodb',
+        ResourceIds=[resource_id],
+        ScalableDimension=f'dynamodb:{dimension}'
+    )
+    assert len(resp['ScalableTargets']) == 1, resp
+    return resp['ScalableTargets'][0]['MaxCapacity']
+
+
+def get_dynamodb_max_table_capacity(table_name):
+    write_capacity = _get_max_dynamodb_capacity(
+        resource_id=f'table/{table_name}',
+        dimension='table:WriteCapacityUnits'
+    )
+
+    read_capacity = _get_max_dynamodb_capacity(
+        resource_id=f'table/{table_name}',
+        dimension='table:ReadCapacityUnits'
+    )
+
+    return DynamoDBCapacity(write=write_capacity, read=read_capacity)
+
+
+def get_dynamodb_max_gsi_capacity(table_name, gsi_name):
+    write_capacity = _get_max_dynamodb_capacity(
+        resource_id=f'table/{table_name}/index/{gsi_name}',
+        dimension='index:WriteCapacityUnits'
+    )
+
+    read_capacity = _get_max_dynamodb_capacity(
+        resource_id=f'table/{table_name}/index/{gsi_name}',
+        dimension='index:ReadCapacityUnits'
+    )
+
+    return DynamoDBCapacity(write=write_capacity, read=read_capacity)
+
+
+def set_dynamodb_table_capacity(table_name, desired_capacity):
+    dynamodb = boto3.client('dynamodb')
+    try:
+        dynamodb.update_table(
+            TableName=table_name,
+            ProvisionedThroughput={
+                'ReadCapacityUnits': desired_capacity.read,
+                'WriteCapacityUnits': desired_capacity.write,
+            },
+        )
+    except ClientError as err:
+        if err.response['Error']['Message'].startswith(
+            'The provisioned throughput for the table will not change. '
+            'The requested value equals the current value.'
+        ):
+            pass
+        else:
+            raise
+
+
+def set_dynamodb_gsi_capacity(table_name, gsi_name, desired_capacity):
+    dynamodb = boto3.client('dynamodb')
+    try:
+        dynamodb.update_table(
+            TableName=table_name,
+            GlobalSecondaryIndexUpdates=[
+                {
+                    'Update': {
+                        'IndexName': gsi_name,
+                        'ProvisionedThroughput': {
+                            'ReadCapacityUnits': desired_capacity.read,
+                            'WriteCapacityUnits': desired_capacity.write,
+                        }
+                    }
+                }
+            ]
+        )
+    except ClientError as err:
+        if err.response['Error']['Message'].startswith(
+            f'The provisioned throughput for the index {gsi_name} will not '
+            f'change. The requested value equals the current value.'
+        ):
+            pass
+        else:
+            raise

--- a/reindexer/trigger_reindex.py
+++ b/reindexer/trigger_reindex.py
@@ -73,7 +73,7 @@ def publish_messages(topic_arn, messages):
     """Publish a sequence of messages to an SNS topic."""
     sns_client = boto3.client('sns')
     for m in tqdm.tqdm(messages):
-        sns_client.publish(
+        resp = sns_client.publish(
             TopicArn=topic_arn,
             MessageStructure='json',
             Message=json.dumps({
@@ -81,6 +81,7 @@ def publish_messages(topic_arn, messages):
             }),
             Subject=f'Source: {__file__}'
         )
+        assert response['ResponseMetadata']['HTTPStatusCode'] == 200, resp
 
 
 def post_to_slack(source_name, reason):

--- a/reindexer/trigger_reindex.py
+++ b/reindexer/trigger_reindex.py
@@ -104,7 +104,7 @@ def post_to_slack(source_name, reason):
     webhook_url = tfvars['non_critical_slack_webhook']
 
     message = (
-        f'*{username}* started a reindex in *{source_name}*\n
+        f'*{username}* started a reindex in *{source_name}*\n'
         f'Reason: *{reason}*'
     )
 

--- a/reindexer/trigger_reindex.py
+++ b/reindexer/trigger_reindex.py
@@ -81,7 +81,7 @@ def publish_messages(topic_arn, messages):
             }),
             Subject=f'Source: {__file__}'
         )
-        assert response['ResponseMetadata']['HTTPStatusCode'] == 200, resp
+        assert resp['ResponseMetadata']['HTTPStatusCode'] == 200, resp
 
 
 def post_to_slack(source_name, reason):
@@ -103,7 +103,10 @@ def post_to_slack(source_name, reason):
 
     webhook_url = tfvars['non_critical_slack_webhook']
 
-    message = f'*{username}* started a reindex in *{source_name}*\nReason: *{reason}*'
+    message = (
+        f'*{username}* started a reindex in *{source_name}*\n
+        f'Reason: *{reason}*'
+    )
 
     slack_data = {
         'username': 'reindex-tracker',


### PR DESCRIPTION
As discussed as a rudimentary fix for pipeline stability.

The script always turns up the capacity to the max.