### PR TITLE
Have per-library/app exceptions that extend GracefulFailureException, not throw it

### DIFF
--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
@@ -5,8 +5,8 @@ import java.sql.SQLIntegrityConstraintViolationException
 import com.google.inject.{Inject, Singleton}
 import com.twitter.inject.Logging
 import scalikejdbc._
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal.SourceIdentifier
+import uk.ac.wellcome.platform.idminter.database.exceptions.IdMinterException
 import uk.ac.wellcome.platform.idminter.models.{Identifier, IdentifiersTable}
 
 import scala.concurrent.blocking
@@ -76,7 +76,7 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
       case e: SQLIntegrityConstraintViolationException =>
         warn(
           s"Unable to insert $identifier because of integrity constraints: ${e.getMessage}")
-        throw GracefulFailureException(e)
+        throw IdMinterException(e)
       case e =>
         error(s"Failed inserting identifier $identifier in database", e)
         throw e

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/exceptions/IdMinterException.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/exceptions/IdMinterException.scala
@@ -1,0 +1,5 @@
+package uk.ac.wellcome.platform.idminter.database.exceptions
+
+import uk.ac.wellcome.exceptions.GracefulFailureException
+
+case class IdMinterException(e: Throwable) extends GracefulFailureException

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -2,8 +2,8 @@ package uk.ac.wellcome.platform.idminter.database
 
 import org.scalatest.{FunSpec, Matchers}
 import scalikejdbc._
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.test.util.IdentifiersUtil
+import uk.ac.wellcome.platform.idminter.database.exceptions.IdMinterException
 import uk.ac.wellcome.platform.idminter.fixtures
 import uk.ac.wellcome.platform.idminter.models.{Identifier, IdentifiersTable}
 import uk.ac.wellcome.test.fixtures.TestWith
@@ -122,7 +122,7 @@ class IdentifiersDaoTest
           val triedSave = identifiersDao.saveIdentifier(duplicateIdentifier)
 
           triedSave shouldBe a[Failure[_]]
-          triedSave.failed.get shouldBe a[GracefulFailureException]
+          triedSave.failed.get shouldBe a[IdMinterException]
       }
     }
 
@@ -198,7 +198,7 @@ class IdentifiersDaoTest
           val triedSave = identifiersDao.saveIdentifier(identifier2)
 
           triedSave shouldBe a[Failure[_]]
-          triedSave.failed.get shouldBe a[GracefulFailureException]
+          triedSave.failed.get shouldBe a[IdMinterException]
       }
     }
   }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/exceptions/IngestorException.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/exceptions/IngestorException.scala
@@ -1,0 +1,10 @@
+package uk.ac.wellcome.platform.ingestor.exceptions
+
+import uk.ac.wellcome.exceptions.GracefulFailureException
+
+case class IngestorException(e: Throwable) extends GracefulFailureException
+
+case object IngestorException {
+  def apply(message: String): IngestorException =
+    IngestorException(new RuntimeException(message))
+}

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -82,7 +82,8 @@ class IngestorWorkerService @Inject()(
       case sierraIdentifier.id =>
         Set(ingestorConfig.elasticConfig.indexV2name)
       case _ =>
-        throw IngestorException(s"Cannot ingest work with identifierType: ${work.sourceIdentifier.identifierType}")
+        throw IngestorException(
+          s"Cannot ingest work with identifierType: ${work.sourceIdentifier.identifierType}")
     }
 
   }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -3,10 +3,10 @@ package uk.ac.wellcome.platform.ingestor.services
 import akka.actor.{ActorSystem, Terminated}
 import com.amazonaws.services.sqs.model.Message
 import com.google.inject.Inject
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.messaging.message.MessageStream
 import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, IdentifierType}
 import uk.ac.wellcome.platform.ingestor.IngestorConfig
+import uk.ac.wellcome.platform.ingestor.exceptions.IngestorException
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -82,8 +82,7 @@ class IngestorWorkerService @Inject()(
       case sierraIdentifier.id =>
         Set(ingestorConfig.elasticConfig.indexV2name)
       case _ =>
-        throw GracefulFailureException(new RuntimeException(
-          s"Cannot ingest work with identifierType: ${work.sourceIdentifier.identifierType}"))
+        throw IngestorException(s"Cannot ingest work with identifierType: ${work.sourceIdentifier.identifierType}")
     }
 
   }

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/exceptions/MatcherException.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/exceptions/MatcherException.scala
@@ -1,0 +1,5 @@
+package uk.ac.wellcome.platform.matcher.exceptions
+
+import uk.ac.wellcome.exceptions.GracefulFailureException
+
+case class MatcherException(e: Throwable) extends GracefulFailureException

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
@@ -2,24 +2,11 @@ package uk.ac.wellcome.platform.matcher.matcher
 
 import com.google.inject.Inject
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.Sourced
-import uk.ac.wellcome.models.matcher.{
-  MatchedIdentifiers,
-  MatcherResult,
-  WorkIdentifier,
-  WorkNode
-}
-import uk.ac.wellcome.models.work.internal.{
-  TransformedBaseWork,
-  UnidentifiedInvisibleWork,
-  UnidentifiedWork
-}
-import uk.ac.wellcome.platform.matcher.locking.{
-  DynamoLockingService,
-  FailedLockException,
-  FailedUnlockException
-}
+import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult, WorkIdentifier, WorkNode}
+import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedInvisibleWork, UnidentifiedWork}
+import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
+import uk.ac.wellcome.platform.matcher.locking.{DynamoLockingService, FailedLockException, FailedUnlockException}
 import uk.ac.wellcome.platform.matcher.models._
 import uk.ac.wellcome.platform.matcher.storage.WorkGraphStore
 import uk.ac.wellcome.platform.matcher.workgraph.WorkGraphUpdater
