### PR TITLE
Break up MergerWorkerService to add a PlaybackService

### DIFF
--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/modules/RecorderWorkEntryModule.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/modules/RecorderWorkEntryModule.scala
@@ -13,7 +13,7 @@ import scala.concurrent.ExecutionContext
 object RecorderWorkEntryModule extends TwitterModule {
   @Provides
   @Singleton
-  def provideUnidentifiedWorkStore(
+  def provideRecorderWorkEntryStore(
     injector: Injector): ObjectStore[RecorderWorkEntry] = {
     implicit val storageBackend = injector.instance[S3StorageBackend]
     implicit val executionContext = injector.instance[ExecutionContext]

--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
@@ -9,9 +9,6 @@ import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.models.matcher.{MatcherResult, WorkIdentifier}
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
 import uk.ac.wellcome.models.work.internal.{BaseWork, UnidentifiedWork}
-import uk.ac.wellcome.storage.ObjectStore
-import uk.ac.wellcome.storage.dynamo._
-import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}
 import uk.ac.wellcome.json.JsonUtil._
 
 import scala.collection.Set
@@ -20,9 +17,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class MergerWorkerService @Inject()(
   system: ActorSystem,
   sqsStream: SQSStream[NotificationMessage],
-  vhs: VersionedHybridStore[RecorderWorkEntry,
-                            EmptyMetadata,
-                            ObjectStore[RecorderWorkEntry]],
+  playbackService: RecorderPlaybackService,
   merger: Merger,
   messageWriter: MessageWriter[BaseWork]
 )(implicit ec: ExecutionContext)
@@ -52,15 +47,9 @@ class MergerWorkerService @Inject()(
   }
 
   private def getFromVHS(
-    matcherResult: MatcherResult): Future[List[Option[RecorderWorkEntry]]] = {
-    val worksIdentifiers = getWorksIdentifiers(matcherResult)
-    for {
-      maybeWorkEntries <- Future.sequence(worksIdentifiers.toList.map {
-        workId =>
-          getRecorderEntryForIdentifier(workId)
-      })
-    } yield maybeWorkEntries
-  }
+    matcherResult: MatcherResult): Future[List[Option[RecorderWorkEntry]]] =
+    playbackService
+      .fetchAllRecorderWorkEntries(getWorksIdentifiers(matcherResult).toList)
 
   private def sendWorks(mergedWorks: Seq[BaseWork]) = {
     Future
@@ -76,26 +65,6 @@ class MergerWorkerService @Inject()(
       matchedIdentifiers <- matcherResult.works
       workIdentifier <- matchedIdentifiers.identifiers
     } yield workIdentifier
-  }
-
-  private def getRecorderEntryForIdentifier(
-    workIdentifier: WorkIdentifier): Future[Option[RecorderWorkEntry]] = {
-    workIdentifier.version match {
-      case 0 =>
-        Future.successful(None)
-      case _ =>
-        vhs.getRecord(id = workIdentifier.identifier).map {
-          case None =>
-            throw new RuntimeException(
-              s"Work ${workIdentifier.identifier} is not in vhs!")
-          case Some(record) if record.work.version == workIdentifier.version =>
-            Some(record)
-          case Some(record) =>
-            debug(
-              s"VHS version = ${record.work.version}, identifier version = ${workIdentifier.version}, so discarding work")
-            None
-        }
-    }
   }
 
   def stop(): Future[Terminated] = system.terminate()

--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackService.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackService.scala
@@ -5,9 +5,10 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.matcher.WorkIdentifier
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
 import uk.ac.wellcome.storage.ObjectStore
+import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 /** Before the matcher/merger, the recorder stores a copy of every
   * transformed work in an instance of the VHS.
@@ -20,7 +21,7 @@ class RecorderPlaybackService @Inject() (
   versionedHybridStore: VersionedHybridStore[RecorderWorkEntry,
                                              EmptyMetadata,
                                              ObjectStore[RecorderWorkEntry]],
-) extends Logging {
+)(implicit ec: ExecutionContext) extends Logging {
 
   /** Given a collection of matched identifiers, return all the
     * corresponding works from VHS.

--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackService.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackService.scala
@@ -1,0 +1,60 @@
+package uk.ac.wellcome.platform.merger.services
+
+import com.google.inject.Inject
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.models.matcher.WorkIdentifier
+import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
+import uk.ac.wellcome.storage.ObjectStore
+import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}
+
+import scala.concurrent.Future
+
+/** Before the matcher/merger, the recorder stores a copy of every
+  * transformed work in an instance of the VHS.
+  *
+  * This class looks up recorded works in the VHS, and returns them
+  * so the merger has everything it needs to work with.
+  *
+  */
+class RecorderPlaybackService @Inject() (
+  versionedHybridStore: VersionedHybridStore[RecorderWorkEntry,
+                                             EmptyMetadata,
+                                             ObjectStore[RecorderWorkEntry]],
+) extends Logging {
+
+  /** Given a collection of matched identifiers, return all the
+    * corresponding works from VHS.
+    */
+  def fetchAllRecorderWorkEntries(works: List[WorkIdentifier]): Future[List[Option[RecorderWorkEntry]]] = {
+    Future.sequence(
+      works
+        .map { getRecorderEntryForIdentifier }
+    )
+  }
+
+  /** Retrieve a single work from the recorder table.
+    *
+    * If the work is present in VHS but has a different version to what
+    * we're expecting, this method returns [[None]].
+    *
+    * If the work is missing from VHS, it throws [[NoSuchElementException]].
+    */
+  private def getRecorderEntryForIdentifier(
+    workIdentifier: WorkIdentifier): Future[Option[RecorderWorkEntry]] = {
+    workIdentifier.version match {
+      case 0 => Future.successful(None)
+      case _ =>
+        versionedHybridStore.getRecord(id = workIdentifier.identifier).map {
+          case None =>
+            throw new NoSuchElementException(
+              s"Work ${workIdentifier.identifier} is not in VHS!")
+          case Some(record) if record.work.version == workIdentifier.version =>
+            Some(record)
+          case Some(record) =>
+            debug(
+              s"VHS version = ${record.work.version}, identifier version = ${workIdentifier.version}, so discarding work")
+            None
+        }
+    }
+  }
+}

--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackService.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackService.scala
@@ -26,9 +26,9 @@ class RecorderPlaybackService @Inject() (
   /** Given a collection of matched identifiers, return all the
     * corresponding works from VHS.
     */
-  def fetchAllRecorderWorkEntries(works: List[WorkIdentifier]): Future[List[Option[RecorderWorkEntry]]] = {
+  def fetchAllRecorderWorkEntries(workIdentifiers: List[WorkIdentifier]): Future[List[Option[RecorderWorkEntry]]] = {
     Future.sequence(
-      works
+      workIdentifiers
         .map { getRecorderEntryForIdentifier }
     )
   }

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -11,8 +11,6 @@ import uk.ac.wellcome.storage.vhs.EmptyMetadata
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.json.JsonUtil._
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 class MergerFeatureTest
     extends FunSpec
     with Messaging
@@ -41,17 +39,18 @@ class MergerFeatureTest
                     val recorderWorkEntry =
                       createRecorderWorkEntryWith(version = 1)
 
-                    whenReady(storeInVHS(vhs, recorderWorkEntry)) { _ =>
-                      val matcherResult =
-                        matcherResultWith(Set(Set(recorderWorkEntry)))
-                      sendNotificationToSQS(queue, matcherResult)
+                    storeInVHS(vhs, recorderWorkEntry)
 
-                      eventually {
-                        assertQueueEmpty(queue)
-                        assertQueueEmpty(dlq)
-                        val worksSent = getMessages[TransformedBaseWork](topic)
-                        worksSent should contain only recorderWorkEntry.work
-                      }
+                    val matcherResult =
+                      matcherResultWith(Set(Set(recorderWorkEntry)))
+                    sendNotificationToSQS(queue, matcherResult)
+
+                    eventually {
+                      assertQueueEmpty(queue)
+                      assertQueueEmpty(dlq)
+                      val worksSent = getMessages[TransformedBaseWork](topic)
+                      worksSent should contain only recorderWorkEntry.work
+
                     }
                   }
               }

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -41,8 +41,7 @@ class MergerFeatureTest
 
                     storeInVHS(vhs, recorderWorkEntry)
 
-                    val matcherResult =
-                      matcherResultWith(Set(Set(recorderWorkEntry)))
+                    val matcherResult = matcherResultWith(Set(Set(recorderWorkEntry)))
                     sendNotificationToSQS(queue, matcherResult)
 
                     eventually {
@@ -50,7 +49,6 @@ class MergerFeatureTest
                       assertQueueEmpty(dlq)
                       val worksSent = getMessages[TransformedBaseWork](topic)
                       worksSent should contain only recorderWorkEntry.work
-
                     }
                   }
               }

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -11,6 +11,8 @@ import uk.ac.wellcome.storage.vhs.EmptyMetadata
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.json.JsonUtil._
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class MergerFeatureTest
     extends FunSpec
     with Messaging

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -56,28 +56,26 @@ class MergerWorkerServiceTest
             Set(recorderWorkEntry3),
             Set(recorderWorkEntry1, recorderWorkEntry2)))
 
