### PR TITLE
Reindexer gets the table from the SNS message, not from prebaked config

### DIFF
--- a/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/Server.scala
+++ b/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/Server.scala
@@ -19,7 +19,6 @@ import uk.ac.wellcome.finatra.messaging.{
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
 import uk.ac.wellcome.finatra.storage.{
   DynamoClientModule,
-  DynamoConfigModule,
   S3ClientModule
 }
 import uk.ac.wellcome.platform.reindex.creator.modules.ReindexerWorkerModule
@@ -34,7 +33,6 @@ class Server extends HttpServer {
     ExecutionContextModule,
     MetricsSenderModule,
     DynamoClientModule,
-    DynamoConfigModule,
     SNSClientModule,
     SNSConfigModule,
     SQSClientModule,

--- a/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/Server.scala
+++ b/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/Server.scala
@@ -17,10 +17,7 @@ import uk.ac.wellcome.finatra.messaging.{
   SQSConfigModule
 }
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
-import uk.ac.wellcome.finatra.storage.{
-  DynamoClientModule,
-  S3ClientModule
-}
+import uk.ac.wellcome.finatra.storage.{DynamoClientModule, S3ClientModule}
 import uk.ac.wellcome.platform.reindex.creator.modules.ReindexerWorkerModule
 
 object ServerMain extends Server

--- a/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/models/ReindexJob.scala
+++ b/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/models/ReindexJob.scala
@@ -1,11 +1,15 @@
 package uk.ac.wellcome.platform.reindex.creator.models
 
+import uk.ac.wellcome.storage.dynamo.DynamoConfig
+
 /** A request to identify all the shards in the table that need reindexing.
   *
+  * @param dynamoConfig Table and index configuration for the table to reindex.
   * @param shardId Name of the shard to reindex.
   * @param desiredVersion Version to reindex everything in this shard to.
   */
 case class ReindexJob(
+  dynamoConfig: DynamoConfig,
   shardId: String,
   desiredVersion: Int
 )

--- a/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/services/NotificationSender.scala
+++ b/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/services/NotificationSender.scala
@@ -29,7 +29,8 @@ class NotificationSender @Inject()(snsWriter: SNSWriter)(
                                          desiredVersion: Int): Future[Unit] = {
     val request = ReindexRequest(
       id = recordId,
-      desiredVersion = desiredVersion
+      desiredVersion = desiredVersion,
+      tableName = dynamoConfig.table
     )
 
     for {

--- a/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/services/NotificationSender.scala
+++ b/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/services/NotificationSender.scala
@@ -4,7 +4,7 @@ import com.google.inject.Inject
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.SNSWriter
 import uk.ac.wellcome.models.reindexer.ReindexRequest
-import uk.ac.wellcome.platform.reindex_request_creator.models.ReindexJob
+import uk.ac.wellcome.platform.reindex.creator.models.ReindexJob
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/services/NotificationSender.scala
+++ b/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/services/NotificationSender.scala
@@ -1,24 +1,31 @@
 package uk.ac.wellcome.platform.reindex.creator.services
 
 import com.google.inject.Inject
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.SNSWriter
 import uk.ac.wellcome.models.reindexer.ReindexRequest
-import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.reindex_request_creator.models.ReindexJob
+import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class NotificationSender @Inject()(snsWriter: SNSWriter)(
   implicit ec: ExecutionContext) {
   def sendNotifications(recordIds: List[String],
-                        desiredVersion: Int): Future[List[Unit]] = {
+                        reindexJob: ReindexJob): Future[List[Unit]] = {
     Future.sequence {
-      recordIds.map {
-        sendIndividualNotification(_, desiredVersion = desiredVersion)
+      recordIds.map { recordId: String =>
+        sendIndividualNotification(
+          recordId = recordId,
+          dynamoConfig = reindexJob.dynamoConfig,
+          desiredVersion = reindexJob.desiredVersion
+        )
       }
     }
   }
 
   private def sendIndividualNotification(recordId: String,
+                                         dynamoConfig: DynamoConfig,
                                          desiredVersion: Int): Future[Unit] = {
     val request = ReindexRequest(
       id = recordId,

--- a/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/services/RecordReader.scala
+++ b/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/services/RecordReader.scala
@@ -19,7 +19,8 @@ import scala.util.Try
   * This class should only be doing reading -- deciding how to act on records
   * that need reindexing is the responsibility of another class.
   */
-class RecordReader @Inject()(dynamoDbClient: AmazonDynamoDB)(implicit ec: ExecutionContext)
+class RecordReader @Inject()(dynamoDbClient: AmazonDynamoDB)(
+  implicit ec: ExecutionContext)
     extends Logging {
 
   def findRecordsForReindexing(reindexJob: ReindexJob): Future[List[String]] = {

--- a/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/services/ReindexRequestCreatorWorker.scala
+++ b/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/services/ReindexRequestCreatorWorker.scala
@@ -24,8 +24,8 @@ class ReindexRequestCreatorWorker @Inject()(
       outdatedRecordIds: List[String] <- readerService.findRecordsForReindexing(
         reindexJob)
       _ <- notificationService.sendNotifications(
-        outdatedRecordIds,
-        desiredVersion = reindexJob.desiredVersion)
+        recordIds = outdatedRecordIds,
+        reindexJob = reindexJob)
     } yield ()
 
   def stop() = system.terminate()

--- a/reindexer/reindex_request_creator/src/test/resources/logback-test.xml
+++ b/reindexer/reindex_request_creator/src/test/resources/logback-test.xml
@@ -1,3 +1,5 @@
 <configuration>
   <include resource="base-logback-test.xml"/>
+
+  <logger name="uk.ac.wellcome.platform.reindex.creator.Server" level="WARN"/>
 </configuration>

--- a/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/creator/fixtures/ReindexFixtures.scala
+++ b/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/creator/fixtures/ReindexFixtures.scala
@@ -1,6 +1,6 @@
-package uk.ac.wellcome.platform.reindex_request_creator.fixtures
+package uk.ac.wellcome.platform.creator.fixtures
 
-import uk.ac.wellcome.platform.reindex_request_creator.models.ReindexJob
+import uk.ac.wellcome.platform.creator.models.ReindexJob
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 

--- a/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/ReindexRequestCreatorFeatureTest.scala
+++ b/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/ReindexRequestCreatorFeatureTest.scala
@@ -67,7 +67,8 @@ class ReindexRequestCreatorFeatureTest
     withLocalSqsQueue { queue =>
       withLocalDynamoDbTable { table =>
         withLocalSnsTopic { topic =>
-          val flags = snsLocalFlags(topic) ++ dynamoClientLocalFlags ++ sqsLocalFlags(queue)
+          val flags = snsLocalFlags(topic) ++ dynamoClientLocalFlags ++ sqsLocalFlags(
+            queue)
 
           withServer(flags) { _ =>
             val reindexJob = createReindexJobWith(

--- a/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/ReindexRequestCreatorFeatureTest.scala
+++ b/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/ReindexRequestCreatorFeatureTest.scala
@@ -71,6 +71,8 @@ class ReindexRequestCreatorFeatureTest
             queue)
 
           withServer(flags) { _ =>
+            val expectedRecords = createReindexableData(queue, table)
+
             val reindexJob = createReindexJobWith(
               table = table,
               shardId = shardName,
@@ -81,9 +83,6 @@ class ReindexRequestCreatorFeatureTest
               queue = queue,
               message = reindexJob
             )
-
-            val expectedRecords =
-              createReindexableData(queue, table)
 
             eventually {
               val actualRecords: Seq[ReindexRequest] =

--- a/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/ReindexRequestCreatorFeatureTest.scala
+++ b/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/ReindexRequestCreatorFeatureTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
 import uk.ac.wellcome.models.reindexer.ReindexRequest
-import uk.ac.wellcome.platform.reindex.creator.models.ReindexJob
+import uk.ac.wellcome.platform.reindex.creator.fixtures.ReindexFixtures
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDbVersioned
 import uk.ac.wellcome.test.utils.ExtendedPatience
@@ -27,6 +27,7 @@ class ReindexRequestCreatorFeatureTest
     with ExtendedPatience
     with fixtures.Server
     with LocalDynamoDbVersioned
+    with ReindexFixtures
     with SNS
     with SQS
     with ScalaFutures {
@@ -53,20 +54,11 @@ class ReindexRequestCreatorFeatureTest
     //TODO re-factor shared test state here into fixture method
     testRecords.foreach(Scanamo.put(dynamoDbClient)(table.name)(_))
 
-    val reindexJob = ReindexJob(
-      shardId = shardName,
-      desiredVersion = desiredVersion
-    )
-
-    sendNotificationToSQS(
-      queue = queue,
-      message = reindexJob
-    )
-
     testRecords.map { record =>
       ReindexRequest(
         id = record.id,
-        desiredVersion = desiredVersion
+        desiredVersion = desiredVersion,
+        tableName = table.name
       )
     }
   }
@@ -75,10 +67,20 @@ class ReindexRequestCreatorFeatureTest
     withLocalSqsQueue { queue =>
       withLocalDynamoDbTable { table =>
         withLocalSnsTopic { topic =>
-          val flags = snsLocalFlags(topic) ++ dynamoDbLocalEndpointFlags(table) ++ sqsLocalFlags(
-            queue)
+          val flags = snsLocalFlags(topic) ++ dynamoClientLocalFlags ++ sqsLocalFlags(queue)
 
           withServer(flags) { _ =>
+            val reindexJob = createReindexJobWith(
+              table = table,
+              shardId = shardName,
+              desiredVersion = desiredVersion
+            )
+
+            sendNotificationToSQS(
+              queue = queue,
+              message = reindexJob
+            )
+
             val expectedRecords =
               createReindexableData(queue, table)
 

--- a/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/fixtures/ReindexFixtures.scala
+++ b/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/fixtures/ReindexFixtures.scala
@@ -1,6 +1,6 @@
-package uk.ac.wellcome.platform.creator.fixtures
+package uk.ac.wellcome.platform.reindex.creator.fixtures
 
-import uk.ac.wellcome.platform.creator.models.ReindexJob
+import uk.ac.wellcome.platform.reindex.creator.models.ReindexJob
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 

--- a/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/services/NotificationSenderTest.scala
+++ b/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/services/NotificationSenderTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.test.fixtures.SNS
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.models.reindexer.ReindexRequest
-import uk.ac.wellcome.platform.reindex_request_creator.fixtures.ReindexFixtures
+import uk.ac.wellcome.platform.reindex.creator.fixtures.ReindexFixtures
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.json.JsonUtil._

--- a/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/services/NotificationSenderTest.scala
+++ b/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/services/NotificationSenderTest.scala
@@ -6,6 +6,8 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.test.fixtures.SNS
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.models.reindexer.ReindexRequest
+import uk.ac.wellcome.platform.reindex_request_creator.fixtures.ReindexFixtures
+import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.json.JsonUtil._
 
@@ -15,6 +17,7 @@ class NotificationSenderTest
     extends FunSpec
     with Matchers
     with ExtendedPatience
+    with ReindexFixtures
     with ScalaFutures
     with SNS {
   it("sends ReindexRequests for the provided IDs") {
@@ -27,13 +30,22 @@ class NotificationSenderTest
         val recordIds = List("miro/1", "miro/2", "miro/3")
         val desiredVersion = 5
 
+        val table = Table("my-test-table", "my-index")
+
         val expectedRequests = recordIds.map { id =>
-          ReindexRequest(id = id, desiredVersion = desiredVersion)
+          ReindexRequest(
+            id = id,
+            desiredVersion = desiredVersion,
+            tableName = table.name
+          )
         }
 
         val future = notificationSender.sendNotifications(
           recordIds = recordIds,
-          desiredVersion = desiredVersion
+          reindexJob = createReindexJobWith(
+            table = table,
+            desiredVersion = desiredVersion
+          )
         )
 
         whenReady(future) { _ =>
@@ -60,7 +72,10 @@ class NotificationSenderTest
 
       val future = notificationSender.sendNotifications(
         recordIds = List("1", "2", "3"),
-        desiredVersion = 2)
+        reindexJob = createReindexJobWith(
+          table = Table("my-test-table", "my-index")
+        )
+      )
       whenReady(future.failed) {
         _ shouldBe a[AmazonSNSException]
       }

--- a/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/services/RecordReaderTest.scala
+++ b/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/services/RecordReaderTest.scala
@@ -109,13 +109,12 @@ class RecordReaderTest
   }
 
   it("returns a failed Future if there's a DynamoDB error") {
-    withReindexRecordReaderService {
-      service =>
-        val future = service.findRecordsForReindexing(
-          createReindexJobWith(Table("does-not-exist", "no-such-index")))
-        whenReady(future.failed) {
-          _ shouldBe a[ResourceNotFoundException]
-        }
+    withReindexRecordReaderService { service =>
+      val future = service.findRecordsForReindexing(
+        createReindexJobWith(Table("does-not-exist", "no-such-index")))
+      whenReady(future.failed) {
+        _ shouldBe a[ResourceNotFoundException]
+      }
     }
   }
 

--- a/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/services/ReindexRequestCreatorWorkerTest.scala
+++ b/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/services/ReindexRequestCreatorWorkerTest.scala
@@ -44,11 +44,7 @@ class ReindexRequestCreatorWorkerTest
               queue,
               metricsSender) { sqsStream =>
               val readerService = new RecordReader(
-                dynamoDbClient = dynamoDbClient,
-                dynamoConfig = DynamoConfig(
-                  table = table.name,
-                  index = table.index
-                )
+                dynamoDbClient = dynamoDbClient
               )
 
               withSNSWriter(topic) { snsWriter =>
@@ -78,7 +74,7 @@ class ReindexRequestCreatorWorkerTest
   it("successfully completes a reindex") {
     withLocalDynamoDbTable { table =>
       withLocalSnsTopic { topic =>
-        withReindexWorkerService(table, topic) {
+        withReindexWorkerService(topic) {
           case (service, QueuePair(queue, dlq)) =>
             val reindexJob = createReindexJobWith(
               table = table,
@@ -127,7 +123,7 @@ class ReindexRequestCreatorWorkerTest
   it("fails if it cannot parse the SQS message as a ReindexJob") {
     withLocalDynamoDbTable { table =>
       withLocalSnsTopic { topic =>
-        withReindexWorkerService(table, topic) {
+        withReindexWorkerService(topic) {
           case (_, QueuePair(queue, dlq)) =>
             sendNotificationToSQS(
               queue = queue,
@@ -153,11 +149,7 @@ class ReindexRequestCreatorWorkerTest
               queue,
               metricsSender) { sqsStream =>
               val readerService = new RecordReader(
-                dynamoDbClient = dynamoDbClient,
-                dynamoConfig = DynamoConfig(
-                  table = "doesnotexist",
-                  index = "whatindex?"
-                )
+                dynamoDbClient = dynamoDbClient
               )
 
               withSNSWriter(Topic("does-not-exist")) { snsWriter =>

--- a/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/services/ReindexRequestCreatorWorkerTest.scala
+++ b/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/services/ReindexRequestCreatorWorkerTest.scala
@@ -10,8 +10,8 @@ import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
 import uk.ac.wellcome.models.reindexer.ReindexRequest
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
-import uk.ac.wellcome.platform.reindex_request.creator.TestRecord
-import uk.ac.wellcome.platform.reindex_request.creator.fixtures.ReindexFixtures
+import uk.ac.wellcome.platform.reindex.creator.TestRecord
+import uk.ac.wellcome.platform.reindex.creator.fixtures.ReindexFixtures
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDbVersioned
 import uk.ac.wellcome.test.fixtures._

--- a/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/services/ReindexRequestCreatorWorkerTest.scala
+++ b/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/services/ReindexRequestCreatorWorkerTest.scala
@@ -10,11 +10,9 @@ import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
 import uk.ac.wellcome.models.reindexer.ReindexRequest
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
-import uk.ac.wellcome.platform.reindex.creator.TestRecord
-import uk.ac.wellcome.platform.reindex.creator.fixtures.ReindexFixtures
-import uk.ac.wellcome.platform.reindex.creator.models.ReindexJob
+import uk.ac.wellcome.platform.reindex_request.creator.TestRecord
+import uk.ac.wellcome.platform.reindex_request.creator.fixtures.ReindexFixtures
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
-import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDbVersioned
 import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.json.JsonUtil._
@@ -95,7 +93,8 @@ class ReindexRequestCreatorWorkerTest
             val expectedRecords = Seq(
               ReindexRequest(
                 id = testRecord.id,
-                desiredVersion = reindexJob.desiredVersion
+                desiredVersion = reindexJob.desiredVersion,
+                tableName = table.name
               )
             )
 

--- a/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/services/ReindexRequestCreatorWorkerTest.scala
+++ b/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/services/ReindexRequestCreatorWorkerTest.scala
@@ -79,6 +79,10 @@ class ReindexRequestCreatorWorkerTest
         withReindexWorkerService(table, topic) {
           case (service, QueuePair(queue, dlq)) =>
             val reindexJob = ReindexJob(
+              dynamoConfig = DynamoConfig(
+                table = table.name,
+                index = table.index
+              ),
               shardId = "sierra/123",
               desiredVersion = 6
             )
@@ -170,6 +174,10 @@ class ReindexRequestCreatorWorkerTest
                 )
 
                 val reindexJob = ReindexJob(
+                  dynamoConfig = DynamoConfig(
+                    table = "doesnotexist",
+                    index = "whatindex?"
+                  ),
                   shardId = "sierra/444",
                   desiredVersion = 4
                 )

--- a/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/services/ReindexRequestCreatorWorkerTest.scala
+++ b/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex/creator/services/ReindexRequestCreatorWorkerTest.scala
@@ -31,7 +31,7 @@ class ReindexRequestCreatorWorkerTest
     with SQS
     with ScalaFutures {
 
-  def withReindexWorkerService(table: Table, topic: Topic)(
+  def withReindexWorkerService(topic: Topic)(
     testWith: TestWith[(ReindexRequestCreatorWorker, QueuePair), Assertion]) = {
     withActorSystem { actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>

--- a/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex_request_creator/fixtures/ReindexFixtures.scala
+++ b/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex_request_creator/fixtures/ReindexFixtures.scala
@@ -1,0 +1,30 @@
+package uk.ac.wellcome.platform.reindex_request_creator.fixtures
+
+import uk.ac.wellcome.platform.reindex_request_creator.models.ReindexJob
+import uk.ac.wellcome.storage.dynamo.DynamoConfig
+import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
+
+trait ReindexFixtures {
+  def createReindexJobWith(
+    table: Table,
+    shardId: String = "sierra/123",
+    desiredVersion: Int = 5
+  ): ReindexJob = ReindexJob(
+    dynamoConfig = DynamoConfig(
+      table = table.name,
+      index = table.index
+    ),
+    shardId = shardId,
+    desiredVersion = desiredVersion
+  )
+
+  def createReindexJobWith(
+    dynamoConfig: DynamoConfig,
+    shardId: String = "sierra/123",
+    desiredVersion: Int = 5
+  ): ReindexJob = ReindexJob(
+    dynamoConfig = dynamoConfig,
+    shardId = shardId,
+    desiredVersion = desiredVersion
+  )
+}

--- a/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex_request_creator/fixtures/ReindexFixtures.scala
+++ b/reindexer/reindex_request_creator/src/test/scala/uk/ac/wellcome/platform/reindex_request_creator/fixtures/ReindexFixtures.scala
@@ -18,13 +18,9 @@ trait ReindexFixtures {
     desiredVersion = desiredVersion
   )
 
-  def createReindexJobWith(
-    dynamoConfig: DynamoConfig,
-    shardId: String = "sierra/123",
-    desiredVersion: Int = 5
-  ): ReindexJob = ReindexJob(
+  def createReindexJobWith(dynamoConfig: DynamoConfig): ReindexJob = ReindexJob(
     dynamoConfig = dynamoConfig,
-    shardId = shardId,
-    desiredVersion = desiredVersion
+    shardId = "sierra/123",
+    desiredVersion = 5
   )
 }

--- a/reindexer/reindex_request_creator/src/universal/conf/application.ini.template
+++ b/reindexer/reindex_request_creator/src/universal/conf/application.ini.template
@@ -1,5 +1,3 @@
--aws.dynamo.tableName=${dynamo_table_name}
--aws.dynamo.tableIndex=reindexTracker
 -aws.sqs.queue.url=${reindex_jobs_queue_id}
 -aws.sns.topic.arn=${reindex_requests_topic_arn}
 -aws.metrics.namespace=${metrics_namespace}

--- a/reindexer/reindex_request_processor/src/main/scala/uk/ac/wellcome/platform/reindex/processor/Server.scala
+++ b/reindexer/reindex_request_processor/src/main/scala/uk/ac/wellcome/platform/reindex/processor/Server.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.finatra.akka.{AkkaModule, ExecutionContextModule}
 import uk.ac.wellcome.finatra.controllers.ManagementController
 import uk.ac.wellcome.finatra.messaging.{SQSClientModule, SQSConfigModule}
 import uk.ac.wellcome.finatra.monitoring.MetricsSenderModule
-import uk.ac.wellcome.finatra.storage.{DynamoClientModule, DynamoConfigModule}
+import uk.ac.wellcome.finatra.storage.DynamoClientModule
 import uk.ac.wellcome.platform.reindex.processor.modules.ReindexerWorkerModule
 
 object ServerMain extends Server
@@ -27,7 +27,6 @@ class Server extends HttpServer {
     MetricsSenderModule,
     SQSConfigModule,
     SQSClientModule,
-    DynamoConfigModule,
     DynamoClientModule,
     ReindexerWorkerModule
   )

--- a/reindexer/reindex_request_processor/src/main/scala/uk/ac/wellcome/platform/reindex/processor/services/ReindexRequestProcessorWorker.scala
+++ b/reindexer/reindex_request_processor/src/main/scala/uk/ac/wellcome/platform/reindex/processor/services/ReindexRequestProcessorWorker.scala
@@ -51,7 +51,8 @@ class ReindexRequestProcessorWorker @Inject()(
     }
   }
 
-  private def createVersionedDaoFor(reindexRequest: ReindexRequest): VersionedDao =
+  private def createVersionedDaoFor(
+    reindexRequest: ReindexRequest): VersionedDao =
     new VersionedDao(
       dynamoDbClient = dynamoDbClient,
       dynamoConfig = DynamoConfig(

--- a/reindexer/reindex_request_processor/src/test/scala/uk/ac/wellcome/platform/reindex/processor/ReindexProcessorFeatureTest.scala
+++ b/reindexer/reindex_request_processor/src/test/scala/uk/ac/wellcome/platform/reindex/processor/ReindexProcessorFeatureTest.scala
@@ -27,7 +27,11 @@ class ReindexProcessorFeatureTest
 
             givenTableHasItem(record, table)
 
-            val reindexRequest = ReindexRequest(id = id, desiredVersion = 11)
+            val reindexRequest = ReindexRequest(
+              id = id,
+              tableName = table.name,
+              desiredVersion = 11
+            )
 
             sendNotificationToSQS(queue, reindexRequest)
 

--- a/reindexer/reindex_request_processor/src/test/scala/uk/ac/wellcome/platform/reindex/processor/ReindexProcessorFeatureTest.scala
+++ b/reindexer/reindex_request_processor/src/test/scala/uk/ac/wellcome/platform/reindex/processor/ReindexProcessorFeatureTest.scala
@@ -19,7 +19,7 @@ class ReindexProcessorFeatureTest
   it("processes a ReindexRequest") {
     withLocalSqsQueue { queue =>
       withLocalDynamoDbTable { table =>
-        withServer(sqsLocalFlags(queue) ++ dynamoDbLocalEndpointFlags(table)) {
+        withServer(sqsLocalFlags(queue) ++ dynamoClientLocalFlags) {
           _ =>
             val id = "sierra/1234567"
             val record =

--- a/reindexer/reindex_request_processor/src/test/scala/uk/ac/wellcome/platform/reindex/processor/ServerTest.scala
+++ b/reindexer/reindex_request_processor/src/test/scala/uk/ac/wellcome/platform/reindex/processor/ServerTest.scala
@@ -14,12 +14,11 @@ class ServerTest
   it("shows the healthcheck message") {
     withLocalSqsQueue { queue =>
       withLocalDynamoDbTable { table =>
-        withServer(sqsLocalFlags(queue) ++ dynamoClientLocalFlags) {
-          server =>
-            server.httpGet(
-              path = "/management/healthcheck",
-              andExpect = Ok,
-              withJsonBody = """{"message": "ok"}""")
+        withServer(sqsLocalFlags(queue) ++ dynamoClientLocalFlags) { server =>
+          server.httpGet(
+            path = "/management/healthcheck",
+            andExpect = Ok,
+            withJsonBody = """{"message": "ok"}""")
         }
       }
     }

--- a/reindexer/reindex_request_processor/src/test/scala/uk/ac/wellcome/platform/reindex/processor/ServerTest.scala
+++ b/reindexer/reindex_request_processor/src/test/scala/uk/ac/wellcome/platform/reindex/processor/ServerTest.scala
@@ -14,7 +14,7 @@ class ServerTest
   it("shows the healthcheck message") {
     withLocalSqsQueue { queue =>
       withLocalDynamoDbTable { table =>
-        withServer(sqsLocalFlags(queue) ++ dynamoDbLocalEndpointFlags(table)) {
+        withServer(sqsLocalFlags(queue) ++ dynamoClientLocalFlags) {
           server =>
             server.httpGet(
               path = "/management/healthcheck",

--- a/reindexer/reindex_request_processor/src/test/scala/uk/ac/wellcome/platform/reindex/processor/services/ReindexRequestProcessorWorkerTest.scala
+++ b/reindexer/reindex_request_processor/src/test/scala/uk/ac/wellcome/platform/reindex/processor/services/ReindexRequestProcessorWorkerTest.scala
@@ -190,21 +190,19 @@ class ReindexRequestProcessorWorkerTest
     testWith: TestWith[ReindexRequestProcessorWorker, R]) = {
     withActorSystem { actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>
-        withSQSStream[NotificationMessage, R](
-          actorSystem,
-          queue,
-          metricsSender) { sqsStream =>
-          val workerService = new ReindexRequestProcessorWorker(
-            dynamoDbClient = dynamoDbClient,
-            sqsStream = sqsStream,
-            system = actorSystem
-          )
+        withSQSStream[NotificationMessage, R](actorSystem, queue, metricsSender) {
+          sqsStream =>
+            val workerService = new ReindexRequestProcessorWorker(
+              dynamoDbClient = dynamoDbClient,
+              sqsStream = sqsStream,
+              system = actorSystem
+            )
 
-          try {
-            testWith(workerService)
-          } finally {
-            workerService.stop()
-          }
+            try {
+              testWith(workerService)
+            } finally {
+              workerService.stop()
+            }
         }
       }
     }

--- a/reindexer/reindex_request_processor/src/universal/conf/application.ini.template
+++ b/reindexer/reindex_request_processor/src/universal/conf/application.ini.template
@@ -1,3 +1,2 @@
--aws.dynamo.tableName=${dynamo_table_name}
 -aws.sqs.queue.url=${reindex_requests_queue_id}
 -aws.metrics.namespace=${metrics_namespace}

--- a/reindexer/terraform/service_reindex_request_creator.tf
+++ b/reindexer/terraform/service_reindex_request_creator.tf
@@ -13,13 +13,12 @@ module "reindex_request_creator" {
   memory = 2048
 
   env_vars = {
-    dynamo_table_name          = "${local.vhs_sourcedata_table_name}"
     reindex_jobs_queue_id      = "${module.reindexer_queue.id}"
     reindex_requests_topic_arn = "${module.reindex_requests_topic.arn}"
     metrics_namespace          = "reindex_request_creator"
   }
 
-  env_vars_length = 4
+  env_vars_length = 3
 
   ecs_cluster_name = "${aws_ecs_cluster.cluster.name}"
   ecs_cluster_id   = "${aws_ecs_cluster.cluster.id}"

--- a/reindexer/terraform/service_reindex_request_processor.tf
+++ b/reindexer/terraform/service_reindex_request_processor.tf
@@ -11,12 +11,11 @@ module "reindex_request_processor" {
   memory          = 2048
 
   env_vars = {
-    dynamo_table_name         = "${local.vhs_sourcedata_table_name}"
     reindex_requests_queue_id = "${module.reindex_requests_queue.id}"
     metrics_namespace         = "reindex_request_processor"
   }
 
-  env_vars_length = 3
+  env_vars_length = 2
 
   ecs_cluster_name   = "${aws_ecs_cluster.cluster.name}"
   ecs_cluster_id     = "${aws_ecs_cluster.cluster.id}"

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/reindexer/ReindexRequest.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/reindexer/ReindexRequest.scala
@@ -1,13 +1,16 @@
 package uk.ac.wellcome.models.reindexer
 
-/** A request to update a single record in SourceData to [[desiredVersion]].
+/** A request to update a single record to [[desiredVersion]].
   *
   * This is sent to an SNS topic, and handled by another application.
   *
   * @param id ID of the record to update (e.g. "miro/A1234567")
+  * @param tableName The name of the DynamoDB table where the record lives
+  *                  (e.g. SourceData, vhs-sierra).
   * @param desiredVersion The reindex version to set on the record.
   */
 case class ReindexRequest(
   id: String,
+  tableName: String,
   desiredVersion: Int
 )


### PR DESCRIPTION
Resolves #2230.

As we start to split different sources into different VHS cassettes, we can either duplicate the reindexer with different config, or run a single reindexer that gets table config from inputs. This PR sketches out what the latter would look like.