### PR TITLE
Redirect HTTP requests to HTTPS in the catalogue API

### DIFF
--- a/catalogue_api/terraform/data_api/provider.tf
+++ b/catalogue_api/terraform/data_api/provider.tf
@@ -1,6 +1,1 @@
-provider "aws" {
-  region  = "${var.aws_region}"
-  version = "1.23.0"
-}
-
 data "aws_caller_identity" "current" {}

--- a/catalogue_api/terraform/load_balancer/main.tf
+++ b/catalogue_api/terraform/load_balancer/main.tf
@@ -26,6 +26,7 @@ resource "aws_lb_listener" "http" {
 
   default_action {
     type = "redirect"
+
     redirect {
       port        = 443
       protocol    = "HTTPS"
@@ -33,7 +34,6 @@ resource "aws_lb_listener" "http" {
     }
   }
 }
-
 
 data "aws_acm_certificate" "certificate" {
   domain   = "${var.certificate_domain}"

--- a/catalogue_api/terraform/load_balancer/main.tf
+++ b/catalogue_api/terraform/load_balancer/main.tf
@@ -19,6 +19,22 @@ resource "aws_alb_listener" "https" {
   }
 }
 
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = "${aws_alb.api_delta.arn}"
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = 443
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+
 data "aws_acm_certificate" "certificate" {
   domain   = "${var.certificate_domain}"
   statuses = ["ISSUED"]

--- a/catalogue_api/terraform/load_balancer/outputs.tf
+++ b/catalogue_api/terraform/load_balancer/outputs.tf
@@ -6,6 +6,10 @@ output "https_listener_arn" {
   value = "${aws_alb_listener.https.arn}"
 }
 
+output "http_listener_arn" {
+  value = "${aws_lb_listener.http.arn}"
+}
+
 output "cloudwatch_id" {
   value = "${aws_alb.api_delta.arn_suffix}"
 }

--- a/catalogue_api/terraform/provider.tf
+++ b/catalogue_api/terraform/provider.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.23.0"
+  version = "1.33.0"
 }
 
 data "aws_caller_identity" "current" {}

--- a/catalogue_api/terraform/service/load_balancer.tf
+++ b/catalogue_api/terraform/service/load_balancer.tf
@@ -1,5 +1,24 @@
 resource "aws_alb_listener_rule" "https" {
-  listener_arn = "${var.alb_listener_arn}"
+  listener_arn = "${var.alb_listener_arn_https}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${module.service.target_group_arn}"
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["${var.host_name}"]
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["${var.path_pattern}"]
+  }
+}
+
+resource "aws_alb_listener_rule" "http" {
+  listener_arn = "${var.alb_listener_arn_http}"
 
   action {
     type             = "forward"

--- a/catalogue_api/terraform/service/variables.tf
+++ b/catalogue_api/terraform/service/variables.tf
@@ -1,7 +1,8 @@
 variable "name" {}
 variable "vpc_id" {}
 variable "aws_region" {}
-variable "alb_listener_arn" {}
+variable "alb_listener_arn_https" {}
+variable "alb_listener_arn_http" {}
 variable "host_name" {}
 
 variable "private_subnets" {

--- a/catalogue_api/terraform/services.tf
+++ b/catalogue_api/terraform/services.tf
@@ -40,8 +40,9 @@ module "api_romulus_delta" {
   namespace_id    = "${aws_service_discovery_private_dns_namespace.namespace.id}"
   private_subnets = "${local.private_subnets}"
 
-  alb_id           = "${module.load_balancer.id}"
-  alb_listener_arn = "${module.load_balancer.https_listener_arn}"
+  alb_id                 = "${module.load_balancer.id}"
+  alb_listener_arn_https = "${module.load_balancer.https_listener_arn}"
+  alb_listener_arn_http  = "${module.load_balancer.http_listener_arn}"
 
   sidecar_container_image = "${local.romulus_nginx_uri}"
   app_container_image     = "${local.romulus_app_uri}"
@@ -68,8 +69,9 @@ module "api_remus_delta" {
   namespace_id    = "${aws_service_discovery_private_dns_namespace.namespace.id}"
   private_subnets = "${local.private_subnets}"
 
-  alb_id           = "${module.load_balancer.id}"
-  alb_listener_arn = "${module.load_balancer.https_listener_arn}"
+  alb_id                 = "${module.load_balancer.id}"
+  alb_listener_arn_https = "${module.load_balancer.https_listener_arn}"
+  alb_listener_arn_http  = "${module.load_balancer.http_listener_arn}"
 
   sidecar_container_image = "${local.remus_nginx_uri}"
   app_container_image     = "${local.remus_app_uri}"


### PR DESCRIPTION
Resolves #2493, because that keeps biting me.

Already deployed, just needs a review:

```console
$ curl --head http://api.wellcomecollection.org/catalogue/v1/works
HTTP/1.1 301 Moved Permanently
Date: Wed, 29 Aug 2018 14:59:57 GMT
Content-Type: text/html
Content-Length: 178
Connection: keep-alive
Server: nginx
Location: https://api.wellcomecollection.org/catalogue/v1/works
Strict-Transport-Security: max-age=31536000; includeSubDomains;
```

This uses the [Redirect action](https://www.terraform.io/docs/providers/aws/r/lb_listener.html#redirect-action) in the lb_listener resource, which only appeared in the latest version ([a week ago!](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#1330-august-22-2018)).