-        whenReady(
-          storeInVHS(
-            vhs,
-            List(recorderWorkEntry1, recorderWorkEntry2, recorderWorkEntry3))) {
-          _ =>
-            sendNotificationToSQS(
-              queue = queue,
-              message = matcherResult
-            )
+        storeInVHS(
+          vhs,
+          List(recorderWorkEntry1, recorderWorkEntry2, recorderWorkEntry3))
 
-            eventually {
-              assertQueueEmpty(queue)
-              assertQueueEmpty(dlq)
+        sendNotificationToSQS(
+          queue = queue,
+          message = matcherResult
+        )
 
-              val worksSent = getMessages[BaseWork](topic)
-              worksSent should contain only (recorderWorkEntry1.work,
-              recorderWorkEntry2.work,
-              recorderWorkEntry3.work)
+        eventually {
+          assertQueueEmpty(queue)
+          assertQueueEmpty(dlq)
 
-              verify(metricsSender, times(1))
-                .countSuccess(any[String])
-            }
+          val worksSent = getMessages[BaseWork](topic)
+          worksSent should contain only(recorderWorkEntry1.work,
+            recorderWorkEntry2.work,
+            recorderWorkEntry3.work)
+
+          verify(metricsSender, times(1))
+            .countSuccess(any[String])
         }
     }
   }

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -89,22 +89,22 @@ class MergerWorkerServiceTest
 
         val matcherResult = matcherResultWith(Set(Set(recorderWorkEntry)))
 
