### PR TITLE
Merger doesn't handle multiple output works correctly

### DIFF
--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
@@ -26,9 +26,7 @@ class MergerWorkerService @Inject()(
   private def processMessage(message: NotificationMessage): Future[Unit] =
     for {
       matcherResult <- Future.fromTry(fromJson[MatcherResult](message.Message))
-      _ <- Future.sequence(
-        matcherResult.works.map { applyMerge }
-      )
+      _ <- Future.sequence(matcherResult.works.map { applyMerge })
     } yield ()
 
   private def applyMerge(matchedIdentifiers: MatchedIdentifiers): Future[Unit] =

--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
@@ -43,6 +43,15 @@ class MergerWorkerService @Inject()(
         ))
   }
 
+  // val r = MatcherResult(works = Set(
+  //     |   MatchedIdentifiers(identifiers = Set(WorkIdentifier("111", 1), WorkIdentifier("112", 1), WorkIdentifier("113", 1))),
+  //     |   MatchedIdentifiers(identifiers = Set(WorkIdentifier("211", 1), WorkIdentifier("212", 1)))
+  //     | )
+  //     |
+  //     | )
+
+  // getWorksIdentifiers(r)
+  //res0: Set[WorkIdentifier] = Set(WorkIdentifier(212,1), WorkIdentifier(211,1), WorkIdentifier(113,1), WorkIdentifier(111,1), WorkIdentifier(112,1))
   private def getWorksIdentifiers(
     matcherResult: MatcherResult): Set[WorkIdentifier] = {
     for {

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
@@ -80,7 +80,7 @@ trait MergerTestUtils
         createSourceIdentifierWith(identifierType = "miro-library-reference")),
       workType = Some(WorkType("v", "E-books")),
       items = List(
-        createIdentifiableItemWith(locations = List(createDigitalLocation)))
+        createUnidentifiableItemWith(locations = List(createDigitalLocation)))
     )
   }
 

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
@@ -8,6 +8,7 @@ import uk.ac.wellcome.models.matcher.{
   WorkIdentifier
 }
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
+import uk.ac.wellcome.models.work.internal.{UnidentifiedWork, WorkType}
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}
@@ -25,10 +26,22 @@ trait MergerTestUtils
       matchedEntries.map(
         recorderWorkEntries =>
           MatchedIdentifiers(
-            recorderWorkEntries.map(workEntry =>
-              WorkIdentifier(
-                identifier = workEntry.id,
-                version = workEntry.work.version)))))
+            recorderWorkEntriesToWorkIdentifiers(recorderWorkEntries)
+          )
+      )
+    )
+
+  def recorderWorkEntriesToWorkIdentifiers(workEntries: Seq[RecorderWorkEntry]): Set[WorkIdentifier] =
+    recorderWorkEntriesToWorkIdentifiers(workEntries.toSet)
+
+  def recorderWorkEntriesToWorkIdentifiers(workEntries: Set[RecorderWorkEntry]): Set[WorkIdentifier] =
+    workEntries
+      .map {
+        workEntry => WorkIdentifier(
+          identifier = workEntry.id,
+          version = workEntry.work.version
+        )
+      }
 
   def storeInVHS(vhs: VersionedHybridStore[RecorderWorkEntry,
                                            EmptyMetadata,
@@ -56,6 +69,31 @@ trait MergerTestUtils
   def createRecorderWorkEntryWith(version: Int): RecorderWorkEntry =
     RecorderWorkEntry(createUnidentifiedWorkWith(version = version))
 
+<<<<<<< HEAD
   def createRecorderWorkEntry: RecorderWorkEntry =
     createRecorderWorkEntryWith(version = 1)
+=======
+  def createDigitalWork: UnidentifiedWork = {
+    createUnidentifiedWorkWith(
+      sourceIdentifier =
+        createSourceIdentifierWith(identifierType = "miro-image-number"),
+      otherIdentifiers = List(
+        createSourceIdentifierWith(identifierType = "miro-library-reference")),
+      workType = Some(WorkType("v", "E-books")),
+      items = List(
+        createIdentifiableItemWith(locations = List(createDigitalLocation)))
+    )
+  }
+
+  def createPhysicalWork: UnidentifiedWork = {
+    createUnidentifiedWorkWith(
+      sourceIdentifier =
+        createSourceIdentifierWith(identifierType = "sierra-system-number"),
+      otherIdentifiers =
+        List(createSourceIdentifierWith(identifierType = "sierra-identifier")),
+      items = List(
+        createIdentifiableItemWith(locations = List(createPhysicalLocation)))
+    )
+  }
+>>>>>>> I have a funky feeling there's a bug here!
 }

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
@@ -69,10 +69,9 @@ trait MergerTestUtils
   def createRecorderWorkEntryWith(version: Int): RecorderWorkEntry =
     RecorderWorkEntry(createUnidentifiedWorkWith(version = version))
 
-<<<<<<< HEAD
   def createRecorderWorkEntry: RecorderWorkEntry =
     createRecorderWorkEntryWith(version = 1)
-=======
+
   def createDigitalWork: UnidentifiedWork = {
     createUnidentifiedWorkWith(
       sourceIdentifier =
@@ -95,5 +94,4 @@ trait MergerTestUtils
         createIdentifiableItemWith(locations = List(createPhysicalLocation)))
     )
   }
