### PR TITLE
Remove some Jackson-specific logic from DisplayItem

### DIFF
--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1.scala
@@ -33,20 +33,9 @@ object DisplayItemV1 {
       id = item.canonicalId,
       identifiers =
         if (includesIdentifiers)
-          // If there aren't any identifiers on the item JSON, Jackson puts a
-          // nil here.  Wrapping it in an Option casts it into a None or Some
-          // as appropriate, and avoids throwing a NullPointerError when
-          // we map over the value.
-          Option[List[SourceIdentifier]](item.identifiers) match {
-            case Some(identifiers) =>
-              Some(identifiers.map(DisplayIdentifierV1(_)))
-            case None => Some(List())
-          } else None,
-      locations = // Same as with identifiers
-        Option[List[Location]](item.agent.locations) match {
-          case Some(locations) => locations.map(DisplayLocationV1(_))
-          case None            => List()
-        }
+          Some(item.identifiers.map { DisplayIdentifierV1(_) })
+        else None,
+      locations = item.agent.locations.map { DisplayLocationV1(_) }
     )
   }
 }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2.scala
@@ -37,13 +37,17 @@ object DisplayItemV2 {
             if (includesIdentifiers)
               Some(identifiedItem.identifiers.map { DisplayIdentifierV2(_) })
             else None,
-          locations = identifiedItem.agent.locations.map { DisplayLocationV2(_) }
+          locations = identifiedItem.agent.locations.map {
+            DisplayLocationV2(_)
+          }
         )
       case unidentifiableItem: Unidentifiable[Item] =>
         DisplayItemV2(
           id = None,
           identifiers = None,
-          locations = unidentifiableItem.agent.locations.map { DisplayLocationV2(_) }
+          locations = unidentifiableItem.agent.locations.map {
+            DisplayLocationV2(_)
+          }
         )
     }
 

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2.scala
@@ -35,30 +35,15 @@ object DisplayItemV2 {
           id = Some(identifiedItem.canonicalId),
           identifiers =
             if (includesIdentifiers)
-              // If there aren't any identifiers on the item JSON, Jackson puts a
-              // nil here.  Wrapping it in an Option casts it into a None or Some
-              // as appropriate, and avoids throwing a NullPointerError when
-              // we map over the value.
-              Option[List[SourceIdentifier]](identifiedItem.identifiers) match {
-                case Some(identifiers) =>
-                  Some(identifiers.map(DisplayIdentifierV2(_)))
-                case None => Some(List())
-              } else None,
-          locations = // Same as with identifiers
-            Option[List[Location]](identifiedItem.agent.locations) match {
-              case Some(locations) => locations.map(DisplayLocationV2(_))
-              case None            => List()
-            }
+              Some(identifiedItem.identifiers.map { DisplayIdentifierV2(_) })
+            else None,
+          locations = identifiedItem.agent.locations.map { DisplayLocationV2(_) }
         )
-      case unidientifiableItem: Unidentifiable[Item] =>
+      case unidentifiableItem: Unidentifiable[Item] =>
         DisplayItemV2(
           id = None,
           identifiers = None,
-          locations =
-            Option[List[Location]](unidientifiableItem.agent.locations) match {
-              case Some(locations) => locations.map(DisplayLocationV2(_))
-              case None            => List()
-            }
+          locations = unidentifiableItem.agent.locations.map { DisplayLocationV2(_) }
         )
     }
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2Test.scala
@@ -36,7 +36,7 @@ class DisplayItemV2Test extends FunSpec with Matchers with ItemsUtil {
 
   it("parses an unidentified Item without any locations") {
     val item = createUnidentifiableItemWith(
-      locations = null
+      locations = List()
     )
 
     val displayItemV2 = DisplayItemV2(


### PR DESCRIPTION
We no longer parse documents from Elasticsearch using Jackson, only Circe -- so this workaround for a Jackson bug can be removed.

Another bit of refactoring for #2163.