### PR TITLE
Don't through on ProvisionedThroughputException in dynamo_write_heartbeat

### DIFF
--- a/shared_infra/dynamo_write_heartbeat/src/dynamo_write_heartbeat.py
+++ b/shared_infra/dynamo_write_heartbeat/src/dynamo_write_heartbeat.py
@@ -6,14 +6,16 @@ make DynamoDB scale down when there would otherwise be zero throughput and it ot
 TABLE_NAMES: comma separated list of dynamoDb tables to call
 """
 
-import boto3
 import os
+
+import boto3
+from botocore.exceptions import ClientError
 
 from wellcome_aws_utils.lambda_utils import log_on_error
 
 
 @log_on_error
-def main(event, context, dynamodb_client=None):
+def main(event=None, context=None, dynamodb_client=None):
     try:
         table_names = [t.strip() for t in os.environ['TABLE_NAMES'].split(',')]
     except KeyError:
@@ -21,6 +23,25 @@ def main(event, context, dynamodb_client=None):
 
     dynamodb_client = dynamodb_client or boto3.client('dynamodb')
     for table_name in table_names:
-        response = dynamodb_client.delete_item(TableName=table_name.strip(),
-                                               Key={'id': {'S': 'dummy-id-not-there'}})
-        print("Heartbeat, delete_item on dynamoDb table:{}, returned-status:{}".format(table_name, response['ResponseMetadata']['HTTPStatusCode']))
+        try:
+            response = dynamodb_client.delete_item(
+                TableName=table_name.strip(),
+                Key={'id': {'S': 'dummy-id-not-there'}}
+            )
+
+        # Although in general a ProvisionedThroughputExceededException is
+        # an error, we don't actually need the DeleteItem to succeed in this
+        # case.  We want to keep a minimum level of throughput on the table --
+        # if this exception is thrown, then other services are using
+        # the table and it's okay if we miss a heartbeat.
+        except ClientError as err:
+            if err.response['Error']['Code'] == 'ProvisionedThroughputExceededException':
+                pass
+            else:
+                raise
+
+        else:
+            print(
+                f'Heartbeat, delete_item on dynamoDb table: {table_name}, '
+                f'returned-status: {response["ResponseMetadata"]["HTTPStatusCode"]}'
+            )


### PR DESCRIPTION
In the wider context, somebody else is using the table, so we don't need the heartbeat right now.