->>>>>>> I have a funky feeling there's a bug here!
 }

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerTestUtils.scala
@@ -27,17 +27,19 @@ trait MergerTestUtils
         recorderWorkEntries =>
           MatchedIdentifiers(
             recorderWorkEntriesToWorkIdentifiers(recorderWorkEntries)
-          )
+        )
       )
     )
 
-  def recorderWorkEntriesToWorkIdentifiers(workEntries: Seq[RecorderWorkEntry]): Set[WorkIdentifier] =
+  def recorderWorkEntriesToWorkIdentifiers(
+    workEntries: Seq[RecorderWorkEntry]): Set[WorkIdentifier] =
     recorderWorkEntriesToWorkIdentifiers(workEntries.toSet)
 
-  def recorderWorkEntriesToWorkIdentifiers(workEntries: Set[RecorderWorkEntry]): Set[WorkIdentifier] =
+  def recorderWorkEntriesToWorkIdentifiers(
+    workEntries: Set[RecorderWorkEntry]): Set[WorkIdentifier] =
     workEntries
-      .map {
-        workEntry => WorkIdentifier(
+      .map { workEntry =>
+        WorkIdentifier(
           identifier = workEntry.id,
           version = workEntry.work.version
         )

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -85,29 +85,6 @@ class MergerTest extends FunSpec with MergerTestUtils {
     assertDoesNotMerge(works)
   }
 
-  private def createDigitalWork = {
-    createUnidentifiedWorkWith(
-      sourceIdentifier =
-        createSourceIdentifierWith(identifierType = "miro-image-number"),
-      otherIdentifiers = List(
-        createSourceIdentifierWith(identifierType = "miro-library-reference")),
-      workType = Some(WorkType("v", "E-books")),
-      items = List(
-        createUnidentifiableItemWith(locations = List(createDigitalLocation)))
-    )
-  }
-
-  private def createPhysicalWork = {
-    createUnidentifiedWorkWith(
-      sourceIdentifier =
-        createSourceIdentifierWith(identifierType = "sierra-system-number"),
-      otherIdentifiers =
-        List(createSourceIdentifierWith(identifierType = "sierra-identifier")),
-      items = List(
-        createIdentifiableItemWith(locations = List(createPhysicalLocation)))
-    )
-  }
-
   private def assertDoesNotMerge(works: List[UnidentifiedWork]) = {
     merger.merge(works) should contain theSameElementsAs works
   }

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -201,36 +201,34 @@ class MergerWorkerServiceTest
 
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, metricsSender) =>
-        val future = storeInVHS(vhs, recorderWorkEntries)
+        storeInVHS(vhs, recorderWorkEntries)
 
         val matcherResult = MatcherResult(Set(
           MatchedIdentifiers(recorderWorkEntriesToWorkIdentifiers(recorderWorkEntries))
         ))
 
-        whenReady(future) { _ =>
-          sendNotificationToSQS(queue = queue, message = matcherResult)
+        sendNotificationToSQS(queue = queue, message = matcherResult)
 
-          eventually {
-            assertQueueEmpty(queue)
-            assertQueueEmpty(dlq)
+        eventually {
+          assertQueueEmpty(queue)
+          assertQueueEmpty(dlq)
 
-            val worksSent = getMessages[BaseWork](topic).distinct
-            worksSent should have size 2
+          val worksSent = getMessages[BaseWork](topic).distinct
+          worksSent should have size 2
 
-            val redirectedWorks = worksSent.collect {
-              case work: UnidentifiedRedirectedWork => work
-            }
-            val mergedWorks = worksSent.collect {
-              case work: UnidentifiedWork => work
-            }
-
-            redirectedWorks should have size 1
-            redirectedWorks.head.sourceIdentifier shouldBe digitalWork.sourceIdentifier
-            redirectedWorks.head.redirect shouldBe IdentifiableRedirect(physicalWork.sourceIdentifier)
-
-            mergedWorks should have size 1
-            mergedWorks.head.sourceIdentifier shouldBe physicalWork.sourceIdentifier
+          val redirectedWorks = worksSent.collect {
+            case work: UnidentifiedRedirectedWork => work
           }
+          val mergedWorks = worksSent.collect {
+            case work: UnidentifiedWork => work
+          }
+
+          redirectedWorks should have size 1
+          redirectedWorks.head.sourceIdentifier shouldBe digitalWork.sourceIdentifier
+          redirectedWorks.head.redirect shouldBe IdentifiableRedirect(physicalWork.sourceIdentifier)
+
+          mergedWorks should have size 1
+          mergedWorks.head.sourceIdentifier shouldBe physicalWork.sourceIdentifier
         }
     }
   }
@@ -244,33 +242,31 @@ class MergerWorkerServiceTest
 
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, metricsSender) =>
-        val future = storeInVHS(vhs, recorderWorkEntries1 ++ recorderWorkEntries2)
+        storeInVHS(vhs, recorderWorkEntries1 ++ recorderWorkEntries2)
 
         val matcherResult = MatcherResult(Set(
           MatchedIdentifiers(recorderWorkEntriesToWorkIdentifiers(recorderWorkEntries1)),
           MatchedIdentifiers(recorderWorkEntriesToWorkIdentifiers(recorderWorkEntries2))
         ))
 
-        whenReady(future) { _ =>
-          sendNotificationToSQS(queue = queue, message = matcherResult)
+        sendNotificationToSQS(queue = queue, message = matcherResult)
 
-          eventually {
-            assertQueueEmpty(queue)
-            assertQueueEmpty(dlq)
+        eventually {
+          assertQueueEmpty(queue)
+          assertQueueEmpty(dlq)
 
-            val worksSent = getMessages[BaseWork](topic).distinct
-            worksSent should have size 4
+          val worksSent = getMessages[BaseWork](topic).distinct
+          worksSent should have size 4
 
-            val redirectedWorks = worksSent.collect {
-              case work: UnidentifiedRedirectedWork => work
-            }
-            val mergedWorks = worksSent.collect {
-              case work: UnidentifiedWork => work
-            }
-
-            redirectedWorks should have size 2
-            mergedWorks should have size 2
+          val redirectedWorks = worksSent.collect {
+            case work: UnidentifiedRedirectedWork => work
           }
+          val mergedWorks = worksSent.collect {
+            case work: UnidentifiedWork => work
+          }
+
+          redirectedWorks should have size 2
+          mergedWorks should have size 2
         }
     }
   }

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -14,7 +14,12 @@ import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult}
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
-import uk.ac.wellcome.models.work.internal.{BaseWork, IdentifiableRedirect, UnidentifiedRedirectedWork, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  BaseWork,
+  IdentifiableRedirect,
+  UnidentifiedRedirectedWork,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.merger.MergerTestUtils
@@ -197,15 +202,19 @@ class MergerWorkerServiceTest
     val digitalWork = createDigitalWork
 
     val recorderWorkEntries = List(physicalWork, digitalWork)
-      .map { w => RecorderWorkEntry(w.copy(version = 1)) }
+      .map { w =>
+        RecorderWorkEntry(w.copy(version = 1))
+      }
 
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, metricsSender) =>
         storeInVHS(vhs, recorderWorkEntries)
 
