### PR TITLE
Improve our handling of Sierra records that have both a 260 and a 264 field

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
@@ -146,10 +146,12 @@ trait SierraProduction {
         )
       }
 
-  // In general, it's a cataloguing error for a bib record to have both
-  // 260 and 264 fields.  Sometimes we can detect the duplicate data, and
-  // still get a useful result.
-  //
+  /** Populate the production data if both 260 and 264 are present.
+    *
+    * In general, this is a cataloguing error, but sometimes we can do
+    * something more sensible depending on if/how they're duplicated.
+    *
+    */
   private def getProductionFromBothFields(
     marc260fields: List[VarField],
     marc264fields: List[VarField]) = {

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
@@ -33,7 +33,8 @@ trait SierraProduction {
       case (Nil, Nil)           => List()
       case (marc260fields, Nil) => getProductionFrom260Fields(marc260fields)
       case (Nil, marc264fields) => getProductionFrom264Fields(marc264fields)
-      case (marc260fields, marc264fields) => getProductionFromBothFields(marc260fields, marc264fields)
+      case (marc260fields, marc264fields) =>
+        getProductionFromBothFields(marc260fields, marc264fields)
     }
   }
 
@@ -151,9 +152,8 @@ trait SierraProduction {
     * In general, this is a cataloguing error, but sometimes we can do
     * something more sensible depending on if/how they're duplicated.
     */
-  private def getProductionFromBothFields(
-    marc260fields: List[VarField],
-    marc264fields: List[VarField]) = {
+  private def getProductionFromBothFields(marc260fields: List[VarField],
+                                          marc264fields: List[VarField]) = {
 
     // We've seen cases where the 264 field only has the following subfields:
     //
@@ -162,21 +162,20 @@ trait SierraProduction {
     // or similar, and the 260 field is populated.  In that case, we can
     // discard the 264 and just use the 260 fields.
     if (marc264fields.length == 1 &&
-      marc264fields.head.subfields.length == 1 &&
-      marc264fields.head.subfields.head.tag == "c" &&
-      marc264fields.head.subfields.head.content.matches("^©\\d+$")
-    ) {
+        marc264fields.head.subfields.length == 1 &&
+        marc264fields.head.subfields.head.tag == "c" &&
+        marc264fields.head.subfields.head.content.matches("^©\\d+$")) {
       getProductionFrom260Fields(marc260fields)
     }
 
     // We've also seen cases where the 260 and 264 field are both present,
     // and they have matching subfields!  We use the 260 field as it's not
     // going to throw an exception about unrecognised second indicator.
-    else if (marc260fields.map { _.subfields } == marc264fields.map { _.subfields }) {
+    else if (marc260fields.map { _.subfields } == marc264fields.map {
+               _.subfields
+             }) {
       getProductionFrom260Fields(marc260fields)
-    }
-
-    else {
+    } else {
       throw GracefulFailureException(
         new RuntimeException(
           "Record has both 260 and 264 fields; this is a cataloguing error."

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
@@ -150,7 +150,6 @@ trait SierraProduction {
     *
     * In general, this is a cataloguing error, but sometimes we can do
     * something more sensible depending on if/how they're duplicated.
-    *
     */
   private def getProductionFromBothFields(
     marc260fields: List[VarField],

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
@@ -168,6 +168,13 @@ trait SierraProduction {
       getProductionFrom260Fields(marc260fields)
     }
 
+    // We've also seen cases where the 260 and 264 field are both present,
+    // and they have matching subfields!  We use the 260 field as it's not
+    // going to throw an exception about unrecognised second indicator.
+    else if (marc260fields.map { _.subfields } == marc264fields.map { _.subfields }) {
+      getProductionFrom260Fields(marc260fields)
+    }
+
     else {
       throw GracefulFailureException(
         new RuntimeException(

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
@@ -150,7 +150,7 @@ trait SierraProduction {
   private def marc264OnlyContainsCopyright(marc264fields: List[VarField]): Boolean =
     marc264fields match {
       case List(
-        VarField(_, _, Some("260"), _, _, , List(MarcSubfield("c", content)))) =>
+        VarField(_, _, Some("264"), _, _, List(MarcSubfield("c", content)))) =>
         content.matches("^©\\d{4}$")
       case _ => false
     }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
@@ -147,10 +147,17 @@ trait SierraProduction {
         )
       }
 
-  private def marc264OnlyContainsCopyright(marc264fields: List[VarField]): Boolean =
+  private def marc264OnlyContainsCopyright(
+    marc264fields: List[VarField]): Boolean =
     marc264fields match {
       case List(
-        VarField(_, _, Some("264"), _, _, List(MarcSubfield("c", content)))) =>
+          VarField(
+            _,
+            _,
+            Some("264"),
+            _,
+            _,
+            List(MarcSubfield("c", content)))) =>
         content.matches("^©\\d{4}$")
       case _ => false
     }
@@ -176,9 +183,8 @@ trait SierraProduction {
     // We've also seen cases where the 260 and 264 field are both present,
     // and they have matching subfields!  We use the 260 field as it's not
     // going to throw an exception about unrecognised second indicator.
-    else if (
-      marc260fields.map { _.subfields } ==
-        marc264fields.map { _.subfields }) {
+    else if (marc260fields.map { _.subfields } ==
+               marc264fields.map { _.subfields }) {
       getProductionFrom260Fields(marc260fields)
     }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProductionTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProductionTest.scala
@@ -417,6 +417,40 @@ class SierraProductionTest extends FunSpec with Matchers with SierraDataUtil {
 
       transformToProduction(varFields) shouldBe expectedProductions
     }
+
+    it("returns correctly if 260 and 264 contain the same subfields") {
+      val subfields = List(
+        MarcSubfield(tag = "a", content = "London"),
+        MarcSubfield(tag = "b", content = "Wellcome Trust"),
+        MarcSubfield(tag = "c", content = "1992")
+      )
+
+      val varFields = List(
+        VarField(
+          marcTag = Some("260"),
+          fieldTag = "p",
+          subfields = subfields
+        ),
+        VarField(
+          marcTag = Some("264"),
+          fieldTag = "p",
+          subfields = subfields
+        )
+      )
+
+      val expectedProductions = List(
+        ProductionEvent(
+          places = List(Place("London")),
+          agents = List(
+            Unidentifiable(Agent("Wellcome Trust"))
+          ),
+          dates = List(Period("1992")),
+          function = None
+        )
+      )
+
+      transformToProduction(varFields) shouldBe expectedProductions
+    }
   }
 
   // Test helpers

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProductionTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProductionTest.scala
@@ -383,6 +383,42 @@ class SierraProductionTest extends FunSpec with Matchers with SierraDataUtil {
     }
   }
 
+  describe("Both MARC field 260 and 264") {
+    it("uses field 260 if field 264 only contains a copyright statement in subfield c") {
+      val varFields = List(
+        VarField(
+          marcTag = Some("260"),
+          fieldTag = "p",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "San Francisco"),
+            MarcSubfield(tag = "b", content = "Morgan Kaufmann Publishers"),
+            MarcSubfield(tag = "c", content = "2004")
+          )
+        ),
+        VarField(
+          marcTag = Some("264"),
+          fieldTag = "p",
+          subfields = List(
+            MarcSubfield(tag = "c", content = "©2004")
+          )
+        )
+      )
+
+      val expectedProductions = List(
+        ProductionEvent(
+          places = List(Place("San Francisco")),
+          agents = List(
+            Unidentifiable(Agent("Morgan Kaufmann Publishers"))
+          ),
+          dates = List(Period("2004")),
+          function = None
+        )
+      )
+
+      transformToProduction(varFields) shouldBe expectedProductions
+    }
+  }
+
   // Test helpers
 
   private def transform260ToProduction(subfields: List[MarcSubfield]) = {

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProductionTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProductionTest.scala
@@ -12,27 +12,6 @@ class SierraProductionTest extends FunSpec with Matchers with SierraDataUtil {
     transformToProduction(varFields = List()) shouldBe List()
   }
 
-  it("throws an error if both 260 and 264 are present") {
-    transformVarFieldsAndAssertIsError(
-      varFields = List(
-        VarField(
-          marcTag = Some("260"),
-          fieldTag = "p",
-          subfields = List(
-            MarcSubfield(tag = "a", content = "Paris")
-          )
-        ),
-        VarField(
-          marcTag = Some("264"),
-          fieldTag = "p",
-          subfields = List(
-            MarcSubfield(tag = "a", content = "London")
-          )
-        )
-      )
-    )
-  }
-
   // Examples are taken from the MARC spec for field 260.
   // https://www.loc.gov/marc/bibliographic/bd260.html
 
@@ -396,6 +375,27 @@ class SierraProductionTest extends FunSpec with Matchers with SierraDataUtil {
   }
 
   describe("Both MARC field 260 and 264") {
+    it("throws an error if both 260 and 264 are present") {
+      transformVarFieldsAndAssertIsError(
+        varFields = List(
+          VarField(
+            marcTag = Some("260"),
+            fieldTag = "p",
+            subfields = List(
+              MarcSubfield(tag = "a", content = "Paris")
+            )
+          ),
+          VarField(
+            marcTag = Some("264"),
+            fieldTag = "p",
+            subfields = List(
+              MarcSubfield(tag = "a", content = "London")
+            )
+          )
+        )
+      )
+    }
+
     it(
       "uses field 260 if field 264 only contains a copyright statement in subfield c") {
       val varFields = List(

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProductionTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProductionTest.scala
@@ -15,8 +15,20 @@ class SierraProductionTest extends FunSpec with Matchers with SierraDataUtil {
   it("throws an error if both 260 and 264 are present") {
     transformVarFieldsAndAssertIsError(
       varFields = List(
-        VarField(marcTag = Some("260"), fieldTag = "a"),
-        VarField(marcTag = Some("264"), fieldTag = "a")
+        VarField(
+          marcTag = Some("260"),
+          fieldTag = "p",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "Paris")
+          )
+        ),
+        VarField(
+          marcTag = Some("264"),
+          fieldTag = "p",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "London")
+          )
+        )
       )
     )
   }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProductionTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProductionTest.scala
@@ -384,7 +384,8 @@ class SierraProductionTest extends FunSpec with Matchers with SierraDataUtil {
   }
 
   describe("Both MARC field 260 and 264") {
-    it("uses field 260 if field 264 only contains a copyright statement in subfield c") {
+    it(
+      "uses field 260 if field 264 only contains a copyright statement in subfield c") {
       val varFields = List(
         VarField(
           marcTag = Some("260"),


### PR DESCRIPTION
We use 260 and 264 for production events, and Silver's original rules say “if both are present, that’s a cataloguing error” – and the original transformer raised an error, sending 95 records to a DLQ.

This patch applies two blunt heuristics to reduce that number to 4:

* If 264 only contains a copyright statement, discard it
* If 260 and 264 have matching subfields, discard 264

Part of #2280.