### PR TITLE
Make matcher process updates for an already stored version of a work

### DIFF
--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiver.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiver.scala
@@ -7,10 +7,10 @@ import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSWriter}
 import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
 import uk.ac.wellcome.platform.matcher.matcher.WorkMatcher
-import uk.ac.wellcome.platform.matcher.models.VersionConflictException
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectStore}
+import uk.ac.wellcome.platform.matcher.models.VersionExpectedConflictException
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.vhs.HybridRecord
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectStore}
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.{ExecutionContextExecutor, Future}
@@ -40,7 +40,7 @@ class MatcherMessageReceiver @Inject()(
         subject = s"source: ${this.getClass.getSimpleName}.processMessage"
       )
     } yield ()).recover {
-      case e: VersionConflictException =>
+      case e: VersionExpectedConflictException =>
         debug(s"Not matching work due to version: ${e.getMessage}")
     }
   }

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/VersionConflictException.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/VersionConflictException.scala
@@ -1,7 +1,9 @@
 package uk.ac.wellcome.platform.matcher.models
 
-final case class VersionExpectedConflictException(message: String = "Version conflict!")
+final case class VersionExpectedConflictException(
+  message: String = "Version conflict!")
     extends Exception(message)
 
-final case class VersionUnexpectedConflictException(message: String = "Version conflict!")
+final case class VersionUnexpectedConflictException(
+  message: String = "Version conflict!")
     extends Exception(message)

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/VersionConflictException.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/VersionConflictException.scala
@@ -1,4 +1,7 @@
 package uk.ac.wellcome.platform.matcher.models
 
