### PR TITLE
In SierraContributors, multiple identifiers => unidentified

### DIFF
--- a/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributors.scala
+++ b/catalogue_pipeline/transformer/src/main/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributors.scala
@@ -165,8 +165,10 @@ trait SierraContributors extends MarcUtils {
       case MarcSubfield("0", content) => content.replaceAll("[.,\\s]", "")
     }
 
+    // If we get exactly one value, we can use it to identify the record.
+    // Some records have multiple instances of subfield $0 (it's a repeatable
+    // field in the MARC spec).
     codes.distinct match {
-      case Nil => Unidentifiable(agent)
       case Seq(code) => {
         val sourceIdentifier = SourceIdentifier(
           identifierType = IdentifierType("lc-names"),
@@ -178,9 +180,7 @@ trait SierraContributors extends MarcUtils {
           sourceIdentifier = sourceIdentifier
         )
       }
-      case _ =>
-        throw TransformerException(
-          s"Multiple identifiers in subfield $$0: $codes")
+      case _ => Unidentifiable(agent)
     }
   }
 }

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConceptsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraConceptsTest.scala
@@ -76,7 +76,7 @@ class SierraConceptsTest extends FunSpec with Matchers {
     )
   }
 
-  it("ignores multiple instances of subfield 0 im the otherIdentifiers") {
+  it("ignores multiple instances of subfield 0 in the otherIdentifiers") {
     val concept = Concept(label = "Hitchhiking horses hurry home")
 
     val maybeIdentifiedConcept = transformer.identifyPrimaryConcept[Concept](

--- a/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributorsTest.scala
+++ b/catalogue_pipeline/transformer/src/test/scala/uk/ac/wellcome/platform/transformer/transformers/sierra/SierraContributorsTest.scala
@@ -626,7 +626,8 @@ class SierraContributorsTest extends FunSpec with Matchers with SierraDataUtil {
     }
 
     it(
-      "fails the transform if there are multiple distinct identifiers in subfield $$0") {
+      "does not identify the contributor if there are multiple distinct identifiers in subfield $$0") {
+      val name = "Luke the lime"
       val varFields = List(
         VarField(
           fieldTag = "p",
@@ -634,14 +635,22 @@ class SierraContributorsTest extends FunSpec with Matchers with SierraDataUtil {
           indicator1 = "",
           indicator2 = "",
           subfields = List(
-            MarcSubfield(tag = "a", content = "Luke the lime"),
+            MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "0", content = "lcsh3349285"),
             MarcSubfield(tag = "0", content = "lcsh9059917")
           )
         )
       )
 
-      assertTransformFails(varFields = varFields)
+      val expectedContributors = List(
+        Contributor(
+          agent = Unidentifiable(Organisation(label = name))
+        )
+      )
+
+      transformAndCheckContributors(
+        varFields = varFields,
+        expectedContributors = expectedContributors)
     }
   }
 


### PR DESCRIPTION
This fixes the last outstanding issue which is causing the transformer to drop records, I believe.