### PR TITLE
Tweaks and refactoring

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiver.scala
@@ -7,9 +7,16 @@ import io.circe.ParsingFailure
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.messaging.message.MessageWriter
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, PublishAttempt}
-import uk.ac.wellcome.models.transformable.{MiroTransformable, SierraTransformable, Transformable}
+import uk.ac.wellcome.models.transformable.{
+  MiroTransformable,
+  SierraTransformable,
+  Transformable
+}
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
-import uk.ac.wellcome.platform.transformer.transformers.{MiroTransformableTransformer, SierraTransformableTransformer}
+import uk.ac.wellcome.platform.transformer.transformers.{
+  MiroTransformableTransformer,
+  SierraTransformableTransformer
+}
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.vhs.{HybridRecord, SourceMetadata}
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectStore}
@@ -38,7 +45,8 @@ class NotificationMessageReceiver @Inject()(
       cleanRecord <- Future.fromTry(
         transformTransformable(transformableRecord, hybridRecord.version))
       publishResult <- publishMessage(cleanRecord)
-      _ = debug(s"Published work: ${cleanRecord.sourceIdentifier} with message $publishResult")
+      _ = debug(
+        s"Published work: ${cleanRecord.sourceIdentifier} with message $publishResult")
     } yield publishResult
 
     futurePublishAttempt
@@ -89,7 +97,8 @@ class NotificationMessageReceiver @Inject()(
     }
   }
 
