### PR TITLE
Add a helper method for creating instances of SierraItemData

### DIFF
--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocationTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocationTest.scala
@@ -2,12 +2,10 @@ package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal.{LocationType, PhysicalLocation}
-import uk.ac.wellcome.platform.transformer.source.{
-  SierraItemData,
-  SierraItemLocation
-}
+import uk.ac.wellcome.platform.transformer.source.SierraItemLocation
+import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
-class SierraLocationTest extends FunSpec with Matchers {
+class SierraLocationTest extends FunSpec with Matchers with SierraDataUtil {
 
   val transformer = new SierraLocation {}
 
@@ -15,8 +13,7 @@ class SierraLocationTest extends FunSpec with Matchers {
     val locationTypeCode = "sgmed"
     val locationType = LocationType("sgmed")
     val label = "A museum of mermaids"
-    val itemData = SierraItemData(
-      id = "i1234567",
+    val itemData = createSierraItemDataWith(
       location = Some(SierraItemLocation(locationTypeCode, label))
     )
 
@@ -26,8 +23,7 @@ class SierraLocationTest extends FunSpec with Matchers {
   }
 
   it("returns None if the location field only contains empty strings") {
-    val itemData = SierraItemData(
-      id = "i1234567",
+    val itemData = createSierraItemDataWith(
       location = Some(SierraItemLocation("", ""))
     )
 
@@ -35,8 +31,7 @@ class SierraLocationTest extends FunSpec with Matchers {
   }
 
   it("returns None if the location field only contains the string 'none'") {
-    val itemData = SierraItemData(
-      id = "i1234567",
+    val itemData = createSierraItemDataWith(
       location = Some(SierraItemLocation("none", "none"))
     )
 
@@ -44,8 +39,8 @@ class SierraLocationTest extends FunSpec with Matchers {
   }
 
   it("returns None if there is no location in the item data") {
-    val itemData = SierraItemData(
-      id = "i1234567"
+    val itemData = createSierraItemDataWith(
+      location = None
     )
 
     transformer.getLocation(itemData = itemData) shouldBe None

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/utils/SierraDataUtil.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/utils/SierraDataUtil.scala
@@ -2,11 +2,7 @@ package uk.ac.wellcome.platform.transformer.utils
 
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraUtil
 import uk.ac.wellcome.models.work.test.util.IdentifiersUtil
-import uk.ac.wellcome.platform.transformer.source.{
-  SierraBibData,
-  SierraMaterialType,
-  VarField
-}
+import uk.ac.wellcome.platform.transformer.source._
 import uk.ac.wellcome.platform.transformer.source.sierra.{
   Language => SierraLanguage
 }
@@ -28,4 +24,17 @@ trait SierraDataUtil extends IdentifiersUtil with SierraUtil {
     )
 
   def createSierraBibData: SierraBibData = createSierraBibDataWith()
+
+  def createSierraItemDataWith(
+    id: String = createSierraRecordNumberString,
+    deleted: Boolean = false,
+    location: Option[SierraItemLocation] = None
+  ): SierraItemData =
+    SierraItemData(
+      id = id,
+      deleted = deleted,
+      location = location
+    )
+
+  def createSierraItemData: SierraItemData = createSierraItemDataWith()
 }


### PR DESCRIPTION
Follows #2439, a piece spun out of #2432.

We never create instances of `SierraItemData` directly in tests; instead we create them with a helper method that defaults fields which are uninteresting to the current test.