### PR TITLE
Clean up the interface to SierraItems

### DIFF
--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -83,9 +83,9 @@ class SierraTransformableTransformer
                 language = getLanguage(sierraBibData),
                 dimensions = getDimensions(sierraBibData),
                 items = getItems(
+                  bibId = bibId,
                   bibData = sierraBibData,
-                  itemDataMap = sierraItemDataMap,
-                  bibId = bibId
+                  itemDataMap = sierraItemDataMap
                 ),
                 itemsV1 = List(),
                 version = version

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -3,12 +3,24 @@ package uk.ac.wellcome.platform.transformer.sierra
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.exceptions.JsonDecodingError
 import uk.ac.wellcome.models.transformable.SierraTransformable
-import uk.ac.wellcome.models.transformable.sierra.{SierraItemNumber, SierraItemRecord}
+import uk.ac.wellcome.models.transformable.sierra.{
+  SierraItemNumber,
+  SierraItemRecord
+}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.exceptions.{ShouldNotTransformException, TransformerException}
-import uk.ac.wellcome.platform.transformer.sierra.source.{SierraBibData, SierraItemData}
+import uk.ac.wellcome.platform.transformer.exceptions.{
+  ShouldNotTransformException,
+  TransformerException
+}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  SierraBibData,
+  SierraItemData
+}
 import uk.ac.wellcome.platform.transformer.sierra.transformers.sierra._
-import uk.ac.wellcome.platform.transformer.sierra.transformers.sierra.subjects.{SierraConceptSubjects, SierraPersonSubjects}
+import uk.ac.wellcome.platform.transformer.sierra.transformers.sierra.subjects.{
+  SierraConceptSubjects,
+  SierraPersonSubjects
+}
 
 import scala.util.{Failure, Success, Try}
 