@@ -52,7 +39,7 @@ class WorkMatcher @Inject()(
         case e @ (_: FailedLockException | _: FailedUnlockException) =>
           debug(
             s"Locking failed while matching work ${work.sourceIdentifier} ${e.getClass.getSimpleName} ${e.getMessage}")
-          throw GracefulFailureException(e)
+          throw MatcherException(e)
       }
   }
 

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
@@ -3,10 +3,23 @@ package uk.ac.wellcome.platform.matcher.matcher
 import com.google.inject.Inject
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.Sourced
-import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult, WorkIdentifier, WorkNode}
-import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedInvisibleWork, UnidentifiedWork}
+import uk.ac.wellcome.models.matcher.{
+  MatchedIdentifiers,
+  MatcherResult,
+  WorkIdentifier,
+  WorkNode
+}
+import uk.ac.wellcome.models.work.internal.{
+  TransformedBaseWork,
+  UnidentifiedInvisibleWork,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
-import uk.ac.wellcome.platform.matcher.locking.{DynamoLockingService, FailedLockException, FailedUnlockException}
+import uk.ac.wellcome.platform.matcher.locking.{
+  DynamoLockingService,
+  FailedLockException,
+  FailedUnlockException
+}
 import uk.ac.wellcome.platform.matcher.models._
 import uk.ac.wellcome.platform.matcher.storage.WorkGraphStore
 import uk.ac.wellcome.platform.matcher.workgraph.WorkGraphUpdater

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
@@ -7,8 +7,8 @@ import com.gu.scanamo.Scanamo
 import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo.syntax._
 import com.twitter.inject.Logging
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.matcher.WorkNode
+import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -25,7 +25,7 @@ class WorkNodeDao @Inject()(
       Scanamo.put(dynamoDbClient)(dynamoConfig.table)(work)
     }.recover {
       case exception: ProvisionedThroughputExceededException =>
-        throw GracefulFailureException(exception)
+        throw MatcherException(exception)
     }
 
   def get(ids: Set[String]): Future[Set[WorkNode]] =
@@ -44,7 +44,7 @@ class WorkNodeDao @Inject()(
         }
     }.recover {
       case exception: ProvisionedThroughputExceededException =>
-        throw GracefulFailureException(exception)
+        throw MatcherException(exception)
     }
 
   def getByComponentIds(setIds: Set[String]): Future[Set[WorkNode]] =
@@ -70,6 +70,6 @@ class WorkNodeDao @Inject()(
         }
     }.recover {
       case exception: ProvisionedThroughputExceededException =>
-        throw GracefulFailureException(exception)
+        throw MatcherException(exception)
     }
 }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -15,6 +15,7 @@ import uk.ac.wellcome.models.matcher.{
   WorkNode
 }
 import uk.ac.wellcome.models.work.internal.MergeCandidate
+import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.platform.matcher.locking.{
   DynamoRowLockDao,
@@ -232,7 +233,7 @@ class WorkMatcherTest
                     } yield result
 
                     whenReady(failedLock.failed) { failedMatch =>
-                      failedMatch shouldBe a[GracefulFailureException]
+                      failedMatch shouldBe a[MatcherException]
                     }
 
                   }
@@ -285,7 +286,7 @@ class WorkMatcherTest
                     } yield result
 
                     whenReady(failedLock.failed) { failedMatch =>
-                      failedMatch shouldBe a[GracefulFailureException]
+                      failedMatch shouldBe a[MatcherException]
                     }
                   }
               }
@@ -318,7 +319,7 @@ class WorkMatcherTest
                   whenReady(
                     workMatcher.matchWork(anUnidentifiedSierraWork).failed) {
                     failedMatch =>
-                      failedMatch shouldBe a[GracefulFailureException]
+                      failedMatch shouldBe a[MatcherException]
                   }
                 }
             }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -7,7 +7,6 @@ import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.matcher.{
   MatchedIdentifiers,
   MatcherResult,
@@ -213,7 +212,7 @@ class WorkMatcherTest
     }
   }
 