-        whenReady(storeInVHS(vhs, recorderWorkEntry)) { _ =>
-          sendNotificationToSQS(
-            queue = queue,
-            message = matcherResult
-          )
+        storeInVHS(vhs, recorderWorkEntry)
 
-          eventually {
-            assertQueueEmpty(queue)
-            assertQueueEmpty(dlq)
+        sendNotificationToSQS(
+          queue = queue,
+          message = matcherResult
+        )
 
-            val worksSent = getMessages[BaseWork](topic)
-            worksSent should contain only recorderWorkEntry.work
+        eventually {
+          assertQueueEmpty(queue)
+          assertQueueEmpty(dlq)
 
-            verify(metricsSender, times(1))
-              .countSuccess(any[String])
-          }
+          val worksSent = getMessages[BaseWork](topic)
+          worksSent should contain only recorderWorkEntry.work
+
+          verify(metricsSender, times(1))
+            .countSuccess(any[String])
         }
     }
   }
@@ -144,21 +144,20 @@ class MergerWorkerServiceTest
         val matcherResult = matcherResultWith(
           Set(Set(recorderWorkEntry, olderVersionRecorderWorkEntry)))
 
-        whenReady(
-          storeInVHS(
-            vhs,
-            List(recorderWorkEntry, newerVersionRecorderWorkEntry))) { _ =>
-          sendNotificationToSQS(
-            queue = queue,
-            message = matcherResult
-          )
+        storeInVHS(
+          vhs,
+          List(recorderWorkEntry, newerVersionRecorderWorkEntry))
 
-          eventually {
-            assertQueueEmpty(queue)
-            assertQueueEmpty(dlq)
-            val worksSent = getMessages[BaseWork](topic)
-            worksSent should contain only recorderWorkEntry.work
-          }
+        sendNotificationToSQS(
+          queue = queue,
+          message = matcherResult
+        )
+
+        eventually {
+          assertQueueEmpty(queue)
+          assertQueueEmpty(dlq)
+          val worksSent = getMessages[BaseWork](topic)
+          worksSent should contain only recorderWorkEntry.work
         }
     }
   }