@@ -60,7 +72,8 @@ class SierraTransformableTransformer
 
         fromJson[SierraBibData](bibRecord.data)
           .map { sierraBibData =>
-            val sierraItemDataMap = extractItemData(sierraTransformable.itemRecords)
+            val sierraItemDataMap =
+              extractItemData(sierraTransformable.itemRecords)
 
             if (!(sierraBibData.deleted || sierraBibData.suppressed)) {
               UnidentifiedWork(
@@ -124,7 +137,8 @@ class SierraTransformableTransformer
       }
   }
 
-  def extractItemData(itemRecords: Map[SierraItemNumber, SierraItemRecord]): Map[SierraItemNumber, SierraItemData] =
+  def extractItemData(itemRecords: Map[SierraItemNumber, SierraItemRecord])
+    : Map[SierraItemNumber, SierraItemData] =
     itemRecords
       .map { case (id, itemRecord) => (id, itemRecord.data) }
       .map {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -82,11 +82,11 @@ class SierraTransformableTransformer
                 production = getProduction(sierraBibData),
                 language = getLanguage(sierraBibData),
                 dimensions = getDimensions(sierraBibData),
-                items =
-                  getPhysicalItems(sierraItemDataMap) ++
-                    getDigitalItems(
-                      sourceIdentifier.copy(ontologyType = "Item"),
-                      sierraBibData),
+                items = getItems(
+                  bibData = sierraBibData,
+                  itemDataMap = sierraItemDataMap,
+                  bibId = bibId
+                ),
                 itemsV1 = List(),
                 version = version
               )

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -1,17 +1,16 @@
 package uk.ac.wellcome.platform.transformer.sierra
 
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.json.exceptions.JsonDecodingError
 import uk.ac.wellcome.models.transformable.SierraTransformable
+import uk.ac.wellcome.models.transformable.sierra.{SierraItemNumber, SierraItemRecord}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.exceptions.ShouldNotTransformException
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
+import uk.ac.wellcome.platform.transformer.exceptions.{ShouldNotTransformException, TransformerException}
+import uk.ac.wellcome.platform.transformer.sierra.source.{SierraBibData, SierraItemData}
 import uk.ac.wellcome.platform.transformer.sierra.transformers.sierra._
-import uk.ac.wellcome.platform.transformer.sierra.transformers.sierra.subjects.{
-  SierraConceptSubjects,
-  SierraPersonSubjects
-}
+import uk.ac.wellcome.platform.transformer.sierra.transformers.sierra.subjects.{SierraConceptSubjects, SierraPersonSubjects}
 
-import scala.util.{Success, Try}
+import scala.util.{Failure, Success, Try}
 
 class SierraTransformableTransformer
     extends SierraIdentifiers
@@ -61,6 +60,8 @@ class SierraTransformableTransformer
 
         fromJson[SierraBibData](bibRecord.data)
           .map { sierraBibData =>
+            val sierraItemDataMap = extractItemData(sierraTransformable.itemRecords)
+
             if (!(sierraBibData.deleted || sierraBibData.suppressed)) {
               UnidentifiedWork(
                 sourceIdentifier = sourceIdentifier,
@@ -82,7 +83,7 @@ class SierraTransformableTransformer
                 language = getLanguage(sierraBibData),
                 dimensions = getDimensions(sierraBibData),
                 items =
-                  getPhysicalItems(sierraTransformable) ++
+                  getPhysicalItems(sierraItemDataMap) ++
                     getDigitalItems(
                       sourceIdentifier.copy(ontologyType = "Item"),
                       sierraBibData),
@@ -96,6 +97,10 @@ class SierraTransformableTransformer
             }
           }
           .recover {
+            case e: JsonDecodingError =>
+              throw TransformerException(
+                s"Unable to parse bib data for ${bibRecord.id} as JSON: <<${bibRecord.data}>>"
+              )
             case e: ShouldNotTransformException =>
               info(s"Should not transform $bibId: ${e.getMessage}")
               UnidentifiedInvisibleWork(
@@ -118,5 +123,18 @@ class SierraTransformableTransformer
         )
       }
   }
+
+  def extractItemData(itemRecords: Map[SierraItemNumber, SierraItemRecord]): Map[SierraItemNumber, SierraItemData] =
+    itemRecords
+      .map { case (id, itemRecord) => (id, itemRecord.data) }
+      .map {
+        case (id, jsonString) =>
+          fromJson[SierraItemData](jsonString) match {
+            case Success(data) => id -> data
+            case Failure(_) =>
+              throw TransformerException(
+                s"Unable to parse item data for $id as JSON: <<$jsonString>>")
+          }
+      }
 
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItems.scala
@@ -10,9 +10,9 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
 
 trait SierraItems extends Logging with SierraLocation {
   def getItems(
+    bibId: SierraBibNumber,
     bibData: SierraBibData,
-    itemDataMap: Map[SierraItemNumber, SierraItemData],
-    bibId: SierraBibNumber): List[MaybeDisplayable[Item]] =
+    itemDataMap: Map[SierraItemNumber, SierraItemData]): List[MaybeDisplayable[Item]] =
     getPhysicalItems(itemDataMap) ++
       getDigitalItems(
         bibId = bibId,

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItems.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.models.transformable.sierra.{SierraBibNumber, SierraItemNumber}
+import uk.ac.wellcome.models.transformable.sierra.{
+  SierraBibNumber,
+  SierraItemNumber
+}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraBibData,
@@ -9,17 +12,16 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
 }
 
 trait SierraItems extends Logging with SierraLocation {
-  def getItems(
-    bibId: SierraBibNumber,
-    bibData: SierraBibData,
-    itemDataMap: Map[SierraItemNumber, SierraItemData]): List[MaybeDisplayable[Item]] =
+  def getItems(bibId: SierraBibNumber,
+               bibData: SierraBibData,
+               itemDataMap: Map[SierraItemNumber, SierraItemData])
+    : List[MaybeDisplayable[Item]] =
     getPhysicalItems(itemDataMap) ++
-      getDigitalItems(
-        bibId = bibId,
-        bibData = bibData)
+      getDigitalItems(bibId = bibId, bibData = bibData)
 
-  private def transformItemData(itemId: SierraItemNumber,
-                                itemData: SierraItemData): Identifiable[Item] = {
+  private def transformItemData(
+    itemId: SierraItemNumber,
+    itemData: SierraItemData): Identifiable[Item] = {
     debug(s"Attempting to transform $itemId")
     Identifiable(
       sourceIdentifier = SourceIdentifier(
@@ -40,7 +42,9 @@ trait SierraItems extends Logging with SierraLocation {
     )
   }
 
-  private def getPhysicalItems(sierraItemDataMap: Map[SierraItemNumber, SierraItemData]): List[Identifiable[Item]] =
+  private def getPhysicalItems(
+    sierraItemDataMap: Map[SierraItemNumber, SierraItemData])
+    : List[Identifiable[Item]] =
     sierraItemDataMap
       .filterNot {
         case (_: SierraItemNumber, itemData: SierraItemData) => itemData.deleted

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItems.scala
@@ -18,8 +18,8 @@ trait SierraItems extends Logging with SierraLocation {
         bibId = bibId,
         bibData = bibData)
 
-  def transformItemData(itemId: SierraItemNumber,
-                        itemData: SierraItemData): Identifiable[Item] = {
+  private def transformItemData(itemId: SierraItemNumber,
+                                itemData: SierraItemData): Identifiable[Item] = {
     debug(s"Attempting to transform $itemId")
     Identifiable(
       sourceIdentifier = SourceIdentifier(
@@ -40,7 +40,7 @@ trait SierraItems extends Logging with SierraLocation {
     )
   }
 
-  def getPhysicalItems(sierraItemDataMap: Map[SierraItemNumber, SierraItemData]): List[Identifiable[Item]] =
+  private def getPhysicalItems(sierraItemDataMap: Map[SierraItemNumber, SierraItemData]): List[Identifiable[Item]] =
     sierraItemDataMap
       .filterNot {
         case (_: SierraItemNumber, itemData: SierraItemData) => itemData.deleted
@@ -74,7 +74,7 @@ trait SierraItems extends Logging with SierraLocation {
     * away with this code.
     *
     */
-  def getDigitalItems(
+  private def getDigitalItems(
     bibId: SierraBibNumber,
     bibData: SierraBibData): List[Unidentifiable[Item]] = {
     val hasDlnkLocation = bibData.locations match {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItems.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItems.scala
@@ -1,33 +1,14 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraItemNumber
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraBibData,
   SierraItemData
 }
 
-import scala.util.{Failure, Success}
-
 trait SierraItems extends Logging with SierraLocation {
-  def extractItemData(sierraTransformable: SierraTransformable)
-    : Map[SierraItemNumber, SierraItemData] =
-    sierraTransformable.itemRecords
-      .map { case (id, itemRecord) => (id, itemRecord.data) }
-      .map {
-        case (id, jsonString) =>
-          fromJson[SierraItemData](jsonString) match {
-            case Success(data) => id -> data
-            case Failure(_) =>
-              throw TransformerException(
-                s"Unable to parse item data for $id as JSON: <<$jsonString>>")
-          }
-      }
-
   def transformItemData(itemId: SierraItemNumber,
                         itemData: SierraItemData): Identifiable[Item] = {
     debug(s"Attempting to transform $itemId")
@@ -50,9 +31,8 @@ trait SierraItems extends Logging with SierraLocation {
     )
   }
 
-  def getPhysicalItems(
-    sierraTransformable: SierraTransformable): List[Identifiable[Item]] =
-    extractItemData(sierraTransformable)
+  def getPhysicalItems(sierraItemDataMap: Map[SierraItemNumber, SierraItemData]): List[Identifiable[Item]] =
+    sierraItemDataMap
       .filterNot {
         case (_: SierraItemNumber, itemData: SierraItemData) => itemData.deleted
       }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -11,6 +11,7 @@ import uk.ac.wellcome.models.transformable.sierra.{
 }
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.test.util.WorksGenerators
+import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.sierra.SierraTransformableTransformer
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
@@ -669,6 +670,56 @@ class SierraTransformableTransformerTest
     work.asInstanceOf[UnidentifiedWork].workType shouldBe Some(
       WorkType(id = "k", label = "Pictures")
     )
+  }
+
+  describe("throws a TransformerException when passed invalid data") {
+    it("an item record") {
+      val bibRecord = createSierraBibRecord
+      val transformable = SierraTransformable(
+        sierraId = bibRecord.id,
+        maybeBibRecord = Some(bibRecord),
+        itemRecords = Map(
+          createSierraItemNumber -> createSierraItemRecordWith(data = "Not valid JSON")
+        )
+      )
+
+      val result = transformer.transform(transformable, version = 1)
+      result.isFailure shouldBe true
+      result.failed.get shouldBe a[TransformerException]
+      result.failed.get.asInstanceOf[TransformerException].e.getMessage should include("Unable to parse item data")
+    }
+
+    it("one of several item records") {
+      val bibRecord = createSierraBibRecord
+      val transformable = SierraTransformable(
+        sierraId = bibRecord.id,
+        maybeBibRecord = Some(bibRecord),
+        itemRecords = Map(
+          createSierraItemNumber -> createSierraItemRecord,
+          createSierraItemNumber -> createSierraItemRecordWith(data = "Not valid JSON"),
+          createSierraItemNumber -> createSierraItemRecord
+        )
+      )
+
+      val result = transformer.transform(transformable, version = 1)
+      result.isFailure shouldBe true
+      result.failed.get shouldBe a[TransformerException]
+      result.failed.get.asInstanceOf[TransformerException].e.getMessage should include("Unable to parse item data")
+    }
+
+    it("the bib record") {
+      val bibRecord = createSierraBibRecordWith(
+        data = "Not a valid JSON string"
+      )
+      val transformable = SierraTransformable(
+        bibRecord = bibRecord
+      )
+
+      val result = transformer.transform(transformable, version = 1)
+      result.isFailure shouldBe true
+      result.failed.get shouldBe a[TransformerException]
+      result.failed.get.asInstanceOf[TransformerException].e.getMessage should include("Unable to parse bib data")
+    }
   }
 
   private def transformDataToWork(id: SierraBibNumber,

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -679,14 +679,18 @@ class SierraTransformableTransformerTest
         sierraId = bibRecord.id,
         maybeBibRecord = Some(bibRecord),
         itemRecords = Map(
-          createSierraItemNumber -> createSierraItemRecordWith(data = "Not valid JSON")
+          createSierraItemNumber -> createSierraItemRecordWith(
+            data = "Not valid JSON")
         )
       )
 
       val result = transformer.transform(transformable, version = 1)
       result.isFailure shouldBe true
       result.failed.get shouldBe a[TransformerException]
-      result.failed.get.asInstanceOf[TransformerException].e.getMessage should include("Unable to parse item data")
+      result.failed.get
+        .asInstanceOf[TransformerException]
+        .e
+        .getMessage should include("Unable to parse item data")
     }
 
     it("one of several item records") {
@@ -696,7 +700,8 @@ class SierraTransformableTransformerTest
         maybeBibRecord = Some(bibRecord),
         itemRecords = Map(
           createSierraItemNumber -> createSierraItemRecord,
-          createSierraItemNumber -> createSierraItemRecordWith(data = "Not valid JSON"),
+          createSierraItemNumber -> createSierraItemRecordWith(
+            data = "Not valid JSON"),
           createSierraItemNumber -> createSierraItemRecord
         )
       )
@@ -704,7 +709,10 @@ class SierraTransformableTransformerTest
       val result = transformer.transform(transformable, version = 1)
       result.isFailure shouldBe true
       result.failed.get shouldBe a[TransformerException]
-      result.failed.get.asInstanceOf[TransformerException].e.getMessage should include("Unable to parse item data")
+      result.failed.get
+        .asInstanceOf[TransformerException]
+        .e
+        .getMessage should include("Unable to parse item data")
     }
 
     it("the bib record") {
@@ -718,7 +726,10 @@ class SierraTransformableTransformerTest
       val result = transformer.transform(transformable, version = 1)
       result.isFailure shouldBe true
       result.failed.get shouldBe a[TransformerException]
-      result.failed.get.asInstanceOf[TransformerException].e.getMessage should include("Unable to parse bib data")
+      result.failed.get
+        .asInstanceOf[TransformerException]
+        .e
+        .getMessage should include("Unable to parse bib data")
     }
   }
 

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItemsTest.scala
@@ -1,9 +1,15 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.transformable.sierra.{SierraBibNumber, SierraItemNumber}
+import uk.ac.wellcome.models.transformable.sierra.{
+  SierraBibNumber,
+  SierraItemNumber
+}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.sierra.source.{SierraBibData, SierraItemData}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  SierraBibData,
+  SierraItemData
+}
 import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLocation
 import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
 
@@ -75,7 +81,8 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
   // location, but I left a modified version of these tests in place to
   // check the old code wasn't left lying around!
 
-  it("does not create any items for an e-book record without the 'dlnk' location") {
+  it(
+    "does not create any items for an e-book record without the 'dlnk' location") {
     val bibData = createSierraBibDataWith(
       materialType = Some(createSierraMaterialTypeWith(code = "v"))
     )
@@ -83,7 +90,8 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
     getTransformedItems(bibData = bibData) shouldBe List()
   }
 
-  it("does not create any items for a non e-book record without the 'dlnk' location") {
+  it(
+    "does not create any items for a non e-book record without the 'dlnk' location") {
     val bibData = createSierraBibDataWith(
       materialType = Some(createSierraMaterialTypeWith(code = "x"))
     )
@@ -93,9 +101,10 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
 
   it("ignores a digital item on a bib record without a 'dlnk' location") {
     val bibData = createSierraBibDataWith(
-      locations = Some(List(
-        SierraSourceLocation("digi", "Digitised Collections")
-      ))
+      locations = Some(
+        List(
+          SierraSourceLocation("digi", "Digitised Collections")
+        ))
     )
 
     getTransformedItems(bibData = bibData) shouldBe List()
@@ -104,17 +113,18 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
   it("adds a digital item on a bib record with a 'dlnk' location") {
     val bibId = createSierraBibNumber
     val bibData = createSierraBibDataWith(
-      locations = Some(List(
-        SierraSourceLocation("digi", "Digitised Collections"),
-        SierraSourceLocation("dlnk", "Digitised content")
-      ))
+      locations = Some(
+        List(
+          SierraSourceLocation("digi", "Digitised Collections"),
+          SierraSourceLocation("dlnk", "Digitised content")
+        ))
     )
 
     val expectedItems = List(
       Unidentifiable(
-        agent = Item(
-        locations = List(DigitalLocation(
-          url = s"https://wellcomelibrary.org/iiif/${bibId.withCheckDigit}/manifest",
+        agent = Item(locations = List(DigitalLocation(
+          url =
+            s"https://wellcomelibrary.org/iiif/${bibId.withCheckDigit}/manifest",
           license = None,
           locationType = LocationType("iiif-presentation"))))
       )
@@ -144,7 +154,8 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
   private def getTransformedItems(
     bibId: SierraBibNumber = createSierraBibNumber,
     bibData: SierraBibData = createSierraBibData,
-    itemDataMap: Map[SierraItemNumber, SierraItemData] = Map()): List[MaybeDisplayable[Item]] =
+    itemDataMap: Map[SierraItemNumber, SierraItemData] = Map())
+    : List[MaybeDisplayable[Item]] =
     transformer.getItems(
       bibId = bibId,
       bibData = bibData,

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItemsTest.scala
@@ -77,21 +77,19 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
     // check the old code wasn't left lying around!
 
     it("does not create any items for an e-book record without the 'dlnk' location") {
-      val sourceIdentifier = createSierraSourceIdentifier
       val bibData = createSierraBibDataWith(
         materialType = Some(createSierraMaterialTypeWith(code = "v"))
       )
 
-      transformer.getDigitalItems(sourceIdentifier, bibData) shouldBe List()
+      transformer.getDigitalItems(bibId = createSierraBibNumber, bibData = bibData) shouldBe List()
     }
 
     it("does not create any items for a non e-book record without the 'dlnk' location") {
-      val sourceIdentifier = createSierraSourceIdentifier
       val bibData = createSierraBibDataWith(
         materialType = Some(createSierraMaterialTypeWith(code = "x"))
       )
 
-      transformer.getDigitalItems(sourceIdentifier, bibData) shouldBe List.empty
+      transformer.getDigitalItems(bibId = createSierraBibNumber, bibData = bibData) shouldBe List.empty
     }
 
     it("ignores a digital item on a bib record without a 'dlnk' location") {
@@ -102,14 +100,14 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
       )
 
       val result = transformer.getDigitalItems(
-        sourceIdentifier = createSierraSourceIdentifier,
-        sierraBibData = bibData)
+        bibId = createSierraBibNumber,
+        bibData = bibData)
 
       result shouldBe List()
     }
 
     it("adds a digital item on a bib record with a 'dlnk' location") {
-      val sourceIdentifier = createSierraSourceIdentifier
+      val bibId = createSierraBibNumber
       val bibData = createSierraBibDataWith(
         locations = Some(List(
           SierraSourceLocation("digi", "Digitised Collections"),
@@ -118,14 +116,14 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
       )
 
       val result = transformer.getDigitalItems(
-        sourceIdentifier = sourceIdentifier,
-        sierraBibData = bibData)
+        bibId = bibId,
+        bibData = bibData)
 
       val expectedItems = List(
         Unidentifiable(
         agent = Item(
         locations = List(DigitalLocation(
-          url = s"https://wellcomelibrary.org/iiif/${sourceIdentifier.value}/manifest",
+          url = s"https://wellcomelibrary.org/iiif/${bibId.withCheckDigit}/manifest",
           license = None,
           locationType = LocationType("iiif-presentation"))))
       ))

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItemsTest.scala
@@ -122,6 +122,24 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
     getTransformedItems(bibId = bibId, bibData = bibData) shouldBe expectedItems
   }
 
+  it("creates an item with a physical location") {
+    val sierraLocation = SierraSourceLocation(
+      code = "sghi2",
+      name = "Closed stores Hist. 2"
+    )
+    val itemData = createSierraItemDataWith(location = Some(sierraLocation))
+
+    val itemDataMap = Map(createSierraItemNumber -> itemData)
+
+    val item = getTransformedItems(itemDataMap = itemDataMap).head
+    item.agent.locations shouldBe List(
+      PhysicalLocation(
+        locationType = LocationType(sierraLocation.code),
+        label = sierraLocation.name
+      )
+    )
+  }
+
   private def getTransformedItems(
     bibId: SierraBibNumber = createSierraBibNumber,
     bibData: SierraBibData = createSierraBibData,

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItemsTest.scala
@@ -2,55 +2,12 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraItemData
 import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLocation
 import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
 
 class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
 
   val transformer = new Object with SierraItems
-
-  describe("extractItemData") {
-    it("parses instances of SierraItemData") {
-      val itemData = (1 to 2).map { _ =>
-        createSierraItemData
-      }
-      val itemRecords = itemData.map { data: SierraItemData =>
-        createSierraItemRecordWith(data = data)
-      }.toList
-
-      val transformable = createSierraTransformableWith(
-        itemRecords = itemRecords
-      )
-
-      transformer
-        .extractItemData(transformable)
-        .values should contain theSameElementsAs itemData
-    }
-
-    it("throws an error if it gets some item data that isn't JSON") {
-      val itemData = createSierraItemData
-      val itemIdBad = createSierraItemNumber
-
-      val notAJsonString = "<xml?>This is not a real 'JSON' string"
-
-      val itemRecords = List(
-        createSierraItemRecordWith(data = itemData),
-        createSierraItemRecordWith(id = itemIdBad, data = notAJsonString)
-      )
-
-      val transformable = createSierraTransformableWith(
-        itemRecords = itemRecords
-      )
-
-      val caught = intercept[TransformerException] {
-        transformer.extractItemData(transformable)
-      }
-
-      caught.e.getMessage shouldBe s"Unable to parse item data for $itemIdBad as JSON: <<$notAJsonString>>"
-    }
-  }
 
   describe("transformItemData") {
     it("creates both forms of the Sierra ID in 'identifiers'") {
@@ -103,14 +60,12 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
       val item1 = createSierraItemDataWith(deleted = true)
       val item2 = createSierraItemDataWith(deleted = false)
 
-      val transformable = createSierraTransformableWith(
-        itemRecords = List(
-          createSierraItemRecordWith(data = item1),
-          createSierraItemRecordWith(data = item2)
-        )
+      val itemDataMap = Map(
+        createSierraItemNumber -> item1,
+        createSierraItemNumber -> item2
       )
 
-      transformer.getPhysicalItems(transformable) should have size 1
+      transformer.getPhysicalItems(itemDataMap) should have size 1
     }
 
     // Note: the following two tests are for historical reasons -- an old

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItemsTest.scala
@@ -112,12 +112,13 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
 
     val expectedItems = List(
       Unidentifiable(
-      agent = Item(
-      locations = List(DigitalLocation(
-        url = s"https://wellcomelibrary.org/iiif/${bibId.withCheckDigit}/manifest",
-        license = None,
-        locationType = LocationType("iiif-presentation"))))
-    ))
+        agent = Item(
+        locations = List(DigitalLocation(
+          url = s"https://wellcomelibrary.org/iiif/${bibId.withCheckDigit}/manifest",
+          license = None,
+          locationType = LocationType("iiif-presentation"))))
+      )
+    )
 
     getTransformedItems(bibId = bibId, bibData = bibData) shouldBe expectedItems
   }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItemsTest.scala
@@ -1,7 +1,9 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.transformable.sierra.{SierraBibNumber, SierraItemNumber}
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.platform.transformer.sierra.source.{SierraBibData, SierraItemData}
 import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLocation
 import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
 
@@ -9,126 +11,124 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
 
   val transformer = new Object with SierraItems
 
-  describe("transformItemData") {
-    it("creates both forms of the Sierra ID in 'identifiers'") {
-      val item = createSierraItemData
-      val itemId = createSierraItemNumber
+  it("creates both forms of the Sierra ID in 'identifiers'") {
+    val itemData = createSierraItemData
+    val itemId = createSierraItemNumber
 
-      val sourceIdentifier1 = createSierraSourceIdentifierWith(
-        ontologyType = "Item",
-        value = itemId.withCheckDigit)
+    val sourceIdentifier1 = createSierraSourceIdentifierWith(
+      ontologyType = "Item",
+      value = itemId.withCheckDigit)
 
-      val sourceIdentifier2 = SourceIdentifier(
-        identifierType = IdentifierType("sierra-identifier"),
-        ontologyType = "Item",
-        value = itemId.withoutCheckDigit
+    val sourceIdentifier2 = SourceIdentifier(
+      identifierType = IdentifierType("sierra-identifier"),
+      ontologyType = "Item",
+      value = itemId.withoutCheckDigit
+    )
+
+    val expectedIdentifiers = List(sourceIdentifier1, sourceIdentifier2)
+
+    val transformedItem: MaybeDisplayable[Item] = getTransformedItems(
+      itemDataMap = Map(
+        itemId -> itemData
       )
+    ).head
 
-      val expectedIdentifiers = List(sourceIdentifier1, sourceIdentifier2)
-
-      val transformedItem = transformer.transformItemData(
-        itemId = itemId,
-        itemData = item
-      )
-
-      transformedItem shouldBe Identifiable(
-        sourceIdentifier = sourceIdentifier1,
-        otherIdentifiers = List(sourceIdentifier2),
-        agent = Item(locations = List()))
-
-      transformedItem.identifiers shouldBe expectedIdentifiers
-    }
-
-    it("uses the full Sierra system number as the source identifier") {
-      val itemId = createSierraItemNumber
-      val sourceIdentifier = createSierraSourceIdentifierWith(
-        ontologyType = "Item",
-        value = itemId.withCheckDigit
-      )
-      val sierraItemData = createSierraItemData
-
-      val transformedItem = transformer.transformItemData(
-        itemId = itemId,
-        itemData = sierraItemData
-      )
-      transformedItem.sourceIdentifier shouldBe sourceIdentifier
-    }
+    transformedItem
+      .asInstanceOf[Identifiable[Item]]
+      .identifiers shouldBe expectedIdentifiers
   }
 
-  describe("getItems") {
-    it("removes items with deleted=true") {
-      val item1 = createSierraItemDataWith(deleted = true)
-      val item2 = createSierraItemDataWith(deleted = false)
+  it("uses the full Sierra system number as the source identifier") {
+    val itemId = createSierraItemNumber
+    val sourceIdentifier = createSierraSourceIdentifierWith(
+      ontologyType = "Item",
+      value = itemId.withCheckDigit
+    )
+    val itemData = createSierraItemData
 
-      val itemDataMap = Map(
-        createSierraItemNumber -> item1,
-        createSierraItemNumber -> item2
-      )
+    val transformedItem: MaybeDisplayable[Item] = getTransformedItems(
+      itemDataMap = Map(itemId -> itemData)
+    ).head
 
-      transformer.getPhysicalItems(itemDataMap) should have size 1
-    }
+    transformedItem
+      .asInstanceOf[Identifiable[Item]]
+      .sourceIdentifier shouldBe sourceIdentifier
+  }
 
-    // Note: the following two tests are for historical reasons -- an old
-    // version of this code used "v"/"e-book" as the distinction for whether
-    // we would add a digital item.
-    //
-    // The current rule (2018-08-09) is to use the presence of the 'dlnk'
-    // location, but I left a modified version of these tests in place to
-    // check the old code wasn't left lying around!
+  it("removes items with deleted=true") {
+    val item1 = createSierraItemDataWith(deleted = true)
+    val item2 = createSierraItemDataWith(deleted = false)
 
-    it("does not create any items for an e-book record without the 'dlnk' location") {
-      val bibData = createSierraBibDataWith(
-        materialType = Some(createSierraMaterialTypeWith(code = "v"))
-      )
+    val itemDataMap = Map(
+      createSierraItemNumber -> item1,
+      createSierraItemNumber -> item2
+    )
 
-      transformer.getDigitalItems(bibId = createSierraBibNumber, bibData = bibData) shouldBe List()
-    }
+    getTransformedItems(itemDataMap = itemDataMap) should have size 1
+  }
 
-    it("does not create any items for a non e-book record without the 'dlnk' location") {
-      val bibData = createSierraBibDataWith(
-        materialType = Some(createSierraMaterialTypeWith(code = "x"))
-      )
+  // Note: the following two tests are for historical reasons -- an old
+  // version of this code used "v"/"e-book" as the distinction for whether
+  // we would add a digital item.
+  //
+  // The current rule (2018-08-09) is to use the presence of the 'dlnk'
+  // location, but I left a modified version of these tests in place to
+  // check the old code wasn't left lying around!
 
-      transformer.getDigitalItems(bibId = createSierraBibNumber, bibData = bibData) shouldBe List.empty
-    }
+  it("does not create any items for an e-book record without the 'dlnk' location") {
+    val bibData = createSierraBibDataWith(
+      materialType = Some(createSierraMaterialTypeWith(code = "v"))
+    )
 
-    it("ignores a digital item on a bib record without a 'dlnk' location") {
-      val bibData = createSierraBibDataWith(
-        locations = Some(List(
-          SierraSourceLocation("digi", "Digitised Collections")
-        ))
-      )
+    getTransformedItems(bibData = bibData) shouldBe List()
+  }
 
-      val result = transformer.getDigitalItems(
-        bibId = createSierraBibNumber,
-        bibData = bibData)
+  it("does not create any items for a non e-book record without the 'dlnk' location") {
+    val bibData = createSierraBibDataWith(
+      materialType = Some(createSierraMaterialTypeWith(code = "x"))
+    )
 
-      result shouldBe List()
-    }
+    getTransformedItems(bibData = bibData) shouldBe List()
+  }
 
-    it("adds a digital item on a bib record with a 'dlnk' location") {
-      val bibId = createSierraBibNumber
-      val bibData = createSierraBibDataWith(
-        locations = Some(List(
-          SierraSourceLocation("digi", "Digitised Collections"),
-          SierraSourceLocation("dlnk", "Digitised content")
-        ))
-      )
-
-      val result = transformer.getDigitalItems(
-        bibId = bibId,
-        bibData = bibData)
-
-      val expectedItems = List(
-        Unidentifiable(
-        agent = Item(
-        locations = List(DigitalLocation(
-          url = s"https://wellcomelibrary.org/iiif/${bibId.withCheckDigit}/manifest",
-          license = None,
-          locationType = LocationType("iiif-presentation"))))
+  it("ignores a digital item on a bib record without a 'dlnk' location") {
+    val bibData = createSierraBibDataWith(
+      locations = Some(List(
+        SierraSourceLocation("digi", "Digitised Collections")
       ))
+    )
 
-      result shouldBe expectedItems
-    }
+    getTransformedItems(bibData = bibData) shouldBe List()
   }
+
+  it("adds a digital item on a bib record with a 'dlnk' location") {
+    val bibId = createSierraBibNumber
+    val bibData = createSierraBibDataWith(
+      locations = Some(List(
+        SierraSourceLocation("digi", "Digitised Collections"),
+        SierraSourceLocation("dlnk", "Digitised content")
+      ))
+    )
+
+    val expectedItems = List(
+      Unidentifiable(
+      agent = Item(
+      locations = List(DigitalLocation(
+        url = s"https://wellcomelibrary.org/iiif/${bibId.withCheckDigit}/manifest",
+        license = None,
+        locationType = LocationType("iiif-presentation"))))
+    ))
+
+    getTransformedItems(bibId = bibId, bibData = bibData) shouldBe expectedItems
+  }
+
+  private def getTransformedItems(
+    bibId: SierraBibNumber = createSierraBibNumber,
+    bibData: SierraBibData = createSierraBibData,
+    itemDataMap: Map[SierraItemNumber, SierraItemData] = Map()): List[MaybeDisplayable[Item]] =
+    transformer.getItems(
+      bibId = bibId,
+      bibData = bibData,
+      itemDataMap = itemDataMap
+    )
 }


### PR DESCRIPTION
The responsibility for SierraItems was a bit all over the place:

* It was doing JSON decoding of the item data, whereas SierraTransformableTransformer handles the bib JSON
* It had a mishmash of public methods
* SierraTransformableTransformer was the thing that actually constructs the list of items on a work, in contrast to everything else – internal logic was leaking

So as a refactoring before #2572, this refactors the trait to present a single public method – `getItems()` – which callers can use to get a list of all items on this work.