### PR TITLE
Downgrade version of sqs autoscaling modules for snapshot generator

### DIFF
--- a/data_api/terraform/service_snapshot_generator.tf
+++ b/data_api/terraform/service_snapshot_generator.tf
@@ -8,7 +8,7 @@ data "template_file" "es_cluster_host_snapshot" {
 }
 
 module "snapshot_generator" {
-  source             = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/service/prebuilt/sqs_scaling?ref=v11.4.1"
+  source             = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/service/prebuilt/sqs_scaling?ref=v11.4.0"
   service_name       = "snapshot_generator"
   task_desired_count = "0"
 


### PR DESCRIPTION
Temporarily use the old modules version that scales down on ApproximateNumberOfMessagesVisible.

Proper fix should be to make the sqs scaling more customisable probably, but in the meantime this should get the snapshot generator working again