-        val matcherResult = MatcherResult(Set(
-          MatchedIdentifiers(recorderWorkEntriesToWorkIdentifiers(recorderWorkEntries))
-        ))
+        val matcherResult = MatcherResult(
+          Set(
+            MatchedIdentifiers(
+              recorderWorkEntriesToWorkIdentifiers(recorderWorkEntries))
+          ))
 
         sendNotificationToSQS(queue = queue, message = matcherResult)
 
@@ -225,7 +234,8 @@ class MergerWorkerServiceTest
 
           redirectedWorks should have size 1
           redirectedWorks.head.sourceIdentifier shouldBe digitalWork.sourceIdentifier
-          redirectedWorks.head.redirect shouldBe IdentifiableRedirect(physicalWork.sourceIdentifier)
+          redirectedWorks.head.redirect shouldBe IdentifiableRedirect(
+            physicalWork.sourceIdentifier)
 
           mergedWorks should have size 1
           mergedWorks.head.sourceIdentifier shouldBe physicalWork.sourceIdentifier
@@ -237,17 +247,24 @@ class MergerWorkerServiceTest
     val workPair1 = List(createPhysicalWork, createDigitalWork)
     val workPair2 = List(createPhysicalWork, createDigitalWork)
 
-    val recorderWorkEntries1 = workPair1.map { w => RecorderWorkEntry(w.copy(version = 1)) }
-    val recorderWorkEntries2 = workPair2.map { w => RecorderWorkEntry(w.copy(version = 1)) }
+    val recorderWorkEntries1 = workPair1.map { w =>
+      RecorderWorkEntry(w.copy(version = 1))
+    }
+    val recorderWorkEntries2 = workPair2.map { w =>
+      RecorderWorkEntry(w.copy(version = 1))
+    }
 
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), topic, metricsSender) =>
         storeInVHS(vhs, recorderWorkEntries1 ++ recorderWorkEntries2)
 
