### PR TITLE
Use consistent intercapping of “Elasticsearch” (there’s no uppercase “S”)

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.elasticsearch.ElasticConfig
 import scala.concurrent.Future
 
 @Singleton
-class ElasticSearchService @Inject()(elasticClient: HttpClient,
+class ElasticsearchService @Inject()(elasticClient: HttpClient,
                                      elasticConfig: ElasticConfig) {
 
   val documentType: String = elasticConfig.documentType

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -13,7 +13,7 @@ import scala.util.{Failure, Success}
 
 @Singleton
 class WorksService @Inject()(apiConfig: ApiConfig,
-                             searchService: ElasticSearchService) {
+                             searchService: ElasticsearchService) {
 
   def findWorkById(canonicalId: String,
                    indexName: String): Future[Option[IdentifiedBaseWork]] =

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ElasticsearchServiceFixture.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ElasticsearchServiceFixture.scala
@@ -3,14 +3,14 @@ package uk.ac.wellcome.platform.api.fixtures
 import org.scalatest.{Assertion, Suite}
 import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.platform.api.services.ElasticSearchService
+import uk.ac.wellcome.platform.api.services.ElasticsearchService
 import uk.ac.wellcome.test.fixtures.TestWith
 
 trait ElasticsearchServiceFixture extends ElasticsearchFixtures {
   this: Suite =>
   def withElasticSearchService(indexName: String, itemType: String)(
-    testWith: TestWith[ElasticSearchService, Assertion]) = {
-    val searchService = new ElasticSearchService(
+    testWith: TestWith[ElasticsearchService, Assertion]) = {
+    val searchService = new ElasticsearchService(
       elasticClient = elasticClient,
       elasticConfig = ElasticConfig(
         documentType = itemType,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ElasticsearchServiceFixture.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ElasticsearchServiceFixture.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.test.fixtures.TestWith
 
 trait ElasticsearchServiceFixture extends ElasticsearchFixtures {
   this: Suite =>
-  def withElasticSearchService(indexName: String, itemType: String)(
+  def withElasticsearchService(indexName: String, itemType: String)(
     testWith: TestWith[ElasticsearchService, Assertion]) = {
     val searchService = new ElasticsearchService(
       elasticClient = elasticClient,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/WorksServiceFixture.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/WorksServiceFixture.scala
@@ -1,12 +1,12 @@
 package uk.ac.wellcome.platform.api.fixtures
 
 import org.scalatest.{Assertion, Suite}
-import uk.ac.wellcome.platform.api.services.{ElasticSearchService, WorksService}
+import uk.ac.wellcome.platform.api.services.{ElasticsearchService, WorksService}
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.test.fixtures.TestWith
 
 trait WorksServiceFixture { this: Suite =>
-  def withWorksService(searchService: ElasticSearchService)(
+  def withWorksService(searchService: ElasticsearchService)(
     testWith: TestWith[WorksService, Assertion]) = {
     val worksService = new WorksService(
       apiConfig = ApiConfig(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -29,7 +29,7 @@ class ElasticsearchServiceTest
 
         insertIntoElasticsearch(indexName, itemType, work1, work2, work3)
 
-        withElasticSearchService(indexName = indexName, itemType = itemType) {
+        withElasticsearchService(indexName = indexName, itemType = itemType) {
           searchService =>
             val searchResultFuture = searchService.simpleStringQueryResults(
               queryString = "Aegean",
@@ -56,7 +56,7 @@ class ElasticsearchServiceTest
 
         insertIntoElasticsearch(indexName, itemType, work)
 
-        withElasticSearchService(indexName = indexName, itemType = itemType) {
+        withElasticsearchService(indexName = indexName, itemType = itemType) {
           searchService =>
             val searchResultFuture: Future[GetResponse] =
               searchService.findResultById(
@@ -188,7 +188,7 @@ class ElasticsearchServiceTest
     from: Int,
     expectedWorks: List[IdentifiedBaseWork]
   ) = {
-    withElasticSearchService(indexName = indexName, itemType = itemType) {
+    withElasticsearchService(indexName = indexName, itemType = itemType) {
       searchService =>
         val searchResultFuture = searchService.listResults(
           sortByField = "canonicalId",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -20,7 +20,7 @@ class WorksServiceTest
 
   it("gets records in Elasticsearch") {
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withElasticSearchService(indexName = indexName, itemType = itemType) {
+      withElasticsearchService(indexName = indexName, itemType = itemType) {
         searchService =>
           withWorksService(searchService) { worksService =>
             val works = createIdentifiedWorks(count = 2)
@@ -39,7 +39,7 @@ class WorksServiceTest
 
   it("gets a DisplayWork by id") {
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withElasticSearchService(indexName = indexName, itemType = itemType) {
+      withElasticsearchService(indexName = indexName, itemType = itemType) {
         searchService =>
           withWorksService(searchService) { worksService =>
             val work = createIdentifiedWork
@@ -63,7 +63,7 @@ class WorksServiceTest
 
   it("only finds results that match a query if doing a full-text search") {
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withElasticSearchService(indexName = indexName, itemType = itemType) {
+      withElasticsearchService(indexName = indexName, itemType = itemType) {
         searchService =>
           withWorksService(searchService) { worksService =>
             val workDodo = createIdentifiedWorkWith(
@@ -100,7 +100,7 @@ class WorksServiceTest
 
   it("returns a future of None if it cannot get a record by id") {
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withElasticSearchService(indexName = indexName, itemType = itemType) {
+      withElasticsearchService(indexName = indexName, itemType = itemType) {
         searchService =>
           withWorksService(searchService) { worksService =>
             val recordsFuture = worksService.findWorkById(
@@ -118,7 +118,7 @@ class WorksServiceTest
 
   it("returns 0 pages when no results are available") {
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withElasticSearchService(indexName = indexName, itemType = itemType) {
+      withElasticsearchService(indexName = indexName, itemType = itemType) {
         searchService =>
           withWorksService(searchService) { worksService =>
             val displayWorksFuture =
@@ -134,7 +134,7 @@ class WorksServiceTest
 
   it("returns an empty result set when asked for a page that does not exist") {
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withElasticSearchService(indexName = indexName, itemType = itemType) {
+      withElasticsearchService(indexName = indexName, itemType = itemType) {
         searchService =>
           withWorksService(searchService) { worksService =>
             val works = createIdentifiedWorks(count = 3)
@@ -158,7 +158,7 @@ class WorksServiceTest
   it(
     "doesn't throw an exception if passed an invalid query string for full-text search") {
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withElasticSearchService(indexName = indexName, itemType = itemType) {
+      withElasticsearchService(indexName = indexName, itemType = itemType) {
         searchService =>
           withWorksService(searchService) { worksService =>
             val workEmu = createIdentifiedWorkWith(

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/CustomElasticSearchMapping.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/CustomElasticSearchMapping.scala
@@ -12,12 +12,12 @@ import com.sksamuel.elastic4s.http.ElasticDsl.{
 import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicMapping
 import com.sksamuel.elastic4s.mappings.{FieldDefinition, MappingDefinition}
-import uk.ac.wellcome.elasticsearch.ElasticSearchIndex
+import uk.ac.wellcome.elasticsearch.ElasticsearchIndex
 
 trait CustomElasticSearchMapping {
 
   class SubsetOfFieldsWorksIndex(elasticClient: HttpClient, esType: String)
-      extends ElasticSearchIndex {
+      extends ElasticsearchIndex {
     override val httpClient: HttpClient = elasticClient
 
     def sourceIdentifierFields = Seq(

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/CustomElasticsearchMapping.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/CustomElasticsearchMapping.scala
@@ -14,7 +14,7 @@ import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicMapping
 import com.sksamuel.elastic4s.mappings.{FieldDefinition, MappingDefinition}
 import uk.ac.wellcome.elasticsearch.ElasticsearchIndex
 
-trait CustomElasticSearchMapping {
+trait CustomElasticsearchMapping {
 
   class SubsetOfFieldsWorksIndex(elasticClient: HttpClient, esType: String)
       extends ElasticsearchIndex {

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -34,7 +34,7 @@ class IngestorWorkerServiceTest
     with S3
     with WorkIndexerFixtures
     with WorksUtil
-    with CustomElasticSearchMapping {
+    with CustomElasticsearchMapping {
 
   val itemType = "work"
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -18,7 +18,7 @@ class WorkIndexerTest
     with ElasticsearchFixtures
     with WorksUtil
     with WorkIndexerFixtures
-    with CustomElasticSearchMapping {
+    with CustomElasticsearchMapping {
 
   val esType = "work"
 

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndex.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.elasticsearch.GlobalExecutionContext.context
 
 import scala.concurrent.Future
 
-trait ElasticSearchIndex extends Logging {
+trait ElasticsearchIndex extends Logging {
   val httpClient: HttpClient
   val mappingDefinition: MappingDefinition
 

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -9,7 +9,7 @@ import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicMapping
 import grizzled.slf4j.Logging
 
 class WorksIndex @Inject()(client: HttpClient, elasticConfig: ElasticConfig)
-    extends ElasticSearchIndex
+    extends ElasticsearchIndex
     with Logging {
 
   val rootIndexType = elasticConfig.documentType

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndexTest.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndexTest.scala
@@ -31,7 +31,7 @@ case class BadTestObject(
   weight: Int
 )
 
-class ElasticSearchIndexTest
+class ElasticsearchIndexTest
     extends FunSpec
     with ElasticsearchFixtures
     with ScalaFutures
@@ -42,7 +42,7 @@ class ElasticSearchIndexTest
 
   val testType = "thing"
 
-  object TestIndex extends ElasticSearchIndex {
+  object TestIndex extends ElasticsearchIndex {
 
     override val httpClient: HttpClient = elasticClient
     override val mappingDefinition = mapping(testType)
@@ -54,7 +54,7 @@ class ElasticSearchIndexTest
       )
   }
 
-  object CompatibleTestIndex extends ElasticSearchIndex {
+  object CompatibleTestIndex extends ElasticsearchIndex {
 
     override val httpClient = elasticClient
     override val mappingDefinition = mapping(testType)

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -8,7 +8,7 @@ import org.scalatest.{Matchers, Suite}
 import uk.ac.wellcome.elasticsearch.{
   ElasticClientBuilder,
   ElasticConfig,
-  ElasticSearchIndex,
+  ElasticsearchIndex,
   WorksIndex
 }
 import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
@@ -69,7 +69,7 @@ trait ElasticsearchFixtures
   }
 
   def withLocalElasticsearchIndex[R](
-    index: ElasticSearchIndex,
+    index: ElasticsearchIndex,
     indexName: String)(testWith: TestWith[String, R]): R = {
 
     index.create(indexName).await


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Elasticsearch