### PR TITLE
[WIP] Fix resuming of windows in the Sierra reader

### DIFF
--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbers.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbers.scala
@@ -75,6 +75,12 @@ object SierraRecordNumbers {
     if (remainder == 10) "x" else remainder.toString
   }
 
+  private def is7digitRecordNumber(s: String): Boolean =
+    """^[0-9]{7}$""".r.unapplySeq(s) isDefined
+
+  private def is8digitRecordNumber(s: String): Boolean =
+    """^[0-9]{7}[0-9xX]$""".r.unapplySeq(s) isDefined
+
   /** Throws an exception if the given string doesn't look like a valid
     * Sierra record number.
     *
@@ -82,8 +88,26 @@ object SierraRecordNumbers {
     * a seven- or eight-digit string.
     */
   def assertValidRecordNumber(s: String): Unit =
-    """^[0-9]{7}[0-9xX]?$""".r.unapplySeq(s) match {
-      case Some(_) => ()
-      case None => throw new RuntimeException(s"Not a valid Sierra record number: $s")
+    if (is7digitRecordNumber(s) || is8digitRecordNumber(s)) {
+      ()
+    } else {
+      throw new RuntimeException(s"Not a valid Sierra record number: $s")
     }
+
+  /** Increments a Sierra record number.
+    *
+    * For example, "1000001" -> "1000002".  This can only be used on a
+    * seven-digit number; the eighth digit is a check digit, not sequential.
+    */
+  def increment(s: String): String = {
+    if (!is7digitRecordNumber(s)) {
+      throw new RuntimeException(
+        s"increment() can only be used with 7-digit record numbers; not $s"
+      )
+    }
+
+    val result = (s.toInt + 1).toString
+    assert(is7digitRecordNumber(result))
+    result
+  }
 }

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbers.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbers.scala
@@ -88,11 +88,9 @@ object SierraRecordNumbers {
     * a seven- or eight-digit string.
     */
   def assertValidRecordNumber(s: String): Unit =
-    if (is7digitRecordNumber(s) || is8digitRecordNumber(s)) {
-      ()
-    } else {
-      throw new RuntimeException(s"Not a valid Sierra record number: $s")
-    }
+    assert(
+      is7digitRecordNumber(s) || is8digitRecordNumber(s),
+      s"Not a valid Sierra record number: $s")
 
   /** Increments a Sierra record number.
     *
@@ -100,11 +98,9 @@ object SierraRecordNumbers {
     * seven-digit number; the eighth digit is a check digit, not sequential.
     */
   def increment(s: String): String = {
-    if (!is7digitRecordNumber(s)) {
-      throw new RuntimeException(
-        s"increment() can only be used with 7-digit record numbers; not $s"
-      )
-    }
+    assert(
+      is7digitRecordNumber(s),
+      s"increment() can only be used with 7-digit record numbers; not $s")
 
     val result = (s.toInt + 1).toString
     assert(is7digitRecordNumber(result))

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbers.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbers.scala
@@ -79,17 +79,13 @@ object SierraRecordNumbers {
     """^[0-9]{7}$""".r.unapplySeq(s) isDefined
 
   def assertIs7DigitRecordNumber(s: String): Unit =
-    assert(
-      is7digitRecordNumber(s),
-      s"Not a 7-digit Sierra record number: $s")
+    assert(is7digitRecordNumber(s), s"Not a 7-digit Sierra record number: $s")
 
   private def is8digitRecordNumber(s: String): Boolean =
     """^[0-9]{7}[0-9xX]$""".r.unapplySeq(s) isDefined
 
   def assertIs8DigitRecordNumber(s: String): Unit =
-    assert(
-      is8digitRecordNumber(s),
-      s"Not an 8-digit Sierra record number: $s")
+    assert(is8digitRecordNumber(s), s"Not an 8-digit Sierra record number: $s")
 
   /** Throws an exception if the given string doesn't look like a valid
     * Sierra record number.

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbers.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbers.scala
@@ -74,4 +74,16 @@ object SierraRecordNumbers {
       .sum % 11
     if (remainder == 10) "x" else remainder.toString
   }
+
+  /** Throws an exception if the given string doesn't look like a valid
+    * Sierra record number.
+    *
+    * Note: this doesn't inspect the check digit (yet), just that it's
+    * a seven- or eight-digit string.
+    */
+  def assertValidRecordNumber(s: String): Unit =
+    """^[0-9]{7}[0-9xX]?$""".r.unapplySeq(s) match {
+      case Some(_) => ()
+      case None => throw new RuntimeException(s"Not a valid Sierra record number: $s")
+    }
 }

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbers.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbers.scala
@@ -78,8 +78,18 @@ object SierraRecordNumbers {
   private def is7digitRecordNumber(s: String): Boolean =
     """^[0-9]{7}$""".r.unapplySeq(s) isDefined
 
+  def assertIs7DigitRecordNumber(s: String): Unit =
+    assert(
+      is7digitRecordNumber(s),
+      s"Not a 7-digit Sierra record number: $s")
+
   private def is8digitRecordNumber(s: String): Boolean =
     """^[0-9]{7}[0-9xX]$""".r.unapplySeq(s) isDefined
+
+  def assertIs8DigitRecordNumber(s: String): Unit =
+    assert(
+      is8digitRecordNumber(s),
+      s"Not an 8-digit Sierra record number: $s")
 
   /** Throws an exception if the given string doesn't look like a valid
     * Sierra record number.

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbers.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbers.scala
@@ -42,9 +42,9 @@ object SierraRecordNumbers {
         )
     }
 
-    val result = s"$prefix$sierraId$checkDigit"
-    assertIs8DigitRecordNumber(result)
-    result
+    val recordNumber = s"$sierraId$checkDigit"
+    assertIs8DigitRecordNumber(recordNumber)
+    s"$prefix$recordNumber"
   }
 
   /** Returns the check digit that should be added to a record ID.

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbers.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbers.scala
@@ -26,14 +26,11 @@ object SierraRecordNumbers {
 
     // First check that we're being passed a 7-digit numeric ID -- anything
     // else is an error.
-    val regexMatch = """^([0-9]{7})$""".r.unapplySeq(sierraId)
-    val checkDigit = regexMatch match {
-      case Some(s) => getCheckDigit(s.head)
-      case _ =>
-        throw new RuntimeException(
-          s"Expected 7-digit numeric ID, got $sierraId"
-        )
-    }
+    assert(
+      is7digitRecordNumber(sierraId),
+      s"addCheckDigit() can only be used with 7-digit record numbers; not $sierraId")
+
+    val checkDigit = getCheckDigit(sierraId)
 
     // Then pick the record type prefix.
     val prefix = recordType match {
@@ -45,7 +42,9 @@ object SierraRecordNumbers {
         )
     }
 
-    s"$prefix$sierraId$checkDigit"
+    val result = s"$prefix$sierraId$checkDigit"
+    assertIs8DigitRecordNumber(result)
+    result
   }
 
   /** Returns the check digit that should be added to a record ID.
@@ -64,10 +63,11 @@ object SierraRecordNumbers {
     *     after the division is the check digit.  If the remainder is 10,
     *     the letter x is used as the check digit.
     *
-    * This method does no error checking, and assumes it is passed a 7-digit
-    * Sierra ID.
+    * This method can only be passed a 7-digit Sierra ID.
+    *
     */
   private def getCheckDigit(sierraId: String): String = {
+    assertIs7DigitRecordNumber(sierraId)
     val remainder = sierraId.reverse
       .zip(Stream from 2)
       .map { case (char: Char, count: Int) => char.toString.toInt * count }
@@ -113,7 +113,7 @@ object SierraRecordNumbers {
       s"increment() can only be used with 7-digit record numbers; not $s")
 
     val result = (s.toInt + 1).toString
-    assert(is7digitRecordNumber(result))
+    assertIs7DigitRecordNumber(result)
     result
   }
 }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbersTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbersTest.scala
@@ -32,28 +32,31 @@ class SierraRecordNumbersTest extends FunSpec with Matchers {
 
     it("throws an error if passed a Sierra ID which is non-numeric") {
       assertThrowsAssertionError(
-        () => SierraRecordNumbers.addCheckDigit(
-          "abcdefg",
-          recordType = SierraRecordTypes.bibs),
-        expectedMessage = "addCheckDigit() can only be used with 7-digit record numbers; not abcdefg"
+        () =>
+          SierraRecordNumbers
+            .addCheckDigit("abcdefg", recordType = SierraRecordTypes.bibs),
+        expectedMessage =
+          "addCheckDigit() can only be used with 7-digit record numbers; not abcdefg"
       )
     }
 
     it("throws an error if passed a Sierra ID which is too short") {
       assertThrowsAssertionError(
-        () => SierraRecordNumbers.addCheckDigit(
-          "123",
-          recordType = SierraRecordTypes.bibs),
-        expectedMessage = "addCheckDigit() can only be used with 7-digit record numbers; not 123"
+        () =>
+          SierraRecordNumbers
+            .addCheckDigit("123", recordType = SierraRecordTypes.bibs),
+        expectedMessage =
+          "addCheckDigit() can only be used with 7-digit record numbers; not 123"
       )
     }
 
     it("throws an error if passed a Sierra ID which is too long") {
       assertThrowsAssertionError(
-        () => SierraRecordNumbers.addCheckDigit(
-          "12345678",
-          recordType = SierraRecordTypes.bibs),
-        expectedMessage = "addCheckDigit() can only be used with 7-digit record numbers; not 12345678"
+        () =>
+          SierraRecordNumbers
+            .addCheckDigit("12345678", recordType = SierraRecordTypes.bibs),
+        expectedMessage =
+          "addCheckDigit() can only be used with 7-digit record numbers; not 12345678"
       )
     }
   }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbersTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbersTest.scala
@@ -31,32 +31,30 @@ class SierraRecordNumbersTest extends FunSpec with Matchers {
     }
 
     it("throws an error if passed a Sierra ID which is non-numeric") {
-      val caught = intercept[RuntimeException] {
-        SierraRecordNumbers.addCheckDigit(
+      assertThrowsAssertionError(
+        () => SierraRecordNumbers.addCheckDigit(
           "abcdefg",
-          recordType = SierraRecordTypes.bibs)
-      }
-
-      caught.getMessage shouldEqual "addCheckDigit() can only be used with 7-digit record numbers; not abcdefg"
+          recordType = SierraRecordTypes.bibs),
+        expectedMessage = "addCheckDigit() can only be used with 7-digit record numbers; not abcdefg"
+      )
     }
 
     it("throws an error if passed a Sierra ID which is too short") {
-      val caught = intercept[RuntimeException] {
-        SierraRecordNumbers.addCheckDigit(
+      assertThrowsAssertionError(
+        () => SierraRecordNumbers.addCheckDigit(
           "123",
-          recordType = SierraRecordTypes.bibs)
-      }
-
-      caught.getMessage shouldEqual "addCheckDigit() can only be used with 7-digit record numbers; not 123"
+          recordType = SierraRecordTypes.bibs),
+        expectedMessage = "addCheckDigit() can only be used with 7-digit record numbers; not 123"
+      )
     }
 
     it("throws an error if passed a Sierra ID which is too long") {
-      val caught = intercept[RuntimeException] {
-        SierraRecordNumbers.addCheckDigit(
+      assertThrowsAssertionError(
+        () => SierraRecordNumbers.addCheckDigit(
           "12345678",
-          recordType = SierraRecordTypes.bibs)
-      }
-      caught.getMessage shouldEqual "addCheckDigit() can only be used with 7-digit record numbers; not 12345678"
+          recordType = SierraRecordTypes.bibs),
+        expectedMessage = "addCheckDigit() can only be used with 7-digit record numbers; not 12345678"
+      )
     }
   }
 

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbersTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbersTest.scala
@@ -107,14 +107,16 @@ class SierraRecordNumbersTest extends FunSpec with Matchers {
     it("rejects 8-digit record numbers") {
       assertThrowsAssertionError(
         () => SierraRecordNumbers.increment("12345678"),
-        expectedMessage = "increment() can only be used with 7-digit record numbers; not 12345678"
+        expectedMessage =
+          "increment() can only be used with 7-digit record numbers; not 12345678"
       )
     }
 
     it("rejects bad inputs") {
       assertThrowsAssertionError(
         () => SierraRecordNumbers.increment("NaN"),
-        expectedMessage = "increment() can only be used with 7-digit record numbers; not NaN"
+        expectedMessage =
+          "increment() can only be used with 7-digit record numbers; not NaN"
       )
     }
 
@@ -127,7 +129,8 @@ class SierraRecordNumbersTest extends FunSpec with Matchers {
     }
   }
 
-  private def assertThrowsAssertionError(f: => () => Unit, expectedMessage: String): Assertion = {
+  private def assertThrowsAssertionError(f: => () => Unit,
+                                         expectedMessage: String): Assertion = {
     val caught = intercept[AssertionError] { f() }
     caught.getMessage shouldBe s"assertion failed: $expectedMessage"
   }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbersTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbersTest.scala
@@ -37,7 +37,7 @@ class SierraRecordNumbersTest extends FunSpec with Matchers {
           recordType = SierraRecordTypes.bibs)
       }
 
-      caught.getMessage shouldEqual "Expected 7-digit numeric ID, got abcdefg"
+      caught.getMessage shouldEqual "addCheckDigit() can only be used with 7-digit record numbers; not abcdefg"
     }
 
     it("throws an error if passed a Sierra ID which is too short") {
@@ -47,7 +47,7 @@ class SierraRecordNumbersTest extends FunSpec with Matchers {
           recordType = SierraRecordTypes.bibs)
       }
 