-  it("throws GracefulFailureException if it fails to lock primary works") {
+  it("throws MatcherException if it fails to lock primary works") {
     withMockMetricSender { mockMetricsSender =>
       withSpecifiedLocalDynamoDbTable(createLockTable) { lockTable =>
         withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { graphTable =>
@@ -245,7 +244,7 @@ class WorkMatcherTest
     }
   }
 
-  it("throws GracefulFailureException if it fails to lock secondary works") {
+  it("throws MatcherException if it fails to lock secondary works") {
     withMockMetricSender { mockMetricsSender =>
       withSpecifiedLocalDynamoDbTable(createLockTable) { lockTable =>
         withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { graphTable =>
@@ -297,7 +296,7 @@ class WorkMatcherTest
     }
   }
 
-  it("throws GracefulFailureException if it fails to unlock") {
+  it("throws MatcherException if it fails to unlock") {
     withMockMetricSender { mockMetricsSender =>
       withSpecifiedLocalDynamoDbTable(createLockTable) { lockTable =>
         withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { graphTable =>

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
@@ -177,7 +177,7 @@ class WorkGraphStoreTest
     }
   }
 
-  it("throws a GracefulFailureException if workGraphStore fails to put") {
+  it("throws a RuntimeException if workGraphStore fails to put") {
     val mockWorkNodeDao = mock[WorkNodeDao]
     val expectedException = new RuntimeException("FAILED")
     when(mockWorkNodeDao.put(any[WorkNode]))

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
@@ -10,8 +10,8 @@ import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.matcher.WorkNode
+import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
@@ -82,7 +82,7 @@ class WorkNodeDaoTest
         )
 
         whenReady(workNodeDao.get(Set("A")).failed) { failedException =>
-          failedException shouldBe a[GracefulFailureException]
+          failedException shouldBe a[MatcherException]
         }
       }
     }
@@ -150,7 +150,7 @@ class WorkNodeDaoTest
 
         whenReady(workNodeDao.getByComponentIds(Set("A+B")).failed) {
           failedException =>
-            failedException shouldBe a[GracefulFailureException]
+            failedException shouldBe a[MatcherException]
         }
       }
     }
@@ -230,7 +230,7 @@ class WorkNodeDaoTest
 
         whenReady(workNodeDao.put(WorkNode("A", 1, List("B"), "A+B")).failed) {
           failedException =>
-            failedException shouldBe a[GracefulFailureException]
+            failedException shouldBe a[MatcherException]
         }
       }
     }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/exceptions/TransformerException.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/exceptions/TransformerException.scala
@@ -1,0 +1,10 @@
+package uk.ac.wellcome.platform.transformer.exceptions
+
+import uk.ac.wellcome.exceptions.GracefulFailureException
+
+case class TransformerException(e: Throwable) extends GracefulFailureException
+
+case object TransformerException {
+  def apply(message: String): TransformerException =
+    TransformerException(new RuntimeException(message))
+}

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiver.scala
@@ -6,9 +6,16 @@ import com.twitter.inject.Logging
 import io.circe.ParsingFailure
 import uk.ac.wellcome.messaging.message.MessageWriter
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, PublishAttempt}
-import uk.ac.wellcome.models.transformable.{MiroTransformable, SierraTransformable, Transformable}
+import uk.ac.wellcome.models.transformable.{
+  MiroTransformable,
+  SierraTransformable,
+  Transformable
+}
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
-import uk.ac.wellcome.platform.transformer.transformers.{MiroTransformableTransformer, SierraTransformableTransformer}
+import uk.ac.wellcome.platform.transformer.transformers.{
+  MiroTransformableTransformer,
+  SierraTransformableTransformer
+}
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.vhs.{HybridRecord, SourceMetadata}
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectStore}

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiver.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiver.scala
@@ -4,23 +4,16 @@ import com.amazonaws.services.s3.AmazonS3
 import com.google.inject.Inject
 import com.twitter.inject.Logging
 import io.circe.ParsingFailure
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.messaging.message.MessageWriter
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, PublishAttempt}
-import uk.ac.wellcome.models.transformable.{
-  MiroTransformable,
-  SierraTransformable,
-  Transformable
-}
+import uk.ac.wellcome.models.transformable.{MiroTransformable, SierraTransformable, Transformable}
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
-import uk.ac.wellcome.platform.transformer.transformers.{
-  MiroTransformableTransformer,
-  SierraTransformableTransformer
-}
+import uk.ac.wellcome.platform.transformer.transformers.{MiroTransformableTransformer, SierraTransformableTransformer}
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.vhs.{HybridRecord, SourceMetadata}
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectStore}
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -53,7 +46,7 @@ class NotificationMessageReceiver @Inject()(
       .recover {
         case e: ParsingFailure =>
           info("Recoverable failure parsing HybridRecord from message", e)
-          throw GracefulFailureException(e)
+          throw TransformerException(e)
       }
       .map(_ => ())
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributors.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributors.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.transformer.transformers.miro
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal
 import uk.ac.wellcome.models.work.internal.{Agent, Contributor, Unidentifiable}
+import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.source.MiroTransformableData
 
 trait MiroContributors extends MiroContributorCodes {
@@ -35,9 +36,9 @@ trait MiroContributors extends MiroContributorCodes {
           case Some("Wellcome Collection") => None
           case Some(s)                     => Some(s)
           case None =>
-            throw GracefulFailureException(new RuntimeException(
+            throw TransformerException(
               s"Unable to look up contributor credit line for ${miroData.sourceCode} on ${miroId}"
-            ))
+            )
         }
       case None => None
     }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributors.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/miro/MiroContributors.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.transformer.transformers.miro
 
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal
 import uk.ac.wellcome.models.work.internal.{Agent, Contributor, Unidentifiable}
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributors.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributors.scala
@@ -126,8 +126,9 @@ trait SierraContributors extends MarcUtils {
 
     maybeSubfieldA match {
       case Some(content) => content
-      case None => throw TransformerException(
-        s"Unable to find subfield $$a? <<$subfields>>")
+      case None =>
+        throw TransformerException(
+          s"Unable to find subfield $$a? <<$subfields>>")
     }
   }
 
@@ -177,8 +178,9 @@ trait SierraContributors extends MarcUtils {
           sourceIdentifier = sourceIdentifier
         )
       }
-      case _ => throw TransformerException(
-        s"Multiple identifiers in subfield $$0: $codes")
+      case _ =>
+        throw TransformerException(
+          s"Multiple identifiers in subfield $$0: $codes")
     }
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributors.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributors.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, SierraBibData}
 
 trait SierraContributors extends MarcUtils {
@@ -126,11 +126,8 @@ trait SierraContributors extends MarcUtils {
 
     maybeSubfieldA match {
       case Some(content) => content
-      case None =>
-        throw GracefulFailureException(
-          new RuntimeException(
-            s"Unable to find subfield $$a?  $subfields"
-          ))
+      case None => throw TransformerException(
+        s"Unable to find subfield $$a? <<$subfields>>")
     }
   }
 
@@ -180,9 +177,8 @@ trait SierraContributors extends MarcUtils {
           sourceIdentifier = sourceIdentifier
         )
       }
