### PR TITLE
All errors in Slack go to the main channel, not a side channel

### DIFF
--- a/monitoring/post_to_slack/src/platform_alarms.py
+++ b/monitoring/post_to_slack/src/platform_alarms.py
@@ -46,19 +46,6 @@ def guess_cloudwatch_search_terms(alarm_name):
     return []
 
 
-def should_be_sent_to_main_channel(alarm_name):
-    """Should this alarm be sent to the main channel?"""
-    # Alarms for the API or Loris always go the main channel.
-    if any(p in alarm_name for p in ['catalogue-api-remus', 'catalogue-api-romulus', 'loris']):
-        return True
-
-    if alarm_name.endswith('_dlq_not_empty'):
-        return True
-
-    # Otherwise default to False, because we don't know what this alarm is.
-    return False
-
-
 def is_critical_error(alarm_name):
     """Is this a critical error (True) or just a warning (False)?"""
     # Alarms for the API or Loris are always critical.

--- a/monitoring/post_to_slack/src/post_to_slack.py
+++ b/monitoring/post_to_slack/src/post_to_slack.py
@@ -22,7 +22,6 @@ from platform_alarms import (
     guess_cloudwatch_log_group,
     guess_cloudwatch_search_terms,
     is_critical_error,
-    should_be_sent_to_main_channel,
     simplify_message
 )
 
@@ -204,18 +203,12 @@ def prepare_slack_payload(alarm, bitly_access_token, sess=None):
 @log_on_error
 def main(event, _ctxt=None):
     bitly_access_token = os.environ['BITLY_ACCESS_TOKEN']
-    slack_critical_hook = os.environ['CRITICAL_SLACK_WEBHOOK']
-    slack_noncritical_hook = os.environ['NONCRITICAL_SLACK_WEBHOOK']
+    webhook_url = os.environ['CRITICAL_SLACK_WEBHOOK']
 
     alarm = Alarm(event['Records'][0]['Sns']['Message'])
     slack_data = prepare_slack_payload(alarm, bitly_access_token)
 
     print('Sending message %s' % json.dumps(slack_data))
-
-    if should_be_sent_to_main_channel(alarm_name=alarm.name):
-        webhook_url = slack_critical_hook
-    else:
-        webhook_url = slack_noncritical_hook
 
     response = requests.post(
         webhook_url,

--- a/monitoring/post_to_slack/src/test_platform_alarms.py
+++ b/monitoring/post_to_slack/src/test_platform_alarms.py
@@ -8,7 +8,6 @@ from platform_alarms import (
     guess_cloudwatch_log_group,
     guess_cloudwatch_search_terms,
     is_critical_error,
-    should_be_sent_to_main_channel,
     simplify_message
 )
 
@@ -49,23 +48,6 @@ def test_unrecognised_log_group_name_is_valueerror(bad_alarm_name):
 ])
 def test_guess_cloudwatch_search_terms(alarm_name, expected_search_terms):
     assert guess_cloudwatch_search_terms(alarm_name) == expected_search_terms
-
-
-@pytest.mark.parametrize('alarm_name, should_send_to_main', [
-    ('catalogue-api-romulus-alb-target-400-errors', True),
-    ('catalogue-api-remus-alb-target-500-errors', True),
-    ('loris-alb-not-enough-healthy-hosts', True),
-    ('id_minter-alb-unhealthy-hosts', False),
-    ('ingestor-alb-unhealthy-hosts', False),
-    ('transformer-alb-not-enough-healthy-hosts', False),
-    ('grafana-alb-target-500-errors', False),
-    ('IngestorWorkerService_TerminalFailure', False),
-    ('sierra_items_windows_dlq_not_empty', True),
-    ('lambda-post_to_slack-errors', False),
-    ('unknown-alarm-type', False),
-])
-def test_should_be_sent_to_main_channel(alarm_name, should_send_to_main):
-    assert should_be_sent_to_main_channel(alarm_name) == should_send_to_main
 
 
 @pytest.mark.parametrize('alarm_name, expected_is_critical_error', [


### PR DESCRIPTION
The side channel has become quite noisy, and most of it is non-actionable (e.g. GitHub notifications, Terraform changes and reindexing).

This moves the alerts (which we should really be working to get to zero!) back into the main channel, where they're more visible and will encourage us to address them.

[Mostly because I keep #platform-alterations muted, but not #platform.]