### PR TITLE
Don't use the "Sierra" namespace in the Sierra data VHS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,18 +83,18 @@ env:
 
 jobs:
   include:
-    # - stage: quicktest
-    #   env: TASK=travis-format
+    - stage: quicktest
+      env: TASK=travis-format
 
     # Because this isn't under active development, and we're really squeezed
     # for build VMs, we aren't testing this in CI right now.
-    # - env: TASK=travistooling-test
+    - env: TASK=travistooling-test
 
-    # - stage: sbt-common-test
-    #   env: TASK=elasticsearch-test
-    # - env: TASK=messaging-test
-    # - env: TASK=internal_model-test
-    # - env: TASK=display-test
+    - stage: sbt-common-test
+      env: TASK=elasticsearch-test
+    - env: TASK=messaging-test
+    - env: TASK=internal_model-test
+    - env: TASK=display-test
 
     # Lambda tests.
     #
@@ -108,45 +108,45 @@ jobs:
     # When this job runs, all the Lambdas get tested at once, but even this
     # isn't significantly longer than a Scala test.
     #
-    # - stage: test
-    #   env:
-    #     - TRAVIS_LAMBDAS="snapshot_scheduler \
-    #       reindex_shard_generator \
-    #       sierra_window_generator \
-    #       s3_demultiplexer \
-    #       drain_ecs_container_instance \
-    #       dynamo_to_sns \
-    #       ecs_ec2_instance_tagger \
-    #       run_ecs_task \
-    #       gatling_to_cloudwatch \
-    #       notify_old_deploys \
-    #       post_to_slack \
-    #       service_deployment_status \
-    #       update_service_list"
-    #     - TASK=travis-lambda-test
-    #
-    # # Catalogue API stack
-    # - env: TASK=api-test
-    # # (not under active development)
-    # # - env: TASK=api_docs-build
-    #
-    # # Catalogue pipeline stack
-    # - env: TASK=transformer-test
-    # - env: TASK=ingestor-test
-    # - env: TASK=recorder-test
-    # - env: TASK=matcher-test
-    # - env: TASK=merger-test
-    # - env: TASK=id_minter-test
-    #
-    # # Data API stack
-    # - env: TASK=snapshot_generator-test
-    #
-    # # Reindexer stack
-    # - env: TASK=reindex_request_creator-test
-    # - env: TASK=reindex_request_processor-test
-    #
-    # # Goobi adapter stack
-    # - env: TASK=goobi_reader-test
+    - stage: test
+      env:
+        - TRAVIS_LAMBDAS="snapshot_scheduler \
+          reindex_shard_generator \
+          sierra_window_generator \
+          s3_demultiplexer \
+          drain_ecs_container_instance \
+          dynamo_to_sns \
+          ecs_ec2_instance_tagger \
+          run_ecs_task \
+          gatling_to_cloudwatch \
+          notify_old_deploys \
+          post_to_slack \
+          service_deployment_status \
+          update_service_list"
+        - TASK=travis-lambda-test
+
+    # Catalogue API stack
+    - env: TASK=api-test
+    # (not under active development)
+    # - env: TASK=api_docs-build
+
+    # Catalogue pipeline stack
+    - env: TASK=transformer-test
+    - env: TASK=ingestor-test
+    - env: TASK=recorder-test
+    - env: TASK=matcher-test
+    - env: TASK=merger-test
+    - env: TASK=id_minter-test
+
+    # Data API stack
+    - env: TASK=snapshot_generator-test
+
+    # Reindexer stack
+    - env: TASK=reindex_request_creator-test
+    - env: TASK=reindex_request_processor-test
+
+    # Goobi adapter stack
+    - env: TASK=goobi_reader-test
 
     # Sierra adapter stack
     - env: TASK=sierra_reader-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ jobs:
 
     # Because this isn't under active development, and we're really squeezed
     # for build VMs, we aren't testing this in CI right now.
-    - env: TASK=travistooling-test
+    # - env: TASK=travistooling-test
 
     - stage: sbt-common-test
       env: TASK=elasticsearch-test
@@ -163,10 +163,10 @@ jobs:
     # - env: TASK=loris-build
     # - env: TASK=cache_cleaner-build
 
-# stages:
-#   - quicktest
-#   - sbt-common-test
-#   - test
+stages:
+  - quicktest
+  - sbt-common-test
+  - test
 
 # This has a Slack API token for posting messages about build failures to
 # our team channel.  It was created by following the "Setup Instructions" at

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,18 +83,18 @@ env:
 
 jobs:
   include:
-    - stage: quicktest
-      env: TASK=travis-format
+    # - stage: quicktest
+    #   env: TASK=travis-format
 
     # Because this isn't under active development, and we're really squeezed
     # for build VMs, we aren't testing this in CI right now.
     # - env: TASK=travistooling-test
 
-    - stage: sbt-common-test
-      env: TASK=elasticsearch-test
-    - env: TASK=messaging-test
-    - env: TASK=internal_model-test
-    - env: TASK=display-test
+    # - stage: sbt-common-test
+    #   env: TASK=elasticsearch-test
+    # - env: TASK=messaging-test
+    # - env: TASK=internal_model-test
+    # - env: TASK=display-test
 
     # Lambda tests.
     #