@@ -177,22 +176,22 @@ class MergerWorkerServiceTest
         val matcherResult =
           matcherResultWith(Set(Set(recorderWorkEntry, versionZeroWork)))
 
-        whenReady(storeInVHS(vhs, recorderWorkEntry)) { _ =>
-          sendNotificationToSQS(
-            queue = queue,
-            message = matcherResult
-          )
+        storeInVHS(vhs, recorderWorkEntry)
 
-          eventually {
-            assertQueueEmpty(queue)
-            assertQueueEmpty(dlq)
+        sendNotificationToSQS(
+          queue = queue,
+          message = matcherResult
+        )
 
-            val worksSent = getMessages[BaseWork](topic)
-            worksSent should contain only recorderWorkEntry.work
+        eventually {
+          assertQueueEmpty(queue)
+          assertQueueEmpty(dlq)
 
-            verify(metricsSender, times(1))
-              .countSuccess(any[String])
-          }
+          val worksSent = getMessages[BaseWork](topic)
+          worksSent should contain only recorderWorkEntry.work
+
+          verify(metricsSender, times(1))
+            .countSuccess(any[String])
         }
     }
   }
@@ -274,7 +273,7 @@ class MergerWorkerServiceTest
       new MergerWorkerService(
         actorSystem,
         sqsStream,
-        vhs,
+        new RecorderPlaybackService(vhs),
         merger,
         messageWriter))
   }

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -273,7 +273,7 @@ class MergerWorkerServiceTest
       new MergerWorkerService(
         actorSystem,
         sqsStream,
-        new RecorderPlaybackService(vhs),
+        playbackService = new RecorderPlaybackService(vhs),
         merger,
         messageWriter))
   }

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
@@ -95,7 +95,7 @@ class RecorderPlaybackServiceTest extends FunSpec with Matchers with ScalaFuture
       val service = new RecorderPlaybackService(vhs)
 
       whenReady(service.fetchAllRecorderWorkEntries(getWorkIdentifiers(allWorkEntries: _*))) { result =>
-        result shouldBe (workEntriesToFetch ++ (4 to 7).map { _ => None }).toList
+        result shouldBe (workEntriesToFetch.map { Some(_) } ++ (4 to 7).map { _ => None }).toList
       }
     }
   }

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
@@ -6,9 +6,7 @@ import uk.ac.wellcome.models.matcher.WorkIdentifier
 import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
 import uk.ac.wellcome.platform.merger.MergerTestUtils
 import uk.ac.wellcome.storage.ObjectStore
-import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.fixtures.LocalVersionedHybridStore
-import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}
 import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.json.JsonUtil._