-  private def publishMessage(work: TransformedBaseWork): Future[PublishAttempt] =
+  private def publishMessage(
+    work: TransformedBaseWork): Future[PublishAttempt] =
     messageWriter.write(
       message = work,
       subject = s"source: ${this.getClass.getSimpleName}.publishMessage"

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/services/TransformerWorkerService.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/services/TransformerWorkerService.scala
@@ -18,7 +18,7 @@ class TransformerWorkerService @Inject()(
   sqsStream.foreach(this.getClass.getSimpleName, processMessage)
 
   private def processMessage(message: NotificationMessage): Future[Unit] =
-    messageReceiver.receiveMessage(message).map(_ => ())
+    messageReceiver.receiveMessage(message)
 
   def stop() = system.terminate()
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/services/TransformerWorkerService.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/services/TransformerWorkerService.scala
@@ -7,13 +7,13 @@ import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.platform.transformer.receive.NotificationMessageReceiver
 import uk.ac.wellcome.utils.JsonUtil._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 class TransformerWorkerService @Inject()(
   system: ActorSystem,
   messageReceiver: NotificationMessageReceiver,
   sqsStream: SQSStream[NotificationMessage]
-)(implicit ec: ExecutionContext) {
+) {
 
   sqsStream.foreach(this.getClass.getSimpleName, processMessage)
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTransformer.scala
@@ -12,10 +12,11 @@ trait TransformableTransformer[T <: Transformable] extends Logging {
 
   def transform(transformable: Transformable,
                 version: Int): Try[TransformedBaseWork] =
-      transformable match {
-        case t if transformForType.isDefinedAt((t, version)) =>
-          transformForType((t, version))
-        case _ =>
-          Failure(new RuntimeException(s"$transformable is not of the right type"))
-      }
+    transformable match {
+      case t if transformForType.isDefinedAt((t, version)) =>
+        transformForType((t, version))
+      case _ =>
+        Failure(
+          new RuntimeException(s"$transformable is not of the right type"))
+    }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/TransformableTransformer.scala
@@ -4,7 +4,7 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.transformable.Transformable
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 
-import scala.util.Try
+import scala.util.{Failure, Try}
 
 trait TransformableTransformer[T <: Transformable] extends Logging {
   def transformForType
@@ -12,12 +12,10 @@ trait TransformableTransformer[T <: Transformable] extends Logging {
 
   def transform(transformable: Transformable,
                 version: Int): Try[TransformedBaseWork] =
-    Try {
       transformable match {
         case t if transformForType.isDefinedAt((t, version)) =>
           transformForType((t, version))
         case _ =>
-          throw new RuntimeException(s"$transformable is not of the right type")
+          Failure(new RuntimeException(s"$transformable is not of the right type"))
       }
-    }.flatten
 }

--- a/sbt_common/common/src/main/resources/base-logback.xml
+++ b/sbt_common/common/src/main/resources/base-logback.xml
@@ -17,4 +17,10 @@
   <root level="${log_level:-INFO}">
     <appender-ref ref="STDOUT" />
   </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.twitter" level="WARN"/>
+  <logger name="com.amazonaws" level="WARN"/>
 </included>

--- a/sbt_common/finatra_monitoring/src/main/scala/uk/ac/wellcome/finatra/monitoring/MetricsSenderModule.scala
+++ b/sbt_common/finatra_monitoring/src/main/scala/uk/ac/wellcome/finatra/monitoring/MetricsSenderModule.scala
@@ -7,6 +7,8 @@ import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.finatra.akka.AkkaModule
 import uk.ac.wellcome.monitoring.{MetricsConfig, MetricsSender}
 
+import scala.concurrent.ExecutionContext
+
 object MetricsSenderModule extends TwitterModule {
   override val modules = Seq(
     AkkaModule,
@@ -18,10 +20,10 @@ object MetricsSenderModule extends TwitterModule {
   @Singleton
   def providesMetricsSender(amazonCloudWatch: AmazonCloudWatch,
                             actorSystem: ActorSystem,
-                            metricsConfig: MetricsConfig) =
+                            metricsConfig: MetricsConfig, executionContext: ExecutionContext) =
     new MetricsSender(
       amazonCloudWatch = amazonCloudWatch,
       actorSystem = actorSystem,
       metricsConfig = metricsConfig
-    )
+    )(executionContext)
 }

--- a/sbt_common/finatra_monitoring/src/main/scala/uk/ac/wellcome/finatra/monitoring/MetricsSenderModule.scala
+++ b/sbt_common/finatra_monitoring/src/main/scala/uk/ac/wellcome/finatra/monitoring/MetricsSenderModule.scala
@@ -7,8 +7,6 @@ import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.finatra.akka.AkkaModule
 import uk.ac.wellcome.monitoring.{MetricsConfig, MetricsSender}
 
-import scala.concurrent.ExecutionContext
-
 object MetricsSenderModule extends TwitterModule {
   override val modules = Seq(
     AkkaModule,
@@ -20,10 +18,10 @@ object MetricsSenderModule extends TwitterModule {
   @Singleton
   def providesMetricsSender(amazonCloudWatch: AmazonCloudWatch,
                             actorSystem: ActorSystem,
-                            metricsConfig: MetricsConfig, executionContext: ExecutionContext) =
+                            metricsConfig: MetricsConfig) =
     new MetricsSender(
       amazonCloudWatch = amazonCloudWatch,
       actorSystem = actorSystem,
       metricsConfig = metricsConfig
-    )(executionContext)
+    )
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -45,6 +45,7 @@ class MessageWriter[T] @Inject()(
         message,
         keyPrefix = KeyPrefix(getKeyPrefix())
       )
+      _ = debug(s"Successfully stored message $message in location: $location")
       pointer <- Future.fromTry(toJson(MessagePointer(location)))
       publishAttempt <- sns.writeMessage(pointer, subject)
       _ = debug(publishAttempt)

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -7,7 +7,7 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sns.AmazonSNS
 import com.google.inject.Inject
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.messaging.sns.{SNSConfig, SNSWriter}
+import uk.ac.wellcome.messaging.sns.{PublishAttempt, SNSConfig, SNSWriter}
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.messaging.GlobalExecutionContext.context
 import uk.ac.wellcome.storage.{KeyPrefix, ObjectStore}
@@ -39,7 +39,7 @@ class MessageWriter[T] @Inject()(
     s"$topicName/${dateFormat.format(new Date())}"
   }
 
-  def write(message: T, subject: String): Future[Unit] = {
+  def write(message: T, subject: String): Future[PublishAttempt] = {
     for {
       location <- objectStore.put(messageConfig.s3Config.bucketName)(
         message,
@@ -48,7 +48,7 @@ class MessageWriter[T] @Inject()(
       pointer <- Future.fromTry(toJson(MessagePointer(location)))
       publishAttempt <- sns.writeMessage(pointer, subject)
       _ = debug(publishAttempt)
-    } yield ()
+    } yield publishAttempt
 
   }
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
@@ -23,7 +23,7 @@ class SNSWriter @Inject()(snsClient: AmazonSNS, snsConfig: SNSConfig)
     }.map { publishResult =>
         debug(
           s"Published message $message to ${snsConfig.topicArn} (${publishResult.getMessageId})")
-        PublishAttempt(Right(publishResult.getMessageId))
+        PublishAttempt(Right(message))
       }
       .recover {
         case e: Throwable =>

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class MessageStreamTest
     extends FunSpec
@@ -73,7 +73,7 @@ class MessageStreamTest
 
         eventually {
           verify(metricsSender, times(1))
-            .count(equalTo("test-stream_ProcessMessage"), any[Future[Unit]]())
+            .count(equalTo("test-stream_ProcessMessage"), any[Future[Unit]]())(any[ExecutionContext])
         }
     }
   }

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
@@ -73,7 +73,8 @@ class MessageStreamTest
 
         eventually {
           verify(metricsSender, times(1))
-            .count(equalTo("test-stream_ProcessMessage"), any[Future[Unit]]())(any[ExecutionContext])
+            .count(equalTo("test-stream_ProcessMessage"), any[Future[Unit]]())(
+              any[ExecutionContext])
         }
     }
   }

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sns/SNSWriterTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/sns/SNSWriterTest.scala
@@ -28,7 +28,7 @@ class SNSWriterTest
         messages should have size (1)
         messages.head.message shouldBe message
         messages.head.subject shouldBe subject
-        publishAttempt.id should be(Right(messages.head.messageId))
+        publishAttempt.id should be(Right(messages.head.message))
       }
     }
   }

--- a/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
+++ b/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
@@ -5,7 +5,12 @@ import java.util.Date
 import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source, SourceQueueWithComplete}