-      caught.getMessage shouldEqual "Expected 7-digit numeric ID, got 123"
+      caught.getMessage shouldEqual "addCheckDigit() can only be used with 7-digit record numbers; not 123"
     }
 
     it("throws an error if passed a Sierra ID which is too long") {
@@ -56,8 +56,7 @@ class SierraRecordNumbersTest extends FunSpec with Matchers {
           "12345678",
           recordType = SierraRecordTypes.bibs)
       }
-
-      caught.getMessage shouldEqual "Expected 7-digit numeric ID, got 12345678"
+      caught.getMessage shouldEqual "addCheckDigit() can only be used with 7-digit record numbers; not 12345678"
     }
   }
 

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbersTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbersTest.scala
@@ -77,4 +77,28 @@ class SierraRecordNumbersTest extends FunSpec with Matchers {
       caught.getMessage shouldBe "Not a valid Sierra record number: NaN"
     }
   }
+
+  describe("increment") {
+    it("rejects 8-digit record numbers") {
+      val caught = intercept[RuntimeException] {
+        SierraRecordNumbers.increment("12345678")
+      }
+      caught.getMessage shouldBe "increment() can only be used with 7-digit record numbers; not 12345678"
+    }
+
+    it("rejects bad inputs") {
+      val caught = intercept[RuntimeException] {
+        SierraRecordNumbers.increment("NaN")
+      }
+      caught.getMessage shouldBe "increment() can only be used with 7-digit record numbers; not NaN"
+    }
+
+    it("increments a 7-digit record number") {
+      SierraRecordNumbers.increment("1000001") shouldBe "1000002"
+    }
+
+    it("increments a 7-digit record number that wraps around") {
+      SierraRecordNumbers.increment("1000009") shouldBe "1000010"
+    }
+  }
 }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbersTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbersTest.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.models.transformable.sierra
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 import org.scalatest.prop.TableDrivenPropertyChecks._
 
 class SierraRecordNumbersTest extends FunSpec with Matchers {
@@ -71,26 +71,52 @@ class SierraRecordNumbersTest extends FunSpec with Matchers {
     }
 
     it("rejects an invalid string") {
-      val caught = intercept[AssertionError] {
-        SierraRecordNumbers.assertValidRecordNumber("NaN")
-      }
-      caught.getMessage shouldBe "assertion failed: Not a valid Sierra record number: NaN"
+      assertThrowsAssertionError(
+        () => SierraRecordNumbers.assertValidRecordNumber("NaN"),
+        expectedMessage = "Not a valid Sierra record number: NaN"
+      )
+    }
+  }
+
+  describe("assertIs7DigitRecordNumber") {
+    it("accepts a valid record number") {
+      SierraRecordNumbers.assertIs7DigitRecordNumber("1234567")
+    }
+
+    it("rejects an invalid record number") {
+      assertThrowsAssertionError(
+        () => SierraRecordNumbers.assertIs7DigitRecordNumber("NaN"),
+        expectedMessage = "Not a 7-digit Sierra record number: NaN"
+      )
+    }
+  }
+
+  describe("assertIs8DigitRecordNumber") {
+    it("accepts a valid record number") {
+      SierraRecordNumbers.assertIs8DigitRecordNumber("12345678")
+    }
+
+    it("rejects an invalid record number") {
+      assertThrowsAssertionError(
+        () => SierraRecordNumbers.assertIs8DigitRecordNumber("NaN"),
+        expectedMessage = "Not an 8-digit Sierra record number: NaN"
+      )
     }
   }
 
   describe("increment") {
     it("rejects 8-digit record numbers") {
-      val caught = intercept[AssertionError] {
-        SierraRecordNumbers.increment("12345678")
-      }
-      caught.getMessage shouldBe "assertion failed: increment() can only be used with 7-digit record numbers; not 12345678"
+      assertThrowsAssertionError(
+        () => SierraRecordNumbers.increment("12345678"),
+        expectedMessage = "increment() can only be used with 7-digit record numbers; not 12345678"
+      )
     }
 
     it("rejects bad inputs") {
-      val caught = intercept[AssertionError] {
-        SierraRecordNumbers.increment("NaN")
-      }
-      caught.getMessage shouldBe "assertion failed: increment() can only be used with 7-digit record numbers; not NaN"
+      assertThrowsAssertionError(
+        () => SierraRecordNumbers.increment("NaN"),
+        expectedMessage = "increment() can only be used with 7-digit record numbers; not NaN"
+      )
     }
 
     it("increments a 7-digit record number") {
@@ -100,5 +126,10 @@ class SierraRecordNumbersTest extends FunSpec with Matchers {
     it("increments a 7-digit record number that wraps around") {
       SierraRecordNumbers.increment("1000009") shouldBe "1000010"
     }
+  }
+
+  private def assertThrowsAssertionError(f: => () => Unit, expectedMessage: String): Assertion = {
+    val caught = intercept[AssertionError] { f() }
+    caught.getMessage shouldBe s"assertion failed: $expectedMessage"
   }
 }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbersTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbersTest.scala
@@ -60,4 +60,21 @@ class SierraRecordNumbersTest extends FunSpec with Matchers {
       caught.getMessage shouldEqual "Expected 7-digit numeric ID, got 12345678"
     }
   }
