### PR TITLE
Terraform for the new Sierra adapter

### DIFF
--- a/catalogue_pipeline/terraform/outputs.tf
+++ b/catalogue_pipeline/terraform/outputs.tf
@@ -18,6 +18,26 @@ output "vhs_sourcedata_bucket_name" {
   value = "${module.vhs_sourcedata.bucket_name}"
 }
 
+output "vhs_sierra_full_access_policy" {
+  value = "${module.vhs_sierra.full_access_policy}"
+}
+
+output "vhs_sierra_dynamodb_update_policy" {
+  value = "${module.vhs_sierra.dynamodb_update_policy}"
+}
+
+output "vhs_sierra_table_name" {
+  value = "${module.vhs_sierra.table_name}"
+}
+
+output "vhs_sierra_table_stream_arn" {
+  value = "${module.vhs_sierra.table_stream_arn}"
+}
+
+output "vhs_sierra_bucket_name" {
+  value = "${module.vhs_sierra.bucket_name}"
+}
+
 output "vhs_goobi_full_access_policy" {
   value = "${module.vhs_goobi_mets.full_access_policy}"
 }

--- a/catalogue_pipeline/terraform/vhs_sierra_sourcedata.tf
+++ b/catalogue_pipeline/terraform/vhs_sierra_sourcedata.tf
@@ -1,0 +1,6 @@
+module "vhs_sierra" {
+  source = "./vhs"
+
+  name                     = "sierra"
+  table_write_max_capacity = 750
+}

--- a/reindexer/terraform/lambda_reindex_shard_generator.tf
+++ b/reindexer/terraform/lambda_reindex_shard_generator.tf
@@ -1,34 +1,10 @@
-module "shard_generator_lambda" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
+module "sourcedata_reindex_shard_generator" {
+  source = "reindex_shard_generator"
 
-  name      = "reindex_shard_generator"
-  s3_bucket = "${var.infra_bucket}"
-  s3_key    = "lambdas/reindexer/reindex_shard_generator.zip"
+  vhs_table_name          = "${local.vhs_table_name}"
+  vhs_table_stream_arn    = "${local.vhs_table_stream_arn}"
+  vhs_table_update_policy = "${local.vhs_dynamodb_update_policy}"
 
-  description = "Generate reindexShards for items in the ${local.vhs_table_name} table"
-
-  timeout = 60
-
-  environment_variables = {
-    TABLE_NAME = "${local.vhs_table_name}"
-  }
-
-  alarm_topic_arn = "${local.lambda_error_alarm_arn}"
-
-  log_retention_in_days = 30
-}
-
-module "trigger_shard_generator_lambda" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//lambda/trigger_dynamo?ref=v6.4.0"
-
-  stream_arn    = "${local.vhs_table_stream_arn}"
-  function_arn  = "${module.shard_generator_lambda.arn}"
-  function_role = "${module.shard_generator_lambda.role_name}"
-
-  batch_size = 50
-}
-
-resource "aws_iam_role_policy" "allow_shard_generator_put_vhs" {
-  role   = "${module.shard_generator_lambda.role_name}"
-  policy = "${local.vhs_dynamodb_update_policy}"
+  infra_bucket           = "${var.infra_bucket}"
+  lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
 }

