### PR TITLE
JSON decoding errors in the Sierra transformer should bubble up, not be silently dropped

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
@@ -27,9 +27,10 @@ trait SierraItems extends Logging with SierraLocation {
           fromJson[SierraItemData](jsonString) match {
             case Success(data) => id -> data
             case Failure(_) =>
-              throw GracefulFailureException(new RuntimeException(
-                s"Unable to parse item data for $id as JSON: <<$jsonString>>"
-              ))
+              throw GracefulFailureException(
+                new RuntimeException(
+                  s"Unable to parse item data for $id as JSON: <<$jsonString>>"
+                ))
           }
       }
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
@@ -28,11 +28,10 @@ trait SierraItems extends Logging with SierraLocation {
             case Success(data) => id -> data
             case Failure(_) =>
               throw GracefulFailureException(new RuntimeException(
-                s"Unable to parse item data as JSON: <<$jsonString>>"
+                s"Unable to parse item data for $id as JSON: <<$jsonString>>"
               ))
           }
       }
-      .toMap
 
   def transformItemData(itemId: String,
                         itemData: SierraItemData): Identifiable[Item] = {

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import grizzled.slf4j.Logging
+import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.{
   SierraRecordNumbers,
@@ -24,14 +25,13 @@ trait SierraItems extends Logging with SierraLocation {
       .map {
         case (id, jsonString) =>
           fromJson[SierraItemData](jsonString) match {
-            case Success(data) => Some(id -> data)
-            case Failure(e) => {
-              error(s"Failed to parse item!", e)
-              None
-            }
+            case Success(data) => id -> data
+            case Failure(_) =>
+              throw GracefulFailureException(new RuntimeException(
+                s"Unable to parse item data as JSON: <<$jsonString>>"
+              ))
           }
       }
-      .flatten
       .toMap
 
   def transformItemData(itemId: String,

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
@@ -33,12 +33,13 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
     it("throws an error if it gets some item data that isn't JSON") {
       val itemData = createSierraItemData
       val itemId = createSierraRecordNumberString
+      val itemIdBad = createSierraRecordNumberString
 
       val notAJsonString = "<xml?>This is not a real 'JSON' string"
 
       val itemRecords = List(
         createSierraItemRecordWith(id = itemId, data = itemData),
-        createSierraItemRecordWith(data = notAJsonString)
+        createSierraItemRecordWith(id = itemIdBad, data = notAJsonString)
       )
 
       val transformable = createSierraTransformableWith(
@@ -49,7 +50,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
         transformer.extractItemData(transformable)
       }
 
-      caught.getMessage shouldBe s"Unable to parse item data as JSON: <<$notAJsonString>>"
+      caught.getMessage shouldBe s"Unable to parse item data for $itemIdBad as JSON: <<$notAJsonString>>"
     }
   }
 


### PR DESCRIPTION
You know how I said we should fix all the errors in the Sierra transformer? Yeah, about that…

Previously we’d quietly discard any items which can't be decoded as JSON – even though we know we're getting JSON from the Sierra API, and a problem decoding it as our ItemData model is the sort of thing we'd like to know about.

In theory, we should never hit this codepath – but until now, we've had no way of knowing that, so let's find out.

Resolves #2469.