-        val matcherResult = MatcherResult(Set(
-          MatchedIdentifiers(recorderWorkEntriesToWorkIdentifiers(recorderWorkEntries1)),
-          MatchedIdentifiers(recorderWorkEntriesToWorkIdentifiers(recorderWorkEntries2))
-        ))
+        val matcherResult = MatcherResult(
+          Set(
+            MatchedIdentifiers(
+              recorderWorkEntriesToWorkIdentifiers(recorderWorkEntries1)),
+            MatchedIdentifiers(
+              recorderWorkEntriesToWorkIdentifiers(recorderWorkEntries2))
+          ))
 
         sendNotificationToSQS(queue = queue, message = matcherResult)
 

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -12,8 +12,9 @@ import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
+import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult}
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
-import uk.ac.wellcome.models.work.internal.{BaseWork, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{BaseWork, IdentifiableRedirect, UnidentifiedRedirectedWork, UnidentifiedWork}
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.merger.MergerTestUtils
@@ -187,6 +188,89 @@ class MergerWorkerServiceTest
 
           verify(metricsSender, times(1))
             .countSuccess(any[String])
+        }
+    }
+  }
+
+  it("sends a merged work and a redirected work to SQS") {
+    val physicalWork = createPhysicalWork
+    val digitalWork = createDigitalWork
+
+    val recorderWorkEntries = List(physicalWork, digitalWork)
+      .map { w => RecorderWorkEntry(w.copy(version = 1)) }
+
+    withMergerWorkerServiceFixtures {
+      case (vhs, QueuePair(queue, dlq), topic, metricsSender) =>
+        val future = storeInVHS(vhs, recorderWorkEntries)
+
+        val matcherResult = MatcherResult(Set(
+          MatchedIdentifiers(recorderWorkEntriesToWorkIdentifiers(recorderWorkEntries))
+        ))
+
+        whenReady(future) { _ =>
+          sendNotificationToSQS(queue = queue, message = matcherResult)
+
+          eventually {
+            assertQueueEmpty(queue)
+            assertQueueEmpty(dlq)
+
+            val worksSent = getMessages[BaseWork](topic).distinct
+            worksSent should have size 2
+
+            val redirectedWorks = worksSent.collect {
+              case work: UnidentifiedRedirectedWork => work
+            }
+            val mergedWorks = worksSent.collect {
+              case work: UnidentifiedWork => work
+            }
+
+            redirectedWorks should have size 1
+            redirectedWorks.head.sourceIdentifier shouldBe digitalWork.sourceIdentifier
+            redirectedWorks.head.redirect shouldBe IdentifiableRedirect(physicalWork.sourceIdentifier)
+
+            mergedWorks should have size 1
+            mergedWorks.head.sourceIdentifier shouldBe physicalWork.sourceIdentifier
+          }
+        }
+    }
+  }
+
+  it("splits the received works into multiple merged works if required") {
+    val workPair1 = List(createPhysicalWork, createDigitalWork)
+    val workPair2 = List(createPhysicalWork, createDigitalWork)
+
+    val recorderWorkEntries1 = workPair1.map { w => RecorderWorkEntry(w.copy(version = 1)) }
+    val recorderWorkEntries2 = workPair2.map { w => RecorderWorkEntry(w.copy(version = 1)) }
+
+    withMergerWorkerServiceFixtures {
+      case (vhs, QueuePair(queue, dlq), topic, metricsSender) =>
+        val future = storeInVHS(vhs, recorderWorkEntries1 ++ recorderWorkEntries2)
+
+        val matcherResult = MatcherResult(Set(
+          MatchedIdentifiers(recorderWorkEntriesToWorkIdentifiers(recorderWorkEntries1)),
+          MatchedIdentifiers(recorderWorkEntriesToWorkIdentifiers(recorderWorkEntries2))
+        ))
+
+        whenReady(future) { _ =>
+          sendNotificationToSQS(queue = queue, message = matcherResult)
+
+          eventually {
+            assertQueueEmpty(queue)
+            assertQueueEmpty(dlq)
+
+            val worksSent = getMessages[BaseWork](topic).distinct
+            worksSent should have size 4
+
+            val redirectedWorks = worksSent.collect {
+              case work: UnidentifiedRedirectedWork => work
+            }
+            val mergedWorks = worksSent.collect {
+              case work: UnidentifiedWork => work
+            }
+
+            redirectedWorks should have size 2
+            mergedWorks should have size 2
+          }
         }
     }
   }


### PR DESCRIPTION
Consider the following scenario: four works joined together, which get split into two pairs of physical/digital works when a link breaks:

![graph](https://user-images.githubusercontent.com/301220/43578557-06e13606-9647-11e8-91f0-c2dd3757dba0.png)

The merger should send two digital works, two physical works; in fact, it sees an attempt to merge four works together and doesn't do any merging. I've added a test to show the error, and included a comment showing where I think the error appears.

Spotted doing a code read ahead of #1408.