@@ -108,45 +108,45 @@ jobs:
     # When this job runs, all the Lambdas get tested at once, but even this
     # isn't significantly longer than a Scala test.
     #
-    - stage: test
-      env:
-        - TRAVIS_LAMBDAS="snapshot_scheduler \
-          reindex_shard_generator \
-          sierra_window_generator \
-          s3_demultiplexer \
-          drain_ecs_container_instance \
-          dynamo_to_sns \
-          ecs_ec2_instance_tagger \
-          run_ecs_task \
-          gatling_to_cloudwatch \
-          notify_old_deploys \
-          post_to_slack \
-          service_deployment_status \
-          update_service_list"
-        - TASK=travis-lambda-test
-
-    # Catalogue API stack
-    - env: TASK=api-test
-    # (not under active development)
-    # - env: TASK=api_docs-build
-
-    # Catalogue pipeline stack
-    - env: TASK=transformer-test
-    - env: TASK=ingestor-test
-    - env: TASK=recorder-test
-    - env: TASK=matcher-test
-    - env: TASK=merger-test
-    - env: TASK=id_minter-test
-
-    # Data API stack
-    - env: TASK=snapshot_generator-test
-
-    # Reindexer stack
-    - env: TASK=reindex_request_creator-test
-    - env: TASK=reindex_request_processor-test
-
-    # Goobi adapter stack
-    - env: TASK=goobi_reader-test
+    # - stage: test
+    #   env:
+    #     - TRAVIS_LAMBDAS="snapshot_scheduler \
+    #       reindex_shard_generator \
+    #       sierra_window_generator \
+    #       s3_demultiplexer \
+    #       drain_ecs_container_instance \
+    #       dynamo_to_sns \
+    #       ecs_ec2_instance_tagger \
+    #       run_ecs_task \
+    #       gatling_to_cloudwatch \
+    #       notify_old_deploys \
+    #       post_to_slack \
+    #       service_deployment_status \
+    #       update_service_list"
+    #     - TASK=travis-lambda-test
+    #
+    # # Catalogue API stack
+    # - env: TASK=api-test
+    # # (not under active development)
+    # # - env: TASK=api_docs-build
+    #
+    # # Catalogue pipeline stack
+    # - env: TASK=transformer-test
+    # - env: TASK=ingestor-test
+    # - env: TASK=recorder-test
+    # - env: TASK=matcher-test
+    # - env: TASK=merger-test
+    # - env: TASK=id_minter-test
+    #
+    # # Data API stack
+    # - env: TASK=snapshot_generator-test
+    #
+    # # Reindexer stack
+    # - env: TASK=reindex_request_creator-test
+    # - env: TASK=reindex_request_processor-test
+    #
+    # # Goobi adapter stack
+    # - env: TASK=goobi_reader-test
 
     # Sierra adapter stack
     - env: TASK=sierra_reader-test
@@ -163,10 +163,10 @@ jobs:
     # - env: TASK=loris-build
     # - env: TASK=cache_cleaner-build
 
-stages:
-  - quicktest
-  - sbt-common-test
-  - test
+# stages:
+#   - quicktest
+#   - sbt-common-test
+#   - test
 
 # This has a Slack API token for posting messages about build failures to
 # our team channel.  It was created by following the "Setup Instructions" at

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraVHSUtil.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraVHSUtil.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}
 
 import scala.concurrent.Future
 
