### PR TITLE
Add a MarcGenerators trait that allows for creating instances of VarField

### DIFF
--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/MarcGenerators.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/MarcGenerators.scala
@@ -1,12 +1,14 @@
 package uk.ac.wellcome.platform.transformer.sierra.generators
 
-import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  VarField
+}
 
 trait MarcGenerators {
-  def createVarFieldWith(
-    marcTag: String,
-    indicator2: Option[String] = None,
-    subfields: List[MarcSubfield] = List()): VarField =
+  def createVarFieldWith(marcTag: String,
+                         indicator2: Option[String] = None,
+                         subfields: List[MarcSubfield] = List()): VarField =
     VarField(
       fieldTag = "p",
       marcTag = Some(marcTag),
@@ -15,10 +17,9 @@ trait MarcGenerators {
       subfields = subfields
     )
 
-  def createVarFieldWith(
-    marcTag: String,
-    indicator2: String,
-    subfields: List[MarcSubfield]): VarField =
+  def createVarFieldWith(marcTag: String,
+                         indicator2: String,
+                         subfields: List[MarcSubfield]): VarField =
     createVarFieldWith(
       marcTag = marcTag,
       indicator2 = Some(indicator2),

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/MarcGenerators.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/MarcGenerators.scala
@@ -1,16 +1,17 @@
 package uk.ac.wellcome.platform.transformer.sierra.generators
 
-import uk.ac.wellcome.platform.transformer.sierra.source.VarField
+import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
 
 trait MarcGenerators {
   def createVarFieldWith(
-    marcTag: String,
-    indicator2: Option[String] = None): VarField =
+    marcTag: String = "XXX",
+    indicator2: Option[String] = None,
+    subfields: List[MarcSubfield] = List()): VarField =
     VarField(
       fieldTag = "p",
       marcTag = Some(marcTag),
       indicator1 = None,
       indicator2 = indicator2,
-      subfields = List()
+      subfields = subfields
     )
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/MarcGenerators.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/MarcGenerators.scala
@@ -1,0 +1,16 @@
+package uk.ac.wellcome.platform.transformer.sierra.generators
+
+import uk.ac.wellcome.platform.transformer.sierra.source.VarField
+
+trait MarcGenerators {
+  def createVarFieldWith(
+    marcTag: String,
+    indicator2: Option[String] = None): VarField =
+    VarField(
+      fieldTag = "p",
+      marcTag = Some(marcTag),
+      indicator1 = None,
+      indicator2 = indicator2,
+      subfields = List()
+    )
+}

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/MarcGenerators.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/MarcGenerators.scala
@@ -4,7 +4,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField
 
 trait MarcGenerators {
   def createVarFieldWith(
-    marcTag: String = "XXX",
+    marcTag: String,
     indicator2: Option[String] = None,
     subfields: List[MarcSubfield] = List()): VarField =
     VarField(
@@ -18,7 +18,7 @@ trait MarcGenerators {
   def createVarFieldWith(
     marcTag: String,
     indicator2: String,
-    subfields: List[MarcSubfield] = List()): VarField =
+    subfields: List[MarcSubfield]): VarField =
     createVarFieldWith(
       marcTag = marcTag,
       indicator2 = Some(indicator2),

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/MarcGenerators.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/MarcGenerators.scala
@@ -16,7 +16,7 @@ trait MarcGenerators {
     )
 
   def createVarFieldWith(
-    marcTag: String = "XXX",
+    marcTag: String,
     indicator2: String,
     subfields: List[MarcSubfield] = List()): VarField =
     createVarFieldWith(

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/MarcGenerators.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/MarcGenerators.scala
@@ -14,4 +14,14 @@ trait MarcGenerators {
       indicator2 = indicator2,
       subfields = subfields
     )
+
+  def createVarFieldWith(
+    marcTag: String = "XXX",
+    indicator2: String,
+    subfields: List[MarcSubfield] = List()): VarField =
+    createVarFieldWith(
+      marcTag = marcTag,
+      indicator2 = Some(indicator2),
+      subfields = subfields
+    )
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/SierraDataGenerators.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/SierraDataGenerators.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.transformer.sierra.utils
+package uk.ac.wellcome.platform.transformer.sierra.generators
 
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/SierraDataGenerators.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/SierraDataGenerators.scala
@@ -28,20 +28,6 @@ trait SierraDataGenerators extends IdentifiersGenerators with SierraGenerators {
 
   def createSierraBibData: SierraBibData = createSierraBibDataWith()
 
-  def bibData(marcTag: String, marcSubfields: List[MarcSubfield]) = {
-    createSierraBibDataWith(
-      varFields = List(
-        VarField(
-          fieldTag = "p",
-          marcTag = marcTag,
-          indicator1 = "",
-          indicator2 = "",
-          subfields = marcSubfields
-        )
-      )
-    )
-  }
-
   def createSierraItemDataWith(
     deleted: Boolean = false,
     location: Option[SierraSourceLocation] = None

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/MarcFieldTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/MarcFieldTest.scala
@@ -6,27 +6,8 @@ import uk.ac.wellcome.json.utils.JsonAssertions
 
 class MarcFieldTest extends FunSpec with Matchers with JsonAssertions {
 
-  it("converts a long-form VarField to JSON") {
-    val varField = VarField(
-      fieldTag = "y",
-      marcTag = "007",
-      indicator1 = " ",
-      indicator2 = " ",
-      subfields = List()
-    )
-
-    assertJsonStringsAreEqual(
-      toJson(varField).get,
-      s"""{
-        "fieldTag": "${varField.fieldTag}",
-        "marcTag": "${varField.marcTag.get}",
-        "content": null,
-        "ind1": "${varField.indicator1.get}",
-        "ind2": "${varField.indicator2.get}",
-        "subfields": []
-      }"""
-    )
-  }
+  // These tests are intended to check that we can parse a VarField in
+  // both forms sent by Sierra.
 
   it("reads a JSON string as a long-form VarField") {
     val jsonString = s"""{
@@ -64,25 +45,6 @@ class MarcFieldTest extends FunSpec with Matchers with JsonAssertions {
 
     val varField = fromJson[VarField](jsonString).get
     varField shouldBe expectedVarField
-  }
-
-  it("converts a short-form VarField to JSON") {
-    val varField = VarField(
-      fieldTag = "b",
-      content = "A dallying dance of ducks"
-    )
-
-    assertJsonStringsAreEqual(
-      toJson(varField).get,
-      s"""{
-        "fieldTag": "${varField.fieldTag}",
-        "content": "${varField.content.get}",
-        "marcTag": null,
-        "ind1": null,
-        "ind2": null,
-        "subfields": []
-      }"""
-    )
   }
 
   it("reads a JSON string as a short-form VarField") {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -13,14 +13,13 @@ import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.sierra.SierraTransformableTransformer
-import uk.ac.wellcome.platform.transformer.sierra.source.{
-  MarcSubfield,
-  VarField
-}
+import uk.ac.wellcome.platform.transformer.sierra.generators.MarcGenerators
+import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
 
 class SierraTransformableTransformerTest
     extends FunSpec
     with Matchers
+    with MarcGenerators
     with SierraGenerators
     with SierraTransformableTestBase
     with WorksGenerators {
@@ -172,11 +171,8 @@ class SierraTransformableTransformerTest
     val lettering = "An actor's life for me"
 
     val productionFields = List(
-      VarField(
-        fieldTag = "p",
+      createVarFieldWith(
         marcTag = "260",
-        indicator1 = " ",
-        indicator2 = " ",
         subfields = List(
           MarcSubfield(tag = "b", content = "Peaceful Poetry"),
           MarcSubfield(tag = "c", content = "1923.")
@@ -185,29 +181,18 @@ class SierraTransformableTransformerTest
     )
 
     val descriptionFields = List(
-      VarField(
-        fieldTag = "?",
+      createVarFieldWith(
         marcTag = "520",
-        indicator1 = " ",
-        indicator2 = " ",
         subfields = List(
-          MarcSubfield(
-            tag = "a",
-            content = "A delightful description of a dead daisy."
-          ),
-          MarcSubfield(
-            tag = "c",
-            content = "1923."
-          )
+          MarcSubfield(tag = "a", content = "A delightful description of a dead daisy."),
+          MarcSubfield(tag = "c", content = "1923.")
         )
       )
     )
 
     val letteringFields = List(
-      VarField(
-        fieldTag = "?",
+      createVarFieldWith(
         marcTag = "246",
-        indicator1 = " ",
         indicator2 = "6",
         subfields = List(
           MarcSubfield(tag = "a", content = lettering)

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -184,7 +184,9 @@ class SierraTransformableTransformerTest
       createVarFieldWith(
         marcTag = "520",
         subfields = List(
-          MarcSubfield(tag = "a", content = "A delightful description of a dead daisy."),
+          MarcSubfield(
+            tag = "a",
+            content = "A delightful description of a dead daisy."),
           MarcSubfield(tag = "c", content = "1923.")
         )
       )

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraConceptIdentifierTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraConceptIdentifierTest.scala
@@ -5,7 +5,10 @@ import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.sierra.generators.MarcGenerators
 import uk.ac.wellcome.platform.transformer.sierra.source.VarField
 
-class SierraConceptIdentifierTest extends FunSpec with Matchers with MarcGenerators {
+class SierraConceptIdentifierTest
+    extends FunSpec
+    with Matchers
+    with MarcGenerators {
 
   it("finds an LCSH identifier") {
     val varField = create655VarFieldWith(indicator2 = "0")

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraConceptIdentifierTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraConceptIdentifierTest.scala
@@ -2,12 +2,13 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.platform.transformer.sierra.generators.MarcGenerators
 import uk.ac.wellcome.platform.transformer.sierra.source.VarField
 
-class SierraConceptIdentifierTest extends FunSpec with Matchers {
+class SierraConceptIdentifierTest extends FunSpec with Matchers with MarcGenerators {
 
   it("finds an LCSH identifier") {
-    val varField = baseVarField.copy(indicator2 = Some("0"))
+    val varField = create655VarFieldWith(indicator2 = "0")
 
     val expectedSourceIdentifier = SourceIdentifier(
       identifierType = IdentifierType("lc-subjects"),
@@ -27,7 +28,7 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
   }
 
   it("finds a MESH identifier") {
-    val varField = baseVarField.copy(indicator2 = Some("2"))
+    val varField = create655VarFieldWith(indicator2 = "2")
 
     val expectedSourceIdentifier = SourceIdentifier(
       identifierType = IdentifierType("nlm-mesh"),
@@ -47,7 +48,7 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
   }
 
   it("finds a no-ID identifier if indicator 2 = 4") {
-    val varField = baseVarField.copy(indicator2 = Some("4"))
+    val varField = create655VarFieldWith(indicator2 = "4")
 
     SierraConceptIdentifier.maybeFindIdentifier(
       varField = varField,
@@ -57,7 +58,7 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
   }
 
   it("returns None if indicator 2 is empty") {
-    val varField = baseVarField.copy(indicator2 = None)
+    val varField = create655VarFieldWith(indicator2 = None)
 
     SierraConceptIdentifier.maybeFindIdentifier(
       varField = varField,
@@ -67,7 +68,7 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
   }
 
   it("returns None if it sees an unrecognised identifier scheme") {
-    val varField = baseVarField.copy(indicator2 = Some("8"))
+    val varField = create655VarFieldWith(indicator2 = "8")
 
     SierraConceptIdentifier.maybeFindIdentifier(
       varField = varField,
@@ -77,7 +78,7 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
   }
 
   it("passes through the ontology type") {
-    val varField = baseVarField.copy(indicator2 = Some("2"))
+    val varField = create655VarFieldWith(indicator2 = "2")
 
     val expectedSourceIdentifier = SourceIdentifier(
       identifierType = IdentifierType("nlm-mesh"),
@@ -98,11 +99,9 @@ class SierraConceptIdentifierTest extends FunSpec with Matchers {
 
   val ontologyType = "Concept"
 
-  val baseVarField = VarField(
-    fieldTag = "p",
-    marcTag = "655",
-    indicator1 = "",
-    indicator2 = "",
-    subfields = List()
-  )
+  private def create655VarFieldWith(indicator2: Option[String]): VarField =
+    createVarFieldWith(marcTag = "655", indicator2 = indicator2)
+
+  private def create655VarFieldWith(indicator2: String): VarField =
+    create655VarFieldWith(indicator2 = Some(indicator2))
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraConceptsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraConceptsTest.scala
@@ -2,12 +2,10 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.sierra.source.{
-  MarcSubfield,
-  VarField
-}
+import uk.ac.wellcome.platform.transformer.sierra.generators.MarcGenerators
+import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
 
-class SierraConceptsTest extends FunSpec with Matchers {
+class SierraConceptsTest extends FunSpec with Matchers with MarcGenerators {
 
   it("extracts identifiers from subfield 0") {
     val concept =
@@ -15,11 +13,7 @@ class SierraConceptsTest extends FunSpec with Matchers {
 
     val maybeIdentifiedConcept = transformer.identifyPrimaryConcept[Concept](
       concept = concept,
-      varField = VarField(
-        fieldTag = "p",
-        marcTag = "655",
-        indicator1 = "",
-        indicator2 = "0",
+      varField = createVarFieldWith(
         subfields = List(
           MarcSubfield(tag = "a", content = "pilots"),
           MarcSubfield(tag = "0", content = "lcsh/ppp")
@@ -44,11 +38,7 @@ class SierraConceptsTest extends FunSpec with Matchers {
 
     val maybeIdentifiedConcept = transformer.identifyPrimaryConcept[Concept](
       concept = concept,
-      varField = VarField(
-        fieldTag = "p",
-        marcTag = "655",
-        indicator1 = "",
-        indicator2 = "0",
+      varField = createVarFieldWith(
         subfields = List(
           MarcSubfield(tag = "a", content = "martians"),
           MarcSubfield(tag = "0", content = "lcsh/bbb"),
@@ -84,11 +74,7 @@ class SierraConceptsTest extends FunSpec with Matchers {
 
     val maybeIdentifiedConcept = transformer.identifyPrimaryConcept[Concept](
       concept = concept,
-      varField = VarField(
-        fieldTag = "p",
-        marcTag = "655",
-        indicator1 = "",
-        indicator2 = "0",
+      varField = createVarFieldWith(
         subfields = List(
           MarcSubfield(tag = "a", content = "hitchhiking"),
           MarcSubfield(tag = "0", content = "u/xxx"),

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraConceptsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraConceptsTest.scala
@@ -15,6 +15,7 @@ class SierraConceptsTest extends FunSpec with Matchers with MarcGenerators {
       concept = concept,
       varField = createVarFieldWith(
         marcTag = "CCC",
+        indicator2 = "0",
         subfields = List(
           MarcSubfield(tag = "a", content = "pilots"),
           MarcSubfield(tag = "0", content = "lcsh/ppp")
@@ -41,6 +42,7 @@ class SierraConceptsTest extends FunSpec with Matchers with MarcGenerators {
       concept = concept,
       varField = createVarFieldWith(
         marcTag = "CCC",
+        indicator2 = "0",
         subfields = List(
           MarcSubfield(tag = "a", content = "martians"),
           MarcSubfield(tag = "0", content = "lcsh/bbb"),

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraConceptsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraConceptsTest.scala
@@ -14,6 +14,7 @@ class SierraConceptsTest extends FunSpec with Matchers with MarcGenerators {
     val maybeIdentifiedConcept = transformer.identifyPrimaryConcept[Concept](
       concept = concept,
       varField = createVarFieldWith(
+        marcTag = "CCC",
         subfields = List(
           MarcSubfield(tag = "a", content = "pilots"),
           MarcSubfield(tag = "0", content = "lcsh/ppp")
@@ -39,6 +40,7 @@ class SierraConceptsTest extends FunSpec with Matchers with MarcGenerators {
     val maybeIdentifiedConcept = transformer.identifyPrimaryConcept[Concept](
       concept = concept,
       varField = createVarFieldWith(
+        marcTag = "CCC",
         subfields = List(
           MarcSubfield(tag = "a", content = "martians"),
           MarcSubfield(tag = "0", content = "lcsh/bbb"),
@@ -75,6 +77,7 @@ class SierraConceptsTest extends FunSpec with Matchers with MarcGenerators {
     val maybeIdentifiedConcept = transformer.identifyPrimaryConcept[Concept](
       concept = concept,
       varField = createVarFieldWith(
+        marcTag = "CCC",
         subfields = List(
           MarcSubfield(tag = "a", content = "hitchhiking"),
           MarcSubfield(tag = "0", content = "u/xxx"),

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraContributorsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraContributorsTest.scala
@@ -3,15 +3,13 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
-import uk.ac.wellcome.platform.transformer.sierra.source.{
-  MarcSubfield,
-  VarField
-}
-import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
 
 class SierraContributorsTest
     extends FunSpec
     with Matchers
+    with MarcGenerators
     with SierraDataGenerators {
 
   val transformer = new SierraContributors {}
@@ -24,48 +22,33 @@ class SierraContributorsTest
 
   it("extracts a mixture of Person and Organisation contributors") {
     val varFields = List(
-      VarField(
-        fieldTag = "p",
+      createVarFieldWith(
         marcTag = "100",
-        indicator1 = "",
-        indicator2 = "",
         subfields = List(
           MarcSubfield(tag = "a", content = "Sarah the soybean")
         )
       ),
-      VarField(
-        fieldTag = "p",
+      createVarFieldWith(
         marcTag = "100",
-        indicator1 = "",
-        indicator2 = "",
         subfields = List(
           MarcSubfield(tag = "a", content = "Sam the squash"),
           MarcSubfield(tag = "c", content = "Sir")
         )
       ),
-      VarField(
-        fieldTag = "p",
+      createVarFieldWith(
         marcTag = "110",
-        indicator1 = "",
-        indicator2 = "",
         subfields = List(
           MarcSubfield(tag = "a", content = "Spinach Solicitors")
         )
       ),
-      VarField(
-        fieldTag = "p",
+      createVarFieldWith(
         marcTag = "700",
-        indicator1 = "",
-        indicator2 = "",
         subfields = List(
           MarcSubfield(tag = "a", content = "Sebastian the sugarsnap")
         )
       ),
-      VarField(
-        fieldTag = "p",
+      createVarFieldWith(
         marcTag = "710",
-        indicator1 = "",
-        indicator2 = "",
         subfields = List(
           MarcSubfield(tag = "a", content = "Shallot Swimmers")
         )
@@ -90,11 +73,8 @@ class SierraContributorsTest
       val name = "Carol the Carrot"
 
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "100",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(MarcSubfield(tag = "a", content = name))
         )
       )
@@ -112,11 +92,8 @@ class SierraContributorsTest
       val name = "Bertrand the Beetroot"
 
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "700",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(MarcSubfield(tag = "a", content = name))
         )
       )
@@ -140,25 +117,16 @@ class SierraContributorsTest
       // we deliberately pick an ordering that's different from that for
       // the MARC fields, so we can check it really is applying this rule.
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "700",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(MarcSubfield(tag = "a", content = name2))
         ),
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "100",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(MarcSubfield(tag = "a", content = name1))
         ),
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "700",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(MarcSubfield(tag = "a", content = name3))
         )
       )
@@ -179,11 +147,8 @@ class SierraContributorsTest
       val prefix = "Dr"
 
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "100",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "c", content = prefix)
@@ -211,11 +176,8 @@ class SierraContributorsTest
       val prefix = "Rev"
 
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "100",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "c", content = prefix)
@@ -244,11 +206,8 @@ class SierraContributorsTest
       val prefix2 = "Mr"
 
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "100",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "c", content = prefix1),
@@ -277,11 +236,8 @@ class SierraContributorsTest
       val numeration = "LX"
 
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "100",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "b", content = numeration)
@@ -307,11 +263,8 @@ class SierraContributorsTest
       val role2 = "flavour"
 
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "100",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "e", content = role1),
@@ -337,11 +290,8 @@ class SierraContributorsTest
       val lcshCode = "lcsh7101607"
 
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "100",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "0", content = lcshCode)
@@ -380,11 +330,8 @@ class SierraContributorsTest
       val lcshCode4 = "lcsh 2055034.,"
 
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "100",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "0", content = lcshCode1),
@@ -418,11 +365,8 @@ class SierraContributorsTest
       "does not identify the contributor if there are multiple distinct identifiers in subfield $$0") {
       val name = "Darren the Dill"
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "100",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "0", content = "lcsh9069541"),
@@ -448,11 +392,8 @@ class SierraContributorsTest
       val name = "Ona the orache"
 
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "110",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(MarcSubfield(tag = "a", content = name))
         )
       )
@@ -470,11 +411,8 @@ class SierraContributorsTest
       val name = "Karl the kale"
 
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "710",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(MarcSubfield(tag = "a", content = name))
         )
       )
@@ -498,25 +436,16 @@ class SierraContributorsTest
       // we deliberately pick an ordering that's different from that for
       // the MARC fields, so we can check it really is applying this rule.
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "710",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(MarcSubfield(tag = "a", content = name2))
         ),
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "110",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(MarcSubfield(tag = "a", content = name1))
         ),
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "710",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(MarcSubfield(tag = "a", content = name3))
         )
       )
@@ -538,11 +467,8 @@ class SierraContributorsTest
       val role2 = "colouring"
 
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "110",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "e", content = role1),
@@ -568,11 +494,8 @@ class SierraContributorsTest
       val lcshCode = "lcsh7212"
 
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "110",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "0", content = lcshCode)
@@ -607,11 +530,8 @@ class SierraContributorsTest
       val lcshCode3 = " lc sh 6791210"
 
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "110",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "0", content = lcshCode1),
@@ -644,11 +564,8 @@ class SierraContributorsTest
       "does not identify the contributor if there are multiple distinct identifiers in subfield $$0") {
       val name = "Luke the lime"
       val varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "110",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "0", content = "lcsh3349285"),
@@ -671,11 +588,8 @@ class SierraContributorsTest
 
   it("fails the transform if subfield $$a is missing") {
     val varFields = List(
-      VarField(
-        fieldTag = "p",
+      createVarFieldWith(
         marcTag = "100",
-        indicator1 = "",
-        indicator2 = "",
         subfields = List()
       )
     )

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraContributorsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraContributorsTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraContributorsTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraContributorsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraContributorsTest.scala
@@ -3,8 +3,14 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
-import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
-import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  VarField
+}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
 
 class SierraContributorsTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraDescriptionTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraDescriptionTest.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraDescriptionTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraDescriptionTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraDescriptionTest.scala
@@ -5,7 +5,10 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
 
 class SierraDescriptionTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraDescriptionTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraDescriptionTest.scala
@@ -5,11 +5,12 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
 
 class SierraDescriptionTest
     extends FunSpec
     with Matchers
+    with MarcGenerators
     with SierraDataGenerators {
 
   it(
@@ -18,16 +19,10 @@ class SierraDescriptionTest
 
     assertFindsCorrectDescription(
       varFields = List(
-        VarField(
-          fieldTag = "?",
+        createVarFieldWith(
           marcTag = "520",
-          indicator1 = " ",
-          indicator2 = " ",
           subfields = List(
-            MarcSubfield(
-              tag = "a",
-              content = description
-            )
+            MarcSubfield(tag = "a", content = description)
           )
         )
       ),
@@ -44,32 +39,17 @@ class SierraDescriptionTest
 
     assertFindsCorrectDescription(
       varFields = List(
-        VarField(
-          fieldTag = "?",
+        createVarFieldWith(
           marcTag = "520",
-          indicator1 = " ",
-          indicator2 = " ",
           subfields = List(
-            MarcSubfield(
-              tag = "a",
-              content = description1
-            )
+            MarcSubfield(tag = "a", content = description1)
           )
         ),
-        VarField(
-          fieldTag = "?",
+        createVarFieldWith(
           marcTag = "520",
-          indicator1 = " ",
-          indicator2 = " ",
           subfields = List(
-            MarcSubfield(
-              tag = "a",
-              content = description2
-            ),
-            MarcSubfield(
-              tag = "b",
-              content = summaryDescription2
-            )
+            MarcSubfield(tag = "a", content = description2),
+            MarcSubfield(tag = "b", content = summaryDescription2)
           )
         )
       ),
@@ -84,20 +64,11 @@ class SierraDescriptionTest
 
     assertFindsCorrectDescription(
       varFields = List(
-        VarField(
-          fieldTag = "?",
+        createVarFieldWith(
           marcTag = "520",
-          indicator1 = " ",
-          indicator2 = " ",
           subfields = List(
-            MarcSubfield(
-              tag = "a",
-              content = description
-            ),
-            MarcSubfield(
-              tag = "b",
-              content = summaryDescription
-            )
+            MarcSubfield(tag = "a", content = description),
+            MarcSubfield(tag = "b", content = summaryDescription)
           )
         )
       ),
@@ -108,13 +79,7 @@ class SierraDescriptionTest
   it("does not extract a work description where MARC field 520 is absent") {
     assertFindsCorrectDescription(
       varFields = List(
-        VarField(
-          fieldTag = "?",
-          marcTag = "666",
-          indicator1 = " ",
-          indicator2 = " ",
-          subfields = Nil
-        )
+        createVarFieldWith(marcTag = "666")
       ),
       expectedDescription = None
     )

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraDimensionsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraDimensionsTest.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
-import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
 
 class SierraDimensionsTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraDimensionsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraDimensionsTest.scala
@@ -1,15 +1,13 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.platform.transformer.sierra.source.{
-  MarcSubfield,
-  VarField
-}
-import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
+import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
 
 class SierraDimensionsTest
     extends FunSpec
     with Matchers
+    with MarcGenerators
     with SierraDataGenerators {
 
   val transformer = new SierraDimensions {}
@@ -23,20 +21,11 @@ class SierraDimensionsTest
     val dimensions = "23cm"
 
     val varFields = List(
-      VarField(
-        fieldTag = "?",
+      createVarFieldWith(
         marcTag = "300",
-        indicator1 = " ",
-        indicator2 = " ",
         subfields = List(
-          MarcSubfield(
-            tag = "a",
-            content = "149 p. ;"
-          ),
-          MarcSubfield(
-            tag = "c",
-            content = "23cm"
-          )
+          MarcSubfield(tag = "a", content = "149 p. ;"),
+          MarcSubfield(tag = "c", content = "23cm")
         )
       )
     )
@@ -52,32 +41,17 @@ class SierraDimensionsTest
     val expectedDimensions = s"$dimensions1 $dimensions2"
 
     val varFields = List(
-      VarField(
-        fieldTag = "?",
+      createVarFieldWith(
         marcTag = "300",
-        indicator1 = " ",
-        indicator2 = " ",
         subfields = List(
-          MarcSubfield(
-            tag = "a",
-            content = "1 print :"
-          ),
-          MarcSubfield(
-            tag = "c",
-            content = dimensions1
-          )
+          MarcSubfield(tag = "a", content = "1 print :"),
+          MarcSubfield(tag = "c", content = dimensions1)
         )
       ),
-      VarField(
-        fieldTag = "?",
+      createVarFieldWith(
         marcTag = "300",
-        indicator1 = " ",
-        indicator2 = " ",
         subfields = List(
-          MarcSubfield(
-            tag = "c",
-            content = dimensions2
-          )
+          MarcSubfield(tag = "c", content = dimensions2)
         )
       )
     )

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraDimensionsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraDimensionsTest.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraDimensionsTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraExtentTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraExtentTest.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraExtentTest extends FunSpec with Matchers with SierraDataGenerators {
 

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraExtentTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraExtentTest.scala
@@ -2,9 +2,16 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
-import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
 
-class SierraExtentTest extends FunSpec with Matchers with MarcGenerators with SierraDataGenerators {
+class SierraExtentTest
+    extends FunSpec
+    with Matchers
+    with MarcGenerators
+    with SierraDataGenerators {
 
   val transformer = new SierraExtent {}
 
@@ -50,7 +57,9 @@ class SierraExtentTest extends FunSpec with Matchers with MarcGenerators with Si
         marcTag = "300",
         subfields = List(
           MarcSubfield(tag = "a", content = extent2),
-          MarcSubfield(tag = "b", content = "Endless ecstasy from ecclesiastic echoes")
+          MarcSubfield(
+            tag = "b",
+            content = "Endless ecstasy from ecclesiastic echoes")
         )
       ),
       createVarFieldWith(

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraExtentTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraExtentTest.scala
@@ -1,13 +1,10 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.platform.transformer.sierra.source.{
-  MarcSubfield,
-  VarField
-}
-import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
+import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
 
-class SierraExtentTest extends FunSpec with Matchers with SierraDataGenerators {
+class SierraExtentTest extends FunSpec with Matchers with MarcGenerators with SierraDataGenerators {
 
   val transformer = new SierraExtent {}
 
@@ -20,20 +17,11 @@ class SierraExtentTest extends FunSpec with Matchers with SierraDataGenerators {
     val extent = "Eleven elephant etchings"
 
     val varFields = List(
-      VarField(
-        fieldTag = "?",
+      createVarFieldWith(
         marcTag = "300",
-        indicator1 = " ",
-        indicator2 = " ",
         subfields = List(
-          MarcSubfield(
-            tag = "a",
-            content = extent
-          ),
-          MarcSubfield(
-            tag = "b",
-            content = "Grey, gigantic, graceful (?)"
-          )
+          MarcSubfield(tag = "a", content = extent),
+          MarcSubfield(tag = "b", content = "Grey, gigantic, graceful (?)")
         )
       )
     )
@@ -52,44 +40,23 @@ class SierraExtentTest extends FunSpec with Matchers with SierraDataGenerators {
     val expectedExtent = s"$extent1 $extent2 $extent3"
 
     val varFields = List(
-      VarField(
-        fieldTag = "?",
+      createVarFieldWith(
         marcTag = "300",
-        indicator1 = " ",
-        indicator2 = " ",
         subfields = List(
-          MarcSubfield(
-            tag = "a",
-            content = extent1
-          )
+          MarcSubfield(tag = "a", content = extent1)
         )
       ),
-      VarField(
-        fieldTag = "?",
+      createVarFieldWith(
         marcTag = "300",
-        indicator1 = " ",
-        indicator2 = " ",
         subfields = List(
-          MarcSubfield(
-            tag = "a",
-            content = extent2
-          ),
-          MarcSubfield(
-            tag = "b",
-            content = "Endless ecstasy from ecclesiastic echoes"
-          )
+          MarcSubfield(tag = "a", content = extent2),
+          MarcSubfield(tag = "b", content = "Endless ecstasy from ecclesiastic echoes")
         )
       ),
-      VarField(
-        fieldTag = "?",
+      createVarFieldWith(
         marcTag = "300",
-        indicator1 = " ",
-        indicator2 = " ",
         subfields = List(
-          MarcSubfield(
-            tag = "a",
-            content = extent3
-          )
+          MarcSubfield(tag = "a", content = extent3)
         )
       )
     )

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraGenresTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraGenresTest.scala
@@ -7,9 +7,9 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraBibData,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
 
-class SierraGenresTest extends FunSpec with Matchers with SierraDataGenerators {
+class SierraGenresTest extends FunSpec with Matchers with MarcGenerators with SierraDataGenerators {
 
   it("returns zero genres if there are none") {
     val bibData = createSierraBibDataWith(varFields = List())
@@ -23,9 +23,16 @@ class SierraGenresTest extends FunSpec with Matchers with SierraDataGenerators {
           label = "A Content",
           concepts = List(Unidentifiable(Concept(label = "A Content")))))
 
-    assertExtractsGenres(
-      bibData("655", List(MarcSubfield(tag = "a", content = "A Content"))),
-      expectedGenres)
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "655",
+          subfields = List(MarcSubfield(tag = "a", content = "A Content"))
+        )
+      )
+    )
+
+    assertExtractsGenres(bibData, expectedGenres)
   }
 
   it("returns subjects for tag 655 with subfields a and v") {
@@ -40,14 +47,19 @@ class SierraGenresTest extends FunSpec with Matchers with SierraDataGenerators {
         )
       )
 
-    assertExtractsGenres(
-      bibData(
-        "655",
-        List(
-          MarcSubfield(tag = "a", content = "A Content"),
-          MarcSubfield(tag = "v", content = "V Content")
-        )),
-      expectedGenres)
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "655",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "A Content"),
+            MarcSubfield(tag = "v", content = "V Content")
+          )
+        )
+      )
+    )
+
+    assertExtractsGenres(bibData, expectedGenres)
   }
 
   it(
@@ -63,14 +75,19 @@ class SierraGenresTest extends FunSpec with Matchers with SierraDataGenerators {
         )
       )
 
-    assertExtractsGenres(
-      bibData(
-        "655",
-        List(
-          MarcSubfield(tag = "v", content = "V Content"),
-          MarcSubfield(tag = "a", content = "A Content")
-        )),
-      expectedGenres)
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "655",
+          subfields = List(
+            MarcSubfield(tag = "v", content = "V Content"),
+            MarcSubfield(tag = "a", content = "A Content")
+          )
+        )
+      )
+    )
+
+    assertExtractsGenres(bibData, expectedGenres)
   }
 
   it("returns genres for tag 655 subfields a, v, and x") {
@@ -85,16 +102,20 @@ class SierraGenresTest extends FunSpec with Matchers with SierraDataGenerators {
           )
         ))
 
-    assertExtractsGenres(
-      bibData(
-        "655",
-        List(
-          MarcSubfield(tag = "a", content = "A Content"),
-          MarcSubfield(tag = "x", content = "X Content"),
-          MarcSubfield(tag = "v", content = "V Content")
-        )),
-      expectedGenres
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "655",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "A Content"),
+            MarcSubfield(tag = "x", content = "X Content"),
+            MarcSubfield(tag = "v", content = "V Content")
+          )
+        )
+      )
     )
+
+    assertExtractsGenres(bibData, expectedGenres)
   }
 
   it("returns subjects for tag 655 with subfields a, y") {
@@ -107,14 +128,19 @@ class SierraGenresTest extends FunSpec with Matchers with SierraDataGenerators {
             Unidentifiable(Period(label = "Y Content"))
           )))
 
-    assertExtractsGenres(
-      bibData(
-        "655",
-        List(
-          MarcSubfield(tag = "y", content = "Y Content"),
-          MarcSubfield(tag = "a", content = "A Content")
-        )),
-      expectedGenres)
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "655",
+          subfields = List(
+            MarcSubfield(tag = "y", content = "Y Content"),
+            MarcSubfield(tag = "a", content = "A Content")
+          )
+        )
+      )
+    )
+
+    assertExtractsGenres(bibData, expectedGenres)
   }
 
   it("returns subjects for tag 655 with subfields a, z") {
@@ -127,14 +153,19 @@ class SierraGenresTest extends FunSpec with Matchers with SierraDataGenerators {
             Unidentifiable(Place(label = "Z Content"))
           )))
 
-    assertExtractsGenres(
-      bibData(
-        "655",
-        List(
-          MarcSubfield(tag = "z", content = "Z Content"),
-          MarcSubfield(tag = "a", content = "A Content")
-        )),
-      expectedGenres)
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "655",
+          subfields = List(
+            MarcSubfield(tag = "z", content = "Z Content"),
+            MarcSubfield(tag = "a", content = "A Content")
+          )
+        )
+      )
+    )
+
+    assertExtractsGenres(bibData, expectedGenres)
   }
 
   it("returns subjects for multiple 655 tags with different subfields") {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraGenresTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraGenresTest.scala
@@ -4,8 +4,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
-  SierraBibData,
-  VarField
+  SierraBibData
 }
 import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
 
@@ -171,21 +170,15 @@ class SierraGenresTest extends FunSpec with Matchers with MarcGenerators with Si
   it("returns subjects for multiple 655 tags with different subfields") {
     val bibData = createSierraBibDataWith(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "655",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = "A1 Content"),
             MarcSubfield(tag = "z", content = "Z1 Content")
           )
         ),
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "655",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = "A2 Content"),
             MarcSubfield(tag = "v", content = "V2 Content")
@@ -215,10 +208,8 @@ class SierraGenresTest extends FunSpec with Matchers with MarcGenerators with Si
   it(s"gets identifiers from subfield $$0") {
     val bibData = createSierraBibDataWith(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "655",
-          indicator1 = "",
           // LCSH heading
           indicator2 = "0",
           subfields = List(
@@ -226,10 +217,8 @@ class SierraGenresTest extends FunSpec with Matchers with MarcGenerators with Si
             MarcSubfield(tag = "0", content = "lcsh/123")
           )
         ),
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "655",
-          indicator1 = "",
           // MESH heading
           indicator2 = "2",
           subfields = List(
@@ -239,6 +228,8 @@ class SierraGenresTest extends FunSpec with Matchers with MarcGenerators with Si
         )
       )
     )
+
+    // TODO Get rid of the check method??
 
     val expectedSourceIdentifiers = List(
       SourceIdentifier(

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraGenresTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraGenresTest.scala
@@ -6,9 +6,16 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   SierraBibData
 }
-import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
 
-class SierraGenresTest extends FunSpec with Matchers with MarcGenerators with SierraDataGenerators {
+class SierraGenresTest
+    extends FunSpec
+    with Matchers
+    with MarcGenerators
+    with SierraDataGenerators {
 
   it("returns zero genres if there are none") {
     val bibData = createSierraBibDataWith(varFields = List())

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraGenresTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraGenresTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraBibData,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraGenresTest extends FunSpec with Matchers with SierraDataGenerators {
 

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraIdentifiersTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraIdentifiersTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier}
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraIdentifiersTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItemsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraItemsTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraItemData
 }
 import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLocation
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
 

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraLanguageTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraLanguageTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal.Language
 import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLanguage
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraLanguageTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraLetteringTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraLetteringTest.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraLetteringTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraLetteringTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraLetteringTest.scala
@@ -1,8 +1,14 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
-import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  VarField
+}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
 
 class SierraLetteringTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraLetteringTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraLetteringTest.scala
@@ -1,24 +1,20 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.platform.transformer.sierra.source.{
-  MarcSubfield,
-  VarField
-}
-import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
 
 class SierraLetteringTest
     extends FunSpec
     with Matchers
+    with MarcGenerators
     with SierraDataGenerators {
 
   it("ignores records with the wrong MARC field") {
     assertFindsCorrectLettering(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "300",
-          indicator1 = " ",
           indicator2 = "6",
           subfields = List(
             MarcSubfield(tag = "a", content = "Alas, ailments are annoying")
@@ -32,10 +28,8 @@ class SierraLetteringTest
   it("ignores records with the right MARC field but wrong indicator 2") {
     assertFindsCorrectLettering(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "246",
-          indicator1 = " ",
           indicator2 = "7",
           subfields = List(
             MarcSubfield(tag = "a", content = "Alas, ailments are annoying")
@@ -49,10 +43,8 @@ class SierraLetteringTest
   it("ignores records with the MARC field and 2nd indicator but wrong subfield") {
     assertFindsCorrectLettering(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "246",
-          indicator1 = " ",
           indicator2 = "6",
           subfields = List(
             MarcSubfield(
@@ -68,10 +60,8 @@ class SierraLetteringTest
   it("passes through a single instance of 246 .6 $$a, if present") {
     assertFindsCorrectLettering(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "246",
-          indicator1 = " ",
           indicator2 = "6",
           subfields = List(
             MarcSubfield(
@@ -87,10 +77,8 @@ class SierraLetteringTest
   it("joins multiple instances of 246 .6 $$a, if present") {
     assertFindsCorrectLettering(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "246",
-          indicator1 = " ",
           indicator2 = "6",
           subfields = List(
             MarcSubfield(
@@ -98,10 +86,8 @@ class SierraLetteringTest
               content = "Daring dalmations dance with danger")
           )
         ),
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "246",
-          indicator1 = "1",
           indicator2 = "6",
           subfields = List(
             MarcSubfield(

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraLocationTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraLocationTest.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.models.work.internal.{
 }
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLocation
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraLocationTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraMergeCandidatesTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -1,20 +1,14 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal.{
-  IdentifierType,
-  MergeCandidate,
-  SourceIdentifier
-}
-import uk.ac.wellcome.platform.transformer.sierra.source.{
-  MarcSubfield,
-  VarField
-}
-import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
+import uk.ac.wellcome.models.work.internal.{IdentifierType, MergeCandidate, SourceIdentifier}
+import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
+import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
 
 class SierraMergeCandidatesTest
     extends FunSpec
     with Matchers
+    with MarcGenerators
     with SierraDataGenerators {
 
   val transformer = new SierraMergeCandidates {}
@@ -22,11 +16,8 @@ class SierraMergeCandidatesTest
     val mergeCandidateBibNumber = "b21414440"
     val sierraData = createSierraBibDataWith(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "776",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "w", content = s"(UkLW)$mergeCandidateBibNumber")
           )
@@ -46,11 +37,8 @@ class SierraMergeCandidatesTest
     val mergeCandidateBibNumber = "b21414440"
     val sierraData = createSierraBibDataWith(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "776",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(
               tag = "w",
@@ -76,11 +64,8 @@ class SierraMergeCandidatesTest
   it("returns an empty list if marc tag 776 does not contain a subfield w") {
     val sierraData = createSierraBibDataWith(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "776",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = s"blah blah")
           )
@@ -94,11 +79,8 @@ class SierraMergeCandidatesTest
   it("ignores values in 776$$w that aren't prefixed with (UkLW)") {
     val sierraData = createSierraBibDataWith(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "776",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "w", content = s"(OCoLC)14322288")
           )

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -1,9 +1,16 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal.{IdentifierType, MergeCandidate, SourceIdentifier}
+import uk.ac.wellcome.models.work.internal.{
+  IdentifierType,
+  MergeCandidate,
+  SourceIdentifier
+}
 import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
-import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
 
 class SierraMergeCandidatesTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraPhysicalDescriptionTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraPhysicalDescriptionTest.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraPhysicalDescriptionTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraPhysicalDescriptionTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraPhysicalDescriptionTest.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
-import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
 
 class SierraPhysicalDescriptionTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraPhysicalDescriptionTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraPhysicalDescriptionTest.scala
@@ -1,15 +1,13 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.platform.transformer.sierra.source.{
-  MarcSubfield,
-  VarField
-}
-import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
+import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
 
 class SierraPhysicalDescriptionTest
     extends FunSpec
     with Matchers
+    with MarcGenerators
     with SierraDataGenerators {
 
   val transformer = new SierraPhysicalDescription {}
@@ -24,11 +22,8 @@ class SierraPhysicalDescriptionTest
     val physicalDescription = "Queuing quokkas quarrel about Quirinus Quirrell"
 
     val varFields = List(
-      VarField(
-        fieldTag = "?",
+      createVarFieldWith(
         marcTag = "300",
-        indicator1 = " ",
-        indicator2 = " ",
         subfields = List(
           MarcSubfield(
             tag = "a",
@@ -58,11 +53,8 @@ class SierraPhysicalDescriptionTest
       s"$physicalDescription1\n\n$physicalDescription2"
 
     val varFields = List(
-      VarField(
-        fieldTag = "?",
+      createVarFieldWith(
         marcTag = "300",
-        indicator1 = " ",
-        indicator2 = " ",
         subfields = List(
           MarcSubfield(
             tag = "b",
@@ -70,11 +62,8 @@ class SierraPhysicalDescriptionTest
           )
         )
       ),
-      VarField(
-        fieldTag = "?",
+      createVarFieldWith(
         marcTag = "300",
-        indicator1 = " ",
-        indicator2 = " ",
         subfields = List(
           MarcSubfield(
             tag = "a",

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraProductionTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraProductionTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraProductionTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraProductionTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraProductionTest.scala
@@ -3,15 +3,13 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
-import uk.ac.wellcome.platform.transformer.sierra.source.{
-  MarcSubfield,
-  VarField
-}
-import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
 
 class SierraProductionTest
     extends FunSpec
     with Matchers
+    with MarcGenerators
     with SierraDataGenerators {
 
   it("returns an empty list if neither 260 nor 264 are present") {
@@ -127,9 +125,8 @@ class SierraProductionTest
 
     it("picks up multiple instances of the 260 field") {
       val varFields = List(
-        VarField(
-          marcTag = Some("260"),
-          fieldTag = "a",
+        createVarFieldWith(
+          marcTag = "260",
           subfields = List(
             MarcSubfield(tag = "a", content = "London"),
             MarcSubfield(tag = "b", content = "Arts Council of Great Britain"),
@@ -139,9 +136,8 @@ class SierraProductionTest
             MarcSubfield(tag = "g", content = "1974")
           )
         ),
-        VarField(
-          marcTag = Some("260"),
-          fieldTag = "a",
+        createVarFieldWith(
+          marcTag = "260",
           subfields = List(
             MarcSubfield(tag = "a", content = "Bethesda, Md"),
             MarcSubfield(
@@ -255,10 +251,9 @@ class SierraProductionTest
 
       it("throws an error if the 2nd indicator is unrecognised") {
         val varFields = List(
-          VarField(
-            marcTag = Some("264"),
-            fieldTag = "a",
-            indicator2 = Some("x")
+          createVarFieldWith(
+            marcTag = "264",
+            indicator2 = "x"
           )
         )
 
@@ -273,18 +268,16 @@ class SierraProductionTest
     it(
       "ignores instances of the 264 field related to copyright (2nd indicator 4)") {
       val varFields = List(
-        VarField(
-          marcTag = Some("264"),
-          fieldTag = "a",
-          indicator2 = Some("4"),
+        createVarFieldWith(
+          marcTag = "264",
+          indicator2 = "4",
           subfields = List(
             MarcSubfield(tag = "c", content = "copyright 2005")
           )
         ),
-        VarField(
-          marcTag = Some("264"),
-          fieldTag = "a",
-          indicator2 = Some("3"),
+        createVarFieldWith(
+          marcTag = "264",
+          indicator2 = "3",
           subfields = List(
             MarcSubfield(tag = "a", content = "Cambridge"),
             MarcSubfield(tag = "b", content = "Kinsey Printing Company")
@@ -306,18 +299,16 @@ class SierraProductionTest
 
     it("ignores instances of the 264 field with an empty 2nd indicator") {
       val varFields = List(
-        VarField(
-          marcTag = Some("264"),
-          fieldTag = "a",
-          indicator2 = Some(" "),
+        createVarFieldWith(
+          marcTag = "264",
+          indicator2 = " ",
           subfields = List(
             MarcSubfield(tag = "c", content = "copyright 2005")
           )
         ),
-        VarField(
-          marcTag = Some("264"),
-          fieldTag = "a",
-          indicator2 = Some("3"),
+        createVarFieldWith(
+          marcTag = "264",
+          indicator2 = "3",
           subfields = List(
             MarcSubfield(tag = "a", content = "London"),
             MarcSubfield(tag = "b", content = "Wellcome Collection Publishing")
@@ -339,20 +330,18 @@ class SierraProductionTest
 
     it("picks up multiple instances of the 264 field") {
       val varFields = List(
-        VarField(
-          marcTag = Some("264"),
-          fieldTag = "a",
-          indicator2 = Some("1"),
+        createVarFieldWith(
+          marcTag = "264",
+          indicator2 = "1",
           subfields = List(
             MarcSubfield(tag = "a", content = "Columbia, S.C."),
             MarcSubfield(tag = "b", content = "H.W. Williams Co."),
             MarcSubfield(tag = "c", content = "1982")
           )
         ),
-        VarField(
-          marcTag = Some("264"),
-          fieldTag = "a",
-          indicator2 = Some("2"),
+        createVarFieldWith(
+          marcTag = "264",
+          indicator2 = "2",
           subfields = List(
             MarcSubfield(tag = "a", content = "Washington"),
             MarcSubfield(tag = "b", content = "U.S. G.P.O."),
@@ -384,16 +373,14 @@ class SierraProductionTest
     it("throws an error if both 260 and 264 are present") {
       transformVarFieldsAndAssertIsError(
         varFields = List(
-          VarField(
-            marcTag = Some("260"),
-            fieldTag = "p",
+          createVarFieldWith(
+            marcTag = "260",
             subfields = List(
               MarcSubfield(tag = "a", content = "Paris")
             )
           ),
-          VarField(
-            marcTag = Some("264"),
-            fieldTag = "p",
+          createVarFieldWith(
+            marcTag = "264",
             subfields = List(
               MarcSubfield(tag = "a", content = "London")
             )
@@ -405,18 +392,16 @@ class SierraProductionTest
     it(
       "uses field 260 if field 264 only contains a copyright statement in subfield c") {
       val varFields = List(
-        VarField(
-          marcTag = Some("260"),
-          fieldTag = "p",
+        createVarFieldWith(
+          marcTag = "260",
           subfields = List(
             MarcSubfield(tag = "a", content = "San Francisco"),
             MarcSubfield(tag = "b", content = "Morgan Kaufmann Publishers"),
             MarcSubfield(tag = "c", content = "2004")
           )
         ),
-        VarField(
-          marcTag = Some("264"),
-          fieldTag = "p",
+        createVarFieldWith(
+          marcTag = "264",
           subfields = List(
             MarcSubfield(tag = "c", content = "©2004")
           )
@@ -445,14 +430,12 @@ class SierraProductionTest
       )
 
       val varFields = List(
-        VarField(
-          marcTag = Some("260"),
-          fieldTag = "p",
+        createVarFieldWith(
+          marcTag = "260",
           subfields = subfields
         ),
-        VarField(
-          marcTag = Some("264"),
-          fieldTag = "p",
+        createVarFieldWith(
+          marcTag = "264",
           subfields = subfields
         )
       )
@@ -476,9 +459,8 @@ class SierraProductionTest
 
   private def transform260ToProduction(subfields: List[MarcSubfield]) = {
     val varFields = List(
-      VarField(
-        marcTag = Some("260"),
-        fieldTag = "a",
+      createVarFieldWith(
+        marcTag = "260",
         subfields = subfields
       )
     )
@@ -488,11 +470,10 @@ class SierraProductionTest
 
   private def transform264ToProduction(subfields: List[MarcSubfield]) = {
     val varFields = List(
-      VarField(
-        marcTag = Some("264"),
-        fieldTag = "a",
-        subfields = subfields,
-        indicator2 = Some("1")
+      createVarFieldWith(
+        marcTag = "264",
+        indicator2 = "1",
+        subfields = subfields
       )
     )
 
@@ -502,10 +483,9 @@ class SierraProductionTest
   private def checkProductionFunctionFor264(indicator2: String,
                                             expectedFunction: String) = {
     val varFields = List(
-      VarField(
-        marcTag = Some("264"),
-        fieldTag = "a",
-        indicator2 = Some(indicator2)
+      createVarFieldWith(
+        marcTag = "264",
+        indicator2 = indicator2
       )
     )
 

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraProductionTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraProductionTest.scala
@@ -3,8 +3,14 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
-import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
-import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  VarField
+}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
 
 class SierraProductionTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraProductionTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraProductionTest.scala
@@ -253,7 +253,8 @@ class SierraProductionTest
         val varFields = List(
           createVarFieldWith(
             marcTag = "264",
-            indicator2 = "x"
+            indicator2 = "x",
+            subfields = List()
           )
         )
 
@@ -485,7 +486,8 @@ class SierraProductionTest
     val varFields = List(
       createVarFieldWith(
         marcTag = "264",
-        indicator2 = indicator2
+        indicator2 = indicator2,
+        subfields = List()
       )
     )
 

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraTitleTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraTitleTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.transformer.exceptions.ShouldNotTransformException
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraTitleTest extends FunSpec with Matchers with SierraDataGenerators {
 

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraWorkTypeTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraWorkTypeTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal.WorkType
 import uk.ac.wellcome.platform.transformer.sierra.source.SierraMaterialType
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraWorkTypeTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraConceptSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraConceptSubjectsTest.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra.subjects
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
-import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
 
 class SierraConceptSubjectsTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraConceptSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraConceptSubjectsTest.scala
@@ -2,10 +2,7 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra.subjects
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.sierra.source.{
-  MarcSubfield,
-  VarField
-}
+import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
 import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
 
 class SierraConceptSubjectsTest
@@ -152,21 +149,15 @@ class SierraConceptSubjectsTest
   it("returns subjects for multiple 650 tags with different subfields") {
     val bibData = createSierraBibDataWith(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "650",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = "A1 Content"),
             MarcSubfield(tag = "z", content = "Z1 Content")
           )
         ),
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "650",
-          indicator1 = "",
-          indicator2 = "",
           subfields = List(
             MarcSubfield(tag = "a", content = "A2 Content"),
             MarcSubfield(tag = "v", content = "V2 Content")
@@ -244,10 +235,8 @@ class SierraConceptSubjectsTest
   it(s"gets identifiers from subfield $$0") {
     val bibData = createSierraBibDataWith(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "650",
-          indicator1 = "",
           // LCSH heading
           indicator2 = "0",
           subfields = List(
@@ -255,10 +244,8 @@ class SierraConceptSubjectsTest
             MarcSubfield(tag = "0", content = "lcsh/123")
           )
         ),
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "650",
-          indicator1 = "",
           // MESH heading
           indicator2 = "2",
           subfields = List(
@@ -299,20 +286,16 @@ class SierraConceptSubjectsTest
   it("ignores subject with second indicator 7") {
     val bibData = createSierraBibDataWith(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "650",
-          indicator1 = "",
           indicator2 = "7",
           subfields = List(
             MarcSubfield(tag = "a", content = "absence"),
             MarcSubfield(tag = "0", content = "lcsh/123")
           )
         ),
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "650",
-          indicator1 = "",
           // MESH heading
           indicator2 = "2",
           subfields = List(
@@ -341,10 +324,8 @@ class SierraConceptSubjectsTest
   it("Ignores a subject with second indicator 7 but no subfield 0") {
     val bibData = createSierraBibDataWith(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "650",
-          indicator1 = "",
           indicator2 = "7",
           subfields = List(
             MarcSubfield(tag = "a", content = "abolition")

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraConceptSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraConceptSubjectsTest.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraConceptSubjectsTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraConceptSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraConceptSubjectsTest.scala
@@ -6,11 +6,12 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
 
 class SierraConceptSubjectsTest
     extends FunSpec
     with Matchers
+    with MarcGenerators
     with SierraDataGenerators {
   private val transformer = new SierraConceptSubjects {}
 
@@ -20,13 +21,18 @@ class SierraConceptSubjectsTest
   }
 
   it("returns subjects for tag 650 with only subfield a") {
+    val sierraBibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "650",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "A Content")
+          )
+        )
+      )
+    )
 
-    transformer.getSubjectswithAbstractConcepts(
-      bibData(
-        "650",
-        List(
-          MarcSubfield(tag = "a", content = "A Content")
-        ))) shouldBe List(
+    transformer.getSubjectswithAbstractConcepts(sierraBibData) shouldBe List(
       Subject(
         label = "A Content",
         concepts = List(Unidentifiable(Concept(label = "A Content")))))
@@ -34,12 +40,17 @@ class SierraConceptSubjectsTest
   }
 
   it("returns subjects for tag 650 with only subfields a and v") {
-    val sierraBibData = bibData(
-      "650",
-      List(
-        MarcSubfield(tag = "a", content = "A Content"),
-        MarcSubfield(tag = "v", content = "V Content")
-      ))
+    val sierraBibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "650",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "A Content"),
+            MarcSubfield(tag = "v", content = "V Content")
+          )
+        )
+      )
+    )
 
     transformer.getSubjectswithAbstractConcepts(sierraBibData) shouldBe List(
       Subject(
@@ -51,12 +62,17 @@ class SierraConceptSubjectsTest
 
   it(
     "subfield a is always first concept when returning subjects for tag 650 with subfields a, v") {
-    val sierraBibData = bibData(
-      "650",
-      List(
-        MarcSubfield(tag = "v", content = "V Content"),
-        MarcSubfield(tag = "a", content = "A Content")
-      ))
+    val sierraBibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "650",
+          subfields = List(
+            MarcSubfield(tag = "v", content = "V Content"),
+            MarcSubfield(tag = "a", content = "A Content")
+          )
+        )
+      )
+    )
     transformer.getSubjectswithAbstractConcepts(sierraBibData) shouldBe List(
       Subject(
         label = "A Content - V Content",
@@ -66,13 +82,18 @@ class SierraConceptSubjectsTest
   }
 
   it("returns subjects for tag 650 subfields a, v, and x") {
-    val sierraBibData = bibData(
-      "650",
-      List(
-        MarcSubfield(tag = "a", content = "A Content"),
-        MarcSubfield(tag = "x", content = "X Content"),
-        MarcSubfield(tag = "v", content = "V Content")
-      ))
+    val sierraBibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "650",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "A Content"),
+            MarcSubfield(tag = "x", content = "X Content"),
+            MarcSubfield(tag = "v", content = "V Content")
+          )
+        )
+      )
+    )
 
     transformer.getSubjectswithAbstractConcepts(sierraBibData) shouldBe List(
       Subject(
@@ -86,12 +107,17 @@ class SierraConceptSubjectsTest
   }
 
   it("returns subjects for tag 650 with subfields a, y") {
-    val sierraBibData = bibData(
-      "650",
-      List(
-        MarcSubfield(tag = "y", content = "Y Content"),
-        MarcSubfield(tag = "a", content = "A Content")
-      ))
+    val sierraBibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "650",
+          subfields = List(
+            MarcSubfield(tag = "y", content = "Y Content"),
+            MarcSubfield(tag = "a", content = "A Content")
+          )
+        )
+      )
+    )
 
     transformer.getSubjectswithAbstractConcepts(sierraBibData) shouldBe List(
       Subject(
@@ -103,12 +129,17 @@ class SierraConceptSubjectsTest
   }
 
   it("returns subjects for tag 650 with subfields a, z") {
-    val sierraBibData = bibData(
-      "650",
-      List(
-        MarcSubfield(tag = "z", content = "Z Content"),
-        MarcSubfield(tag = "a", content = "A Content")
-      ))
+    val sierraBibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "650",
+          subfields = List(
+            MarcSubfield(tag = "z", content = "Z Content"),
+            MarcSubfield(tag = "a", content = "A Content")
+          )
+        )
+      )
+    )
     transformer.getSubjectswithAbstractConcepts(sierraBibData) shouldBe List(
       Subject(
         label = "A Content - Z Content",
@@ -161,13 +192,18 @@ class SierraConceptSubjectsTest
   }
 
   it("returns subjects with primary concept Period for tag 648") {
-    val sierraBibData = bibData(
-      "648",
-      List(
-        MarcSubfield(tag = "a", content = "A Content"),
-        MarcSubfield(tag = "x", content = "X Content"),
-        MarcSubfield(tag = "v", content = "V Content")
-      ))
+    val sierraBibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "648",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "A Content"),
+            MarcSubfield(tag = "x", content = "X Content"),
+            MarcSubfield(tag = "v", content = "V Content")
+          )
+        )
+      )
+    )
 
     transformer.getSubjectswithAbstractConcepts(sierraBibData) shouldBe List(
       Subject(
@@ -181,13 +217,18 @@ class SierraConceptSubjectsTest
   }
 
   it("returns subjects with primary concept Place for tag 651") {
-    val sierraBibData = bibData(
-      "651",
-      List(
-        MarcSubfield(tag = "x", content = "X Content"),
-        MarcSubfield(tag = "a", content = "A Content"),
-        MarcSubfield(tag = "v", content = "V Content")
-      ))
+    val sierraBibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "651",
+          subfields = List(
+            MarcSubfield(tag = "x", content = "X Content"),
+            MarcSubfield(tag = "a", content = "A Content"),
+            MarcSubfield(tag = "v", content = "V Content")
+          )
+        )
+      )
+    )
 
     transformer.getSubjectswithAbstractConcepts(sierraBibData) shouldBe List(
       Subject(

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraPersonSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraPersonSubjectsTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.utils.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraPersonSubjectsTest
     extends FunSpec

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraPersonSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraPersonSubjectsTest.scala
@@ -3,10 +3,7 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra.subjects
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
-import uk.ac.wellcome.platform.transformer.sierra.source.{
-  MarcSubfield,
-  VarField
-}
+import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
 import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
 
 class SierraPersonSubjectsTest
@@ -183,11 +180,8 @@ class SierraPersonSubjectsTest
 
     val sierraBibData = createSierraBibDataWith(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "600",
-          indicator1 = "",
-          indicator2 = "0",
           subfields = List(
             MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "0", content = lcshCode)
@@ -211,10 +205,8 @@ class SierraPersonSubjectsTest
     val name = "Gerry the Garlic"
     val sierraBibData = createSierraBibDataWith(
       varFields = List(
-        VarField(
-          fieldTag = "p",
+        createVarFieldWith(
           marcTag = "600",
-          indicator1 = "",
           indicator2 = "2",
           subfields = List(
             MarcSubfield(tag = "a", content = name),

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraPersonSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraPersonSubjectsTest.scala
@@ -182,6 +182,7 @@ class SierraPersonSubjectsTest
       varFields = List(
         createVarFieldWith(
           marcTag = "600",
+          indicator2 = "0",
           subfields = List(
             MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "0", content = lcshCode)

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraPersonSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraPersonSubjectsTest.scala
@@ -7,11 +7,12 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
 
 class SierraPersonSubjectsTest
     extends FunSpec
     with Matchers
+    with MarcGenerators
     with SierraDataGenerators {
   private val transformer = new SierraPersonSubjects {}
 
@@ -21,11 +22,16 @@ class SierraPersonSubjectsTest
   }
 
   it("returns subjects for tag 600 with only subfield a") {
-    val sierraBibData = bibData(
-      "600",
-      List(
-        MarcSubfield(tag = "a", content = "A Content")
-      ))
+    val sierraBibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "600",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "A Content")
+          )
+        )
+      )
+    )
 
     transformer.getSubjectsWithPerson(sierraBibData) shouldBe List(
       Subject(
@@ -35,12 +41,17 @@ class SierraPersonSubjectsTest
   }
 
   it("returns subjects for tag 600 with only subfields a and c") {
-    val sierraBibData = bibData(
-      "600",
-      List(
-        MarcSubfield(tag = "a", content = "Larrey, D. J."),
-        MarcSubfield(tag = "c", content = "baron")
-      ))
+    val sierraBibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "600",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "Larrey, D. J."),
+            MarcSubfield(tag = "c", content = "baron")
+          )
+        )
+      )
+    )
 
     transformer.getSubjectsWithPerson(sierraBibData) shouldBe List(
       Subject(
@@ -50,13 +61,18 @@ class SierraPersonSubjectsTest
   }
 
   it("returns subjects for tag 600 with only subfields a and multiple c") {
-    val sierraBibData = bibData(
-      "600",
-      List(
-        MarcSubfield(tag = "a", content = "David Attenborough"),
-        MarcSubfield(tag = "c", content = "sir"),
-        MarcSubfield(tag = "c", content = "doctor")
-      ))
+    val sierraBibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "600",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "David Attenborough"),
+            MarcSubfield(tag = "c", content = "sir"),
+            MarcSubfield(tag = "c", content = "doctor")
+          )
+        )
+      )
+    )
 
     transformer.getSubjectsWithPerson(sierraBibData) shouldBe List(
       Subject(
@@ -66,12 +82,17 @@ class SierraPersonSubjectsTest
   }
 
   it("returns subjects for tag 600 with only subfields a and b") {
-    val sierraBibData = bibData(
-      "600",
-      List(
-        MarcSubfield(tag = "a", content = "David Attenborough"),
-        MarcSubfield(tag = "b", content = "II")
-      ))
+    val sierraBibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "600",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "David Attenborough"),
+            MarcSubfield(tag = "b", content = "II")
+          )
+        )
+      )
+    )
 
     transformer.getSubjectsWithPerson(sierraBibData) shouldBe List(
       Subject(
@@ -81,12 +102,17 @@ class SierraPersonSubjectsTest
   }
 
   it("returns subjects for tag 600 with subfields a and e") {
-    val sierraBibData = bibData(
-      "600",
-      List(
-        MarcSubfield(tag = "a", content = "David Attenborough,"),
-        MarcSubfield(tag = "e", content = "author")
-      ))
+    val sierraBibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "600",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "David Attenborough,"),
+            MarcSubfield(tag = "e", content = "author")
+          )
+        )
+      )
+    )
 
     transformer.getSubjectsWithPerson(sierraBibData) shouldBe List(
       Subject(
@@ -95,12 +121,17 @@ class SierraPersonSubjectsTest
   }
 
   it("returns subjects for tag 600 with subfields a and d") {
-    val sierraBibData = bibData(
-      "600",
-      List(
-        MarcSubfield(tag = "a", content = "Rita Levi Montalcini,"),
-        MarcSubfield(tag = "d", content = "22 April 1909 – 30 December 2012")
-      ))
+    val sierraBibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "600",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "Rita Levi Montalcini,"),
+            MarcSubfield(tag = "d", content = "22 April 1909 – 30 December 2012")
+          )
+        )
+      )
+    )
 
     transformer.getSubjectsWithPerson(sierraBibData) shouldBe List(Subject(
       label = "Rita Levi Montalcini, 22 April 1909 – 30 December 2012",
@@ -108,13 +139,18 @@ class SierraPersonSubjectsTest
   }
 
   it("returns subjects for tag 600 with subfields a and multiple e") {
-    val sierraBibData = bibData(
-      "600",
-      List(
-        MarcSubfield(tag = "a", content = "David Attenborough,"),
-        MarcSubfield(tag = "e", content = "author,"),
-        MarcSubfield(tag = "e", content = "editor")
-      ))
+    val sierraBibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "600",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "David Attenborough,"),
+            MarcSubfield(tag = "e", content = "author,"),
+            MarcSubfield(tag = "e", content = "editor")
+          )
+        )
+      )
+    )
 
     transformer.getSubjectsWithPerson(sierraBibData) shouldBe List(
       Subject(
@@ -126,7 +162,14 @@ class SierraPersonSubjectsTest
   // elsewhere. For now, we error in those cases so that we are able
   // to flag cataloguing errors, so error here as well for consistency
   it("errors transforming a subject 600 if subfield a is missing") {
-    val sierraBibData = bibData("600", List())
+    val sierraBibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "600",
+          subfields = List()
+        )
+      )
+    )
 
     intercept[TransformerException] {
       transformer.getSubjectsWithPerson(sierraBibData)

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraPersonSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraPersonSubjectsTest.scala
@@ -4,7 +4,10 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
-import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
 
 class SierraPersonSubjectsTest
     extends FunSpec
@@ -124,7 +127,9 @@ class SierraPersonSubjectsTest
           marcTag = "600",
           subfields = List(
             MarcSubfield(tag = "a", content = "Rita Levi Montalcini,"),
-            MarcSubfield(tag = "d", content = "22 April 1909 – 30 December 2012")
+            MarcSubfield(
+              tag = "d",
+              content = "22 April 1909 – 30 December 2012")
           )
         )
       )


### PR DESCRIPTION
I’ll need a bunch of these for #1408, and the idea of creating so many instances of VarField with values that I‘ll throw away makes me sad. So this fixes that!