--- a/reindexer/terraform/lambda_reindex_shard_generator.tf
+++ b/reindexer/terraform/lambda_reindex_shard_generator.tf
@@ -1,9 +1,9 @@
 module "sourcedata_reindex_shard_generator" {
   source = "reindex_shard_generator"
 
-  vhs_table_name          = "${local.vhs_table_name}"
-  vhs_table_stream_arn    = "${local.vhs_table_stream_arn}"
-  vhs_table_update_policy = "${local.vhs_dynamodb_update_policy}"
+  vhs_table_name          = "${local.vhs_sourcedata_table_name}"
+  vhs_table_stream_arn    = "${local.vhs_sourcedata_table_stream_arn}"
+  vhs_table_update_policy = "${local.vhs_sourcedata_dynamodb_update_policy}"
 
   infra_bucket           = "${var.infra_bucket}"
   lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"

--- a/reindexer/terraform/lambda_reindex_shard_generator.tf
+++ b/reindexer/terraform/lambda_reindex_shard_generator.tf
@@ -8,3 +8,14 @@ module "sourcedata_reindex_shard_generator" {
   infra_bucket           = "${var.infra_bucket}"
   lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
 }
+
+module "sierra_reindex_shard_generator" {
+  source = "reindex_shard_generator"
+
+  vhs_table_name          = "${local.vhs_sierra_table_name}"
+  vhs_table_stream_arn    = "${local.vhs_sierra_table_stream_arn}"
+  vhs_table_update_policy = "${local.vhs_sierra_dynamodb_update_policy}"
+
+  infra_bucket           = "${var.infra_bucket}"
+  lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
+}

--- a/reindexer/terraform/locals.tf
+++ b/reindexer/terraform/locals.tf
@@ -1,8 +1,12 @@
 locals {
-  vhs_full_access_policy     = "${data.terraform_remote_state.catalogue_pipeline.vhs_sourcedata_full_access_policy}"
-  vhs_dynamodb_update_policy = "${data.terraform_remote_state.catalogue_pipeline.vhs_sourcedata_dynamodb_update_policy}"
-  vhs_table_name             = "${data.terraform_remote_state.catalogue_pipeline.vhs_sourcedata_table_name}"
-  vhs_table_stream_arn       = "${data.terraform_remote_state.catalogue_pipeline.vhs_sourcedata_table_stream_arn}"
+  vhs_sourcedata_full_access_policy     = "${data.terraform_remote_state.catalogue_pipeline.vhs_sourcedata_full_access_policy}"
+  vhs_sourcedata_dynamodb_update_policy = "${data.terraform_remote_state.catalogue_pipeline.vhs_sourcedata_dynamodb_update_policy}"
+  vhs_sourcedata_table_name             = "${data.terraform_remote_state.catalogue_pipeline.vhs_sourcedata_table_name}"
+  vhs_sourcedata_table_stream_arn       = "${data.terraform_remote_state.catalogue_pipeline.vhs_sourcedata_table_stream_arn}"
+
+  vhs_sierra_table_name             = "${data.terraform_remote_state.catalogue_pipeline.vhs_sierra_table_name}"
+  vhs_sierra_table_stream_arn       = "${data.terraform_remote_state.catalogue_pipeline.vhs_sierra_table_stream_arn}"
+  vhs_sierra_dynamodb_update_policy = "${data.terraform_remote_state.catalogue_pipeline.vhs_sierra_dynamodb_update_policy}"
 
   vpc_id          = "${data.terraform_remote_state.shared_infra.catalogue_vpc_id}"
   private_subnets = "${data.terraform_remote_state.shared_infra.catalogue_private_subnets}"

--- a/reindexer/terraform/reindex_shard_generator/main.tf
+++ b/reindexer/terraform/reindex_shard_generator/main.tf
@@ -1,7 +1,7 @@
 module "shard_generator_lambda" {
   source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
-  name      = "reindex_shard_generator"
+  name      = "reindex_shard_generator_${var.vhs_table_name}"
   s3_bucket = "${var.infra_bucket}"
   s3_key    = "lambdas/reindexer/reindex_shard_generator.zip"
 

--- a/reindexer/terraform/reindex_shard_generator/main.tf
+++ b/reindexer/terraform/reindex_shard_generator/main.tf
@@ -5,6 +5,8 @@ module "shard_generator_lambda" {
   s3_bucket = "${var.infra_bucket}"
   s3_key    = "lambdas/reindexer/reindex_shard_generator.zip"
 
+  module_name = "reindex_shard_generator"
+
   description = "Generate reindexShards for items in the ${var.vhs_table_name} table"
 
   timeout = 60

--- a/reindexer/terraform/reindex_shard_generator/main.tf
+++ b/reindexer/terraform/reindex_shard_generator/main.tf
@@ -1,0 +1,34 @@
+module "shard_generator_lambda" {
+  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
+
+  name      = "reindex_shard_generator"
+  s3_bucket = "${var.infra_bucket}"
+  s3_key    = "lambdas/reindexer/reindex_shard_generator.zip"
+
+  description = "Generate reindexShards for items in the ${var.vhs_table_name} table"
+
+  timeout = 60
+
+  environment_variables = {
+    TABLE_NAME = "${var.vhs_table_name}"
+  }
+
+  alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+
+  log_retention_in_days = 30
+}
+
+module "trigger_shard_generator_lambda" {
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//lambda/trigger_dynamo?ref=v6.4.0"
+
+  stream_arn    = "${var.vhs_table_stream_arn}"
+  function_arn  = "${module.shard_generator_lambda.arn}"
+  function_role = "${module.shard_generator_lambda.role_name}"
+
+  batch_size = 50
+}
+
+resource "aws_iam_role_policy" "allow_shard_generator_put_vhs" {
+  role   = "${module.shard_generator_lambda.role_name}"
+  policy = "${var.vhs_table_update_policy}"
+}

--- a/reindexer/terraform/reindex_shard_generator/variables.tf
+++ b/reindexer/terraform/reindex_shard_generator/variables.tf
@@ -1,0 +1,6 @@
+variable "vhs_table_name" {}
+variable "vhs_table_stream_arn" {}
+variable "vhs_table_update_policy" {}
+
+variable "infra_bucket" {}
+variable "lambda_error_alarm_arn" {}

--- a/reindexer/terraform/service_reindex_request_creator.tf
+++ b/reindexer/terraform/service_reindex_request_creator.tf
@@ -13,7 +13,7 @@ module "reindex_request_creator" {
   memory = 2048
 
   env_vars = {
-    dynamo_table_name          = "${local.vhs_table_name}"
+    dynamo_table_name          = "${local.vhs_sourcedata_table_name}"
     reindex_jobs_queue_id      = "${module.reindexer_queue.id}"
     reindex_requests_topic_arn = "${module.reindex_requests_topic.arn}"
     metrics_namespace          = "reindex_request_creator"
@@ -42,7 +42,7 @@ resource "aws_iam_role_policy" "reindexer_reindexer_task_cloudwatch_metric" {
 
 resource "aws_iam_role_policy" "reindexer_allow_table_access" {
   role   = "${module.reindex_request_creator.task_role_name}"
-  policy = "${local.vhs_full_access_policy}"
+  policy = "${local.vhs_sourcedata_full_access_policy}"
 }
 
 resource "aws_iam_role_policy" "reindex_creator_publish_requests" {

--- a/reindexer/terraform/service_reindex_request_processor.tf
+++ b/reindexer/terraform/service_reindex_request_processor.tf
@@ -11,7 +11,7 @@ module "reindex_request_processor" {
   memory          = 2048
 
   env_vars = {
-    dynamo_table_name         = "${local.vhs_table_name}"
+    dynamo_table_name         = "${local.vhs_sourcedata_table_name}"
     reindex_requests_queue_id = "${module.reindex_requests_queue.id}"
     metrics_namespace         = "reindex_request_processor"
   }
@@ -40,5 +40,5 @@ resource "aws_iam_role_policy" "reindex_processor_task_cloudwatch_metric" {
 
 resource "aws_iam_role_policy" "reindex_processor_allow_table_access" {
   role   = "${module.reindex_request_processor.task_role_name}"
-  policy = "${local.vhs_full_access_policy}"
+  policy = "${local.vhs_sourcedata_full_access_policy}"
 }

--- a/sierra_adapter/report_adapter_progress.py
+++ b/sierra_adapter/report_adapter_progress.py
@@ -48,7 +48,13 @@ def get_matching_s3_keys(bucket, prefix=''):
         # The S3 API response is a large blob of metadata.
         # 'Contents' contains information about the listed objects.
         resp = s3.list_objects_v2(**kwargs)
-        for obj in resp['Contents']:
+
+        try:
+            contents = resp['Contents']
+        except KeyError:
+            contents = []
+
+        for obj in contents:
             yield obj['Key']
 
         # The S3 API is paginated, returning up to 1000 keys at a time.

--- a/sierra_adapter/terraform/items_to_dynamo/dynamo_sierradata_items.tf
+++ b/sierra_adapter/terraform/items_to_dynamo/dynamo_sierradata_items.tf
@@ -1,5 +1,5 @@
 resource "aws_dynamodb_table" "sierra_table" {
-  name             = "SierraData_items"
+  name             = "sierra-items"
   read_capacity    = 1
   write_capacity   = 1
   hash_key         = "id"

--- a/sierra_adapter/terraform/locals.tf
+++ b/sierra_adapter/terraform/locals.tf
@@ -5,7 +5,7 @@ locals {
   public_subnets  = "${data.terraform_remote_state.shared_infra.catalogue_public_subnets}"
   private_subnets = "${data.terraform_remote_state.shared_infra.catalogue_private_subnets}"
 
-  vhs_full_access_policy = "${data.terraform_remote_state.catalogue_pipeline.vhs_sourcedata_full_access_policy}"
-  vhs_table_name         = "${data.terraform_remote_state.catalogue_pipeline.vhs_sourcedata_table_name}"
-  vhs_bucket_name        = "${data.terraform_remote_state.catalogue_pipeline.vhs_sourcedata_bucket_name}"
+  vhs_full_access_policy = "${data.terraform_remote_state.catalogue_pipeline.vhs_sierra_full_access_policy}"
+  vhs_table_name         = "${data.terraform_remote_state.catalogue_pipeline.vhs_sierra_table_name}"
+  vhs_bucket_name        = "${data.terraform_remote_state.catalogue_pipeline.vhs_sierra_bucket_name}"
 }


### PR DESCRIPTION
This creates an entirely new VHS + reindex shard generator to funnel the new Sierra harvest into. When it's done, we can connect a new Dynamo-to-SNS to the transformer, then reindex the table.