### PR TITLE
Fix three bugs in the reindex shard generator and post to Slack

### DIFF
--- a/monitoring/post_to_slack/src/platform_alarms.py
+++ b/monitoring/post_to_slack/src/platform_alarms.py
@@ -22,9 +22,9 @@ def guess_cloudwatch_log_group(alarm_name):
     if alarm_name.startswith('catalogue-api-remus'):
         return 'ecs/catalogue-api-remus'
 
-    if alarm_name.startswith('lambda-'):
+    if alarm_name.startswith('lambda-') and alarm_name.endswith('-errors'):
         # e.g. lambda-ecs_ec2_instance_tagger-errors
-        lambda_name = alarm_name.split('-')[1]
+        lambda_name = alarm_name[len('lambda-'):-len('-errors')]
         return f'/aws/lambda/{lambda_name}'
 
     raise ValueError(

--- a/monitoring/post_to_slack/src/test_platform_alarms.py
+++ b/monitoring/post_to_slack/src/test_platform_alarms.py
@@ -25,6 +25,7 @@ class Alarm:
     ('catalogue-api-remus-alb-target-500-errors', 'ecs/catalogue-api-remus'),
     ('lambda-ecs_ec2_instance_tagger-errors', '/aws/lambda/ecs_ec2_instance_tagger'),
     ('lambda-post_to_slack-errors', '/aws/lambda/post_to_slack'),
+    ('lambda-reindex_shard_generator_vhs-sourcedata-sierra-errors', '/aws/lambda/reindex_shard_generator_vhs-sourcedata-sierra'),
 ])
 def test_guess_cloudwatch_log_group(alarm_name, expected_log_group_name):
     assert guess_cloudwatch_log_group(alarm_name) == expected_log_group_name

--- a/reindexer/reindex_shard_generator/src/reindex_shard_generator.py
+++ b/reindexer/reindex_shard_generator/src/reindex_shard_generator.py
@@ -68,4 +68,4 @@ def main(event, _ctxt=None, dynamodb_client=None):
             if e.response['Error']['Code'] != 'ConditionalCheckFailedException':
                 raise
             else:
-                print(f'Adding shard for id: {id} failed with ConditionalCheckFailedException')
+                print(f'Adding shard for id: {row["id"]} failed with ConditionalCheckFailedException')

--- a/reindexer/terraform/reindex_shard_generator/main.tf
+++ b/reindexer/terraform/reindex_shard_generator/main.tf
@@ -9,7 +9,7 @@ module "shard_generator_lambda" {
 
   description = "Generate reindexShards for items in the ${var.vhs_table_name} table"
 
-  timeout = 60
+  timeout = 300
 
   environment_variables = {
     TABLE_NAME = "${var.vhs_table_name}"


### PR DESCRIPTION
When looking at the failures from yesterday, I saw three issues:

1. Timeouts – the best fix for which is to increase the timeout to the max
2. Bad logging – this log is very unhelpful, let's make it better:

    > Adding shard for id: <built-in function id> failed with ConditionalCheckFailedException

3. The CloudWatch log links in post-to-slack take you to the wrong log group.