-import akka.stream.{ActorMaterializer, OverflowStrategy, QueueOfferResult, ThrottleMode}
+import akka.stream.{
+  ActorMaterializer,
+  OverflowStrategy,
+  QueueOfferResult,
+  ThrottleMode
+}
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model._
 import com.google.inject.Inject
@@ -57,7 +62,8 @@ class MetricsSender @Inject()(amazonCloudWatch: AmazonCloudWatch,
       .to(sink)
       .run()
 
-  def count[T](metricName: String, f: Future[T])(implicit ec: ExecutionContext): Future[T] = {
+  def count[T](metricName: String, f: Future[T])(
+    implicit ec: ExecutionContext): Future[T] = {
     f.onComplete {
       case Success(_) => incrementCount(s"${metricName}_success")
       case Failure(_: GracefulFailureException) =>

--- a/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
+++ b/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
@@ -18,7 +18,7 @@ import scala.util.{Failure, Success}
 
 class MetricsSender @Inject()(amazonCloudWatch: AmazonCloudWatch,
                               actorSystem: ActorSystem,
-                              metricsConfig: MetricsConfig)(implicit executionContext: ExecutionContext)
+                              metricsConfig: MetricsConfig)
     extends Logging {
 
   implicit val system = actorSystem
@@ -57,7 +57,7 @@ class MetricsSender @Inject()(amazonCloudWatch: AmazonCloudWatch,
       .to(sink)
       .run()
 
-  def count[T](metricName: String, f: Future[T]): Future[T] = {
+  def count[T](metricName: String, f: Future[T])(implicit ec: ExecutionContext): Future[T] = {
     f.onComplete {
       case Success(_) => incrementCount(s"${metricName}_success")
       case Failure(_: GracefulFailureException) =>

--- a/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
+++ b/sbt_common/monitoring/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
@@ -5,26 +5,20 @@ import java.util.Date
 import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source, SourceQueueWithComplete}
-import akka.stream.{
-  ActorMaterializer,
-  OverflowStrategy,
-  QueueOfferResult,
-  ThrottleMode
-}
+import akka.stream.{ActorMaterializer, OverflowStrategy, QueueOfferResult, ThrottleMode}
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model._
 import com.google.inject.Inject
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.monitoring.GlobalExecutionContext.context
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 class MetricsSender @Inject()(amazonCloudWatch: AmazonCloudWatch,
                               actorSystem: ActorSystem,
-                              metricsConfig: MetricsConfig)
+                              metricsConfig: MetricsConfig)(implicit executionContext: ExecutionContext)
     extends Logging {
 
   implicit val system = actorSystem

--- a/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/MetricsSenderFixture.scala
+++ b/sbt_common/monitoring/src/test/scala/uk/ac/wellcome/monitoring/test/fixtures/MetricsSenderFixture.scala
@@ -10,7 +10,7 @@ import org.scalatest.mockito.MockitoSugar
 import uk.ac.wellcome.monitoring.{MetricsConfig, MetricsSender}
 import uk.ac.wellcome.test.fixtures._
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 trait MetricsSenderFixture
     extends Logging
@@ -33,12 +33,11 @@ trait MetricsSenderFixture
   def withMockMetricSender[R] = fixture[MetricsSender, R](
     create = {
       val metricsSender = mock[MetricsSender]
-
       when(
         metricsSender.count(
           anyString(),
           any[Future[Unit]]()
-        )
+        )(any[ExecutionContext])
       ).thenAnswer(new Answer[Future[Unit]] {
         override def answer(invocation: InvocationOnMock): Future[Unit] = {
           invocation.callRealMethod().asInstanceOf[Future[Unit]]


### PR DESCRIPTION
Some refactoring commits spun out of #2453:

- Turn off apache and aws logs, so that when we set the log level to DEBUG we don't get spammed with loads of useless stuff
- MetricSendes gets the execution context ~in the constructor~ as a parameter in the count function rather than having it hardcoded in the imports. This makes it possible to instantiate different metrics sender with different execution contexts and to make MetricSender use the same ExecutionContext as the actor system in production 
- Make SNSWriter return a publish result with the full message sent and print that as debug in the transformer
- Some generic code cleanup