### PR TITLE
Correct merged digital and physical works

### DIFF
--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -54,7 +54,11 @@ class Merger extends Logging {
 
   private def mergePhysicalWithDigitalWork(physicalWork: UnidentifiedWork,
                                            digitalWork: UnidentifiedWork) = {
-    physicalWork.copy(items = physicalWork.items ++ digitalWork.items)
+    physicalWork.copy(items = List(
+      physicalWork.items.head.copy(
+        agent = physicalWork.items.head.agent.copy(
+          locations =
+            physicalWork.items.head.agent.locations ++ digitalWork.items.head.agent.locations))))
   }
 
   private def redirectWork(workToRedirect: UnidentifiedWork,

--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -25,17 +25,14 @@ class Merger extends Logging {
       // As the works are supplied by the matcher these are trusted to refer to the same work without verification.
       // However, it may be prudent to add extra checks before making the merge here.
       case (List(physicalWork), List(digitalWork)) =>
-        mergeAndRedirectWork(
-          physicalWork,
-          digitalWork)
+        mergeAndRedirectWork(physicalWork, digitalWork)
       case _ =>
         None
     }
   }
 
-  private def mergeAndRedirectWork(
-    physicalWork: UnidentifiedWork,
-    digitalWork: UnidentifiedWork) = {
+  private def mergeAndRedirectWork(physicalWork: UnidentifiedWork,
+                                   digitalWork: UnidentifiedWork) = {
     if (physicalWork.items.size == 1 && digitalWork.items.size == 1) {
       info(s"Merging ${describeWorkPair(physicalWork, digitalWork)} work pair.")
       Some(
@@ -52,13 +49,16 @@ class Merger extends Logging {
     }
   }
 
-  private def mergePhysicalAndDigitalWorkItems(physicalWork: UnidentifiedWork,
-                                               digitalWork: UnidentifiedWork) = {
+  private def mergePhysicalAndDigitalWorkItems(
+    physicalWork: UnidentifiedWork,
+    digitalWork: UnidentifiedWork) = {
     val mergedItem = (physicalWork.items, digitalWork.items) match {
       case (List(physicalItem), List(digitalItem)) =>
         physicalItem.copy(agent = physicalItem.agent.copy(
           locations = physicalItem.agent.locations ++ digitalItem.agent.locations))
-      case _ => throw new IllegalArgumentException(s"Cannot merge, physical and digital works must both have a single item (physicalWork:${physicalWork.sourceIdentifier}, digitalWork:${digitalWork.sourceIdentifier}")
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Cannot merge, physical and digital works must both have a single item (physicalWork:${physicalWork.sourceIdentifier}, digitalWork:${digitalWork.sourceIdentifier}")
     }
     physicalWork.copy(items = List(mergedItem))
   }

--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -54,11 +54,9 @@ class Merger extends Logging {
 
   private def mergePhysicalWithDigitalWork(physicalWork: UnidentifiedWork,
                                            digitalWork: UnidentifiedWork) = {
-    physicalWork.copy(items = List(
-      physicalWork.items.head.copy(
-        agent = physicalWork.items.head.agent.copy(
-          locations =
-            physicalWork.items.head.agent.locations ++ digitalWork.items.head.agent.locations))))
+    physicalWork.copy(items = List(physicalWork.items.head.copy(
+      agent = physicalWork.items.head.agent.copy(locations =
+        physicalWork.items.head.agent.locations ++ digitalWork.items.head.agent.locations))))
   }
 
   private def redirectWork(workToRedirect: UnidentifiedWork,

--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -31,31 +31,32 @@ class Merger extends Logging {
     }
   }
 
-  private def mergeAndRedirectWork(
-    physicalWork: UnidentifiedWork,
-    digitalWork: UnidentifiedWork) = {
+  private def mergeAndRedirectWork(physicalWork: UnidentifiedWork,
+                                   digitalWork: UnidentifiedWork) = {
     (physicalWork.items, digitalWork.items) match {
       case (List(physicalItem), List(digitalItem)) =>
-      info(s"Merging ${describeWorkPair(physicalWork, digitalWork)} work pair.")
-      Some(
-        List(
-          physicalWork.copy(
-            otherIdentifiers = physicalWork.otherIdentifiers ++ digitalWork.identifiers,
-            items = mergePhysicalAndDigitalItems(physicalItem, digitalItem)),
-          redirectWork(
-            workToRedirect = digitalWork,
-            redirectTargetSourceIdentifier = physicalWork.sourceIdentifier)
-        ))
+        info(
+          s"Merging ${describeWorkPair(physicalWork, digitalWork)} work pair.")
+        Some(
+          List(
+            physicalWork.copy(
+              otherIdentifiers = physicalWork.otherIdentifiers ++ digitalWork.identifiers,
+              items = mergePhysicalAndDigitalItems(physicalItem, digitalItem)),
+            redirectWork(
+              workToRedirect = digitalWork,
+              redirectTargetSourceIdentifier = physicalWork.sourceIdentifier)
+          ))
       case _ =>
-      debug(
-        s"Not merging physical ${describeWorkPairWithItems(physicalWork, digitalWork)} as there are multiple items")
-      None
+        debug(
+          s"Not merging physical ${describeWorkPairWithItems(physicalWork, digitalWork)} as there are multiple items")
+        None
     }
   }
 
-  private def mergePhysicalAndDigitalItems(physicalItem: Identifiable[Item], digitalItem: Identifiable[Item]) = {
+  private def mergePhysicalAndDigitalItems(physicalItem: Identifiable[Item],
+                                           digitalItem: Identifiable[Item]) = {
     List(physicalItem.copy(agent = physicalItem.agent.copy(
-          locations = physicalItem.agent.locations ++ digitalItem.agent.locations)))
+      locations = physicalItem.agent.locations ++ digitalItem.agent.locations)))
   }
 
   private def redirectWork(workToRedirect: UnidentifiedWork,

--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -31,36 +31,31 @@ class Merger extends Logging {
     }
   }
 
-  private def mergeAndRedirectWork(physicalWork: UnidentifiedWork,
-                                   digitalWork: UnidentifiedWork) = {
-    if (physicalWork.items.size == 1 && digitalWork.items.size == 1) {
+  private def mergeAndRedirectWork(
+    physicalWork: UnidentifiedWork,
+    digitalWork: UnidentifiedWork) = {
+    (physicalWork.items, digitalWork.items) match {
+      case (List(physicalItem), List(digitalItem)) =>
       info(s"Merging ${describeWorkPair(physicalWork, digitalWork)} work pair.")
       Some(
         List(
-          mergePhysicalAndDigitalWorkItems(physicalWork, digitalWork),
+          physicalWork.copy(
+            otherIdentifiers = physicalWork.otherIdentifiers ++ digitalWork.identifiers,
+            items = mergePhysicalAndDigitalItems(physicalItem, digitalItem)),
           redirectWork(
             workToRedirect = digitalWork,
             redirectTargetSourceIdentifier = physicalWork.sourceIdentifier)
         ))
-    } else {
+      case _ =>
       debug(
         s"Not merging physical ${describeWorkPairWithItems(physicalWork, digitalWork)} as there are multiple items")
       None
     }
   }
 
-  private def mergePhysicalAndDigitalWorkItems(
-    physicalWork: UnidentifiedWork,
-    digitalWork: UnidentifiedWork) = {
-    val mergedItem = (physicalWork.items, digitalWork.items) match {
-      case (List(physicalItem), List(digitalItem)) =>
-        physicalItem.copy(agent = physicalItem.agent.copy(
-          locations = physicalItem.agent.locations ++ digitalItem.agent.locations))
-      case _ =>
-        throw new IllegalArgumentException(
-          s"Cannot merge, physical and digital works must both have a single item (physicalWork:${physicalWork.sourceIdentifier}, digitalWork:${digitalWork.sourceIdentifier}")
-    }
-    physicalWork.copy(items = List(mergedItem))
+  private def mergePhysicalAndDigitalItems(physicalItem: Identifiable[Item], digitalItem: Identifiable[Item]) = {
+    List(physicalItem.copy(agent = physicalItem.agent.copy(
+          locations = physicalItem.agent.locations ++ digitalItem.agent.locations)))
   }
 
   private def redirectWork(workToRedirect: UnidentifiedWork,

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -44,9 +44,9 @@ class MergerTest extends FunSpec with MergerTestUtils with MergerFixtures {
 
     val actualMergedWork = actualMergedWorks.head
 
-    val expectedItems = List(physicalWork.items.head.copy(agent = physicalWork.items.head.agent.copy(
-      locations = physicalWork.items.head.agent.locations ++ digitalWork.items.head.agent.locations)
-    ))
+    val expectedItems = List(
+      physicalWork.items.head.copy(agent = physicalWork.items.head.agent.copy(
+        locations = physicalWork.items.head.agent.locations ++ digitalWork.items.head.agent.locations)))
     actualMergedWork shouldBe physicalWork.copy(
       otherIdentifiers = physicalWork.otherIdentifiers ++ digitalWork.identifiers,
       items = expectedItems)
@@ -84,8 +84,8 @@ class MergerTest extends FunSpec with MergerTestUtils with MergerFixtures {
     createUnidentifiedWorkWith(
       sourceIdentifier =
         createSourceIdentifierWith(identifierType = "miro-image-number"),
-      otherIdentifiers =
-        List(createSourceIdentifierWith(identifierType = "miro-library-reference")),
+      otherIdentifiers = List(
+        createSourceIdentifierWith(identifierType = "miro-library-reference")),
       workType = Some(WorkType("v", "E-books")),
       items = List(
         createIdentifiableItemWith(locations = List(createDigitalLocation)))

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -38,8 +38,14 @@ class MergerTest extends FunSpec with MergerTestUtils with MergerFixtures {
     val physicalWork = createPhysicalWork
     val digitalWork = createDigitalWork
 
-    val expectedMergedWork =
-      physicalWork.copy(items = physicalWork.items ++ digitalWork.items)
+    val expectedMergedWork = physicalWork.copy(
+      items = List(
+        Identifiable(
+          sourceIdentifier =
+            physicalWork.items.head.sourceIdentifier,
+          agent =
+            Item(locations = physicalWork.items.head.agent.locations ++ digitalWork.items.head.agent.locations)
+      )))
 
     val expectedRedirectedWork = UnidentifiedRedirectedWork(
       sourceIdentifier = digitalWork.sourceIdentifier,
@@ -75,6 +81,7 @@ class MergerTest extends FunSpec with MergerTestUtils with MergerFixtures {
 
   private def createDigitalWork = {
     createUnidentifiedWorkWith(
+      sourceIdentifier = createSourceIdentifierWith(identifierType="miro-image-number"),
       workType = Some(WorkType("v", "E-books")),
       items = List(
         createIdentifiableItemWith(locations = List(createDigitalLocation)))
@@ -83,6 +90,7 @@ class MergerTest extends FunSpec with MergerTestUtils with MergerFixtures {
 
   private def createPhysicalWork = {
     createUnidentifiedWorkWith(
+      sourceIdentifier = createSourceIdentifierWith(identifierType="sierra-system-number"),
       items = List(
         createIdentifiableItemWith(locations = List(createPhysicalLocation)))
     )

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -39,12 +39,10 @@ class MergerTest extends FunSpec with MergerTestUtils with MergerFixtures {
     val digitalWork = createDigitalWork
 
     val expectedMergedWork = physicalWork.copy(
-      items = List(
-        Identifiable(
-          sourceIdentifier =
-            physicalWork.items.head.sourceIdentifier,
-          agent =
-            Item(locations = physicalWork.items.head.agent.locations ++ digitalWork.items.head.agent.locations)
+      items = List(Identifiable(
+        sourceIdentifier = physicalWork.items.head.sourceIdentifier,
+        agent = Item(
+          locations = physicalWork.items.head.agent.locations ++ digitalWork.items.head.agent.locations)
       )))
 
     val expectedRedirectedWork = UnidentifiedRedirectedWork(
@@ -81,7 +79,8 @@ class MergerTest extends FunSpec with MergerTestUtils with MergerFixtures {
 
   private def createDigitalWork = {
     createUnidentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(identifierType="miro-image-number"),
+      sourceIdentifier =
+        createSourceIdentifierWith(identifierType = "miro-image-number"),
       workType = Some(WorkType("v", "E-books")),
       items = List(
         createIdentifiableItemWith(locations = List(createDigitalLocation)))
@@ -90,7 +89,8 @@ class MergerTest extends FunSpec with MergerTestUtils with MergerFixtures {
 
   private def createPhysicalWork = {
     createUnidentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(identifierType="sierra-system-number"),
+      sourceIdentifier =
+        createSourceIdentifierWith(identifierType = "sierra-system-number"),
       items = List(
         createIdentifiableItemWith(locations = List(createPhysicalLocation)))
     )

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocation.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocation.scala
@@ -28,12 +28,12 @@ trait SierraLocation {
     }
 
   def getDigitalLocation(identifier: String): DigitalLocation = {
-    // This is a defensive check, it may not be needed an identifier should always be present.
+    // This is a defensive check, it may not be needed since an identifier should always be present.
     if (!identifier.isEmpty) {
       DigitalLocation(
         url = s"https://wellcomelibrary.org/iiif/$identifier/manifest",
         license = None,
-        locationType = LocationType("iiif-image")
+        locationType = LocationType("iiif-presentation")
       )
     } else {
       throw GracefulFailureException(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
@@ -112,7 +112,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
             locations = List(DigitalLocation(
               url = s"https://wellcomelibrary.org/iiif/${sourceIdentifier.value}/manifest",
               license = None,
-              locationType = LocationType("iiif-image"))))
+              locationType = LocationType("iiif-presentation"))))
         ))
       transformer.getDigitalItems(sourceIdentifier, bibData) shouldBe expectedItems
     }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocationTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocationTest.scala
@@ -61,7 +61,7 @@ class SierraLocationTest extends FunSpec with Matchers with SierraDataUtil {
       val expectedLocation = DigitalLocation(
         url = "https://wellcomelibrary.org/iiif/b2201508/manifest",
         license = None,
-        locationType = LocationType("iiif-image")
+        locationType = LocationType("iiif-presentation")
       )
       transformer.getDigitalLocation(id) shouldBe expectedLocation
     }

--- a/ontologies/Reference data/location-types.csv
+++ b/ontologies/Reference data/location-types.csv
@@ -1,5 +1,6 @@
 ThumbnailImage,thumbnail-image,Thumbnail Image
-IIIFImage,iiif-image,IIIF image
+IIIFImage,iiif-image,IIIF Image API
+IIIFPresentation,iiif-presentation,IIIF Presentation API
 2,acqi,Info Service acquisitions
 3,acql,Wellcome Library
 4,admi,administration

--- a/sbt_common/internal_model/src/main/resources/location-types.csv
+++ b/sbt_common/internal_model/src/main/resources/location-types.csv
@@ -1,5 +1,6 @@
 ThumbnailImage,thumbnail-image,Thumbnail Image
-IIIFImage,iiif-image,IIIF image
+IIIFImage,iiif-image,IIIF Image API
+IIIFPresentation,iiif-presentation,IIIF Presentation API
 2,acqi,Info Service acquisitions
 3,acql,Wellcome Library
 4,admi,administration

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/ItemsUtil.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/test/util/ItemsUtil.scala
@@ -38,7 +38,7 @@ trait ItemsUtil extends IdentifiersUtil {
   def createDigitalLocation = createDigitalLocationWith()
 
   def createDigitalLocationWith(
-    locationType: LocationType = LocationType("iiif-image"),
+    locationType: LocationType = createPresentationLocationType,
     url: String = defaultLocationUrl,
     license: License = License_CCBY) = DigitalLocation(
     locationType = locationType,
@@ -52,6 +52,8 @@ trait ItemsUtil extends IdentifiersUtil {
     "https://iiif.wellcomecollection.org/image/M0000001.jpg/info.json"
 
   def createImageLocationType = LocationType("iiif-image")
+
+  def createPresentationLocationType = LocationType("iiif-presentation")
 
   def createStoresLocationType = LocationType("sgmed")
 }


### PR DESCRIPTION
* Merged digital and physical works add the location from the digital work to the locations present in the single physical item.  This replaces current incorrect behaviour that creates two item records, one for each location.

* Add a new `iiif-presentation` type for use in digital locations

