### PR TITLE
Better tests and tracing around bulk PUT in the ingestor

### DIFF
--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -4,7 +4,7 @@ import com.google.inject.{Inject, Singleton}
 import com.sksamuel.elastic4s.Indexable
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.HttpClient
-import com.sksamuel.elastic4s.http.bulk.BulkResponse
+import com.sksamuel.elastic4s.http.bulk.{BulkResponse, BulkResponseItem}
 import com.twitter.inject.Logging
 import org.elasticsearch.index.VersionType
 import uk.ac.wellcome.elasticsearch.ElasticsearchExceptionManager
@@ -59,9 +59,20 @@ class WorkIndexer @Inject()(
       }
   }
 
-  private def filterVersionConflictErrors(bulkResponse: BulkResponse) = {
-    bulkResponse.failures.filterNot(bulkResponseItem =>
-      bulkResponseItem.error.exists(bulkError =>
-        bulkError.`type`.contains("version_conflict_engine_exception")))
+  private def filterVersionConflictErrors(bulkResponse: BulkResponse): Seq[BulkResponseItem] = {
+    bulkResponse.failures.filterNot { bulkResponseItem =>
+
+      // This error is returned by Elasticsearch when we try to PUT a document
+      // with a lower version than the existing version.
+      val alreadyIndexedWorkHasHigherVersion = bulkResponseItem
+        .error
+        .exists(bulkError => bulkError.`type`.contains("version_conflict_engine_exception"))
+
+      if (alreadyIndexedWorkHasHigherVersion) {
+        info(s"Skipping ${bulkResponseItem.id} because already indexed work has a higher version (${bulkResponseItem.error}")
+      }
+
+      alreadyIndexedWorkHasHigherVersion
+    }
   }
 }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -59,17 +59,18 @@ class WorkIndexer @Inject()(
       }
   }
 
-  private def filterVersionConflictErrors(bulkResponse: BulkResponse): Seq[BulkResponseItem] = {
+  private def filterVersionConflictErrors(
+    bulkResponse: BulkResponse): Seq[BulkResponseItem] = {
     bulkResponse.failures.filterNot { bulkResponseItem =>
-
       // This error is returned by Elasticsearch when we try to PUT a document
       // with a lower version than the existing version.
-      val alreadyIndexedWorkHasHigherVersion = bulkResponseItem
-        .error
-        .exists(bulkError => bulkError.`type`.contains("version_conflict_engine_exception"))
+      val alreadyIndexedWorkHasHigherVersion = bulkResponseItem.error
+        .exists(bulkError =>
+          bulkError.`type`.contains("version_conflict_engine_exception"))
 
       if (alreadyIndexedWorkHasHigherVersion) {
-        info(s"Skipping ${bulkResponseItem.id} because already indexed work has a higher version (${bulkResponseItem.error}")
+        info(
+          s"Skipping ${bulkResponseItem.id} because already indexed work has a higher version (${bulkResponseItem.error}")
       }
 
       alreadyIndexedWorkHasHigherVersion


### PR DESCRIPTION
Two things occurred to me in the shower:

* Do we have any tests for bulk insert in the ingestor? I couldn’t find any, so I made up a simple one and put it in. Seems to pass which gives me a bit more confidence in that code.

* The ingestor deliberately drops messages that get certain errors from Elasticsearch indexing. I wonder if we're being too broad in our exceptions? This adds a log when we do that. It should probably be DEBUG for long-term work; started at INFO because I want to see the results immediately.