-      case _ =>
-        throw GracefulFailureException(
-          new RuntimeException(s"Multiple identifiers in subfield $$0: $codes"))
+      case _ => throw TransformerException(
+        s"Multiple identifiers in subfield $$0: $codes")
     }
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
@@ -1,16 +1,12 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraItemNumber
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.source.{
-  SierraBibData,
-  SierraItemData,
-  SierraMaterialType
-}
+import uk.ac.wellcome.platform.transformer.source.{SierraBibData, SierraItemData, SierraMaterialType}
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 
 import scala.util.{Failure, Success}
 
@@ -24,10 +20,8 @@ trait SierraItems extends Logging with SierraLocation {
           fromJson[SierraItemData](jsonString) match {
             case Success(data) => id -> data
             case Failure(_) =>
-              throw GracefulFailureException(
-                new RuntimeException(
-                  s"Unable to parse item data for $id as JSON: <<$jsonString>>"
-                ))
+              throw TransformerException(
+                s"Unable to parse item data for $id as JSON: <<$jsonString>>")
           }
       }
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItems.scala
@@ -4,7 +4,11 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraItemNumber
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.source.{SierraBibData, SierraItemData, SierraMaterialType}
+import uk.ac.wellcome.platform.transformer.source.{
+  SierraBibData,
+  SierraItemData,
+  SierraMaterialType
+}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocation.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocation.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
-import uk.ac.wellcome.platform.transformer.source.{SierraItemData, SierraItemLocation}
+import uk.ac.wellcome.platform.transformer.source.{
+  SierraItemData,
+  SierraItemLocation
+}
 
 trait SierraLocation {
   def getPhysicalLocation(itemData: SierraItemData): Option[PhysicalLocation] =

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocation.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocation.scala
@@ -1,11 +1,8 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.source.{
-  SierraItemData,
-  SierraItemLocation
-}
+import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
+import uk.ac.wellcome.platform.transformer.source.{SierraItemData, SierraItemLocation}
 
 trait SierraLocation {
   def getPhysicalLocation(itemData: SierraItemData): Option[PhysicalLocation] =
@@ -36,9 +33,8 @@ trait SierraLocation {
         locationType = LocationType("iiif-presentation")
       )
     } else {
-      throw GracefulFailureException(
-        new RuntimeException(
-          "id required by DigitalLocation has not been provided"))
+      throw TransformerException(
+        "id required by DigitalLocation has not been provided")
     }
   }
 }

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, SierraBibData, VarField}

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
@@ -2,11 +2,8 @@ package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.source.{
-  MarcSubfield,
-  SierraBibData,
-  VarField
-}
+import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
+import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, SierraBibData, VarField}
 
 trait SierraProduction {
 
@@ -132,9 +129,9 @@ trait SierraProduction {
           case Some("2") => "Distribution"
           case Some("3") => "Manufacture"
           case other =>
-            throw GracefulFailureException(new RuntimeException(
+            throw TransformerException(
               s"Unrecognised second indicator for production function: [$other]"
-            ))
+            )
         }
 
         val productionFunction = Some(Concept(label = productionFunctionLabel))
@@ -191,10 +188,9 @@ trait SierraProduction {
     // Otherwise this is some sort of cataloguing error.  This is fairly
     // rare, so let it bubble on to a DLQ.
     else {
-      throw GracefulFailureException(
-        new RuntimeException(
-          "Record has both 260 and 264 fields; this is a cataloguing error."
-        ))
+      throw TransformerException(
+        "Record has both 260 and 264 fields; this is a cataloguing error."
+      )
     }
   }
 

--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProduction.scala
@@ -2,7 +2,11 @@ package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
-import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, SierraBibData, VarField}
+import uk.ac.wellcome.platform.transformer.source.{
+  MarcSubfield,
+  SierraBibData,
+  VarField
+}
 
 trait SierraProduction {
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/receive/NotificationMessageReceiverTest.scala
@@ -7,7 +7,6 @@ import org.mockito.Mockito.when
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.exceptions.JsonDecodingError
 import uk.ac.wellcome.messaging.message.{MessageWriter, MessageWriterConfig}
@@ -24,6 +23,7 @@ import uk.ac.wellcome.models.work.internal.{
   TransformedBaseWork,
   UnidentifiedWork
 }
+import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.platform.transformer.utils.TransformableMessageUtils
 import uk.ac.wellcome.storage.fixtures.S3
@@ -149,7 +149,7 @@ class NotificationMessageReceiverTest
             val future = recordReceiver.receiveMessage(invalidSqsMessage)
 
             whenReady(future.failed) { x =>
-              x shouldBe a[GracefulFailureException]
+              x shouldBe a[TransformerException]
             }
           }
         }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributorsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributorsTest.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, VarField}
 import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
