### PR TITLE
Please have your ID ready for inspection

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/source/SierraBibData.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/source/SierraBibData.scala
@@ -6,7 +6,6 @@ import uk.ac.wellcome.platform.transformer.source.sierra.{
 }
 
 case class SierraBibData(
-  id: String,
   title: Option[String] = None,
   deleted: Boolean = false,
   suppressed: Boolean = false,

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/source/SierraItemData.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/source/SierraItemData.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.transformer.source
 
 case class SierraItemData(
-  id: String,
   deleted: Boolean = false,
   location: Option[SierraItemLocation] = None,
   fixedFields: Map[String, FixedField] = Map(),

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
@@ -45,17 +45,17 @@ class SierraTransformableTransformer
       )
 
       sierraTransformable.maybeBibData
-        .map { bibData =>
-          debug(s"Attempting to transform ${bibData.id}")
+        .map { bibRecord =>
+          debug(s"Attempting to transform ${bibRecord.id}")
 
-          fromJson[SierraBibData](bibData.data)
+          fromJson[SierraBibData](bibRecord.data)
             .map { sierraBibData =>
               if (!(sierraBibData.deleted || sierraBibData.suppressed)) {
                 UnidentifiedWork(
                   sourceIdentifier = sourceIdentifier,
                   otherIdentifiers = getOtherIdentifiers(sierraId),
                   mergeCandidates = getMergeCandidates(sierraBibData),
-                  title = getTitle(bibData = sierraBibData),
+                  title = getTitle(sierraBibData),
                   workType = getWorkType(sierraBibData),
                   description = getDescription(sierraBibData),
                   physicalDescription = getPhysicalDescription(sierraBibData),
@@ -78,7 +78,7 @@ class SierraTransformableTransformer
                 )
               } else {
                 throw new ShouldNotTransformException(
-                  s"Sierra record ${bibData.id} is either deleted or suppressed!"
+                  s"Sierra record ${bibRecord.id} is either deleted or suppressed!"
                 )
               }
             }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
@@ -55,7 +55,7 @@ class SierraTransformableTransformer
                   sourceIdentifier = sourceIdentifier,
                   otherIdentifiers = getOtherIdentifiers(sierraId),
                   mergeCandidates = getMergeCandidates(sierraBibData),
-                  title = getTitle(bibId = sierraId, bibData = sierraBibData),
+                  title = getTitle(bibData = sierraBibData),
                   workType = getWorkType(sierraBibData),
                   description = getDescription(sierraBibData),
                   physicalDescription = getPhysicalDescription(sierraBibData),
@@ -84,7 +84,7 @@ class SierraTransformableTransformer
             }
             .recover {
               case e: ShouldNotTransformException =>
-                info(s"Should not transform: ${e.getMessage}")
+                info(s"Should not transform $sierraId: ${e.getMessage}")
                 UnidentifiedInvisibleWork(
                   sourceIdentifier = sourceIdentifier,
                   version = version

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
@@ -55,7 +55,7 @@ class SierraTransformableTransformer
                   sourceIdentifier = sourceIdentifier,
                   otherIdentifiers = getOtherIdentifiers(sierraId),
                   mergeCandidates = getMergeCandidates(sierraBibData),
-                  title = getTitle(sierraBibData),
+                  title = getTitle(bibId = sierraId, bibData = sierraBibData),
                   workType = getWorkType(sierraBibData),
                   description = getDescription(sierraBibData),
                   physicalDescription = getPhysicalDescription(sierraBibData),

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/SierraTransformableTransformer.scala
@@ -34,11 +34,12 @@ class SierraTransformableTransformer
   override def transformForType
     : PartialFunction[(Transformable, Int), Try[TransformedBaseWork]] = {
     case (sierraTransformable: SierraTransformable, version: Int) =>
+      val sierraId = sierraTransformable.sourceId
       val sourceIdentifier = SourceIdentifier(
         identifierType = IdentifierType("sierra-system-number"),
         ontologyType = "Work",
         value = SierraRecordNumbers.addCheckDigit(
-          sierraTransformable.sourceId,
+          sierraId = sierraId,
           recordType = SierraRecordTypes.bibs
         )
       )
@@ -52,7 +53,7 @@ class SierraTransformableTransformer
               if (!(sierraBibData.deleted || sierraBibData.suppressed)) {
                 UnidentifiedWork(
                   sourceIdentifier = sourceIdentifier,
-                  otherIdentifiers = getOtherIdentifiers(sierraBibData),
+                  otherIdentifiers = getOtherIdentifiers(sierraId),
                   mergeCandidates = getMergeCandidates(sierraBibData),
                   title = getTitle(sierraBibData),
                   workType = getWorkType(sierraBibData),

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraIdentifiers.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraIdentifiers.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
+import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier}
-import uk.ac.wellcome.platform.transformer.source.SierraBibData
 
 trait SierraIdentifiers {
 
@@ -15,12 +15,12 @@ trait SierraIdentifiers {
   //
   //    Adding other identifiers is out-of-scope for now.
   //
-  def getOtherIdentifiers(bibData: SierraBibData): List[SourceIdentifier] =
+  def getOtherIdentifiers(sierraId: String): List[SourceIdentifier] =
     List(
       SourceIdentifier(
         identifierType = IdentifierType("sierra-identifier"),
         ontologyType = "Work",
-        value = bibData.id
+        value = sierraId
       )
     )
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraIdentifiers.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraIdentifiers.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
-import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier}
 
 trait SierraIdentifiers {

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
@@ -34,14 +34,14 @@ trait SierraItems extends Logging with SierraLocation {
       .flatten
       .toMap
 
-  def transformItemData(sierraItemData: SierraItemData): Identifiable[Item] = {
-    debug(s"Attempting to transform ${sierraItemData.id}")
+  def transformItemData(sierraItemId: String, sierraItemData: SierraItemData): Identifiable[Item] = {
+    debug(s"Attempting to transform $sierraItemId")
     Identifiable(
       sourceIdentifier = SourceIdentifier(
         identifierType = IdentifierType("sierra-system-number"),
         ontologyType = "Item",
         value = SierraRecordNumbers.addCheckDigit(
-          sierraItemData.id,
+          sierraId = sierraItemId,
           recordType = SierraRecordTypes.items
         )
       ),
@@ -49,7 +49,7 @@ trait SierraItems extends Logging with SierraLocation {
         SourceIdentifier(
           identifierType = IdentifierType("sierra-identifier"),
           ontologyType = "Item",
-          value = sierraItemData.id
+          value = sierraItemId
         )
       ),
       agent = Item(
@@ -65,8 +65,13 @@ trait SierraItems extends Logging with SierraLocation {
         case (_: String, sierraItemData: SierraItemData) =>
           sierraItemData.deleted
       }
-      .values
-      .map(transformItemData)
+      .map {
+        case (sierraItemId: String, sierraItemData: SierraItemData) =>
+          transformItemData(
+            sierraItemId = sierraItemId,
+            sierraItemData = sierraItemData
+          )
+      }
   }
 
   def getDigitalItem(sourceIdentifier: SourceIdentifier): Identifiable[Item] = {

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
@@ -59,7 +59,7 @@ trait SierraItems extends Logging with SierraLocation {
   }
 
   def getPhysicalItems(
-    sierraTransformable: SierraTransformable): List[Identifiable[Item]] = {
+    sierraTransformable: SierraTransformable): List[Identifiable[Item]] =
     extractItemData(sierraTransformable)
       .filterNot {
         case (_: String, sierraItemData: SierraItemData) =>
@@ -72,7 +72,7 @@ trait SierraItems extends Logging with SierraLocation {
             sierraItemData = sierraItemData
           )
       }
-  }
+      .toList
 
   def getDigitalItem(sourceIdentifier: SourceIdentifier): Identifiable[Item] = {
     Identifiable(

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
@@ -34,14 +34,14 @@ trait SierraItems extends Logging with SierraLocation {
       .flatten
       .toMap
 
-  def transformItemData(sierraItemId: String, sierraItemData: SierraItemData): Identifiable[Item] = {
-    debug(s"Attempting to transform $sierraItemId")
+  def transformItemData(itemId: String, itemData: SierraItemData): Identifiable[Item] = {
+    debug(s"Attempting to transform $itemId")
     Identifiable(
       sourceIdentifier = SourceIdentifier(
         identifierType = IdentifierType("sierra-system-number"),
         ontologyType = "Item",
         value = SierraRecordNumbers.addCheckDigit(
-          sierraId = sierraItemId,
+          sierraId = itemId,
           recordType = SierraRecordTypes.items
         )
       ),
@@ -49,11 +49,11 @@ trait SierraItems extends Logging with SierraLocation {
         SourceIdentifier(
           identifierType = IdentifierType("sierra-identifier"),
           ontologyType = "Item",
-          value = sierraItemId
+          value = itemId
         )
       ),
       agent = Item(
-        locations = getPhysicalLocation(sierraItemData).toList
+        locations = getPhysicalLocation(itemData).toList
       )
     )
   }
@@ -62,14 +62,13 @@ trait SierraItems extends Logging with SierraLocation {
     sierraTransformable: SierraTransformable): List[Identifiable[Item]] =
     extractItemData(sierraTransformable)
       .filterNot {
-        case (_: String, sierraItemData: SierraItemData) =>
-          sierraItemData.deleted
+        case (_: String, itemData: SierraItemData) => itemData.deleted
       }
       .map {
-        case (sierraItemId: String, sierraItemData: SierraItemData) =>
+        case (itemId: String, itemData: SierraItemData) =>
           transformItemData(
-            sierraItemId = sierraItemId,
-            sierraItemData = sierraItemData
+            itemId = itemId,
+            itemData = itemData
           )
       }
       .toList

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
@@ -34,7 +34,8 @@ trait SierraItems extends Logging with SierraLocation {
       .flatten
       .toMap
 
-  def transformItemData(itemId: String, itemData: SierraItemData): Identifiable[Item] = {
+  def transformItemData(itemId: String,
+                        itemData: SierraItemData): Identifiable[Item] = {
     debug(s"Attempting to transform $itemId")
     Identifiable(
       sourceIdentifier = SourceIdentifier(

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
@@ -61,8 +61,11 @@ trait SierraItems extends Logging with SierraLocation {
   def getPhysicalItems(
     sierraTransformable: SierraTransformable): List[Identifiable[Item]] = {
     extractItemData(sierraTransformable)
+      .filterNot {
+        case (_: String, sierraItemData: SierraItemData) =>
+          sierraItemData.deleted
+      }
       .values
-      .filterNot { _.deleted }
       .map(transformItemData)
   }
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraTitle.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraTitle.scala
@@ -11,8 +11,8 @@ trait SierraTitle {
   //
   // Note: Sierra populates this field from MARC field 245 subfields $a and $b.
   // http://www.loc.gov/marc/bibliographic/bd245.html
-  def getTitle(bibData: SierraBibData): String =
+  def getTitle(bibId: String, bibData: SierraBibData): String =
     bibData.title.getOrElse(
       throw new ShouldNotTransformException(
-        s"Sierra record ${bibData.id} has no title!"))
+        s"Sierra record $bibId has no title!"))
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraTitle.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraTitle.scala
@@ -11,8 +11,7 @@ trait SierraTitle {
   //
   // Note: Sierra populates this field from MARC field 245 subfields $a and $b.
   // http://www.loc.gov/marc/bibliographic/bd245.html
-  def getTitle(bibId: String, bibData: SierraBibData): String =
+  def getTitle(bibData: SierraBibData): String =
     bibData.title.getOrElse(
-      throw new ShouldNotTransformException(
-        s"Sierra record $bibId has no title!"))
+      throw new ShouldNotTransformException(s"Sierra record has no title!"))
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraIdentifiersTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraIdentifiersTest.scala
@@ -7,25 +7,18 @@ import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 class SierraIdentifiersTest extends FunSpec with Matchers with SierraDataUtil {
 
   it("passes through the main identifier from the bib record") {
-    assertIdentifiersAreCorrect(
-      bibDataId = "1782863",
-      expectedIdentifiers = List(
-        SourceIdentifier(
-          identifierType = IdentifierType("sierra-identifier"),
-          ontologyType = "Work",
-          value = "1782863"
-        )
+    val sierraId = createSierraRecordNumberString
+
+    val expectedIdentifiers = List(
+      SourceIdentifier(
+        identifierType = IdentifierType("sierra-identifier"),
+        ontologyType = "Work",
+        value = sierraId
       )
     )
+
+    transformer.getOtherIdentifiers(sierraId) shouldBe expectedIdentifiers
   }
 
   val transformer = new Object with SierraIdentifiers
-
-  private def assertIdentifiersAreCorrect(
-    bibDataId: String,
-    expectedIdentifiers: List[SourceIdentifier]
-  ) = {
-    val bibData = createSierraBibDataWith(id = bibDataId)
-    transformer.getOtherIdentifiers(bibData = bibData) shouldBe expectedIdentifiers
-  }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
@@ -15,7 +15,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
         createSierraItemData
       }
       val itemRecords = itemData.map { data: SierraItemData =>
-        createSierraItemRecordWith(data)
+        createSierraItemRecordWith(data = data)
       }.toList
 
       val transformable = createSierraTransformableWith(
@@ -27,9 +27,10 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
 
     it("ignores items it can't parse as JSON") {
       val itemData = createSierraItemData
+      val itemId = createSierraRecordNumberString
 
       val itemRecords = List(
-        createSierraItemRecordWith(itemData),
+        createSierraItemRecordWith(id = itemId, data = itemData),
         createSierraItemRecordWith(
           data = "<xml?>This is not a real 'JSON' string"
         )
@@ -40,16 +41,14 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
       )
 
       transformer.extractItemData(transformable) shouldBe Map(
-        itemData.id -> itemData
+        itemId -> itemData
       )
     }
   }
 
   describe("transformItemData") {
     it("creates both forms of the Sierra ID in 'identifiers'") {
-      val item = createSierraItemDataWith(
-        id = "4000004"
-      )
+      val item = createSierraItemData
 
       val sourceIdentifier1 = createSierraSourceIdentifierWith(
         ontologyType = "Item",
@@ -63,7 +62,9 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
 
       val expectedIdentifiers = List(sourceIdentifier1, sourceIdentifier2)
 
-      val transformedItem = transformer.transformItemData(item)
+      val transformedItem = transformer.transformItemData(
+        sierraItemId = "4000004", sierraItemData = item
+      )
 
       transformedItem shouldBe Identifiable(
         sourceIdentifier = sourceIdentifier1,
@@ -78,9 +79,11 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
         ontologyType = "Item",
         value = "i50000056"
       )
-      val item = createSierraItemDataWith(id = "5000005")
+      val sierraItemData = createSierraItemData
 
-      val transformedItem = transformer.transformItemData(item)
+      val transformedItem = transformer.transformItemData(
+        sierraItemId = "5000005", sierraItemData = sierraItemData
+      )
       transformedItem.sourceIdentifier shouldBe sourceIdentifier
     }
   }
@@ -92,8 +95,8 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
 
       val transformable = createSierraTransformableWith(
         itemRecords = List(
-          createSierraItemRecordWith(item1),
-          createSierraItemRecordWith(item2)
+          createSierraItemRecordWith(data = item1),
+          createSierraItemRecordWith(data = item2)
         )
       )
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
@@ -22,7 +22,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
         itemRecords = itemRecords
       )
 
-      transformer.extractItemData(transformable).values shouldBe itemData
+      transformer.extractItemData(transformable) should contain theSameElementsAs itemData
     }
 
     it("ignores items it can't parse as JSON") {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
@@ -22,7 +22,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
         itemRecords = itemRecords
       )
 
-      transformer.extractItemData(transformable) shouldBe itemData
+      transformer.extractItemData(transformable).values shouldBe itemData
     }
 
     it("ignores items it can't parse as JSON") {
@@ -39,7 +39,9 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
         itemRecords = itemRecords
       )
 
-      transformer.extractItemData(transformable) shouldBe List(itemData)
+      transformer.extractItemData(transformable) shouldBe Map(
+        itemData.id -> itemData
+      )
     }
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
@@ -22,7 +22,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
         itemRecords = itemRecords
       )
 
-      transformer.extractItemData(transformable) should contain theSameElementsAs itemData
+      transformer.extractItemData(transformable).values should contain theSameElementsAs itemData
     }
 
     it("ignores items it can't parse as JSON") {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
@@ -15,14 +15,18 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
         createSierraItemData
       }
       val itemRecords = itemData.map { data: SierraItemData =>
-        createSierraItemRecordWith(id = createSierraRecordNumberString, data = data)
+        createSierraItemRecordWith(
+          id = createSierraRecordNumberString,
+          data = data)
       }.toList
 
       val transformable = createSierraTransformableWith(
         itemRecords = itemRecords
       )
 
-      transformer.extractItemData(transformable).values should contain theSameElementsAs itemData
+      transformer
+        .extractItemData(transformable)
+        .values should contain theSameElementsAs itemData
     }
 
     it("ignores items it can't parse as JSON") {
@@ -63,7 +67,8 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
       val expectedIdentifiers = List(sourceIdentifier1, sourceIdentifier2)
 
       val transformedItem = transformer.transformItemData(
-        itemId = "4000004", itemData = item
+        itemId = "4000004",
+        itemData = item
       )
 
       transformedItem shouldBe Identifiable(
@@ -82,7 +87,8 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
       val sierraItemData = createSierraItemData
 
       val transformedItem = transformer.transformItemData(
-        itemId = "5000005", itemData = sierraItemData
+        itemId = "5000005",
+        itemData = sierraItemData
       )
       transformedItem.sourceIdentifier shouldBe sourceIdentifier
     }
@@ -95,8 +101,12 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
 
       val transformable = createSierraTransformableWith(
         itemRecords = List(
-          createSierraItemRecordWith(id = createSierraRecordNumberString, data = item1),
-          createSierraItemRecordWith(id = createSierraRecordNumberString, data = item2)
+          createSierraItemRecordWith(
+            id = createSierraRecordNumberString,
+            data = item1),
+          createSierraItemRecordWith(
+            id = createSierraRecordNumberString,
+            data = item2)
         )
       )
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
@@ -15,7 +15,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
         createSierraItemData
       }
       val itemRecords = itemData.map { data: SierraItemData =>
-        createSierraItemRecordWith(id = = createSierraRecordNumberString, data = data)
+        createSierraItemRecordWith(id = createSierraRecordNumberString, data = data)
       }.toList
 
       val transformable = createSierraTransformableWith(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
@@ -15,7 +15,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
         createSierraItemData
       }
       val itemRecords = itemData.map { data: SierraItemData =>
-        createSierraItemRecordWith(data = data)
+        createSierraItemRecordWith(id = = createSierraRecordNumberString, data = data)
       }.toList
 
       val transformable = createSierraTransformableWith(
@@ -95,8 +95,8 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
 
       val transformable = createSierraTransformableWith(
         itemRecords = List(
-          createSierraItemRecordWith(data = item1),
-          createSierraItemRecordWith(data = item2)
+          createSierraItemRecordWith(id = createSierraRecordNumberString, data = item1),
+          createSierraItemRecordWith(id = createSierraRecordNumberString, data = item2)
         )
       )
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
@@ -63,7 +63,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
       val expectedIdentifiers = List(sourceIdentifier1, sourceIdentifier2)
 
       val transformedItem = transformer.transformItemData(
-        sierraItemId = "4000004", sierraItemData = item
+        itemId = "4000004", itemData = item
       )
 
       transformedItem shouldBe Identifiable(
@@ -82,7 +82,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
       val sierraItemData = createSierraItemData
 
       val transformedItem = transformer.transformItemData(
-        sierraItemId = "5000005", sierraItemData = sierraItemData
+        itemId = "5000005", itemData = sierraItemData
       )
       transformedItem.sourceIdentifier shouldBe sourceIdentifier
     }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocationTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocationTest.scala
@@ -7,10 +7,7 @@ import uk.ac.wellcome.models.work.internal.{
   LocationType,
   PhysicalLocation
 }
-import uk.ac.wellcome.platform.transformer.source.{
-  SierraItemData,
-  SierraItemLocation
-}
+import uk.ac.wellcome.platform.transformer.source.SierraItemLocation
 import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
 class SierraLocationTest extends FunSpec with Matchers with SierraDataUtil {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocationTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocationTest.scala
@@ -47,8 +47,8 @@ class SierraLocationTest extends FunSpec with Matchers with SierraDataUtil {
     }
 
     it("returns None if there is no location in the item data") {
-      val itemData = SierraItemData(
-        id = "i1234567"
+      val itemData = createSierraItemDataWith(
+        location = None
       )
 
       transformer.getPhysicalLocation(itemData = itemData) shouldBe None

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraTitleTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraTitleTest.scala
@@ -15,10 +15,12 @@ class SierraTitleTest extends FunSpec with Matchers with SierraDataUtil {
   }
 
   it("throws a ShouldNotTransform exception if bibData has no title") {
+    val bibId = createSierraRecordNumberString
     val bibData = createSierraBibDataWith(title = None)
-    intercept[ShouldNotTransformException] {
-      transformer.getTitle(bibData = bibData)
+    val caught = intercept[ShouldNotTransformException] {
+      transformer.getTitle(bibId = bibId, bibData = bibData)
     }
+    caught.getMessage should be s"Sierra record $bibId has no title!"
   }
 
   val transformer = new Object with SierraTitle
@@ -28,6 +30,8 @@ class SierraTitleTest extends FunSpec with Matchers with SierraDataUtil {
     expectedTitle: String
   ) = {
     val bibData = createSierraBibDataWith(title = Some(bibDataTitle))
-    transformer.getTitle(bibData = bibData) shouldBe expectedTitle
+    transformer.getTitle(
+      bibId = createSierraRecordNumberString,
+      bibData = bibData) shouldBe expectedTitle
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraTitleTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraTitleTest.scala
@@ -20,7 +20,7 @@ class SierraTitleTest extends FunSpec with Matchers with SierraDataUtil {
     val caught = intercept[ShouldNotTransformException] {
       transformer.getTitle(bibId = bibId, bibData = bibData)
     }
-    caught.getMessage should be s"Sierra record $bibId has no title!"
+    caught.getMessage shouldBe s"Sierra record $bibId has no title!"
   }
 
   val transformer = new Object with SierraTitle

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraTitleTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraTitleTest.scala
@@ -15,12 +15,11 @@ class SierraTitleTest extends FunSpec with Matchers with SierraDataUtil {
   }
 
   it("throws a ShouldNotTransform exception if bibData has no title") {
-    val bibId = createSierraRecordNumberString
     val bibData = createSierraBibDataWith(title = None)
     val caught = intercept[ShouldNotTransformException] {
-      transformer.getTitle(bibId = bibId, bibData = bibData)
+      transformer.getTitle(bibData = bibData)
     }
-    caught.getMessage shouldBe s"Sierra record $bibId has no title!"
+    caught.getMessage shouldBe "Sierra record has no title!"
   }
 
   val transformer = new Object with SierraTitle
@@ -30,8 +29,6 @@ class SierraTitleTest extends FunSpec with Matchers with SierraDataUtil {
     expectedTitle: String
   ) = {
     val bibData = createSierraBibDataWith(title = Some(bibDataTitle))
-    transformer.getTitle(
-      bibId = createSierraRecordNumberString,
-      bibData = bibData) shouldBe expectedTitle
+    transformer.getTitle(bibData = bibData) shouldBe expectedTitle
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/utils/SierraDataUtil.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/utils/SierraDataUtil.scala
@@ -12,14 +12,12 @@ import uk.ac.wellcome.utils.JsonUtil._
 
 trait SierraDataUtil extends IdentifiersUtil with SierraUtil {
   def createSierraBibDataWith(
-    id: String = createSierraRecordNumberString,
     title: Option[String] = Some(randomAlphanumeric(25)),
     lang: Option[SierraLanguage] = None,
     materialType: Option[SierraMaterialType] = None,
     varFields: List[VarField] = List()
   ): SierraBibData =
     SierraBibData(
-      id = id,
       title = title,
       lang = lang,
       materialType = materialType,

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/utils/SierraDataUtil.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/utils/SierraDataUtil.scala
@@ -27,21 +27,20 @@ trait SierraDataUtil extends IdentifiersUtil with SierraUtil {
   def createSierraBibData: SierraBibData = createSierraBibDataWith()
 
   def createSierraItemDataWith(
-    id: String = createSierraRecordNumberString,
     deleted: Boolean = false,
     location: Option[SierraItemLocation] = None
   ): SierraItemData =
     SierraItemData(
-      id = id,
       deleted = deleted,
       location = location
     )
 
   def createSierraItemData: SierraItemData = createSierraItemDataWith()
 
-  def createSierraItemRecordWith(data: SierraItemData): SierraItemRecord =
+  def createSierraItemRecordWith(id: String = createSierraRecordNumberString,
+                                 data: SierraItemData): SierraItemRecord =
     createSierraItemRecordWith(
-      id = data.id,
+      id = id,
       data = toJson(data).get
     )
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/utils/SierraDataUtil.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/utils/SierraDataUtil.scala
@@ -37,7 +37,7 @@ trait SierraDataUtil extends IdentifiersUtil with SierraUtil {
 
   def createSierraItemData: SierraItemData = createSierraItemDataWith()
 
-  def createSierraItemRecordWith(id: String = createSierraRecordNumberString,
+  def createSierraItemRecordWith(id: String,
                                  data: SierraItemData): SierraItemRecord =
     createSierraItemRecordWith(
       id = id,


### PR DESCRIPTION
One of the complications in #2446 are the `SierraBibData` and `SierraItemData` types. They have to parse the ID from the Sierra JSON – even though we already parsed the ID when we did the original read from Sierra, and we're keeping it as a field on `SierraBibRecord` and `SierraItemRecord`.

If you look at the Miro transformer, we don't parse the ID twice – we pass it around as a string into the transformer methods that need it.

The benefit for #2446 is that we can read the ID once with circe-optics (in the sierra_reader), then stash it as typed object and don't need special decoders to get the ID from the JSON when we re-parse it.