### PR TITLE
Undo renaming of maybeBibData 

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
@@ -43,7 +43,7 @@ class SierraTransformableTransformer
         )
       )
 
-      sierraTransformable.maybeBibRecord
+      sierraTransformable.maybeBibData
         .map { bibData =>
           debug(s"Attempting to transform ${bibData.id}")
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
@@ -19,7 +19,7 @@ import scala.util.{Failure, Success}
 trait SierraItems extends Logging with SierraLocation {
   def extractItemData(
     sierraTransformable: SierraTransformable): List[SierraItemData] = {
-    sierraTransformable.itemRecords.values
+    sierraTransformable.itemData.values
       .map { _.data }
       .map { jsonString =>
         fromJson[SierraItemData](jsonString) match {

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
@@ -27,15 +27,13 @@ case class MiroTransformable(sourceId: String,
   *
   */
 case class SierraTransformable(
-                                sourceId: String,
-                                sourceName: String = "sierra",
-                                maybeBibData: Option[SierraBibRecord] = None,
-                                itemData: Map[String, SierraItemRecord] = Map()
+  sourceId: String,
+  sourceName: String = "sierra",
+  maybeBibData: Option[SierraBibRecord] = None,
+  itemData: Map[String, SierraItemRecord] = Map()
 ) extends Transformable
 
 object SierraTransformable {
   def apply(bibRecord: SierraBibRecord): SierraTransformable =
-    SierraTransformable(
-      sourceId = bibRecord.id,
-      maybeBibData = Some(bibRecord))
+    SierraTransformable(sourceId = bibRecord.id, maybeBibData = Some(bibRecord))
 }

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
@@ -27,15 +27,15 @@ case class MiroTransformable(sourceId: String,
   *
   */
 case class SierraTransformable(
-  sourceId: String,
-  sourceName: String = "sierra",
-  maybeBibRecord: Option[SierraBibRecord] = None,
-  itemRecords: Map[String, SierraItemRecord] = Map()
+                                sourceId: String,
+                                sourceName: String = "sierra",
+                                maybeBibData: Option[SierraBibRecord] = None,
+                                itemRecords: Map[String, SierraItemRecord] = Map()
 ) extends Transformable
 
 object SierraTransformable {
   def apply(bibRecord: SierraBibRecord): SierraTransformable =
     SierraTransformable(
       sourceId = bibRecord.id,
-      maybeBibRecord = Some(bibRecord))
+      maybeBibData = Some(bibRecord))
 }

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/Transformable.scala
@@ -30,7 +30,7 @@ case class SierraTransformable(
                                 sourceId: String,
                                 sourceName: String = "sierra",
                                 maybeBibData: Option[SierraBibRecord] = None,
-                                itemRecords: Map[String, SierraItemRecord] = Map()
+                                itemData: Map[String, SierraItemRecord] = Map()
 ) extends Transformable
 
 object SierraTransformable {

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/SierraTransformableTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/SierraTransformableTest.scala
@@ -13,6 +13,6 @@ class SierraTransformableTest extends FunSpec with Matchers with SierraUtil {
     val bibRecord = createSierraBibRecord
     val mergedRecord = SierraTransformable(bibRecord = bibRecord)
     mergedRecord.sourceId shouldEqual bibRecord.id
-    mergedRecord.maybeBibRecord.get shouldEqual bibRecord
+    mergedRecord.maybeBibData.get shouldEqual bibRecord
   }
 }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/test/utils/SierraUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/test/utils/SierraUtil.scala
@@ -94,7 +94,7 @@ trait SierraUtil extends IdentifiersUtil {
   ): SierraTransformable =
     SierraTransformable(
       sourceId = sourceId,
-      maybeBibRecord = maybeBibRecord,
+      maybeBibData = maybeBibRecord,
       itemRecords = itemRecords.map { record: SierraItemRecord =>
         record.id -> record
       }.toMap

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/test/utils/SierraUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/test/utils/SierraUtil.scala
@@ -95,7 +95,7 @@ trait SierraUtil extends IdentifiersUtil {
     SierraTransformable(
       sourceId = sourceId,
       maybeBibData = maybeBibRecord,
-      itemRecords = itemRecords.map { record: SierraItemRecord =>
+      itemData = itemRecords.map { record: SierraItemRecord =>
         record.id -> record
       }.toMap
     )

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMerger.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMerger.scala
@@ -15,14 +15,14 @@ object BibMerger {
         s"Non-matching bib ids ${sierraBibRecord.id} != ${sierraTransformable.sourceId}")
     }
 
-    val isNewerData = sierraTransformable.maybeBibRecord match {
+    val isNewerData = sierraTransformable.maybeBibData match {
       case Some(bibData) =>
         sierraBibRecord.modifiedDate.isAfter(bibData.modifiedDate)
       case None => true
     }
 
     if (isNewerData) {
-      sierraTransformable.copy(maybeBibRecord = Some(sierraBibRecord))
+      sierraTransformable.copy(maybeBibData = Some(sierraBibRecord))
     } else {
       sierraTransformable
     }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMergerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMergerTest.scala
@@ -12,7 +12,7 @@ class BibMergerTest extends FunSpec with Matchers with SierraUtil {
       val transformable = createSierraTransformableWith(sourceId = bibRecord.id)
 
       val newTransformable = BibMerger.mergeBibRecord(transformable, bibRecord)
-      newTransformable.maybeBibRecord.get shouldEqual bibRecord
+      newTransformable.maybeBibData.get shouldEqual bibRecord
     }
 
     it("only merges bib records with matching ids") {
@@ -59,7 +59,7 @@ class BibMergerTest extends FunSpec with Matchers with SierraUtil {
       )
 
       val result = BibMerger.mergeBibRecord(transformable, newBibRecord)
-      result.maybeBibRecord.get shouldBe newBibRecord
+      result.maybeBibData.get shouldBe newBibRecord
     }
   }
 }

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemLinker.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemLinker.scala
@@ -25,15 +25,15 @@ object ItemLinker {
     //    just received?  If the existing data is older, we need to merge the
     //    new record.
     //
-    val isNewerData = sierraTransformable.itemRecords.get(itemRecord.id) match {
+    val isNewerData = sierraTransformable.itemData.get(itemRecord.id) match {
       case Some(existing) =>
         itemRecord.modifiedDate.isAfter(existing.modifiedDate)
       case None => true
     }
 
     if (isNewerData) {
-      val itemData = sierraTransformable.itemRecords + (itemRecord.id -> itemRecord)
-      sierraTransformable.copy(itemRecords = itemData)
+      val itemData = sierraTransformable.itemData + (itemRecord.id -> itemRecord)
+      sierraTransformable.copy(itemData = itemData)
     } else {
       sierraTransformable
     }

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinker.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinker.scala
@@ -13,7 +13,7 @@ object ItemUnlinker {
     }
 
     val itemData: Map[String, SierraItemRecord] =
-      sierraTransformable.itemRecords
+      sierraTransformable.itemData
         .filterNot {
           case (id, currentItemRecord) => {
             val matchesCurrentItemRecord = id == itemRecord.id
@@ -26,6 +26,6 @@ object ItemUnlinker {
           }
         }
 
-    sierraTransformable.copy(itemRecords = itemData)
+    sierraTransformable.copy(itemData = itemData)
   }
 }

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
@@ -30,7 +30,7 @@ class SierraItemMergerUpdaterService @Inject()(
         ifNotExisting = (
           SierraTransformable(
             sourceId = bibId,
-            itemRecords = Map(itemRecord.id -> itemRecord)),
+            itemData = Map(itemRecord.id -> itemRecord)),
           SourceMetadata(sourceName)))(
         ifExisting = (existingSierraTransformable, _) => {
           (

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemLinkerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemLinkerTest.scala
@@ -14,7 +14,7 @@ class ItemLinkerTest extends FunSpec with Matchers with SierraUtil {
     val sierraTransformable = createSierraTransformableWith(sourceId = bibId)
     val result = ItemLinker.linkItemRecord(sierraTransformable, record)
 
-    result.itemRecords shouldBe Map(record.id -> record)
+    result.itemData shouldBe Map(record.id -> record)
   }
 
   it("updates itemData when merging item records with newer data") {
@@ -37,7 +37,7 @@ class ItemLinkerTest extends FunSpec with Matchers with SierraUtil {
     val result = ItemLinker.linkItemRecord(sierraTransformable, newerRecord)
 
     result shouldBe sierraTransformable.copy(
-      itemRecords = Map(itemRecord.id -> newerRecord))
+      itemData = Map(itemRecord.id -> newerRecord))
   }
 
   it("returns itself when merging item records with stale data") {
@@ -73,8 +73,8 @@ class ItemLinkerTest extends FunSpec with Matchers with SierraUtil {
     val result1 = ItemLinker.linkItemRecord(sierraTransformable, record1)
     val result2 = ItemLinker.linkItemRecord(result1, record2)
 
-    result1.itemRecords(record1.id) shouldBe record1
-    result2.itemRecords(record2.id) shouldBe record2
+    result1.itemData(record1.id) shouldBe record1
+    result2.itemData(record2.id) shouldBe record2
   }
 
   it("only merges item records with matching bib IDs") {

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinkerTests.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinkerTests.scala
@@ -25,7 +25,7 @@ class ItemUnlinkerTests extends FunSpec with Matchers with SierraUtil {
     )
 
     val expectedSierraTransformable = sierraTransformable.copy(
-      itemRecords = Map.empty
+      itemData = Map.empty
     )
 
     ItemUnlinker.unlinkItemRecord(sierraTransformable, unlinkedItemRecord) shouldBe expectedSierraTransformable

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -191,7 +191,7 @@ class SierraItemMergerUpdaterServiceTest
 
               whenReady(sierraUpdaterService.update(newItemRecord)) { _ =>
                 val expectedSierraRecord = oldTransformable.copy(
-                  itemRecords = Map(itemRecord.id -> newItemRecord)
+                  itemData = Map(itemRecord.id -> newItemRecord)
                 )
 
                 assertStored[SierraTransformable](
@@ -255,7 +255,7 @@ class SierraItemMergerUpdaterServiceTest
 
             whenReady(unlinkItemRecordFuture) { _ =>
               val expectedSierraRecord1 = sierraTransformable1.copy(
-                itemRecords = Map.empty
+                itemData = Map.empty
               )
 
               val expectedItemData = Map(
@@ -266,7 +266,7 @@ class SierraItemMergerUpdaterServiceTest
                 )
               )
               val expectedSierraRecord2 = sierraTransformable2.copy(
-                itemRecords = expectedItemData
+                itemData = expectedItemData
               )
 
               assertStored[SierraTransformable](
@@ -335,13 +335,13 @@ class SierraItemMergerUpdaterServiceTest
             whenReady(Future.sequence(List(f1, f2))) { _ =>
               whenReady(sierraUpdaterService.update(unlinkItemRecord)) { _ =>
                 val expectedSierraRecord1 = sierraTransformable1.copy(
-                  itemRecords = Map.empty
+                  itemData = Map.empty
                 )
 
                 // In this situation the item was already linked to sierraTransformable2
                 // but the modified date is updated in line with the item update
                 val expectedSierraRecord2 = sierraTransformable2.copy(
-                  itemRecords = expectedItemData
+                  itemData = expectedItemData
                 )
 
                 assertStored[SierraTransformable](
@@ -418,7 +418,7 @@ class SierraItemMergerUpdaterServiceTest
                 // time we've seen the link so it is valid for that bib.
                 val expectedSierraRecord1 = sierraTransformable1
                 val expectedSierraRecord2 = sierraTransformable2.copy(
-                  itemRecords = expectedItemRecords
+                  itemData = expectedItemRecords
                 )
 
                 assertStored[SierraTransformable](


### PR DESCRIPTION
So that data in the SourceData table is still transformable