### PR TITLE
Loris up to date

### DIFF
--- a/loris/terraform/service/cluster_host.tf
+++ b/loris/terraform/service/cluster_host.tf
@@ -1,5 +1,5 @@
 module "cluster_host" {
-  source = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/ec2/prebuilt/ebs?ref=v11.1.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/ec2/prebuilt/ebs?ref=v11.4.1"
 
   cluster_name = "${aws_ecs_cluster.cluster.name}"
   vpc_id       = "${var.vpc_id}"

--- a/loris/terraform/service/service.tf
+++ b/loris/terraform/service/service.tf
@@ -93,6 +93,8 @@ module "cache_cleaner_task" {
     MAX_AGE        = "${var.ebs_cache_cleaner_daemon_max_age_in_days}"
     MAX_SIZE       = "${var.ebs_cache_cleaner_daemon_max_size_in_gb}G"
   }
+
+  env_vars_length = 3
 }
 
 module "cache_cleaner_service" {

--- a/loris/terraform/service/service.tf
+++ b/loris/terraform/service/service.tf
@@ -8,7 +8,7 @@ resource "aws_ecs_cluster" "cluster" {
 }
 
 module "task" {
-  source = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/task/prebuilt/container_with_sidecar+ebs?ref=v11.1.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/task/prebuilt/container_with_sidecar+ebs?ref=v11.4.1"
 
   aws_region = "${var.aws_region}"
   task_name  = "${var.namespace}"
@@ -39,7 +39,7 @@ module "task" {
 }
 
 module "service" {
-  source = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/service/prebuilt/load_balanced?ref=v11.1.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/service/prebuilt/load_balanced?ref=v11.4.1"
 
   service_name       = "${var.namespace}"
   task_desired_count = "${var.task_desired_count}"
@@ -73,7 +73,7 @@ module "service" {
 }
 
 module "cache_cleaner_task" {
-  source = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/task/prebuilt/single_container+ebs?ref=v11.1.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/task/prebuilt/single_container+ebs?ref=v11.4.1"
 
   aws_region = "${var.aws_region}"
   task_name  = "${var.namespace}_cache_cleaner"
@@ -96,7 +96,7 @@ module "cache_cleaner_task" {
 }
 
 module "cache_cleaner_service" {
-  source = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/service/prebuilt/daemon?ref=v11.1.0"
+  source = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/service/prebuilt/daemon?ref=v11.4.1"
 
   service_name   = "${var.namespace}_cache_cleaner"
   ecs_cluster_id = "${aws_ecs_cluster.cluster.id}"


### PR DESCRIPTION
### What is this PR trying to achieve?

Move Loris to the latest version of the terraform modules for services to avoid permissions and env var issues present in earlier version.

### Who is this change for?

🍭 