@@ -20,17 +18,84 @@ class RecorderPlaybackServiceTest extends FunSpec with Matchers with ScalaFuture
   it("fetches a single RecorderWorkEntry") {
     val recorderWorkEntry = createRecorderWorkEntryWith(version = 1)
 
-    withLocalS3Bucket { bucket =>
-      withLocalDynamoDbTable { table =>
-        withRecorderVHS(bucket, table) { vhs =>
-          storeInVHS(vhs, recorderWorkEntry = recorderWorkEntry)
+    withRecorderVHS { vhs =>
+      storeInVHS(vhs, recorderWorkEntry = recorderWorkEntry)
 
-          val service = new RecorderPlaybackService(vhs)
+      val service = new RecorderPlaybackService(vhs)
 
-          whenReady(service.fetchAllRecorderWorkEntries(getWorkIdentifiers(recorderWorkEntry))) { result =>
-            result shouldBe List(Some(recorderWorkEntry))
-          }
-        }
+      whenReady(service.fetchAllRecorderWorkEntries(getWorkIdentifiers(recorderWorkEntry))) { result =>
+        result shouldBe List(Some(recorderWorkEntry))
+      }
+    }
+  }
+
+  it("throws an error if asked to fetch a missing entry") {
+    val recorderWorkEntry = createRecorderWorkEntryWith(version = 1)
+
+    withRecorderVHS { vhs =>
+      val service = new RecorderPlaybackService(vhs)
+
+      whenReady(service.fetchAllRecorderWorkEntries(getWorkIdentifiers(recorderWorkEntry)).failed) { result =>
+        result shouldBe a[NoSuchElementException]
+        result.getMessage shouldBe s"Work ${recorderWorkEntry.id} is not in VHS!"
+      }
+    }
+  }
+
+  it("returns None if asked to fetch a RecorderWorkEntry with version 0") {
+    val recorderWorkEntry = createRecorderWorkEntryWith(version = 0)
+
+    withRecorderVHS { vhs =>
+      val service = new RecorderPlaybackService(vhs)
+
+      whenReady(service.fetchAllRecorderWorkEntries(getWorkIdentifiers(recorderWorkEntry))) { result =>
+        result shouldBe List(None)
+      }
+    }
+  }
+
+  it("returns None if the version in VHS has a higher version") {
+    val work = createUnidentifiedWorkWith(version = 2)
+    val recorderWorkEntry = RecorderWorkEntry(work)
+
+    val workToStore = createUnidentifiedWorkWith(
+      sourceIdentifier = work.sourceIdentifier,
+      version = work.version + 1
+    )
+
+    withRecorderVHS { vhs =>
+      storeInVHS(vhs, recorderWorkEntry = RecorderWorkEntry(workToStore))
+
+      val service = new RecorderPlaybackService(vhs)
+
+      whenReady(service.fetchAllRecorderWorkEntries(getWorkIdentifiers(recorderWorkEntry))) { result =>
+        result shouldBe List(None)
+      }
+    }
+  }
+
+  it("gets a mixture of works as appropriate") {
+    val workEntriesToFetch = (1 to 3).map { _ => createRecorderWorkEntryWith(version = 1) }
+
+    val outdatedWorks = (4 to 5).map { _ => createUnidentifiedWorkWith(version = 1) }
+    val outdatedWorkEntriesToFetch = outdatedWorks.map { work => RecorderWorkEntry(work) }
+    val updatedWorks = outdatedWorks.map { work => work.copy(version = work.version + 1) }
+    val updatedWorkEntriesToStore = updatedWorks.map { work => RecorderWorkEntry(work) }
+
+    val zeroWorkEntries = (6 to 7).map { _ => createRecorderWorkEntryWith(version = 0) }
+
+    val allWorkEntries = (workEntriesToFetch ++ outdatedWorkEntriesToFetch ++ zeroWorkEntries).toList
+
+    withRecorderVHS { vhs =>
+      storeInVHS(
+        vhs,
+        entries = (workEntriesToFetch ++ updatedWorkEntriesToStore ++ zeroWorkEntries).toList
+      )
+
+      val service = new RecorderPlaybackService(vhs)
+
+      whenReady(service.fetchAllRecorderWorkEntries(getWorkIdentifiers(allWorkEntries: _*))) { result =>
+        result shouldBe (workEntriesToFetch ++ (4 to 7).map { _ => None }).toList
       }
     }
   }
@@ -43,12 +108,16 @@ class RecorderPlaybackServiceTest extends FunSpec with Matchers with ScalaFuture
       )}
       .toList
 
