### PR TITLE
Try to make the reindex_request_creator and sierra_item_merger less flaky

### DIFF
--- a/reindexer/reindex_request_creator/src/universal/conf/application.ini.template
+++ b/reindexer/reindex_request_creator/src/universal/conf/application.ini.template
@@ -1,3 +1,4 @@
+-aws.sqs.parallelism=${sqs_parallelism}
 -aws.sqs.queue.url=${reindex_jobs_queue_id}
 -aws.sns.topic.arn=${reindex_requests_topic_arn}
 -aws.metrics.namespace=${metrics_namespace}

--- a/reindexer/terraform/queues.tf
+++ b/reindexer/terraform/queues.tf
@@ -5,23 +5,23 @@ module "reindex_request_creator_queue" {
   account_id  = "${data.aws_caller_identity.current.account_id}"
   topic_names = ["${module.reindex_jobs_topic.name}"]
 
-  # Each reindexer message requires up to 1500 calls to DynamoDB's PutItem API
-  # (one for every record in the shard).  Particularly when the reindexer has
-  # just started, it tends to hit the throughput limits, and the message
-  # hits the DLQ.
+  # The reindex_request_creator scans a source data table to look for
+  # records that need reindexing, and sends each of them as an SNS notification
+  # for the reindex_request_processor.
   #
-  # The long-term fix is to rearchitect the reindexer to behave in a better
-  # way, but for now we have this short-term fix:
+  # If it fails midway through, it rescans and resends *the entire shard* --
+  # leading to significantly more work for the processor!  If it's already
+  # sent a notification for a record, but the processor hasn't reindexed
+  # it yet, it gets resent.
   #
-  #   - Wait 2 minutes before a message can be reprocessed.  If it hits limits
-  #     on the first attempt, the table should have warmed up before it comes
-  #     round again.
-  #   - Retry 50 times per job, so we have to average 30 successful PutItem
-  #     calls per attempt.  This seems more feasible than the default.
+  # To that end, we have a very long visibility timeout on this queue -- so
+  # once it's sent a batch of notifications, the processor has a chance to
+  # pick them up before the creator sends a fresh batch.
   #
-  # TODO: Reduce these limits when we fix the reindexer.
+  # (tl;dr: There is a sensible reason for the timeout to be this long, and
+  #  we're not just trying to evade flakiness.)
   #
-  visibility_timeout_seconds = 120
+  visibility_timeout_seconds = 600
 
   max_receive_count = 50
   alarm_topic_arn   = "${local.dlq_alarm_arn}"

--- a/reindexer/terraform/queues.tf
+++ b/reindexer/terraform/queues.tf
@@ -1,6 +1,6 @@
-module "reindexer_queue" {
+module "reindex_request_creator_queue" {
   source      = "git::https://github.com/wellcometrust/terraform-modules.git//sqs?ref=v10.2.3"
-  queue_name  = "reindexer_queue"
+  queue_name  = "reindex_request_creator_queue"
   aws_region  = "${var.aws_region}"
   account_id  = "${data.aws_caller_identity.current.account_id}"
   topic_names = ["${module.reindex_jobs_topic.name}"]

--- a/reindexer/terraform/service_reindex_request_creator.tf
+++ b/reindexer/terraform/service_reindex_request_creator.tf
@@ -3,8 +3,8 @@ module "reindex_request_creator" {
   service_name = "reindex_request_creator"
 
   task_desired_count = "0"
-  source_queue_name  = "${module.reindexer_queue.name}"
-  source_queue_arn   = "${module.reindexer_queue.arn}"
+  source_queue_name  = "${module.reindex_request_creator_queue.name}"
+  source_queue_arn   = "${module.reindex_request_creator_queue.arn}"
 
   container_image    = "${local.reindex_request_creator_container_image}"
   security_group_ids = ["${aws_security_group.service_egress_security_group.id}"]
@@ -13,7 +13,7 @@ module "reindex_request_creator" {
   memory = 2048
 
   env_vars = {
-    reindex_jobs_queue_id      = "${module.reindexer_queue.id}"
+    reindex_jobs_queue_id      = "${module.reindex_request_creator_queue.id}"
     reindex_requests_topic_arn = "${module.reindex_requests_topic.arn}"
     metrics_namespace          = "reindex_request_creator"
   }

--- a/reindexer/terraform/service_reindex_request_creator.tf
+++ b/reindexer/terraform/service_reindex_request_creator.tf
@@ -16,9 +16,15 @@ module "reindex_request_creator" {
     reindex_jobs_queue_id      = "${module.reindex_request_creator_queue.id}"
     reindex_requests_topic_arn = "${module.reindex_requests_topic.arn}"
     metrics_namespace          = "reindex_request_creator"
+
+    # The reindex request creator has to send lots of SNS notifications,
+    # and we've seen issues where we exhaust the HTTP connection pool.
+    # Turning down the parallelism is an attempt to reduce the number of
+    # SNS messages in flight, and avoid these errors.
+    sqs_parallelism = 7
   }
 
-  env_vars_length = 3
+  env_vars_length = 4
 
   ecs_cluster_name = "${aws_ecs_cluster.cluster.name}"
   ecs_cluster_id   = "${aws_ecs_cluster.cluster.id}"

--- a/sierra_adapter/sierra_item_merger/src/universal/conf/application.ini.template
+++ b/sierra_adapter/sierra_item_merger/src/universal/conf/application.ini.template
@@ -1,3 +1,4 @@
+-aws.sqs.parallelism=${sqs_parallelism}
 -aws.sqs.queue.url=${windows_queue_url}
 -aws.metrics.namespace=${metrics_namespace}
 -aws.vhs.s3.bucketName=${bucket_name}

--- a/sierra_adapter/terraform/item_merger/main.tf
+++ b/sierra_adapter/terraform/item_merger/main.tf
@@ -30,9 +30,15 @@ module "sierra_merger_service" {
     dynamo_table_name   = "${var.merged_dynamo_table_name}"
     bucket_name         = "${var.bucket_name}"
     sierra_items_bucket = "${var.sierra_items_bucket}"
+
+    # The item merger has to write lots of S3 objects, and we've seen issues
+    # where we exhaust the HTTP connection pool.  Turning down the parallelism
+    # is an attempt to reduce the number of S3 objects in flight, and avoid
+    # these errors.
+    sqs_parallelism = 7
   }
 
-  env_vars_length = 5
+  env_vars_length = 6
 
   aws_region = "${var.aws_region}"
   vpc_id     = "${var.vpc_id}"


### PR DESCRIPTION
As discussed:

* Increase queue visibility timeout for the reindex_request_creator, so we get less duplicates on the processor queue
* Decrease SQS stream parallelism for both of them, which should reduce the number of HTTP connections they're trying to get at once

I looked at ClientConfiguration, but there are too many levers to pull! And exposing this in our config means we can tweak it in Terraform later. I don't think we need much of an adjustment, because most messages are getting through fine.