@@ -670,7 +670,7 @@ class SierraContributorsTest extends FunSpec with Matchers with SierraDataUtil {
   private def assertTransformFails(varFields: List[VarField]) = {
     val bibData = createSierraBibDataWith(varFields = varFields)
 
-    intercept[GracefulFailureException] {
+    intercept[TransformerException] {
       transformer.getContributors(bibData)
     }
   }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributorsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributorsTest.scala
@@ -645,7 +645,7 @@ class SierraContributorsTest extends FunSpec with Matchers with SierraDataUtil {
     }
   }
 
-  it("throws a GracefulFailureException if subfield $$a is missing") {
+  it("fails the transform if subfield $$a is missing") {
     val varFields = List(
       VarField(
         fieldTag = "p",

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraItemsTest.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.source.SierraItemData
 import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
@@ -43,7 +43,7 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataUtil {
         itemRecords = itemRecords
       )
 
-      val caught = intercept[GracefulFailureException] {
+      val caught = intercept[TransformerException] {
         transformer.extractItemData(transformable)
       }
 

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocationTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraLocationTest.scala
@@ -1,12 +1,12 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal.{
   DigitalLocation,
   LocationType,
   PhysicalLocation
 }
+import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.source.SierraItemLocation
 import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
@@ -64,7 +64,7 @@ class SierraLocationTest extends FunSpec with Matchers with SierraDataUtil {
     }
 
     it("throws an exception if no resource identifier is supplied") {
-      val caught = intercept[GracefulFailureException] {
+      val caught = intercept[TransformerException] {
         transformer.getDigitalLocation(identifier = "")
       }
       caught.getMessage shouldEqual "id required by DigitalLocation has not been provided"

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProductionTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraProductionTest.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.transformer.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.source.{MarcSubfield, VarField}
 import uk.ac.wellcome.platform.transformer.utils.SierraDataUtil
 
@@ -256,7 +256,7 @@ class SierraProductionTest extends FunSpec with Matchers with SierraDataUtil {
           )
         )
 
-        val caught = intercept[GracefulFailureException] {
+        val caught = intercept[TransformerException] {
           transformToProduction(varFields)
         }
 
@@ -510,7 +510,7 @@ class SierraProductionTest extends FunSpec with Matchers with SierraDataUtil {
   private def transformVarFieldsAndAssertIsError(varFields: List[VarField]) = {
     val bibData = createSierraBibDataWith(varFields = varFields)
 
-    intercept[GracefulFailureException] {
+    intercept[TransformerException] {
       transformer.getProduction(bibData)
     }
   }

--- a/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/exceptions/ReindexerException.scala
+++ b/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/exceptions/ReindexerException.scala
@@ -1,0 +1,10 @@
+package uk.ac.wellcome.platform.reindex.creator.exceptions
+
+import uk.ac.wellcome.exceptions.GracefulFailureException
+
+case class ReindexerException(e: Throwable) extends GracefulFailureException
+
+case object ReindexerException {
+  def apply(message: String): ReindexerException =
+    ReindexerException(new RuntimeException(message))
+}

--- a/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/services/RecordReader.scala
+++ b/reindexer/reindex_request_creator/src/main/scala/uk/ac/wellcome/platform/reindex/creator/services/RecordReader.scala
@@ -7,8 +7,8 @@ import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo.query._
 import com.gu.scanamo.syntax._
 import com.twitter.inject.Logging
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.reindexer.ReindexableRecord
+import uk.ac.wellcome.platform.reindex.creator.exceptions.ReindexerException
 import uk.ac.wellcome.platform.reindex.creator.models.ReindexJob
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
@@ -59,9 +59,7 @@ class RecordReader @Inject()(
     scanamoResult match {
       case Left(err: DynamoReadError) => {
         warn(s"Failed to read Dynamo records: $err")
-        throw GracefulFailureException(
-          new RuntimeException(s"Error in the DynamoDB query: $err")
-        )
+        throw ReindexerException(s"Error in the DynamoDB query: $err")
       }
       case Right(r: ReindexableRecord) => r.id
     }

--- a/sbt_common/common/src/main/scala/uk/ac/wellcome/exceptions/GracefulFailureException.scala
+++ b/sbt_common/common/src/main/scala/uk/ac/wellcome/exceptions/GracefulFailureException.scala
@@ -1,4 +1,5 @@
 package uk.ac.wellcome.exceptions
 
-case class GracefulFailureException(e: Throwable)
-    extends Exception(e.getMessage)
+trait GracefulFailureException extends Exception { self: Throwable =>
+  val message: String = self.getMessage
+}

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/exceptions/DisplayException.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/exceptions/DisplayException.scala
@@ -1,0 +1,10 @@
+package uk.ac.wellcome.display.exceptions
+
+import uk.ac.wellcome.exceptions.GracefulFailureException
+
+case class DisplayException(e: Throwable) extends GracefulFailureException
+
+case object DisplayException {
+  def apply(message: String): DisplayException =
+    DisplayException(new RuntimeException(message))
+}

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayAgentV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayAgentV1.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.display.models.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.exceptions.GracefulFailureException
+import uk.ac.wellcome.display.exceptions.DisplayException
 import uk.ac.wellcome.models.work.internal._
 
 /** Represents an Agent in the API.
@@ -34,10 +34,8 @@ case object DisplayAgentV1 {
       // bits here, error out -- the nature of the Miro data means we
       // should never hit this in practice.
       case Identified(_, _, _, _) =>
-        throw GracefulFailureException(
-          new RuntimeException(
-            s"Unexpectedly asked to convert identified agent ${displayableAgent} to DisplayAgentV1"
-          )
+        throw DisplayException(
+          s"Unexpectedly asked to convert identified agent $displayableAgent to DisplayAgentV1"
         )
     }
 }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
@@ -2,8 +2,8 @@ package uk.ac.wellcome.display.models.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.display.exceptions.DisplayException
 import uk.ac.wellcome.display.models._
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal.{
   AbstractAgent,
   Contributor,
@@ -112,10 +112,9 @@ case object DisplayWorkV1 {
     // data, which never populates the production field -- so rather than
     // writing and testing code to tease it out, just error here instead.
     if (work.production != Nil) {
-      throw GracefulFailureException(
-        new RuntimeException(
-          s"IdentifiedWork ${work.canonicalId} has production fields set, cannot be converted to a V1 DisplayWork"
-        ))
+      throw DisplayException(
+        s"IdentifiedWork ${work.canonicalId} has production fields set, cannot be converted to a V1 DisplayWork"
+      )
     }
 
     DisplayWorkV1(

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayAgentV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayAgentV1Test.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.exceptions.GracefulFailureException
+import uk.ac.wellcome.display.exceptions.DisplayException
 import uk.ac.wellcome.models.work.internal.{Agent, Identified}
 import uk.ac.wellcome.models.work.test.util.IdentifiersUtil
 
@@ -16,7 +16,7 @@ class DisplayAgentV1Test extends FunSpec with Matchers with IdentifiersUtil {
       otherIdentifiers = List()
     )
 
-    val caught = intercept[GracefulFailureException] {
+    val caught = intercept[DisplayException] {
       DisplayAgentV1(agent)
     }
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.display.exceptions.DisplayException
 import uk.ac.wellcome.display.models._
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.test.util.WorksUtil
 
@@ -209,7 +209,7 @@ class DisplayWorkV1Test extends FunSpec with Matchers with WorksUtil {
       )
     )
 
-    val caught = intercept[GracefulFailureException] {
+    val caught = intercept[DisplayException] {
       DisplayWorkV1(work)
     }
 

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/exceptions/InternalModelException.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/exceptions/InternalModelException.scala
@@ -1,0 +1,10 @@
+package uk.ac.wellcome.models.exceptions
+
+import uk.ac.wellcome.exceptions.GracefulFailureException
+
+case class InternalModelException(e: Throwable) extends GracefulFailureException
+
+case object InternalModelException {
+  def apply(message: String): InternalModelException =
+    InternalModelException(new RuntimeException(message))
+}

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdentifierType.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdentifierType.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.models.work.internal
 
 import java.io.InputStream
 
-import uk.ac.wellcome.exceptions.GracefulFailureException
+import uk.ac.wellcome.models.exceptions.InternalModelException
 
 import scala.io.Source
 
@@ -44,8 +44,7 @@ case object IdentifierType {
     identifierTypeMap.get(platformId) match {
       case Some(id) => id
       case None =>
-        throw GracefulFailureException(
-          new RuntimeException(s"Unrecognised identifier type: [$platformId]")
-        )
+        throw InternalModelException(
+          s"Unrecognised identifier type: [$platformId]")
     }
 }

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/LocationType.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/LocationType.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.models.work.internal
 import java.io.InputStream
 
 import com.github.tototoshi.csv.CSVReader
-import uk.ac.wellcome.exceptions.GracefulFailureException
+import uk.ac.wellcome.models.exceptions.InternalModelException
 
 import scala.io.Source
 
@@ -44,9 +44,7 @@ case object LocationType {
     locationTypeMap.get(id) match {
       case Some(id) => id
       case None =>
-        throw GracefulFailureException(
-          new RuntimeException(s"Unrecognised location type: [$id]")
-        )
+        throw InternalModelException(s"Unrecognised location type: [$id]")
     }
   }
 

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifierTypeTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/IdentifierTypeTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.models.work.internal
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.exceptions.GracefulFailureException
+import uk.ac.wellcome.models.exceptions.InternalModelException
 
 class IdentifierTypeTest extends FunSpec with Matchers {
   it("looks up an identifier type in the CSV") {
@@ -12,7 +12,7 @@ class IdentifierTypeTest extends FunSpec with Matchers {
   }
 
   it("throws an error if looking up a non-existent identifier type") {
-    val caught = intercept[GracefulFailureException] {
+    val caught = intercept[InternalModelException] {
       IdentifierType(platformId = "DoesNotExist")
     }
     caught.e.getMessage shouldBe "Unrecognised identifier type: [DoesNotExist]"

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LocationTypeTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LocationTypeTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.models.work.internal
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.exceptions.GracefulFailureException
+import uk.ac.wellcome.models.exceptions.InternalModelException
 
 class LocationTypeTest extends FunSpec with Matchers {
   it("looks up a location type") {
@@ -12,7 +12,7 @@ class LocationTypeTest extends FunSpec with Matchers {
   }
 
   it("throws an error if looking up a non-existent location type") {
-    val caught = intercept[GracefulFailureException] {
+    val caught = intercept[InternalModelException] {
       LocationType(id = "DoesNotExist")
     }
     caught.e.getMessage shouldBe "Unrecognised location type: [DoesNotExist]"

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -35,7 +35,6 @@ class SierraBibMergerWorkerServiceTest
 
   it(
     "throws a GracefulFailureException if the message on the queue does not represent a SierraRecord") {
-
     withWorkerServiceFixtures {
       case (metricsSender, QueuePair(queue, dlq), _) =>
         sendNotificationToSQS(

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/exceptions/SierraItemMergerException.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/exceptions/SierraItemMergerException.scala
@@ -1,0 +1,10 @@
+package uk.ac.wellcome.platform.sierra_item_merger.exceptions
+
+import uk.ac.wellcome.exceptions.GracefulFailureException
+
+case class SierraItemMergerException(e: Throwable) extends GracefulFailureException
+
+case object SierraItemMergerException {
+  def apply(message: String): SierraItemMergerException =
+    SierraItemMergerException(new RuntimeException(message))
+}

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/exceptions/SierraItemMergerException.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/exceptions/SierraItemMergerException.scala
@@ -2,7 +2,8 @@ package uk.ac.wellcome.platform.sierra_item_merger.exceptions
 
 import uk.ac.wellcome.exceptions.GracefulFailureException
 
-case class SierraItemMergerException(e: Throwable) extends GracefulFailureException
+case class SierraItemMergerException(e: Throwable)
+    extends GracefulFailureException
 
 case object SierraItemMergerException {
   def apply(message: String): SierraItemMergerException =

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.sierra_item_merger.services
 
 import com.google.inject.Inject
 import com.twitter.inject.Logging
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 import uk.ac.wellcome.platform.sierra_item_merger.links.ItemLinker
@@ -10,6 +9,7 @@ import uk.ac.wellcome.platform.sierra_item_merger.links.ItemUnlinker
 import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.vhs.{SourceMetadata, VersionedHybridStore}
 import uk.ac.wellcome.models.Sourced
+import uk.ac.wellcome.platform.sierra_item_merger.exceptions.SierraItemMergerException
 import uk.ac.wellcome.storage.ObjectStore
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -44,10 +44,9 @@ class SierraItemMergerUpdaterService @Inject()(
       itemRecord.unlinkedBibIds.map { unlinkedBibId =>
         versionedHybridStore.updateRecord(
           Sourced.id(sourceName, unlinkedBibId.withoutCheckDigit))(
-          ifNotExisting = throw GracefulFailureException(
-            new RuntimeException(
-              s"Missing Bib record to unlink: $unlinkedBibId")
-          ))(
+          ifNotExisting = throw SierraItemMergerException(
+            s"Missing Bib record to unlink: $unlinkedBibId")
+        )(
           ifExisting = (record, _) =>
             (
               ItemUnlinker.unlinkItemRecord(record, itemRecord),

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/exceptions/SierraReaderException.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/exceptions/SierraReaderException.scala
@@ -1,0 +1,10 @@
+package uk.ac.wellcome.platform.sierra_reader.exceptions
+
+import uk.ac.wellcome.exceptions.GracefulFailureException
+
+case class SierraReaderException(e: Throwable) extends GracefulFailureException
+
+case object SierraReaderException {
+  def apply(message: String): SierraReaderException =
+    SierraReaderException(new RuntimeException(message))
+}

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManager.scala
@@ -59,7 +59,8 @@ class WindowManager @Inject()(
             val newId = (id.toInt + 1).toString
             WindowStatus(id = newId, offset = offset + 1)
           case None =>
-            throw SierraReaderException(s"JSON <<$lastBody>> did not contain an id")
+            throw SierraReaderException(
+              s"JSON <<$lastBody>> did not contain an id")
         }
       }
       case None => WindowStatus(id = None, offset = 0)

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowExtractor.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowExtractor.scala
@@ -7,7 +7,7 @@ import com.twitter.inject.Logging
 import io.circe.Json
 import io.circe.optics.JsonPath.root
 import io.circe.parser.parse
-import uk.ac.wellcome.exceptions.GracefulFailureException
+import uk.ac.wellcome.platform.sierra_reader.exceptions.SierraReaderException
 
 import scala.util.Try
 
@@ -31,7 +31,7 @@ object WindowExtractor extends Logging {
       .recover {
         case e: Exception =>
           warn(s"Error parsing $jsonString", e)
-          throw GracefulFailureException(e)
+          throw SierraReaderException(e)
       }
 
   private def extractField(field: String, json: Json) = {

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.sierra_reader.modules
 import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraUtil
 import uk.ac.wellcome.platform.sierra_reader.models.{
@@ -17,6 +16,7 @@ import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures.TestWith
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.sierra_reader.exceptions.SierraReaderException
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -98,7 +98,7 @@ class WindowManagerTest
         val result = windowManager.getCurrentStatus("[2013,2014]")
 
         whenReady(result.failed) {
-          _ shouldBe a[GracefulFailureException]
+          _ shouldBe a[SierraReaderException]
         }
       }
     }
@@ -114,7 +114,7 @@ class WindowManagerTest
         val result = windowManager.getCurrentStatus("[2013,2014]")
 
         whenReady(result.failed) {
-          _ shouldBe a[GracefulFailureException]
+          _ shouldBe a[SierraReaderException]
         }
       }
     }
@@ -130,7 +130,7 @@ class WindowManagerTest
         val result = windowManager.getCurrentStatus("[2013,2014]")
 
         whenReady(result.failed) {
-          _ shouldBe a[GracefulFailureException]
+          _ shouldBe a[SierraReaderException]
         }
       }
     }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -231,8 +231,7 @@ class SierraReaderWorkerServiceTest
 
   }
 
-  it(
-    "doesn't return a SierraReaderException if it cannot reach the Sierra API") {
+  it("doesn't return a SierraReaderException if it cannot reach the Sierra API") {
     withSierraReaderWorkerService(fields = "", apiUrl = "http://localhost:5050") {
       fixtures =>
         val body =

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -6,7 +6,6 @@ import uk.ac.wellcome.test.utils.ExtendedPatience
 import org.scalatest.FunSpec
 import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.sierra_reader.modules.WindowManager
 import uk.ac.wellcome.storage.s3.S3Config
@@ -20,6 +19,7 @@ import uk.ac.wellcome.models.transformable.sierra.{
   SierraBibRecord,
   SierraItemRecord
 }
+import uk.ac.wellcome.platform.sierra_reader.exceptions.SierraReaderException
 import uk.ac.wellcome.platform.sierra_reader.models.{
   ReaderConfig,
   SierraConfig,
@@ -224,7 +224,7 @@ class SierraReaderWorkerServiceTest
       val notificationMessage = createNotificationMessageWith(body = body)
       whenReady(fixtures.worker.processMessage(notificationMessage).failed) {
         ex =>
-          ex shouldBe a[GracefulFailureException]
+          ex shouldBe a[SierraReaderException]
       }
 
     }
@@ -247,7 +247,7 @@ class SierraReaderWorkerServiceTest
 
         whenReady(fixtures.worker.processMessage(notificationMessage).failed) {
           ex =>
-            ex shouldNot be(a[GracefulFailureException])
+            ex shouldNot be(a[SierraReaderException])
         }
     }
   }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -212,7 +212,7 @@ class SierraReaderWorkerServiceTest
     getObjectFromS3[List[SierraItemRecord]](bucket, key)
 
   it(
-    "returns a GracefulFailureException if it receives a message that doesn't contain start or end values") {
+    "returns a SierraReaderException if it receives a message that doesn't contain start or end values") {
     withSierraReaderWorkerService(fields = "") { fixtures =>
       val body =
         """
@@ -232,7 +232,7 @@ class SierraReaderWorkerServiceTest
   }
 
   it(
-    "does not return a GracefulFailureException if it cannot reach the Sierra API") {
+    "doesn't return a SierraReaderException if it cannot reach the Sierra API") {
     withSierraReaderWorkerService(fields = "", apiUrl = "http://localhost:5050") {
       fixtures =>
         val body =

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowExtractorTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowExtractorTest.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.platform.sierra_reader.services
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.exceptions.GracefulFailureException
+import uk.ac.wellcome.platform.sierra_reader.exceptions.SierraReaderException
 
 class WindowExtractorTest extends FunSpec with Matchers {
 
-  it("should extract a valid message window from a json string") {
+  it("extracts a valid message window from a json string") {
     val start = "2013-12-10T17:16:35Z"
     val end = "2013-12-13T21:34:35Z"
     val jsonString =
@@ -18,8 +18,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor.extractWindow(jsonString).get shouldBe s"[$start,$end]"
   }
 
-  it(
-    "should return a GracefulFailureException if start is not a valid iso datetime") {
+  it("returns a SierraReaderException if start is not a valid iso datetime") {
     val jsonString =
       s"""
          |{
@@ -30,11 +29,11 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor
       .extractWindow(jsonString)
       .failed
-      .get shouldBe a[GracefulFailureException]
+      .get shouldBe a[SierraReaderException]
   }
 
   it(
-    "should return a GracefulFailureException if start is a datetime but does not have a timezone") {
+    "returns a SierraReaderException if start is a datetime but does not have a timezone") {
     val jsonString =
       s"""
          |{
@@ -45,11 +44,10 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor
       .extractWindow(jsonString)
       .failed
-      .get shouldBe a[GracefulFailureException]
+      .get shouldBe a[SierraReaderException]
   }
 
-  it(
-    "should return a GracefulFailureException if end is not a valid iso datetime") {
+  it("returns a SierraReaderException if end is not a valid iso datetime") {
     val jsonString =
       s"""
          |{
@@ -60,11 +58,11 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor
       .extractWindow(jsonString)
       .failed
-      .get shouldBe a[GracefulFailureException]
+      .get shouldBe a[SierraReaderException]
   }
 
   it(
-    "should return a GracefulFailureException if end is a datetime but does not have a timezone") {
+    "returns a SierraReaderException if end is a datetime but does not have a timezone") {
     val jsonString =
       s"""
          |{
@@ -75,11 +73,10 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor
       .extractWindow(jsonString)
       .failed
-      .get shouldBe a[GracefulFailureException]
+      .get shouldBe a[SierraReaderException]
   }
 
-  it(
-    "should return a GracefulFailureException if there is not a start datetime") {
+  it("returns a SierraReaderException if there is not a start datetime") {
     val jsonString =
       s"""
          |{
@@ -89,10 +86,10 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor
       .extractWindow(jsonString)
       .failed
-      .get shouldBe a[GracefulFailureException]
+      .get shouldBe a[SierraReaderException]
   }
 
-  it("should return a GracefulFailureException if there is not an end datetime") {
+  it("returns a SierraReaderException if there is not an end datetime") {
     val jsonString =
       s"""
          |{
@@ -102,11 +99,11 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor
       .extractWindow(jsonString)
       .failed
-      .get shouldBe a[GracefulFailureException]
+      .get shouldBe a[SierraReaderException]
   }
 
   it(
-    "should return a GracefulFailureException if the start time is after the end time") {
+    "returns a SierraReaderException if the start time is after the end time") {
     val jsonString =
       s"""
          |{
@@ -117,11 +114,11 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor
       .extractWindow(jsonString)
       .failed
-      .get shouldBe a[GracefulFailureException]
+      .get shouldBe a[SierraReaderException]
   }
 
   it(
-    "should return a GracefulFailureException if the start time is equal to the end time") {
+    "returns a SierraReaderException if the start time is equal to the end time") {
     val jsonString =
       s"""
          |{
@@ -132,6 +129,6 @@ class WindowExtractorTest extends FunSpec with Matchers {
     WindowExtractor
       .extractWindow(jsonString)
       .failed
-      .get shouldBe a[GracefulFailureException]
+      .get shouldBe a[SierraReaderException]
   }
 }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowExtractorTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowExtractorTest.scala
@@ -102,8 +102,7 @@ class WindowExtractorTest extends FunSpec with Matchers {
       .get shouldBe a[SierraReaderException]
   }
 
-  it(
-    "returns a SierraReaderException if the start time is after the end time") {
+  it("returns a SierraReaderException if the start time is after the end time") {
     val jsonString =
       s"""
          |{


### PR DESCRIPTION
This is prep for removing the messaging library – we can deftly swap out these per-lib/app exceptions to extend from a different exception.

It also exposes a problem we have with removing messaging – because we want to catch all these exceptions as recognised failures, but internal_model and display won't be able to subclass that unless we suddenly flip them to depend on messaging.