-  private def withRecorderVHS[R](bucket: Bucket, table: Table)(
+  private def withRecorderVHS[R](
     testWith: TestWith[VersionedHybridStore[RecorderWorkEntry,
                                             EmptyMetadata,
                                             ObjectStore[RecorderWorkEntry]], R]): R = {
-    withTypeVHS[RecorderWorkEntry, EmptyMetadata, R](bucket, table) {
-      vhs => testWith(vhs)
+    withLocalS3Bucket { bucket =>
+      withLocalDynamoDbTable { table =>
+        withTypeVHS[RecorderWorkEntry, EmptyMetadata, R](bucket, table) {
+          vhs => testWith(vhs)
+        }
+      }
     }
   }
 }

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
@@ -1,0 +1,54 @@
+package uk.ac.wellcome.platform.merger.services
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.matcher.WorkIdentifier
+import uk.ac.wellcome.models.recorder.internal.RecorderWorkEntry
+import uk.ac.wellcome.platform.merger.MergerTestUtils
+import uk.ac.wellcome.storage.ObjectStore
+import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
+import uk.ac.wellcome.storage.fixtures.LocalVersionedHybridStore
+import uk.ac.wellcome.storage.fixtures.S3.Bucket
+import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}
+import uk.ac.wellcome.test.fixtures._
+import uk.ac.wellcome.json.JsonUtil._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class RecorderPlaybackServiceTest extends FunSpec with Matchers with ScalaFutures with LocalVersionedHybridStore with MergerTestUtils {
+
+  it("fetches a single RecorderWorkEntry") {
+    val recorderWorkEntry = createRecorderWorkEntryWith(version = 1)
+
+    withLocalS3Bucket { bucket =>
+      withLocalDynamoDbTable { table =>
+        withRecorderVHS(bucket, table) { vhs =>
+          storeInVHS(vhs, recorderWorkEntry = recorderWorkEntry)
+
+          val service = new RecorderPlaybackService(vhs)
+
+          whenReady(service.fetchAllRecorderWorkEntries(getWorkIdentifiers(recorderWorkEntry))) { result =>
+            result shouldBe List(Some(recorderWorkEntry))
+          }
+        }
+      }
+    }
+  }
+
+  private def getWorkIdentifiers(entries: RecorderWorkEntry*): List[WorkIdentifier] =
+    entries
+      .map { entry => WorkIdentifier(
+        identifier = entry.id,
+        version = entry.work.version
+      )}
+      .toList
+
+  private def withRecorderVHS[R](bucket: Bucket, table: Table)(
+    testWith: TestWith[VersionedHybridStore[RecorderWorkEntry,
+                                            EmptyMetadata,
+                                            ObjectStore[RecorderWorkEntry]], R]): R = {
+    withTypeVHS[RecorderWorkEntry, EmptyMetadata, R](bucket, table) {
+      vhs => testWith(vhs)
+    }
+  }
+}


### PR DESCRIPTION
A possible factor in #2497 is that we’ve got quite a lot of private methods in the worker service, which are hard to test individually. This PR pulls out a “PlaybackService” (for fetching recorded works), which can be tested separately.

It’s not what’s at fault in #2497, but lays the ground for the fix in another PR.