### PR TITLE
Add a helper method for creating instances of SierraBibData

### DIFF
--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributorsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributorsTest.scala
@@ -3,13 +3,10 @@ package uk.ac.wellcome.platform.transformer.transformers.sierra
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.source.{
-  MarcSubfield,
-  SierraBibData,
-  VarField
-}
+import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
-class SierraContributorsTest extends FunSpec with Matchers {
+class SierraContributorsTest extends FunSpec with Matchers with SierraDataUtil {
 
   val transformer = new SierraContributors {}
 
@@ -666,14 +663,12 @@ class SierraContributorsTest extends FunSpec with Matchers {
     varFields: List[VarField],
     expectedContributors: List[Contributor[MaybeDisplayable[AbstractAgent]]]
   ) = {
-    val bibData =
-      SierraBibData(id = "1661847", title = None, varFields = varFields)
+    val bibData = createSierraBibDataWith(varFields = varFields)
     transformer.getContributors(bibData) shouldBe expectedContributors
   }
 
   private def assertTransformFails(varFields: List[VarField]) = {
-    val bibData =
-      SierraBibData(id = "1663540", title = None, varFields = varFields)
+    val bibData = createSierraBibDataWith(varFields = varFields)
 
     intercept[GracefulFailureException] {
       transformer.getContributors(bibData)

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraDescriptionTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraDescriptionTest.scala
@@ -1,14 +1,10 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraData
-import uk.ac.wellcome.platform.transformer.source.{
-  MarcSubfield,
-  SierraBibData,
-  VarField
-}
+import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
-class SierraDescriptionTest extends FunSpec with Matchers with SierraData {
+class SierraDescriptionTest extends FunSpec with Matchers with SierraDataUtil {
 
   it(
     "extracts a work description where MARC field 520 with subfield a is populated") {
@@ -124,13 +120,7 @@ class SierraDescriptionTest extends FunSpec with Matchers with SierraData {
     varFields: List[VarField],
     expectedDescription: Option[String]
   ) = {
-
-    val bibData = SierraBibData(
-      id = "b1234567",
-      title = Some("A xylophone full of xenon."),
-      varFields = varFields
-    )
-
+    val bibData = createSierraBibDataWith(varFields = varFields)
     transformer.getDescription(bibData = bibData) shouldBe expectedDescription
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraDimensionsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraDimensionsTest.scala
@@ -1,18 +1,15 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.platform.transformer.source.{
-  MarcSubfield,
-  SierraBibData,
-  VarField
-}
+import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
-class SierraDimensionsTest extends FunSpec with Matchers {
+class SierraDimensionsTest extends FunSpec with Matchers with SierraDataUtil {
 
   val transformer = new SierraDimensions {}
 
   it("gets no dimensions if there is no MARC field 300 with subfield $$c") {
-    val bibData = SierraBibData(id = "d1000001", varFields = List())
+    val bibData = createSierraBibDataWith(varFields = List())
     transformer.getDimensions(bibData = bibData) shouldBe None
   }
 
@@ -38,7 +35,7 @@ class SierraDimensionsTest extends FunSpec with Matchers {
       )
     )
 
-    val bibData = SierraBibData(id = "d2000002", varFields = varFields)
+    val bibData = createSierraBibDataWith(varFields = varFields)
     transformer.getDimensions(bibData = bibData) shouldBe Some(dimensions)
   }
 
@@ -79,7 +76,7 @@ class SierraDimensionsTest extends FunSpec with Matchers {
       )
     )
 
-    val bibData = SierraBibData(id = "d3000003", varFields = varFields)
+    val bibData = createSierraBibDataWith(varFields = varFields)
     transformer.getDimensions(bibData = bibData) shouldBe Some(
       expectedDimensions)
   }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraExtentTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraExtentTest.scala
@@ -1,23 +1,15 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.platform.transformer.source.{
-  MarcSubfield,
-  SierraBibData,
-  VarField
-}
+import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
-class SierraExtentTest extends FunSpec with Matchers {
+class SierraExtentTest extends FunSpec with Matchers with SierraDataUtil {
 
   val transformer = new SierraExtent {}
 
   it("gets no extent if there is no MARC field 300 with subfield $$a") {
-    val bibData = SierraBibData(
-      id = "e1000001",
-      title = Some("Egad!  An egg exits eastwards."),
-      varFields = List()
-    )
-
+    val bibData = createSierraBibDataWith(varFields = List())
     transformer.getExtent(bibData = bibData) shouldBe None
   }
 
@@ -43,12 +35,7 @@ class SierraExtentTest extends FunSpec with Matchers {
       )
     )
 
-    val bibData = SierraBibData(
-      id = "e2000002",
-      title = Some("Even eagles eschew exasperating elephants"),
-      varFields = varFields
-    )
-
+    val bibData = createSierraBibDataWith(varFields = varFields)
     transformer.getExtent(bibData = bibData) shouldBe Some(extent)
   }
 
@@ -104,12 +91,7 @@ class SierraExtentTest extends FunSpec with Matchers {
       )
     )
 
-    val bibData = SierraBibData(
-      id = "e3000003",
-      title = Some("Eager electric eels are exciting"),
-      varFields = varFields
-    )
-
+    val bibData = createSierraBibDataWith(varFields = varFields)
     transformer.getExtent(bibData = bibData) shouldBe Some(expectedExtent)
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraGenresTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraGenresTest.scala
@@ -2,20 +2,13 @@ package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.source.{
-  MarcSubfield,
-  SierraBibData,
-  VarField
-}
+import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, SierraBibData, VarField}
+import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
-class SierraGenresTest extends FunSpec with Matchers {
+class SierraGenresTest extends FunSpec with Matchers with SierraDataUtil {
 
   it("returns zero genres if there are none") {
-    val bibData = SierraBibData(
-      id = "b1234567",
-      title = Some("A pack of published puffins in Paris"),
-      varFields = List()
-    )
+    val bibData = createSierraBibDataWith(varFields = List())
     assertExtractsGenres(bibData, List())
   }
 
@@ -141,9 +134,7 @@ class SierraGenresTest extends FunSpec with Matchers {
   }
 
   it("returns subjects for multiple 655 tags with different subfields") {
-    val bibData = SierraBibData(
-      id = "b1234567",
-      title = Some("A pack of published puffins in Paris"),
+    val bibData = createSierraBibDataWith(
       varFields = List(
         VarField(
           fieldTag = "p",
@@ -187,9 +178,7 @@ class SierraGenresTest extends FunSpec with Matchers {
   }
 
   it(s"gets identifiers from subfield $$0") {
-    val bibData = SierraBibData(
-      id = "b9161816",
-      title = Some("Impish iguanas inside igloos"),
+    val bibData = createSierraBibDataWith(
       varFields = List(
         VarField(
           fieldTag = "p",
@@ -250,9 +239,7 @@ class SierraGenresTest extends FunSpec with Matchers {
   }
 
   private def bibData(marcTag: String, marcSubfields: List[MarcSubfield]) = {
-    SierraBibData(
-      id = "b1234567",
-      title = Some("A pack of published puffins in Paris"),
+    createSierraBibDataWith(
       varFields = List(
         VarField(
           fieldTag = "p",

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraIdentifiersTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraIdentifiersTest.scala
@@ -1,11 +1,10 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraData
 import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier}
-import uk.ac.wellcome.platform.transformer.source.SierraBibData
+import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
-class SierraIdentifiersTest extends FunSpec with Matchers with SierraData {
+class SierraIdentifiersTest extends FunSpec with Matchers with SierraDataUtil {
 
   it("passes through the main identifier from the bib record") {
     assertIdentifiersAreCorrect(
@@ -26,14 +25,7 @@ class SierraIdentifiersTest extends FunSpec with Matchers with SierraData {
     bibDataId: String,
     expectedIdentifiers: List[SourceIdentifier]
   ) = {
-
-    val bibData = SierraBibData(
-      id = bibDataId,
-      title = Some("An imprint of insects on the inside of an igloo"),
-      deleted = false,
-      suppressed = false
-    )
-
+    val bibData = createSierraBibDataWith(id = bibDataId)
     transformer.getOtherIdentifiers(bibData = bibData) shouldBe expectedIdentifiers
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLanguageTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLanguageTest.scala
@@ -1,29 +1,21 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraData
 import uk.ac.wellcome.models.work.internal.Language
-import uk.ac.wellcome.platform.transformer.source.SierraBibData
-import uk.ac.wellcome.platform.transformer.source.sierra.{
-  Language => SierraLanguageField
-}
+import uk.ac.wellcome.platform.transformer.source.sierra.{Language => SierraLanguageField}
+import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
-class SierraLanguageTest extends FunSpec with Matchers with SierraData {
+class SierraLanguageTest extends FunSpec with Matchers with SierraDataUtil {
 
   val transformer = new SierraLanguage {}
 
   it("ignores records which don't have a lang field") {
-    val bibData = SierraBibData(
-      id = "1000001",
-      lang = None
-    )
-
+    val bibData = createSierraBibDataWith(lang = None)
     transformer.getLanguage(bibData = bibData) shouldBe None
   }
 
   it("picks up the language from the lang field") {
-    val bibData = SierraBibData(
-      id = "2000002",
+    val bibData = createSierraBibDataWith(
       lang = Some(
         SierraLanguageField(
           code = "eng",

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLetteringTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLetteringTest.scala
@@ -1,14 +1,10 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraData
-import uk.ac.wellcome.platform.transformer.source.{
-  MarcSubfield,
-  SierraBibData,
-  VarField
-}
+import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
-class SierraLetteringTest extends FunSpec with Matchers with SierraData {
+class SierraLetteringTest extends FunSpec with Matchers with SierraDataUtil {
 
   it("ignores records with the wrong MARC field") {
     assertFindsCorrectLettering(
@@ -119,13 +115,7 @@ class SierraLetteringTest extends FunSpec with Matchers with SierraData {
     varFields: List[VarField],
     expectedLettering: Option[String]
   ) = {
-
-    val bibData = SierraBibData(
-      id = "b1234567",
-      title = Some("A libel of lions"),
-      varFields = varFields
-    )
-
+    val bibData = createSierraBibDataWith(varFields = varFields)
     transformer.getLettering(bibData = bibData) shouldBe expectedLettering
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -1,26 +1,16 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraData
-import uk.ac.wellcome.models.work.internal.{
-  IdentifierType,
-  MergeCandidate,
-  SourceIdentifier
-}
-import uk.ac.wellcome.platform.transformer.source.{
-  MarcSubfield,
-  SierraBibData,
-  VarField
-}
+import uk.ac.wellcome.models.work.internal.{IdentifierType, MergeCandidate, SourceIdentifier}
+import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
-class SierraMergeCandidatesTest extends FunSpec with Matchers with SierraData {
+class SierraMergeCandidatesTest extends FunSpec with Matchers with SierraDataUtil {
 
   val transformer = new SierraMergeCandidates {}
   it("extracts the bib number in 776$$w and adds it as a mergeCandidate") {
     val mergeCandidateBibNumber = "b21414440"
-    val sierraData = SierraBibData(
-      id = "b1234567",
-      title = Some("A pack of published puffins in Paris"),
+    val sierraData = createSierraBibDataWith(
       varFields = List(
         VarField(
           fieldTag = "p",
@@ -44,9 +34,7 @@ class SierraMergeCandidatesTest extends FunSpec with Matchers with SierraData {
 
   it("strips spaces in tag 776$$w and adds it as a mergeCandidate") {
     val mergeCandidateBibNumber = "b21414440"
-    val sierraData = SierraBibData(
-      id = "b1234567",
-      title = Some("A pack of published puffins in Paris"),
+    val sierraData = createSierraBibDataWith(
       varFields = List(
         VarField(
           fieldTag = "p",
@@ -71,19 +59,12 @@ class SierraMergeCandidatesTest extends FunSpec with Matchers with SierraData {
   }
 
   it("returns an empty list if there is no marc tag 776") {
-    val sierraData = SierraBibData(
-      id = "b1234567",
-      title = Some("A pack of published puffins in Paris"),
-      varFields = List()
-    )
-
+    val sierraData = createSierraBibDataWith(varFields = List())
     transformer.getMergeCandidates(sierraData) shouldBe Nil
   }
 
   it("returns an empty list if marc tag 776 does not contain a subfield w") {
-    val sierraData = SierraBibData(
-      id = "b1234567",
-      title = Some("A pack of published puffins in Paris"),
+    val sierraData = createSierraBibDataWith(
       varFields = List(
         VarField(
           fieldTag = "p",
@@ -101,9 +82,7 @@ class SierraMergeCandidatesTest extends FunSpec with Matchers with SierraData {
   }
 
   it("ignores values in 776$$w that aren't prefixed with (UkLW)") {
-    val sierraData = SierraBibData(
-      id = "b1234567",
-      title = Some("A pack of published puffins in Paris"),
+    val sierraData = createSierraBibDataWith(
       varFields = List(
         VarField(
           fieldTag = "p",

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraPhysicalDescriptionTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraPhysicalDescriptionTest.scala
@@ -1,24 +1,16 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.platform.transformer.source.{
-  MarcSubfield,
-  SierraBibData,
-  VarField
-}
+import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
-class SierraPhysicalDescriptionTest extends FunSpec with Matchers {
+class SierraPhysicalDescriptionTest extends FunSpec with Matchers with SierraDataUtil {
 
   val transformer = new SierraPhysicalDescription {}
 
   it(
     "gets no physical description if there is no MARC field 300 with subfield $b") {
-    val bibData = SierraBibData(
-      id = "pd1000001",
-      title = Some("Quick!  The quails are quadrupling."),
-      varFields = List()
-    )
-
+    val bibData = createSierraBibDataWith(varFields = List())
     transformer.getPhysicalDescription(bibData = bibData) shouldBe None
   }
 
@@ -44,11 +36,7 @@ class SierraPhysicalDescriptionTest extends FunSpec with Matchers {
       )
     )
 
-    val bibData = SierraBibData(
-      id = "pd2000002",
-      title = Some("Quaint quants are quite quiet"),
-      varFields = varFields
-    )
+    val bibData = createSierraBibDataWith(varFields = varFields)
 
     transformer
       .getPhysicalDescription(bibData = bibData)
@@ -94,11 +82,7 @@ class SierraPhysicalDescriptionTest extends FunSpec with Matchers {
       )
     )
 
-    val bibData = SierraBibData(
-      id = "pd3000003",
-      title = Some("A qualified quetzal is quixotic"),
-      varFields = varFields
-    )
+    val bibData = createSierraBibDataWith(varFields = varFields)
 
     transformer
       .getPhysicalDescription(bibData = bibData)

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProductionTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProductionTest.scala
@@ -3,13 +3,10 @@ package uk.ac.wellcome.platform.transformer.transformers.sierra
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.source.{
-  MarcSubfield,
-  SierraBibData,
-  VarField
-}
+import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
-class SierraProductionTest extends FunSpec with Matchers {
+class SierraProductionTest extends FunSpec with Matchers with SierraDataUtil {
 
   it("returns an empty list if neither 260 nor 264 are present") {
     transformToProduction(varFields = List()) shouldBe List()
@@ -428,11 +425,7 @@ class SierraProductionTest extends FunSpec with Matchers {
   }
 
   private def transformVarFieldsAndAssertIsError(varFields: List[VarField]) = {
-    val bibData = SierraBibData(
-      id = "p1000001",
-      title = Some("Practical production of poisonous panthers"),
-      varFields = varFields
-    )
+    val bibData = createSierraBibDataWith(varFields = varFields)
 
     intercept[GracefulFailureException] {
       transformer.getProduction(bibData)
@@ -441,12 +434,7 @@ class SierraProductionTest extends FunSpec with Matchers {
 
   private def transformToProduction(varFields: List[VarField])
     : List[ProductionEvent[MaybeDisplayable[AbstractAgent]]] = {
-    val bibData = SierraBibData(
-      id = "p1000001",
-      title = Some("Practical production of poisonous panthers"),
-      varFields = varFields
-    )
-
+    val bibData = createSierraBibDataWith(varFields = varFields)
     transformer.getProduction(bibData)
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraSubjectsTest.scala
@@ -2,20 +2,13 @@ package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.source.{
-  MarcSubfield,
-  SierraBibData,
-  VarField
-}
+import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, SierraBibData, VarField}
+import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
-class SierraSubjectsTest extends FunSpec with Matchers {
+class SierraSubjectsTest extends FunSpec with Matchers with SierraDataUtil {
 
   it("returns zero subjects if there are none") {
-    val bibData = SierraBibData(
-      id = "b1234567",
-      title = Some("A pack of published puffins in Paris"),
-      varFields = List()
-    )
+    val bibData = createSierraBibDataWith(varFields = List())
     assertExtractsSubjects(bibData, List())
   }
 
@@ -139,9 +132,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   }
 
   it("returns subjects for multiple 650 tags with different subfields") {
-    val bibData = SierraBibData(
-      id = "b1234567",
-      title = Some("A pack of published puffins in Paris"),
+    val bibData = createSierraBibDataWith(
       varFields = List(
         VarField(
           fieldTag = "p",
@@ -234,9 +225,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   }
 
   it(s"gets identifiers from subfield $$0") {
-    val bibData = SierraBibData(
-      id = "b8911791",
-      title = Some("Impish iguanas inside igloos"),
+    val bibData = createSierraBibDataWith(
       varFields = List(
         VarField(
           fieldTag = "p",
@@ -297,9 +286,7 @@ class SierraSubjectsTest extends FunSpec with Matchers {
   }
 
   private def bibData(marcTag: String, marcSubfields: List[MarcSubfield]) = {
-    SierraBibData(
-      id = "b1234567",
-      title = Some("A pack of published puffins in Paris"),
+    createSierraBibDataWith(
       varFields = List(
         VarField(
           fieldTag = "p",

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraTitleTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraTitleTest.scala
@@ -1,11 +1,10 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraData
-import uk.ac.wellcome.platform.transformer.source.SierraBibData
 import uk.ac.wellcome.platform.transformer.transformers.ShouldNotTransformException
+import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
-class SierraTitleTest extends FunSpec with Matchers with SierraData {
+class SierraTitleTest extends FunSpec with Matchers with SierraDataUtil {
 
   it("passes through the title from the bib record") {
     val title = "Tickling a tiny turtle in Tenerife"
@@ -16,12 +15,7 @@ class SierraTitleTest extends FunSpec with Matchers with SierraData {
   }
 
   it("throws a ShouldNotTransform exception if bibData has no title") {
-    val bibData = SierraBibData(
-      id = "b1234567",
-      title = None,
-      deleted = false,
-      suppressed = false
-    )
+    val bibData = createSierraBibDataWith(title = None)
     intercept[ShouldNotTransformException] {
       transformer.getTitle(bibData = bibData)
     }
@@ -33,14 +27,7 @@ class SierraTitleTest extends FunSpec with Matchers with SierraData {
     bibDataTitle: String,
     expectedTitle: String
   ) = {
-
-    val bibData = SierraBibData(
-      id = "b1234567",
-      title = Some(bibDataTitle),
-      deleted = false,
-      suppressed = false
-    )
-
+    val bibData = createSierraBibDataWith(title = Some(bibDataTitle))
     transformer.getTitle(bibData = bibData) shouldBe expectedTitle
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraWorkTypeTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraWorkTypeTest.scala
@@ -2,12 +2,10 @@ package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal.WorkType
-import uk.ac.wellcome.platform.transformer.source.{
-  SierraBibData,
-  SierraMaterialType
-}
+import uk.ac.wellcome.platform.transformer.source.SierraMaterialType
+import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
-class SierraWorkTypeTest extends FunSpec with Matchers {
+class SierraWorkTypeTest extends FunSpec with Matchers with SierraDataUtil {
 
   val transformer = new SierraWorkType {}
 
@@ -16,9 +14,7 @@ class SierraWorkTypeTest extends FunSpec with Matchers {
     val workTypeId = "workTypeCode"
     val sierraValue = "Sierra Material Type Label"
 
-    val bibData = SierraBibData(
-      id = "b1234567",
-      title = Some("A trifle of tangy tangerine tigers"),
+    val bibData = createSierraBibDataWith(
       materialType = Some(
         SierraMaterialType(
           code = workTypeId,

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/utils/SierraDataUtil.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/utils/SierraDataUtil.scala
@@ -1,0 +1,25 @@
+package uk.ac.wellcome.platform.transformer.utils
+
+import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraUtil
+import uk.ac.wellcome.models.work.test.util.IdentifiersUtil
+import uk.ac.wellcome.platform.transformer.source.{SierraBibData, SierraMaterialType, VarField}
+import uk.ac.wellcome.platform.transformer.source.sierra.{Language => SierraLanguage}
+
+class SierraDataUtil extends IdentifiersUtil with SierraUtil {
+  def createSierraBibDataWith(
+    id: String = createSierraRecordNumberString,
+    title: Option[String] = Some(randomAlphanumeric(25)),
+    lang: Option[SierraLanguage] = None,
+    materialType: Option[SierraMaterialType] = None,
+    varFields: List[VarField] = List()
+  ): SierraBibData =
+    SierraBibData(
+      id = id,
+      title = title,
+      lang = lang,
+      materialType = materialType,
+      varFields = varFields
+    )
+
+  def createSierraBibData: SierraBibData = createSierraBibDataWith()
+}

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/utils/SierraDataUtil.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/utils/SierraDataUtil.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.models.work.test.util.IdentifiersUtil
 import uk.ac.wellcome.platform.transformer.source.{SierraBibData, SierraMaterialType, VarField}
 import uk.ac.wellcome.platform.transformer.source.sierra.{Language => SierraLanguage}
 
-class SierraDataUtil extends IdentifiersUtil with SierraUtil {
+trait SierraDataUtil extends IdentifiersUtil with SierraUtil {
   def createSierraBibDataWith(
     id: String = createSierraRecordNumberString,
     title: Option[String] = Some(randomAlphanumeric(25)),

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/test/utils/SierraUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/test/utils/SierraUtil.scala
@@ -1,0 +1,21 @@
+package uk.ac.wellcome.models.transformable.sierra.test.utils
+
+import scala.util.Random
+
+trait SierraUtil {
+  /** Returns a random digit as a string.  This is copied from the
+    * definition of Random.alphanumeric.
+    */
+  private def randomNumeric: Stream[Char] = {
+    def nextDigit: Char = {
+      val chars = '0' to '9'
+      chars charAt Random.nextInt(chars.length)
+    }
+
+    Stream continually nextDigit
+  }
+
+  def createSierraRecordNumberString: String =
+    randomNumeric take 7 mkString
+
+}


### PR DESCRIPTION
A standalone piece spun out of #2432. The tests never create an instance of `SierraBibData` directly; they only create it via a helper method that provides sensible defaults.