### PR TITLE
Ignore extra identifiers in subfield 0 when identifying concepts

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConcepts.scala
@@ -46,8 +46,7 @@ trait SierraConcepts extends MarcUtils {
     //  * The value repeated with a MESH URL prefix
     //    ['D049671', 'https://id.nlm.nih.gov/mesh/D049671']
     //
-    val identifierSubfieldContents = varField.subfields
-      .filter { _.tag == "0" }
+    val identifierSubfieldContents = identifierSubfields
       .map { _.content }
       .map { _.replaceFirst("^\\(DNLM\\)", "") }
       .map { _.replaceFirst("^https://id\\.nlm\\.nih\\.gov/mesh/", "") }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConcepts.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConcepts.scala
@@ -55,16 +55,13 @@ trait SierraConcepts extends MarcUtils {
       .distinct
 
     identifierSubfieldContents match {
-      case Seq() => Unidentifiable(agent = concept)
       case Seq(subfieldContent) =>
         maybeAddIdentifier[T](
           concept = concept,
           varField = varField,
           identifierSubfieldContent = subfieldContent
         )
-      case _ =>
-        throw new RuntimeException(
-          s"Too many identifiers fields: $identifierSubfields")
+      case _ => Unidentifiable(agent = concept)
     }
   }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConceptsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConceptsTest.scala
@@ -1,12 +1,7 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal.{
-  Concept,
-  Identifiable,
-  IdentifierType,
-  SourceIdentifier
-}
+import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, VarField}
 
 class SierraConceptsTest extends FunSpec with Matchers {
@@ -81,25 +76,27 @@ class SierraConceptsTest extends FunSpec with Matchers {
     )
   }
 
-  it("puts extra instances of subfield 0 into the otherIdentifiers field") {
-    val caught = intercept[RuntimeException] {
-      transformer.identifyPrimaryConcept[Concept](
-        concept = Concept(label = "Hitchhiking horses hurry home"),
-        varField = VarField(
-          fieldTag = "p",
-          marcTag = "655",
-          indicator1 = "",
-          indicator2 = "0",
-          subfields = List(
-            MarcSubfield(tag = "a", content = "hitchhiking"),
-            MarcSubfield(tag = "0", content = "u/xxx"),
-            MarcSubfield(tag = "0", content = "u/yyy")
-          )
+  it("ignores multiple instances of subfield 0 im the otherIdentifiers") {
+    val concept = Concept(label = "Hitchhiking horses hurry home")
+
+    val maybeIdentifiedConcept = transformer.identifyPrimaryConcept[Concept](
+      concept = concept,
+      varField = VarField(
+        fieldTag = "p",
+        marcTag = "655",
+        indicator1 = "",
+        indicator2 = "0",
+        subfields = List(
+          MarcSubfield(tag = "a", content = "hitchhiking"),
+          MarcSubfield(tag = "0", content = "u/xxx"),
+          MarcSubfield(tag = "0", content = "u/yyy")
         )
       )
-    }
+    )
 
-    caught.getMessage shouldEqual "Too many identifiers fields: List(MarcSubfield(0,u/xxx), MarcSubfield(0,u/yyy))"
+    maybeIdentifiedConcept shouldBe Unidentifiable(
+      concept
+    )
   }
 
   val transformer = new SierraConcepts {}


### PR DESCRIPTION
A partial fix for #2163. Long term it would be nice to do something other than “throw away these identifiers”, but until we get a better solution this will at least clean up the DLQs.