### PR TITLE
Make sure the Sierra reader resumes windows correctly

### DIFF
--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/AbstractSierraRecord.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/AbstractSierraRecord.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.models.transformable.sierra
 import java.time.Instant
 
 trait AbstractSierraRecord {
-  val id: SierraRecordNumber
+  val id: SierraTypedRecordNumber
   val data: String
   val modifiedDate: Instant
 }

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumber.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumber.scala
@@ -62,9 +62,7 @@ sealed trait SierraTypedRecordNumber extends SierraRecordNumber {
   }
 }
 
-case class UntypedSierraRecordNumber(recordNumber: String) extends SierraRecordNumber {
-  val recordType = None
-}
+case class UntypedSierraRecordNumber(recordNumber: String) extends SierraRecordNumber
 
 case class SierraBibNumber(recordNumber: String) extends SierraTypedRecordNumber {
   val recordType = SierraRecordTypes.bibs

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumber.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumber.scala
@@ -4,9 +4,8 @@ object SierraRecordTypes extends Enumeration {
   val bibs, items = Value
 }
 
-sealed trait SierraRecordNumber {
+trait SierraRecordNumber {
   val recordNumber: String
-  val recordType: Option[SierraRecordTypes.Value]
 
   if ("""^[0-9]{7}$""".r.unapplySeq(recordNumber) isEmpty) {
     throw new IllegalArgumentException(
@@ -18,12 +17,16 @@ sealed trait SierraRecordNumber {
 
   /** Returns the ID without the check digit or prefix. */
   def withoutCheckDigit: String = recordNumber
+}
+
+sealed trait SierraTypedRecordNumber extends SierraRecordNumber {
+  val recordType: SierraRecordTypes.Value
 
   /** Returns the ID with the check digit and prefix. */
   def withCheckDigit: String = {
     val prefix = recordType match {
-      case Some(SierraRecordTypes.bibs)  => "b"
-      case Some(SierraRecordTypes.items) => "i"
+      case SierraRecordTypes.bibs  => "b"
+      case SierraRecordTypes.items => "i"
       case _ =>
         throw new RuntimeException(
           s"Received unrecognised record type: $recordType"
@@ -63,10 +66,10 @@ case class UntypedSierraRecordNumber(recordNumber: String) extends SierraRecordN
   val recordType = None
 }
 
-case class SierraBibNumber(recordNumber: String) extends SierraRecordNumber {
-  val recordType = Some(SierraRecordTypes.bibs)
+case class SierraBibNumber(recordNumber: String) extends SierraTypedRecordNumber {
+  val recordType = SierraRecordTypes.bibs
 }
 
-case class SierraItemNumber(recordNumber: String) extends SierraRecordNumber {
-  val recordType = Some(SierraRecordTypes.items)
+case class SierraItemNumber(recordNumber: String) extends SierraTypedRecordNumber {
+  val recordType = SierraRecordTypes.items
 }

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumber.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumber.scala
@@ -62,12 +62,15 @@ sealed trait SierraTypedRecordNumber extends SierraRecordNumber {
   }
 }
 
-case class UntypedSierraRecordNumber(recordNumber: String) extends SierraRecordNumber
+case class UntypedSierraRecordNumber(recordNumber: String)
+    extends SierraRecordNumber
 
-case class SierraBibNumber(recordNumber: String) extends SierraTypedRecordNumber {
+case class SierraBibNumber(recordNumber: String)
+    extends SierraTypedRecordNumber {
   val recordType: SierraRecordTypes.Value = SierraRecordTypes.bibs
 }
 
-case class SierraItemNumber(recordNumber: String) extends SierraTypedRecordNumber {
+case class SierraItemNumber(recordNumber: String)
+    extends SierraTypedRecordNumber {
   val recordType: SierraRecordTypes.Value = SierraRecordTypes.items
 }

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumber.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumber.scala
@@ -65,9 +65,9 @@ sealed trait SierraTypedRecordNumber extends SierraRecordNumber {
 case class UntypedSierraRecordNumber(recordNumber: String) extends SierraRecordNumber
 
 case class SierraBibNumber(recordNumber: String) extends SierraTypedRecordNumber {
-  val recordType = SierraRecordTypes.bibs
+  val recordType: SierraRecordTypes.Value = SierraRecordTypes.bibs
 }
 
 case class SierraItemNumber(recordNumber: String) extends SierraTypedRecordNumber {
-  val recordType = SierraRecordTypes.items
+  val recordType: SierraRecordTypes.Value = SierraRecordTypes.items
 }

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumber.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/transformable/sierra/SierraRecordNumber.scala
@@ -6,7 +6,7 @@ object SierraRecordTypes extends Enumeration {
 
 sealed trait SierraRecordNumber {
   val recordNumber: String
-  val recordType: SierraRecordTypes.Value
+  val recordType: Option[SierraRecordTypes.Value]
 
   if ("""^[0-9]{7}$""".r.unapplySeq(recordNumber) isEmpty) {
     throw new IllegalArgumentException(
@@ -22,8 +22,8 @@ sealed trait SierraRecordNumber {
   /** Returns the ID with the check digit and prefix. */
   def withCheckDigit: String = {
     val prefix = recordType match {
-      case SierraRecordTypes.bibs  => "b"
-      case SierraRecordTypes.items => "i"
+      case Some(SierraRecordTypes.bibs)  => "b"
+      case Some(SierraRecordTypes.items) => "i"
       case _ =>
         throw new RuntimeException(
           s"Received unrecognised record type: $recordType"
@@ -59,10 +59,14 @@ sealed trait SierraRecordNumber {
   }
 }
 
+case class UntypedSierraRecordNumber(recordNumber: String) extends SierraRecordNumber {
+  val recordType = None
+}
+
 case class SierraBibNumber(recordNumber: String) extends SierraRecordNumber {
-  val recordType: SierraRecordTypes.Value = SierraRecordTypes.bibs
+  val recordType = Some(SierraRecordTypes.bibs)
 }
 
 case class SierraItemNumber(recordNumber: String) extends SierraRecordNumber {
-  val recordType: SierraRecordTypes.Value = SierraRecordTypes.items
+  val recordType = Some(SierraRecordTypes.items)
 }

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/models/WindowStatus.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/models/WindowStatus.scala
@@ -1,0 +1,3 @@
+package uk.ac.wellcome.platform.sierra_reader.models
+
+case class WindowStatus(id: Option[String], offset: Int)

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/models/WindowStatus.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/models/WindowStatus.scala
@@ -1,3 +1,16 @@
 package uk.ac.wellcome.platform.sierra_reader.models
 
-case class WindowStatus(id: Option[String], offset: Int)
+import uk.ac.wellcome.models.transformable.sierra.UntypedSierraRecordNumber
+
+case class WindowStatus(
+  id: Option[UntypedSierraRecordNumber],
+  offset: Int
+)
+
+case object WindowStatus {
+  def apply(offset: Int): WindowStatus =
+    WindowStatus(id = None, offset = offset)
+
+  def apply(id: String, offset: Int): WindowStatus =
+    WindowStatus(id = Some(UntypedSierraRecordNumber(id)), offset = offset)
+}

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
@@ -14,8 +14,6 @@ import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
-
-
 class WindowManager @Inject()(
   s3client: AmazonS3,
   s3Config: S3Config,
@@ -90,10 +88,11 @@ class WindowManager @Inject()(
     case class Identified(id: UntypedSierraRecordNumber)
 
     fromJson[List[Identified]](s3contents) match {
-      case Success(ids) => ids
-        .map { _.id.withoutCheckDigit }
-        .sorted
-        .lastOption
+      case Success(ids) =>
+        ids
+          .map { _.id.withoutCheckDigit }
+          .sorted
+          .lastOption
       case Failure(_) =>
         throw GracefulFailureException(
           new RuntimeException(

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
@@ -63,7 +63,7 @@ class WindowManager @Inject()(
             val unprefixedId = id.substring(1)
 
             val newId = (unprefixedId.toInt + 1).toString
-            WindowStatus(id = Some(newId), offset = offset + 1)
+            WindowStatus(id = newId, offset = offset + 1)
           case None =>
             throw GracefulFailureException(
               new RuntimeException(s"JSON <<$lastBody>> did not contain an id"))

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.s3.AmazonS3
 import com.google.inject.Inject
 import com.twitter.inject.Logging
 import org.apache.commons.io.IOUtils
-import uk.ac.wellcome.platform.sierra_reader.models.SierraConfig
+import uk.ac.wellcome.platform.sierra_reader.models.{SierraConfig, WindowStatus}
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.utils.JsonUtil._
@@ -13,7 +13,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
-case class WindowStatus(id: Option[String], offset: Int)
+
 
 class WindowManager @Inject()(
   s3client: AmazonS3,

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
@@ -59,11 +59,7 @@ class WindowManager @Inject()(
 
         maybeLastId match {
           case Some(id) =>
-            // The Sierra IDs we store in S3 are prefixed with "b" or "i".
-            // Remove the first character
-            val unprefixedId = id.substring(1)
-
-            val newId = (unprefixedId.toInt + 1).toString
+            val newId = (id.toInt + 1).toString
             WindowStatus(id = newId, offset = offset + 1)
           case None =>
             throw GracefulFailureException(

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -11,7 +11,12 @@ import com.twitter.inject.Logging
 import io.circe.Json
 import uk.ac.wellcome.messaging.sqs._
 import uk.ac.wellcome.platform.sierra_reader.flow.SierraRecordWrapperFlow
-import uk.ac.wellcome.platform.sierra_reader.models.{ReaderConfig, SierraConfig, SierraResourceTypes, WindowStatus}
+import uk.ac.wellcome.platform.sierra_reader.models.{
+  ReaderConfig,
+  SierraConfig,
+  SierraResourceTypes,
+  WindowStatus
+}
 import uk.ac.wellcome.sierra.{SierraSource, ThrottleRate}
 import uk.ac.wellcome.storage.s3.S3Config
 import io.circe.syntax._

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -11,11 +11,7 @@ import com.twitter.inject.Logging
 import io.circe.Json
 import uk.ac.wellcome.messaging.sqs._
 import uk.ac.wellcome.platform.sierra_reader.flow.SierraRecordWrapperFlow
-import uk.ac.wellcome.platform.sierra_reader.models.{
-  ReaderConfig,
-  SierraConfig,
-  SierraResourceTypes
-}
+import uk.ac.wellcome.platform.sierra_reader.models.{ReaderConfig, SierraConfig, SierraResourceTypes, WindowStatus}
 import uk.ac.wellcome.sierra.{SierraSource, ThrottleRate}
 import uk.ac.wellcome.storage.s3.S3Config
 import io.circe.syntax._
@@ -26,10 +22,7 @@ import uk.ac.wellcome.models.transformable.sierra.{
   SierraItemRecord
 }
 import uk.ac.wellcome.utils.JsonUtil._
-import uk.ac.wellcome.platform.sierra_reader.modules.{
-  WindowManager,
-  WindowStatus
-}
+import uk.ac.wellcome.platform.sierra_reader.modules.WindowManager
 
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -4,12 +4,15 @@ import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
+import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraUtil
 import uk.ac.wellcome.platform.sierra_reader.models.{SierraConfig, SierraResourceTypes, WindowStatus}
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures.TestWith
 import uk.ac.wellcome.test.utils.ExtendedPatience
+import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -18,7 +21,8 @@ class WindowManagerTest
     with Matchers
     with S3
     with ScalaFutures
-    with ExtendedPatience {
+    with ExtendedPatience
+    with SierraUtil {
 
   private def withWindowManager(bucket: Bucket)(
     testWith: TestWith[WindowManager, Assertion]) = {
@@ -62,21 +66,14 @@ class WindowManagerTest
         // We pre-populate S3 with files as if they'd come from a prior run of the reader.
         s3Client.putObject(bucket.name, s"$prefix/0000.json", "[]")
 
-        val record =
-          """
-            |[
-            |  {
-            |    "id": "1794165",
-            |    "data":"{\"id\": \"1794165\", \"title\": \"fyxpptx0nc3gep3yvloxcmpvrvfkcvau690g3sgg1qvh2u7keo\"}",
-            |    "modifiedDate":"2018-07-30T11:13:42.549Z"
-            |  }
-            |]
-            |""".stripMargin
+        val record = createSierraBibRecordWith(
+          id = SierraBibNumber("1794165")
+        )
 
         s3Client.putObject(
           bucket.name,
           s"$prefix/0001.json",
-          record
+          toJson(List(record)).get
         )
 
         val result = windowManager.getCurrentStatus("[2013,2014]")

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -7,10 +7,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord
-import uk.ac.wellcome.platform.sierra_reader.models.{
-  SierraConfig,
-  SierraResourceTypes
-}
+import uk.ac.wellcome.platform.sierra_reader.models.{SierraConfig, SierraResourceTypes, WindowStatus}
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -4,15 +4,12 @@ import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
-import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraUtil
 import uk.ac.wellcome.platform.sierra_reader.models.{SierraConfig, SierraResourceTypes, WindowStatus}
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures.TestWith
 import uk.ac.wellcome.test.utils.ExtendedPatience
-import uk.ac.wellcome.utils.JsonUtil._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -21,8 +18,7 @@ class WindowManagerTest
     with Matchers
     with S3
     with ScalaFutures
-    with ExtendedPatience
-    with SierraUtil {
+    with ExtendedPatience {
 
   private def withWindowManager(bucket: Bucket)(
     testWith: TestWith[WindowManager, Assertion]) = {
@@ -66,14 +62,21 @@ class WindowManagerTest
         // We pre-populate S3 with files as if they'd come from a prior run of the reader.
         s3Client.putObject(bucket.name, s"$prefix/0000.json", "[]")
 
-        val record = createSierraBibRecordWith(
-          id = SierraBibNumber("1794165")
-        )
+        val record =
+          """
+            |[
+            |  {
+            |    "id": "1794165",
+            |    "data":"{\"id\": \"1794165\", \"title\": \"fyxpptx0nc3gep3yvloxcmpvrvfkcvau690g3sgg1qvh2u7keo\"}",
+            |    "modifiedDate":"2018-07-30T11:13:42.549Z"
+            |  }
+            |]
+            |""".stripMargin
 
         s3Client.putObject(
           bucket.name,
           s"$prefix/0001.json",
-          toJson(List(record)).get
+          record
         )
 
         val result = windowManager.getCurrentStatus("[2013,2014]")

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -6,7 +6,11 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraUtil
-import uk.ac.wellcome.platform.sierra_reader.models.{SierraConfig, SierraResourceTypes, WindowStatus}
+import uk.ac.wellcome.platform.sierra_reader.models.{
+  SierraConfig,
+  SierraResourceTypes,
+  WindowStatus
+}
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -6,7 +6,8 @@ import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord
+import uk.ac.wellcome.models.transformable.sierra.{SierraBibNumber, SierraBibRecord}
+import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraUtil
 import uk.ac.wellcome.platform.sierra_reader.models.{SierraConfig, SierraResourceTypes, WindowStatus}
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.fixtures.S3
@@ -22,7 +23,8 @@ class WindowManagerTest
     with Matchers
     with S3
     with ScalaFutures
-    with ExtendedPatience {
+    with ExtendedPatience
+    with SierraUtil {
 
   private def withWindowManager(bucket: Bucket)(
     testWith: TestWith[WindowManager, Assertion]) = {
@@ -58,7 +60,7 @@ class WindowManagerTest
   // This test isn't actually testing the correct behaviour (see issue 2422:
   // https://github.com/wellcometrust/platform/issues/2422); it's due to be
   // replaced when we fix this behaviour.
-  ignore("finds the ID if there is a window in progress") {
+  it("finds the ID if there is a window in progress") {
     withLocalS3Bucket { bucket =>
       withWindowManager(bucket) { windowManager =>
         val prefix = windowManager.buildWindowShard("[2013,2014]")
@@ -66,11 +68,9 @@ class WindowManagerTest
         // We pre-populate S3 with files as if they'd come from a prior run of the reader.
         s3Client.putObject(bucket.name, s"$prefix/0000.json", "[]")
 
-        val record =
-          SierraBibRecord(
-            id = "b1794165",
-            data = "{}",
-            modifiedDate = Instant.now())
+        val record = createSierraBibRecordWith(
+          id = SierraBibNumber("1794165")
+        )
 
         s3Client.putObject(
           bucket.name,

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -81,7 +81,7 @@ class WindowManagerTest
         val result = windowManager.getCurrentStatus("[2013,2014]")
 
         whenReady(result) {
-          _ shouldBe WindowStatus(id = Some("1794166"), offset = 2)
+          _ shouldBe WindowStatus(id = "1794166", offset = 2)
         }
       }
     }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -1,12 +1,10 @@
 package uk.ac.wellcome.platform.sierra_reader.modules
 
-import java.time.Instant
-
 import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
-import uk.ac.wellcome.models.transformable.sierra.{SierraBibNumber, SierraBibRecord}
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraUtil
 import uk.ac.wellcome.platform.sierra_reader.models.{SierraConfig, SierraResourceTypes, WindowStatus}
 import uk.ac.wellcome.storage.s3.S3Config

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -154,34 +154,11 @@ class SierraReaderWorkerServiceTest
     }
   }
 
-  // This test isn't actually testing the correct behaviour (see issue 2422:
-  // https://github.com/wellcometrust/platform/issues/2422); it's due to be
-  // replaced when we fix this behaviour.
-  ignore("resumes a window if it finds an in-progress set of records") {
+  it("resumes a window if it finds an in-progress set of records") {
     withSierraReaderWorkerService(
       fields = "updatedDate,deleted,deletedDate,bibIds,fixedFields,varFields",
       resourceType = SierraResourceTypes.items
     ) { fixtures =>
-      val prefix = "records_items/2013-12-10T17-16-35Z__2013-12-13T21-34-35Z"
-
-      // First we pre-populate S3 with files as if they'd come from a prior run of the reader.
-      s3Client.putObject(fixtures.bucket.name, s"$prefix/0000.json", "[]")
-      s3Client.putObject(
-        fixtures.bucket.name,
-        s"$prefix/0001.json",
-        """
-          |[
-          |  {
-          |    "id": "i1794165",
-          |    "modifiedDate": "2013-12-10T17:16:35Z",
-          |    "data": "{}",
-          |    "bibIds": [],
-          |  }
-          |]
-        """.stripMargin
-      )
-
-      // Then we trigger the reader, and we expect it to fill in the rest.
       val body =
         """
           |{
@@ -190,25 +167,38 @@ class SierraReaderWorkerServiceTest
           |}
         """.stripMargin
 
+      // Do a complete run of the reader -- this gives us a set of JSON files
+      // to compare to.
       sendNotificationToSQS(queue = fixtures.queue, body = body)
 
-      val pageNames = List("0000.json", "0001.json", "0002.json", "0003.json")
-        .map { label =>
-          s"$prefix/$label"
-        } ++ List(
-        "windows_items_complete/2013-12-10T17-16-35Z__2013-12-13T21-34-35Z")
+      eventually {
+        assertQueueEmpty(queue = fixtures.queue)
+
+        // There are 157 item records in the Sierra wiremock, so we expect
+        // 5 files -- the four JSON files, and a window marker.
+        listKeysInBucket(bucket = fixtures.bucket) should have size 5
+      }
+
+      val expectedContents = getAllObjectContents(bucket = fixtures.bucket)
+
+      // Now, let's delete every key in the bucket _except_ the first --
+      // which we'll use to restart the window.
+      listKeysInBucket(bucket = fixtures.bucket)
+        .filterNot { _.endsWith("0000.json") }
+        .foreach { key =>
+          s3Client.deleteObject(fixtures.bucket.name, key)
+        }
 
       eventually {
-        // There are 157 item records in the Sierra wiremock so we expect 4 files
-        listKeysInBucket(bucket = fixtures.bucket) shouldBe pageNames
+        listKeysInBucket(bucket = fixtures.bucket) should have size 1
+      }
 
-        // These two files were pre-populated -- we check the reader hasn't overwritten these
-        getItemRecordsFromS3(fixtures.bucket, pageNames(0)) should have size 0
-        getItemRecordsFromS3(fixtures.bucket, pageNames(1)) should have size 1
+      // Now, send a second message to the reader, and we'll see if it completes
+      // the window successfully.
+      sendNotificationToSQS(queue = fixtures.queue, body = body)
 
-        // We check the reader has filled these in correctly
-        getItemRecordsFromS3(fixtures.bucket, pageNames(2)) should have size 50
-        getItemRecordsFromS3(fixtures.bucket, pageNames(3)) should have size 7
+      eventually {
+        getAllObjectContents(bucket = fixtures.bucket) shouldBe expectedContents
       }
     }
   }


### PR DESCRIPTION
Code fix for #2422.

The test for resuming windows is seeded with real reader output, so if the format changes again the test will still catch it. And now we validate Sierra record numbers passed around internally as valid, where previously we just passed around unchecked strings.