-final case class VersionConflictException(message: String = "Version conflict!")
+final case class VersionExpectedConflictException(message: String = "Version conflict!")
+    extends Exception(message)
+
+final case class VersionUnexpectedConflictException(message: String = "Version conflict!")
     extends Exception(message)

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
@@ -23,7 +23,7 @@ object WorkGraphUpdater extends Logging {
         throw VersionExpectedConflictException(versionConflictMessage)
       case Some(WorkNode(_, existingVersion, linkedIds, _)) if existingVersion == workUpdate.version && workUpdate.referencedWorkIds != linkedIds.toSet =>
         val versionConflictMessage =
-          s"${workUpdate.workId} v${workUpdate.version} is exists with different content!"
+          s"${workUpdate.workId} v${workUpdate.version} exists with different content!"
         error(versionConflictMessage)
         throw VersionUnexpectedConflictException(versionConflictMessage)
       case _ => doUpdate(workUpdate, existingGraph)

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
@@ -4,7 +4,12 @@ import grizzled.slf4j.Logging
 import scalax.collection.Graph
 import scalax.collection.GraphPredef._
 import uk.ac.wellcome.models.matcher.WorkNode
-import uk.ac.wellcome.platform.matcher.models.{VersionExpectedConflictException, VersionUnexpectedConflictException, WorkGraph, WorkUpdate}
+import uk.ac.wellcome.platform.matcher.models.{
+  VersionExpectedConflictException,
+  VersionUnexpectedConflictException,
+  WorkGraph,
+  WorkUpdate
+}
 
 import scala.collection.immutable.Iterable
 import scala.util.hashing.MurmurHash3
@@ -16,12 +21,14 @@ object WorkGraphUpdater extends Logging {
       existingGraph.nodes.find(_.id == workUpdate.workId)
 
     maybeExistingNode match {
-      case Some(WorkNode(_, existingVersion, _, _)) if existingVersion > workUpdate.version =>
+      case Some(WorkNode(_, existingVersion, _, _))
+          if existingVersion > workUpdate.version =>
         val versionConflictMessage =
           s"${workUpdate.workId} v${workUpdate.version} is not newer than existing work v$existingVersion"
         debug(versionConflictMessage)
         throw VersionExpectedConflictException(versionConflictMessage)
-      case Some(WorkNode(_, existingVersion, linkedIds, _)) if existingVersion == workUpdate.version && workUpdate.referencedWorkIds != linkedIds.toSet =>
+      case Some(WorkNode(_, existingVersion, linkedIds, _))
+          if existingVersion == workUpdate.version && workUpdate.referencedWorkIds != linkedIds.toSet =>
         val versionConflictMessage =
           s"${workUpdate.workId} v${workUpdate.version} exists with different content!"
         error(versionConflictMessage)

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
@@ -6,11 +6,8 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS
-import uk.ac.wellcome.models.matcher.{
-  MatchedIdentifiers,
-  MatcherResult,
-  WorkIdentifier
-}
+import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
+import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult, WorkIdentifier}
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
@@ -313,6 +310,45 @@ class MatcherMessageReceiverTest
                 noMessagesAreWaitingIn(queuePair.queue)
                 noMessagesAreWaitingIn(queuePair.dlq)
                 assertLastMatchedResultIs(topic, expectedMatchedWorkAv2)
+              }
+          }
+        }
+      }
+    }
+  }
+
+  it("does not match an existing version with different information") {
+    withLocalSnsTopic { topic =>
+      withLocalSqsQueueAndDlq { case QueuePair(queue, dlq) =>
+        withLocalS3Bucket { storageBucket =>
+          withMatcherMessageReceiver(queue, storageBucket, topic) {
+            _ =>
+              val workAv2 = createUnidentifiedWorkWith(
+                sourceIdentifier = aIdentifier,
+                version = 2
+              )
+
+              val expectedMatchedWorkAv2 = MatcherResult(
+                Set(MatchedIdentifiers(
+                  Set(WorkIdentifier("sierra-system-number/A", 2)))))
+
+              processAndAssertMatchedWorkIs(
+                workAv2,
+                expectedMatchedWorkAv2,
+                queue,
+                storageBucket,
+                topic)
+
+              // Work V1 is sent but not matched
+              val differentWorkAv2 = createUnidentifiedWorkWith(
+                sourceIdentifier = aIdentifier,
+                mergeCandidates = List(MergeCandidate(bIdentifier)),
+                version = 2)
+
+              sendSQS(queue, storageBucket, differentWorkAv2)
+              eventually {
+                assertQueueEmpty(queue)
+                assertQueueHasSize(dlq, 1)
               }
           }
         }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
@@ -7,7 +7,11 @@ import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
-import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult, WorkIdentifier}
+import uk.ac.wellcome.models.matcher.{
+  MatchedIdentifiers,
+  MatcherResult,
+  WorkIdentifier
+}
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
@@ -319,10 +323,10 @@ class MatcherMessageReceiverTest
 
   it("does not match an existing version with different information") {
     withLocalSnsTopic { topic =>
-      withLocalSqsQueueAndDlq { case QueuePair(queue, dlq) =>
-        withLocalS3Bucket { storageBucket =>
-          withMatcherMessageReceiver(queue, storageBucket, topic) {
-            _ =>
+      withLocalSqsQueueAndDlq {
+        case QueuePair(queue, dlq) =>
+          withLocalS3Bucket { storageBucket =>
+            withMatcherMessageReceiver(queue, storageBucket, topic) { _ =>
               val workAv2 = createUnidentifiedWorkWith(
                 sourceIdentifier = aIdentifier,
                 version = 2
@@ -350,8 +354,8 @@ class MatcherMessageReceiverTest
                 assertQueueEmpty(queue)
                 assertQueueHasSize(dlq, 1)
               }
+            }
           }
-        }
       }
     }
   }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -165,8 +165,8 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
       WorkGraphUpdater
         .update(
           workUpdate = WorkUpdate("A", updateVersion, Set("B")),
-          existingGraph = WorkGraph(
-            Set(WorkNode("A", existingVersion, Nil, "A")))
+          existingGraph =
+            WorkGraph(Set(WorkNode("A", existingVersion, Nil, "A")))
         )
         .nodes should contain theSameElementsAs
         List(
@@ -182,13 +182,14 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
         WorkGraphUpdater
           .update(
             workUpdate = WorkUpdate("A", updateVersion, Set("B")),
-            existingGraph = WorkGraph(
-              Set(WorkNode("A", existingVersion, Nil, "A")))
+            existingGraph =
+              WorkGraph(Set(WorkNode("A", existingVersion, Nil, "A")))
           )
       }
     }
 
-    it("processes an update for the same version if it's the same as the one stored") {
+    it(
+      "processes an update for the same version if it's the same as the one stored") {
       val existingVersion = 2
       val updateVersion = 2
 
@@ -196,7 +197,8 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
         .update(
           workUpdate = WorkUpdate("A", updateVersion, Set("B")),
           existingGraph = WorkGraph(
-            Set(WorkNode("A", existingVersion, List("B"), hashed_AB),
+            Set(
+              WorkNode("A", existingVersion, List("B"), hashed_AB),
               WorkNode("B", 0, List(), hashed_AB)))
         )
         .nodes should contain theSameElementsAs
@@ -205,7 +207,8 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
           WorkNode("B", 0, List(), hashed_AB))
     }
 
-    it("doesn't process an update for the same version if the work is different from the one stored") {
+    it(
+      "doesn't process an update for the same version if the work is different from the one stored") {
       val existingVersion = 2
       val updateVersion = 2
 
@@ -214,7 +217,8 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
           .update(
             workUpdate = WorkUpdate("A", updateVersion, Set("A")),
             existingGraph = WorkGraph(
-              Set(WorkNode("A", existingVersion, List("B"), hashed_AB),
+              Set(
+                WorkNode("A", existingVersion, List("B"), hashed_AB),
                 WorkNode("B", 0, List(), hashed_AB)))
           )
       }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.matcher.workgraph
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.matcher.WorkNode
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
-import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkUpdate}
+import uk.ac.wellcome.platform.matcher.models._
 
 class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
 
@@ -155,6 +155,69 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
         WorkNode("B", 2, List("C"), hashed_ABC),
         WorkNode("C", 2, List("A"), hashed_ABC)
       )
+    }
+  }
+
+  describe("Update version") {
+    it("processes an update for a newer version") {
+      val existingVersion = 1
+      val updateVersion = 2
+      WorkGraphUpdater
+        .update(
+          workUpdate = WorkUpdate("A", updateVersion, Set("B")),
+          existingGraph = WorkGraph(
+            Set(WorkNode("A", existingVersion, Nil, "A")))
+        )
+        .nodes should contain theSameElementsAs
+        List(
+          WorkNode("A", 2, List("B"), hashed_AB),
+          WorkNode("B", 0, List(), hashed_AB))
+    }
+
+    it("doesn't process an update for a lower version") {
+      val existingVersion = 3
+      val updateVersion = 1
+
+      intercept[VersionExpectedConflictException] {
+        WorkGraphUpdater
+          .update(
+            workUpdate = WorkUpdate("A", updateVersion, Set("B")),
+            existingGraph = WorkGraph(
+              Set(WorkNode("A", existingVersion, Nil, "A")))
+          )
+      }
+    }
+
+    it("processes an update for the same version if it's the same as the one stored") {
+      val existingVersion = 2
+      val updateVersion = 2
+
+      WorkGraphUpdater
+        .update(
+          workUpdate = WorkUpdate("A", updateVersion, Set("B")),
+          existingGraph = WorkGraph(
+            Set(WorkNode("A", existingVersion, List("B"), hashed_AB),
+              WorkNode("B", 0, List(), hashed_AB)))
+        )
+        .nodes should contain theSameElementsAs
+        List(
+          WorkNode("A", 2, List("B"), hashed_AB),
+          WorkNode("B", 0, List(), hashed_AB))
+    }
+
+    it("doesn't an update for the same version if the work is different from the one stored") {
+      val existingVersion = 2
+      val updateVersion = 2
+
+      intercept[VersionUnexpectedConflictException] {
+        WorkGraphUpdater
+          .update(
+            workUpdate = WorkUpdate("A", updateVersion, Set("A")),
+            existingGraph = WorkGraph(
+              Set(WorkNode("A", existingVersion, List("B"), hashed_AB),
+                WorkNode("B", 0, List(), hashed_AB)))
+          )
+      }
     }
   }
 

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -205,7 +205,7 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
           WorkNode("B", 0, List(), hashed_AB))
     }
 
-    it("doesn't an update for the same version if the work is different from the one stored") {
+    it("doesn't process an update for the same version if the work is different from the one stored") {
       val existingVersion = 2
       val updateVersion = 2
 


### PR DESCRIPTION
The matcher was eating messages without sending them forward or to the dlq. Inspecting the logs I found a bunch of lines like this:
```
14:38:30.420 [main-actor-system-akka.actor.default-dispatcher-5] DEBUG u.a.w.p.m.m.MatcherMessageReceiver - Not matching work due to version: miro-image-number/L0052589 v51 is not newer than existing work v51
```
The current logic doesn't process updates for a version already store on the assumption that, if it's already stored, it's already been sent on. That assumption, though is not correct in the case where something fails in between storing the graph and sending the SNS message, for example unlocking the rows in the lock table. We know that unlocking errors do happen due to ProvisionedThroughputExceeded exception when the table is still warming up, so this would cause messages to be eaten by the matcher