-class SierraVHSUtil extends LocalVersionedHybridStore {
+trait SierraVHSUtil extends LocalVersionedHybridStore {
   def storeInVHS(transformable: SierraTransformable,
                  hybridStore: VersionedHybridStore[SierraTransformable,
                                                    EmptyMetadata,
@@ -21,10 +21,18 @@ class SierraVHSUtil extends LocalVersionedHybridStore {
       ifExisting = (t, m) => throw new RuntimeException(s"Found record ${transformable.sierraId}, but VHS should be empty")
     )
 
+  def storeInVHS(transformables: List[SierraTransformable],
+                 hybridStore: VersionedHybridStore[SierraTransformable,
+                                                   EmptyMetadata,
+                                                   ObjectStore[SierraTransformable]]): Future[List[Unit]] =
+    Future.sequence(
+      transformables.map { t => storeInVHS(t, hybridStore = hybridStore) }
+    )
+
   def assertStored(transformable: SierraTransformable, bucket: Bucket, table: Table): Assertion =
     assertStored[SierraTransformable](
       bucket,
       table,
-      id = transformable.sierraId.withoutCheckDigit,
+      id = transformable.id,
       record = transformable)
 }

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraVHSUtil.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraVHSUtil.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.sierra_adapter.utils
 
+import io.circe.Encoder
 import org.scalatest.Assertion
-import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.dynamo._
@@ -32,7 +32,9 @@ trait SierraVHSUtil extends LocalVersionedHybridStore {
       transformables.map { t => storeInVHS(t, hybridStore = hybridStore) }
     )
 
-  def assertStored(transformable: SierraTransformable, bucket: Bucket, table: Table): Assertion =
+  def assertStored(transformable: SierraTransformable,
+                   bucket: Bucket,
+                   table: Table)(implicit encoder: Encoder[SierraTransformable]): Assertion =
     assertStored[SierraTransformable](
       bucket,
       table,

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraVHSUtil.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraVHSUtil.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.sierra_adapter.utils
 import org.scalatest.Assertion
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.storage.ObjectStore
+import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.fixtures.LocalVersionedHybridStore
 import uk.ac.wellcome.storage.fixtures.S3.Bucket

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraVHSUtil.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraVHSUtil.scala
@@ -14,27 +14,35 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 trait SierraVHSUtil extends LocalVersionedHybridStore {
-  def storeInVHS(transformable: SierraTransformable,
-                 hybridStore: VersionedHybridStore[SierraTransformable,
-                                                   EmptyMetadata,
-                                                   ObjectStore[SierraTransformable]]): Future[Unit] =
-    hybridStore.updateRecord(
-      id = transformable.sierraId.withoutCheckDigit)(
+  def storeInVHS(
+    transformable: SierraTransformable,
+    hybridStore: VersionedHybridStore[SierraTransformable,
+                                      EmptyMetadata,
+                                      ObjectStore[SierraTransformable]])
+    : Future[Unit] =
+    hybridStore.updateRecord(id = transformable.sierraId.withoutCheckDigit)(
       ifNotExisting = (transformable, EmptyMetadata()))(
-      ifExisting = (t, m) => throw new RuntimeException(s"Found record ${transformable.sierraId}, but VHS should be empty")
+      ifExisting = (t, m) =>
+        throw new RuntimeException(
+          s"Found record ${transformable.sierraId}, but VHS should be empty")
     )
 
-  def storeInVHS(transformables: List[SierraTransformable],
-                 hybridStore: VersionedHybridStore[SierraTransformable,
-                                                   EmptyMetadata,
-                                                   ObjectStore[SierraTransformable]]): Future[List[Unit]] =
+  def storeInVHS(
+    transformables: List[SierraTransformable],
+    hybridStore: VersionedHybridStore[SierraTransformable,
+                                      EmptyMetadata,
+                                      ObjectStore[SierraTransformable]])
+    : Future[List[Unit]] =
     Future.sequence(
-      transformables.map { t => storeInVHS(t, hybridStore = hybridStore) }
+      transformables.map { t =>
+        storeInVHS(t, hybridStore = hybridStore)
+      }
     )
 
-  def assertStored(transformable: SierraTransformable,
-                   bucket: Bucket,
-                   table: Table)(implicit encoder: Encoder[SierraTransformable]): Assertion =
+  def assertStored(
+    transformable: SierraTransformable,
+    bucket: Bucket,
+    table: Table)(implicit encoder: Encoder[SierraTransformable]): Assertion =
     assertStored[SierraTransformable](
       bucket,
       table,

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraVHSUtil.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraVHSUtil.scala
@@ -1,0 +1,30 @@
+package uk.ac.wellcome.sierra_adapter.utils
+
+import org.scalatest.Assertion
+import uk.ac.wellcome.models.transformable.SierraTransformable
+import uk.ac.wellcome.storage.ObjectStore
+import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
+import uk.ac.wellcome.storage.fixtures.LocalVersionedHybridStore
+import uk.ac.wellcome.storage.fixtures.S3.Bucket
+import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}
+
+import scala.concurrent.Future
+
+class SierraVHSUtil extends LocalVersionedHybridStore {
+  def storeInVHS(transformable: SierraTransformable,
+                 hybridStore: VersionedHybridStore[SierraTransformable,
+                                                   EmptyMetadata,
+                                                   ObjectStore[SierraTransformable]]): Future[Unit] =
+    hybridStore.updateRecord(
+      id = transformable.sierraId.withoutCheckDigit)(
+      ifNotExisting = (transformable, EmptyMetadata()))(
+      ifExisting = (t, m) => throw new RuntimeException(s"Found record ${transformable.sierraId}, but VHS should be empty")
+    )
+
+  def assertStored(transformable: SierraTransformable, bucket: Bucket, table: Table): Assertion =
+    assertStored[SierraTransformable](
+      bucket,
+      table,
+      id = transformable.sierraId.withoutCheckDigit,
+      record = transformable)
+}

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraVHSUtil.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraVHSUtil.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.sierra_adapter.utils
 
 import org.scalatest.Assertion
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.dynamo._
@@ -9,6 +10,7 @@ import uk.ac.wellcome.storage.fixtures.LocalVersionedHybridStore
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 trait SierraVHSUtil extends LocalVersionedHybridStore {

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraVHSUtil.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraVHSUtil.scala
@@ -33,6 +33,6 @@ trait SierraVHSUtil extends LocalVersionedHybridStore {
     assertStored[SierraTransformable](
       bucket,
       table,
-      id = transformable.id,
+      id = transformable.sierraId.withoutCheckDigit,
       record = transformable)
 }

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
@@ -6,15 +6,14 @@ import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord
 import uk.ac.wellcome.platform.sierra_bib_merger.merger.BibMerger
 import uk.ac.wellcome.storage.dynamo._
-import uk.ac.wellcome.storage.vhs.{SourceMetadata, VersionedHybridStore}
-import uk.ac.wellcome.models.Sourced
+import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}
 import uk.ac.wellcome.storage.ObjectStore
 
 import scala.concurrent.Future
 
 class SierraBibMergerUpdaterService @Inject()(
   versionedHybridStore: VersionedHybridStore[SierraTransformable,
-                                             SourceMetadata,
+                                             EmptyMetadata,
                                              ObjectStore[SierraTransformable]]
 ) extends Logging {
 
@@ -23,9 +22,9 @@ class SierraBibMergerUpdaterService @Inject()(
     val sourceName = "sierra"
 
     versionedHybridStore.updateRecord(
-      Sourced.id(sourceName, bibRecord.id.withoutCheckDigit))(
-      (SierraTransformable(bibRecord), SourceMetadata(sourceName)))(
-      (existingSierraTransformable, existingMetadata) => {
+      id = bibRecord.id.withoutCheckDigit)(
+      ifNotExisting = (SierraTransformable(bibRecord), EmptyMetadata()))(
+      ifNotExisting = (existingSierraTransformable, existingMetadata) => {
         (
           BibMerger.mergeBibRecord(existingSierraTransformable, bibRecord),
           existingMetadata)

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
@@ -21,8 +21,7 @@ class SierraBibMergerUpdaterService @Inject()(
 
     val sourceName = "sierra"
 
-    versionedHybridStore.updateRecord(
-      id = bibRecord.id.withoutCheckDigit)(
+    versionedHybridStore.updateRecord(id = bibRecord.id.withoutCheckDigit)(
       ifNotExisting = (SierraTransformable(bibRecord), EmptyMetadata()))(
       ifNotExisting = (existingSierraTransformable, existingMetadata) => {
         (

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
@@ -17,10 +17,7 @@ class SierraBibMergerUpdaterService @Inject()(
                                              ObjectStore[SierraTransformable]]
 ) extends Logging {
 
-  def update(bibRecord: SierraBibRecord): Future[Unit] = {
-
-    val sourceName = "sierra"
-
+  def update(bibRecord: SierraBibRecord): Future[Unit] =
     versionedHybridStore.updateRecord(id = bibRecord.id.withoutCheckDigit)(
       ifNotExisting = (SierraTransformable(bibRecord), EmptyMetadata()))(
       ifExisting = (existingSierraTransformable, existingMetadata) => {
@@ -29,5 +26,4 @@ class SierraBibMergerUpdaterService @Inject()(
           existingMetadata)
       }
     )
-  }
 }

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
@@ -23,7 +23,7 @@ class SierraBibMergerUpdaterService @Inject()(
 
     versionedHybridStore.updateRecord(id = bibRecord.id.withoutCheckDigit)(
       ifNotExisting = (SierraTransformable(bibRecord), EmptyMetadata()))(
-      ifNotExisting = (existingSierraTransformable, existingMetadata) => {
+      ifExisting = (existingSierraTransformable, existingMetadata) => {
         (
           BibMerger.mergeBibRecord(existingSierraTransformable, bibRecord),
           existingMetadata)

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -7,7 +7,6 @@ import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.SierraTransformable._
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraUtil
-import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.fixtures.LocalVersionedHybridStore
 import uk.ac.wellcome.storage.vhs.EmptyMetadata
 import uk.ac.wellcome.test.utils.ExtendedPatience

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -48,7 +48,8 @@ class SierraBibMergerFeatureTest
               eventually {
                 assertStored(
                   transformable = expectedSierraTransformable,
-                  bucket = bucket, table = table
+                  bucket = bucket,
+                  table = table
                 )
               }
             }
@@ -83,11 +84,13 @@ class SierraBibMergerFeatureTest
               eventually {
                 assertStored(
                   transformable = expectedTransformable1,
-                  bucket = bucket, table = table
+                  bucket = bucket,
+                  table = table
                 )
                 assertStored(
                   transformable = expectedTransformable2,
-                  bucket = bucket, table = table
+                  bucket = bucket,
+                  table = table
                 )
               }
             }
@@ -121,8 +124,7 @@ class SierraBibMergerFeatureTest
               storeInVHS(
                 transformable = oldTransformable,
                 hybridStore = hybridStore
-              )
-                .map { _ =>
+              ).map { _ =>
                   sendNotificationToSQS(queue = queue, message = newBibRecord)
                 }
 
@@ -132,7 +134,8 @@ class SierraBibMergerFeatureTest
               eventually {
                 assertStored(
                   transformable = expectedTransformable,
-                  bucket = bucket, table = table
+                  bucket = bucket,
+                  table = table
                 )
               }
             }
@@ -166,8 +169,7 @@ class SierraBibMergerFeatureTest
               storeInVHS(
                 transformable = expectedTransformable,
                 hybridStore = hybridStore
-              )
-                .map { _ =>
+              ).map { _ =>
                   sendNotificationToSQS(queue = queue, message = oldBibRecord)
                 }
 
@@ -177,7 +179,8 @@ class SierraBibMergerFeatureTest
 
               assertStored(
                 transformable = expectedTransformable,
-                bucket = bucket, table = table
+                bucket = bucket,
+                table = table
               )
             }
           }
@@ -192,33 +195,32 @@ class SierraBibMergerFeatureTest
         withLocalDynamoDbTable { table =>
           val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(bucket, table)
           withServer(flags) { _ =>
-            withTypeVHS[SierraTransformable, EmptyMetadata, Unit](
-              bucket,
-              table) { hybridStore =>
-              val transformable = createSierraTransformableWith(
-                maybeBibRecord = None
-              )
-
-              val bibRecord =
-                createSierraBibRecordWith(id = transformable.sierraId)
-
-              storeInVHS(
-                transformable = transformable,
-                hybridStore = hybridStore
-              )
-                .map { _ =>
-                  sendNotificationToSQS(queue = queue, message = bibRecord)
-                }
-
-              val expectedTransformable =
-                SierraTransformable(bibRecord = bibRecord)
-
-              eventually {
-                assertStored(
-                  transformable = expectedTransformable,
-                  bucket = bucket, table = table
+            withTypeVHS[SierraTransformable, EmptyMetadata, Unit](bucket, table) {
+              hybridStore =>
+                val transformable = createSierraTransformableWith(
+                  maybeBibRecord = None
                 )
-              }
+
+                val bibRecord =
+                  createSierraBibRecordWith(id = transformable.sierraId)
+
+                storeInVHS(
+                  transformable = transformable,
+                  hybridStore = hybridStore
+                ).map { _ =>
+                    sendNotificationToSQS(queue = queue, message = bibRecord)
+                  }
+
+                val expectedTransformable =
+                  SierraTransformable(bibRecord = bibRecord)
+
+                eventually {
+                  assertStored(
+                    transformable = expectedTransformable,
+                    bucket = bucket,
+                    table = table
+                  )
+                }
             }
           }
         }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -9,9 +9,10 @@ import uk.ac.wellcome.models.transformable.SierraTransformable._
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraUtil
 import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.fixtures.LocalVersionedHybridStore
-import uk.ac.wellcome.storage.vhs.SourceMetadata
+import uk.ac.wellcome.storage.vhs.EmptyMetadata
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.sierra_adapter.utils.SierraVHSUtil
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -25,7 +26,8 @@ class SierraBibMergerFeatureTest
     with SQS
     with fixtures.Server
     with LocalVersionedHybridStore
-    with SierraUtil {
+    with SierraUtil
+    with SierraVHSUtil {
 
   it("stores a bib in the hybrid store") {
     withLocalSqsQueue { queue =>
@@ -33,7 +35,7 @@ class SierraBibMergerFeatureTest
         withLocalDynamoDbTable { table =>
           val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(bucket, table)
           withServer(flags) { _ =>
-            withTypeVHS[SierraTransformable, SourceMetadata, Assertion](
+            withTypeVHS[SierraTransformable, EmptyMetadata, Assertion](
               bucket,
               table) { hybridStore =>
               val bibRecord = createSierraBibRecord
@@ -44,11 +46,10 @@ class SierraBibMergerFeatureTest
                 SierraTransformable(bibRecord = bibRecord)
 
               eventually {
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  id = expectedSierraTransformable.id,
-                  record = expectedSierraTransformable)
+                assertStored(
+                  transformable = expectedSierraTransformable,
+                  bucket = bucket, table = table
+                )
               }
             }
           }
@@ -63,7 +64,7 @@ class SierraBibMergerFeatureTest
         withLocalDynamoDbTable { table =>
           val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(bucket, table)
           withServer(flags) { _ =>
-            withTypeVHS[SierraTransformable, SourceMetadata, Assertion](
+            withTypeVHS[SierraTransformable, EmptyMetadata, Assertion](
               bucket,
               table) { hybridStore =>
               val record1 = createSierraBibRecord
@@ -80,16 +81,14 @@ class SierraBibMergerFeatureTest
                 SierraTransformable(bibRecord = record2)
 
               eventually {
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  id = expectedTransformable1.id,
-                  record = expectedTransformable1)
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  id = expectedTransformable2.id,
-                  record = expectedTransformable2)
+                assertStored(
+                  transformable = expectedTransformable1,
+                  bucket = bucket, table = table
+                )
+                assertStored(
+                  transformable = expectedTransformable2,
+                  bucket = bucket, table = table
+                )
               }
             }
           }
@@ -104,7 +103,7 @@ class SierraBibMergerFeatureTest
         withLocalDynamoDbTable { table =>
           val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(bucket, table)
           withServer(flags) { _ =>
-            withTypeVHS[SierraTransformable, SourceMetadata, Assertion](
+            withTypeVHS[SierraTransformable, EmptyMetadata, Assertion](
               bucket,
               table) { hybridStore =>
               val oldBibRecord = createSierraBibRecordWith(
@@ -119,12 +118,10 @@ class SierraBibMergerFeatureTest
                 modifiedDate = newerDate
               )
 
-              hybridStore
-                .updateRecord(oldTransformable.id)(
-                  (
-                    oldTransformable,
-                    SourceMetadata(oldTransformable.sourceName)))((t, m) =>
-                  (t, m))
+              storeInVHS(
+                transformable = oldTransformable,
+                hybridStore = hybridStore
+              )
                 .map { _ =>
                   sendNotificationToSQS(queue = queue, message = newBibRecord)
                 }
@@ -133,11 +130,10 @@ class SierraBibMergerFeatureTest
                 SierraTransformable(bibRecord = newBibRecord)
 
               eventually {
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  id = expectedTransformable.id,
-                  record = expectedTransformable)
+                assertStored(
+                  transformable = expectedTransformable,
+                  bucket = bucket, table = table
+                )
               }
             }
           }
@@ -152,7 +148,7 @@ class SierraBibMergerFeatureTest
         withLocalDynamoDbTable { table =>
           val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(bucket, table)
           withServer(flags) { _ =>
-            withTypeVHS[SierraTransformable, SourceMetadata, Assertion](
+            withTypeVHS[SierraTransformable, EmptyMetadata, Assertion](
               bucket,
               table) { hybridStore =>
               val newBibRecord = createSierraBibRecordWith(
@@ -167,11 +163,10 @@ class SierraBibMergerFeatureTest
                 modifiedDate = olderDate
               )
 
-              hybridStore
-                .updateRecord(expectedTransformable.id)((
-                  expectedTransformable,
-                  SourceMetadata(expectedTransformable.sourceName)))((t, m) =>
-                  (t, m))
+              storeInVHS(
+                transformable = expectedTransformable,
+                hybridStore = hybridStore
+              )
                 .map { _ =>
                   sendNotificationToSQS(queue = queue, message = oldBibRecord)
                 }
@@ -180,11 +175,10 @@ class SierraBibMergerFeatureTest
               // enough time for this update to have gone through (if it was going to).
               Thread.sleep(5000)
 
-              assertStored[SierraTransformable](
-                bucket,
-                table,
-                id = expectedTransformable.id,
-                record = expectedTransformable)
+              assertStored(
+                transformable = expectedTransformable,
+                bucket = bucket, table = table
+              )
             }
           }
         }
@@ -198,7 +192,7 @@ class SierraBibMergerFeatureTest
         withLocalDynamoDbTable { table =>
           val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(bucket, table)
           withServer(flags) { _ =>
-            withTypeVHS[SierraTransformable, SourceMetadata, Unit](
+            withTypeVHS[SierraTransformable, EmptyMetadata, Unit](
               bucket,
               table) { hybridStore =>
               val transformable = createSierraTransformableWith(
@@ -208,24 +202,22 @@ class SierraBibMergerFeatureTest
               val bibRecord =
                 createSierraBibRecordWith(id = transformable.sierraId)
 
-              val future =
-                hybridStore.updateRecord(transformable.id)(
-                  (transformable, SourceMetadata(transformable.sourceName)))(
-                  (t, m) => (t, m))
+              storeInVHS(
+                transformable = transformable,
+                hybridStore = hybridStore
+              )
+                .map { _ =>
+                  sendNotificationToSQS(queue = queue, message = bibRecord)
+                }
 
-              future.map { _ =>
-                sendNotificationToSQS(queue = queue, message = bibRecord)
-              }
-
-              val expectedSierraTransformable =
+              val expectedTransformable =
                 SierraTransformable(bibRecord = bibRecord)
 
               eventually {
-                assertStored[SierraTransformable](
-                  bucket,
-                  table,
-                  id = expectedSierraTransformable.id,
-                  record = expectedSierraTransformable)
+                assertStored(
+                  transformable = expectedTransformable,
+                  bucket = bucket, table = table
+                )
               }
             }
           }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -125,8 +125,8 @@ class SierraBibMergerFeatureTest
                 transformable = oldTransformable,
                 hybridStore = hybridStore
               ).map { _ =>
-                  sendNotificationToSQS(queue = queue, message = newBibRecord)
-                }
+                sendNotificationToSQS(queue = queue, message = newBibRecord)
+              }
 
               val expectedTransformable =
                 SierraTransformable(bibRecord = newBibRecord)
@@ -170,8 +170,8 @@ class SierraBibMergerFeatureTest
                 transformable = expectedTransformable,
                 hybridStore = hybridStore
               ).map { _ =>
-                  sendNotificationToSQS(queue = queue, message = oldBibRecord)
-                }
+                sendNotificationToSQS(queue = queue, message = oldBibRecord)
+              }
 
               // Blocking in Scala is generally a bad idea; we do it here so there's
               // enough time for this update to have gone through (if it was going to).
@@ -208,8 +208,8 @@ class SierraBibMergerFeatureTest
                   transformable = transformable,
                   hybridStore = hybridStore
                 ).map { _ =>
-                    sendNotificationToSQS(queue = queue, message = bibRecord)
-                  }
+                  sendNotificationToSQS(queue = queue, message = bibRecord)
+                }
 
                 val expectedTransformable =
                   SierraTransformable(bibRecord = bibRecord)

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraUtil
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.storage.fixtures.{LocalVersionedHybridStore, S3}
-import uk.ac.wellcome.storage.vhs.SourceMetadata
+import uk.ac.wellcome.storage.vhs.EmptyMetadata
 import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.json.JsonUtil._
@@ -62,7 +62,7 @@ class SierraBibMergerWorkerServiceTest
               sqsStream =>
                 withLocalDynamoDbTable { table =>
                   withLocalS3Bucket { storageBucket =>
-                    withTypeVHS[SierraTransformable, SourceMetadata, R](
+                    withTypeVHS[SierraTransformable, EmptyMetadata, R](
                       storageBucket,
                       table) { vhs =>
                       val mergerUpdaterService =

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
@@ -25,8 +25,7 @@ class SierraItemMergerUpdaterService @Inject()(
   def update(itemRecord: SierraItemRecord): Future[Unit] = {
 
     val mergeUpdateFutures = itemRecord.bibIds.map { bibId =>
-      versionedHybridStore.updateRecord(
-        id = bibId.withoutCheckDigit)(
+      versionedHybridStore.updateRecord(id = bibId.withoutCheckDigit)(
         ifNotExisting = (
           SierraTransformable(
             sierraId = bibId,
@@ -41,8 +40,7 @@ class SierraItemMergerUpdaterService @Inject()(
 
     val unlinkUpdateFutures: Seq[Future[Unit]] =
       itemRecord.unlinkedBibIds.map { unlinkedBibId =>
-        versionedHybridStore.updateRecord(
-          id = unlinkedBibId.withoutCheckDigit)(
+        versionedHybridStore.updateRecord(id = unlinkedBibId.withoutCheckDigit)(
           ifNotExisting = throw GracefulFailureException(
             new RuntimeException(
               s"Missing Bib record to unlink: $unlinkedBibId")

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
@@ -40,11 +40,11 @@ class SierraItemMergerUpdaterService @Inject()(
 
     val unlinkUpdateFutures: Seq[Future[Unit]] =
       itemRecord.unlinkedBibIds.map { unlinkedBibId =>
-        versionedHybridStore.updateRecord(id = unlinkedBibId.withoutCheckDigit)(
-          ifNotExisting = throw GracefulFailureException(
-            new RuntimeException(
-              s"Missing Bib record to unlink: $unlinkedBibId")
-          ))(
+        versionedHybridStore.updateRecord(
+          id = unlinkedBibId.withoutCheckDigit)(
+          ifNotExisting = throw SierraItemMergerException(
+            s"Missing Bib record to unlink: $unlinkedBibId")
+          )(
           ifExisting = (existingTransformable, existingMetadata) =>
             (
               ItemUnlinker.unlinkItemRecord(existingTransformable, itemRecord),

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
@@ -40,11 +40,10 @@ class SierraItemMergerUpdaterService @Inject()(
 
     val unlinkUpdateFutures: Seq[Future[Unit]] =
       itemRecord.unlinkedBibIds.map { unlinkedBibId =>
-        versionedHybridStore.updateRecord(
-          id = unlinkedBibId.withoutCheckDigit)(
+        versionedHybridStore.updateRecord(id = unlinkedBibId.withoutCheckDigit)(
           ifNotExisting = throw SierraItemMergerException(
             s"Missing Bib record to unlink: $unlinkedBibId")
-          )(
+        )(
           ifExisting = (existingTransformable, existingMetadata) =>
             (
               ItemUnlinker.unlinkItemRecord(existingTransformable, itemRecord),

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
@@ -62,7 +62,8 @@ class SierraItemMergerFeatureTest
                 eventually {
                   assertStored(
                     transformable = expectedSierraTransformable,
-                    bucket = vhsBucket, table = table
+                    bucket = vhsBucket,
+                    table = table
                   )
                 }
               }
@@ -123,11 +124,13 @@ class SierraItemMergerFeatureTest
 
                   assertStored(
                     transformable = expectedSierraTransformable1,
-                    bucket = vhsBucket, table = table
+                    bucket = vhsBucket,
+                    table = table
                   )
                   assertStored(
                     transformable = expectedSierraTransformable2,
-                    bucket = vhsBucket, table = table
+                    bucket = vhsBucket,
+                    table = table
                   )
                 }
               }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraUtil
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import uk.ac.wellcome.storage.fixtures.{LocalVersionedHybridStore, S3}
-import uk.ac.wellcome.storage.vhs.{HybridRecord, SourceMetadata}
+import uk.ac.wellcome.storage.vhs.{EmptyMetadata, HybridRecord}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.sierra_adapter.utils.SierraVHSUtil
@@ -38,7 +38,7 @@ class SierraItemMergerFeatureTest
             val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(vhsBucket, table) ++ s3LocalFlags(
               messagingBucket)
             withServer(flags) { _ =>
-              withTypeVHS[SierraTransformable, SourceMetadata, Assertion](
+              withTypeVHS[SierraTransformable, EmptyMetadata, Assertion](
                 vhsBucket,
                 table) { hybridStore =>
                 val bibId = createSierraBibNumber
@@ -82,7 +82,7 @@ class SierraItemMergerFeatureTest
             val flags = sqsLocalFlags(queue) ++ vhsLocalFlags(vhsBucket, table) ++ s3LocalFlags(
               messagingBucket)
             withServer(flags) { _ =>
-              withTypeVHS[SierraTransformable, SourceMetadata, Assertion](
+              withTypeVHS[SierraTransformable, EmptyMetadata, Assertion](
                 vhsBucket,
                 table) { hybridStore =>
                 val bibId1 = createSierraBibNumber

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
@@ -14,6 +14,7 @@ import uk.ac.wellcome.storage.fixtures.{LocalVersionedHybridStore, S3}
 import uk.ac.wellcome.storage.vhs.{HybridRecord, SourceMetadata}
 import uk.ac.wellcome.test.utils.ExtendedPatience
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.sierra_adapter.utils.SierraVHSUtil
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -26,7 +27,8 @@ class SierraItemMergerFeatureTest
     with SQS
     with S3
     with LocalVersionedHybridStore
-    with SierraUtil {
+    with SierraUtil
+    with SierraVHSUtil {
 
   it("stores an item from SQS") {
     withLocalSqsQueue { queue =>
@@ -58,11 +60,10 @@ class SierraItemMergerFeatureTest
                 )
 
                 eventually {
-                  assertStored[SierraTransformable](
-                    bucket = vhsBucket,
-                    table = table,
-                    id = expectedSierraTransformable.id,
-                    record = expectedSierraTransformable)
+                  assertStored(
+                    transformable = expectedSierraTransformable,
+                    bucket = vhsBucket, table = table
+                  )
                 }
               }
             }
@@ -120,16 +121,14 @@ class SierraItemMergerFeatureTest
                       itemRecords = List(itemRecord2)
                     )
 
-                  assertStored[SierraTransformable](
-                    vhsBucket,
-                    table,
-                    id = expectedSierraTransformable1.id,
-                    record = expectedSierraTransformable1)
-                  assertStored[SierraTransformable](
-                    vhsBucket,
-                    table,
-                    id = expectedSierraTransformable2.id,
-                    record = expectedSierraTransformable2)
+                  assertStored(
+                    transformable = expectedSierraTransformable1,
+                    bucket = vhsBucket, table = table
+                  )
+                  assertStored(
+                    transformable = expectedSierraTransformable2,
+                    bucket = vhsBucket, table = table
+                  )
                 }
               }
             }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -7,7 +7,6 @@ import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.SierraTransformable._
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraUtil
 import uk.ac.wellcome.storage.ObjectStore
-import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.fixtures.LocalVersionedHybridStore
 import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}
@@ -17,7 +16,6 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.sierra_adapter.utils.SierraVHSUtil
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 
 class SierraItemMergerUpdaterServiceTest
     extends FunSpec

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -61,7 +61,8 @@ class SierraItemMergerUpdaterServiceTest
 
               assertStored(
                 transformable = expectedSierraTransformable,
-                bucket = bucket, table = table
+                bucket = bucket,
+                table = table
               )
             }
           }
@@ -134,15 +135,18 @@ class SierraItemMergerUpdaterServiceTest
               whenReady(sierraUpdaterService.update(itemRecord)) { _ =>
                 assertStored(
                   transformable = expectedNewSierraTransformable,
-                  bucket = bucket, table = table
+                  bucket = bucket,
+                  table = table
                 )
                 assertStored(
                   transformable = expectedUpdatedSierraTransformable,
-                  bucket = bucket, table = table
+                  bucket = bucket,
+                  table = table
                 )
                 assertStored(
                   transformable = newTransformable,
-                  bucket = bucket, table = table
+                  bucket = bucket,
+                  table = table
                 )
               }
             }
@@ -190,7 +194,8 @@ class SierraItemMergerUpdaterServiceTest
 
                 assertStored(
                   transformable = expectedTransformable,
-                  bucket = bucket, table = table
+                  bucket = bucket,
+                  table = table
                 )
               }
             }
@@ -255,11 +260,13 @@ class SierraItemMergerUpdaterServiceTest
               whenReady(sierraUpdaterService.update(unlinkItemRecord)) { _ =>
                 assertStored(
                   transformable = expectedTransformable1,
-                  bucket = bucket, table = table
+                  bucket = bucket,
+                  table = table
                 )
                 assertStored(
                   transformable = expectedTransformable2,
-                  bucket = bucket, table = table
+                  bucket = bucket,
+                  table = table
                 )
               }
             }
@@ -324,11 +331,13 @@ class SierraItemMergerUpdaterServiceTest
               whenReady(sierraUpdaterService.update(unlinkItemRecord)) { _ =>
                 assertStored(
                   transformable = expectedTransformable1,
-                  bucket = bucket, table = table
+                  bucket = bucket,
+                  table = table
                 )
                 assertStored(
                   transformable = expectedTransformable2,
-                  bucket = bucket, table = table
+                  bucket = bucket,
+                  table = table
                 )
               }
             }
@@ -394,11 +403,13 @@ class SierraItemMergerUpdaterServiceTest
               whenReady(sierraUpdaterService.update(unlinkItemRecord)) { _ =>
                 assertStored(
                   transformable = expectedTransformable1,
-                  bucket = bucket, table = table
+                  bucket = bucket,
+                  table = table
                 )
                 assertStored(
                   transformable = expectedTransformable2,
-                  bucket = bucket, table = table
+                  bucket = bucket,
+                  table = table
                 )
               }
             }
@@ -441,7 +452,8 @@ class SierraItemMergerUpdaterServiceTest
               whenReady(sierraUpdaterService.update(oldItemRecord)) { _ =>
                 assertStored(
                   transformable = transformable,
-                  bucket = bucket, table = table
+                  bucket = bucket,
+                  table = table
                 )
               }
             }
@@ -483,7 +495,8 @@ class SierraItemMergerUpdaterServiceTest
               whenReady(sierraUpdaterService.update(itemRecord)) { _ =>
                 assertStored(
                   transformable = expectedTransformable,
-                  bucket = bucket, table = table
+                  bucket = bucket,
+                  table = table
                 )
               }
             }


### PR DESCRIPTION
The new Sierra-only VHS is prefixing every ID with "sierra/", which doesn't add anything except noise. Let's get rid of it.