+
+  describe("assertValidRecordNumber") {
+    it("accepts a valid 7-digit record number") {
+      SierraRecordNumbers.assertValidRecordNumber("1234567")
+    }
+
+    it("accepts a valid 8-digit record number") {
+      SierraRecordNumbers.assertValidRecordNumber("12345678")
+    }
+
+    it("rejects an invalid string") {
+      val caught = intercept[RuntimeException] {
+        SierraRecordNumbers.assertValidRecordNumber("NaN")
+      }
+      caught.getMessage shouldBe "Not a valid Sierra record number: NaN"
+    }
+  }
 }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbersTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumbersTest.scala
@@ -71,26 +71,26 @@ class SierraRecordNumbersTest extends FunSpec with Matchers {
     }
 
     it("rejects an invalid string") {
-      val caught = intercept[RuntimeException] {
+      val caught = intercept[AssertionError] {
         SierraRecordNumbers.assertValidRecordNumber("NaN")
       }
-      caught.getMessage shouldBe "Not a valid Sierra record number: NaN"
+      caught.getMessage shouldBe "assertion failed: Not a valid Sierra record number: NaN"
     }
   }
 
   describe("increment") {
     it("rejects 8-digit record numbers") {
-      val caught = intercept[RuntimeException] {
+      val caught = intercept[AssertionError] {
         SierraRecordNumbers.increment("12345678")
       }
-      caught.getMessage shouldBe "increment() can only be used with 7-digit record numbers; not 12345678"
+      caught.getMessage shouldBe "assertion failed: increment() can only be used with 7-digit record numbers; not 12345678"
     }
 
     it("rejects bad inputs") {
-      val caught = intercept[RuntimeException] {
+      val caught = intercept[AssertionError] {
         SierraRecordNumbers.increment("NaN")
       }
-      caught.getMessage shouldBe "increment() can only be used with 7-digit record numbers; not NaN"
+      caught.getMessage shouldBe "assertion failed: increment() can only be used with 7-digit record numbers; not NaN"
     }
 
     it("increments a 7-digit record number") {

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/S3.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/S3.scala
@@ -110,4 +110,16 @@ trait S3 extends ExtendedPatience with Logging with Eventually with Matchers {
       .asScala
       .map { _.getKey }
       .toList
+
+  /** Returns a map (key -> contents) for all objects in an S3 bucket.
+    *
+    * @param bucket The instance of [[Bucket]] to read.
+    *
+    */
+  def getAllObjectContents(bucket: Bucket): Map[String, String] =
+    listKeysInBucket(bucket)
+      .map { key =>
+        key -> getContentFromS3(bucket = bucket, key = key)
+      }
+      .toMap
 }

--- a/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/S3.scala
+++ b/sbt_common/storage/src/test/scala/uk/ac/wellcome/storage/test/fixtures/S3.scala
@@ -117,9 +117,7 @@ trait S3 extends ExtendedPatience with Logging with Eventually with Matchers {
     *
     */
   def getAllObjectContents(bucket: Bucket): Map[String, String] =
-    listKeysInBucket(bucket)
-      .map { key =>
-        key -> getContentFromS3(bucket = bucket, key = key)
-      }
-      .toMap
+    listKeysInBucket(bucket).map { key =>
+      key -> getContentFromS3(bucket = bucket, key = key)
+    }.toMap
 }

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/models/WindowStatus.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/models/WindowStatus.scala
@@ -1,0 +1,3 @@
+package uk.ac.wellcome.platform.sierra_reader.models
+
+case class WindowStatus(id: Option[String], offset: Int)

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/models/WindowStatus.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/models/WindowStatus.scala
@@ -1,3 +1,12 @@
 package uk.ac.wellcome.platform.sierra_reader.models
 
+import uk.ac.wellcome.models.transformable.sierra.SierraRecordNumbers
+
 case class WindowStatus(id: Option[String], offset: Int)
+
+case object WindowStatus {
+  def apply(id: String, offset: Int): WindowStatus = {
+    SierraRecordNumbers.assertIs7DigitRecordNumber(id)
+    WindowStatus(id = Some(id), offset = offset)
+  }
+}

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
@@ -61,14 +61,10 @@ class WindowManager @Inject()(
         val triedStatus = triedMaybeLastId
           .map {
             case Some(id) =>
-              // The Sierra IDs we store in S3 are prefixed with "b" or "i".
-              // Remove the first character
-              val unprefixedId = id.substring(1)
-
-              val newId = (unprefixedId.toInt + 1).toString
-              SierraRecordNumbers.assertValidRecordNumber(newId)
-
-              WindowStatus(id = Some(newId), offset = offset + 1)
+              WindowStatus(
+                id = Some(SierraRecordNumbers.increment(id)),
+                offset = offset + 1
+              )
             case None =>
               throw GracefulFailureException(
                 new RuntimeException("Json did not contain an id"))

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
@@ -8,14 +8,13 @@ import uk.ac.wellcome.platform.sierra_reader.models.SierraConfig
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.transformable.sierra.SierraRecordNumbers
+import uk.ac.wellcome.platform.sierra_reader.models.WindowStatus
 import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.utils.JsonUtil
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
-
-case class WindowStatus(id: Option[String], offset: Int)
 
 class WindowManager @Inject()(
   s3client: AmazonS3,

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
@@ -7,6 +7,7 @@ import org.apache.commons.io.IOUtils
 import uk.ac.wellcome.platform.sierra_reader.models.SierraConfig
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.exceptions.GracefulFailureException
+import uk.ac.wellcome.models.transformable.sierra.SierraRecordNumbers
 import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.utils.JsonUtil
@@ -66,6 +67,8 @@ class WindowManager @Inject()(
               val unprefixedId = id.substring(1)
 
               val newId = (unprefixedId.toInt + 1).toString
+              SierraRecordNumbers.assertValidRecordNumber(newId)
+
               WindowStatus(id = Some(newId), offset = offset + 1)
             case None =>
               throw GracefulFailureException(

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
@@ -4,11 +4,10 @@ import com.amazonaws.services.s3.AmazonS3
 import com.google.inject.Inject
 import com.twitter.inject.Logging
 import org.apache.commons.io.IOUtils
-import uk.ac.wellcome.platform.sierra_reader.models.SierraConfig
+import uk.ac.wellcome.platform.sierra_reader.models.{SierraConfig, WindowStatus}
 import uk.ac.wellcome.utils.JsonUtil._
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.transformable.sierra.SierraRecordNumbers
-import uk.ac.wellcome.platform.sierra_reader.models.WindowStatus
 import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.utils.JsonUtil

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -15,10 +15,8 @@ import uk.ac.wellcome.storage.s3.S3Config
 import io.circe.syntax._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.utils.JsonUtil._
-import uk.ac.wellcome.platform.sierra_reader.modules.{
-  WindowManager,
-  WindowStatus
-}
+import uk.ac.wellcome.platform.sierra_reader.models.WindowStatus
+import uk.ac.wellcome.platform.sierra_reader.modules.WindowManager
 
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/sierra_adapter/sierra_reader/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_reader/src/test/resources/logback-test.xml
@@ -1,3 +1,5 @@
 <configuration>
   <include resource="base-logback-test.xml"/>
+
+  <logger name="uk.ac.wellcome.platform.sierra_reader.Server" level="INFO"/>
 </configuration>

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -8,7 +8,8 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.platform.sierra_reader.models.{
   SierraConfig,
-  SierraResourceTypes
+  SierraResourceTypes,
+  WindowStatus
 }
 import uk.ac.wellcome.sierra_adapter.models.SierraRecord
 import uk.ac.wellcome.storage.s3.S3Config

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -69,7 +69,7 @@ class WindowManagerTest
 
         val record =
           SierraRecord(
-            id = "b1794165",
+            id = "1794165",
             data = "{}",
             modifiedDate = Instant.now())
 

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -157,25 +157,6 @@ class SierraReaderWorkerServiceTest
       fields = "updatedDate,deleted,deletedDate,bibIds,fixedFields,varFields",
       resourceType = SierraResourceTypes.items
     ) { fixtures =>
-      val prefix = "records_items/2013-12-10T17-16-35Z__2013-12-13T21-34-35Z"
-
-      // First we pre-populate S3 with files as if they'd come from a prior run of the reader.
-      s3Client.putObject(fixtures.bucket.name, s"$prefix/0000.json", "[]")
-      s3Client.putObject(
-        fixtures.bucket.name,
-        s"$prefix/0001.json",
-        """
-          |[
-          |  {
-          |    "id": "i1794165",
-          |    "modifiedDate": "2013-12-10T17:16:35Z",
-          |    "data": "{}"
-          |  }
-          |]
-        """.stripMargin
-      )
-
-      // Then we trigger the reader, and we expect it to fill in the rest.
       val body =
         """
           |{
@@ -184,25 +165,36 @@ class SierraReaderWorkerServiceTest
           |}
         """.stripMargin
 
+      // Do a complete run of the reader -- this gives us a set of JSON files
+      // to compare to.
       sendNotificationToSQS(queue = fixtures.queue, body = body)
 
-      val pageNames = List("0000.json", "0001.json", "0002.json", "0003.json")
-        .map { label =>
-          s"$prefix/$label"
-        } ++ List(
-        "windows_items_complete/2013-12-10T17-16-35Z__2013-12-13T21-34-35Z")
+      eventually {
+        assertQueueEmpty(queue = fixtures.queue)
+
+        // There are 157 item records in the Sierra wiremock, so we expect
+        // 5 files -- the four JSON files, and a window marker.
+        listKeysInBucket(bucket = fixtures.bucket) should have size 5
+      }
+
+      val expectedContents = getAllObjectContents(bucket = fixtures.bucket)
+
+      // Now, let's delete every key in the bucket _except_ the first --
+      // which we'll use to restart the window.
+      listKeysInBucket(bucket = fixtures.bucket)
+        .filterNot { _.endsWith("0000.json") }
+        .foreach { key => s3Client.deleteObject(fixtures.bucket.name, key) }
 
       eventually {
-        // There are 157 item records in the Sierra wiremock so we expect 4 files
-        listKeysInBucket(bucket = fixtures.bucket) shouldBe pageNames
+        listKeysInBucket(bucket = fixtures.bucket) should have size 1
+      }
 
-        // These two files were pre-populated -- we check the reader hasn't overwritten these
-        getRecordsFromS3(fixtures.bucket, pageNames(0)) should have size 0
-        getRecordsFromS3(fixtures.bucket, pageNames(1)) should have size 1
+      // Now, send a second message to the reader, and we'll see if it completes
+      // the window successfully.
+      sendNotificationToSQS(queue = fixtures.queue, body = body)
 
-        // We check the reader has filled these in correctly
-        getRecordsFromS3(fixtures.bucket, pageNames(2)) should have size 50
-        getRecordsFromS3(fixtures.bucket, pageNames(3)) should have size 7
+      eventually {
+        getAllObjectContents(bucket = fixtures.bucket) shouldBe expectedContents
       }
     }
   }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -183,7 +183,9 @@ class SierraReaderWorkerServiceTest
       // which we'll use to restart the window.
       listKeysInBucket(bucket = fixtures.bucket)
         .filterNot { _.endsWith("0000.json") }
-        .foreach { key => s3Client.deleteObject(fixtures.bucket.name, key) }
+        .foreach { key =>
+          s3Client.deleteObject(fixtures.bucket.name, key)
+        }
 
       eventually {
         listKeysInBucket(bucket = fixtures.bucket) should have size 1


### PR DESCRIPTION
Code fix for #2422 – then we need to re-run all the windows through the pipeline.

The crux of the patch is some new methods on `SierraRecordNumbers` which check that a string is a well-formed 7/8-digit Sierra ID, sprinkled liberally around bits of the Sierra reader that touch these record numbers.