### PR TITLE
Add a Miro ID parser for Wellcome Images URLs

### DIFF
--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParser.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParser.scala
@@ -24,7 +24,8 @@ trait WellcomeImagesURLParser {
   //    http://wellcomeimages.org/indexplus/image/L0046161.html
   //    http://wellcomeimages.org/indexplus/image/L0041574.html.html
   //
-  private val indexPlusURL: Regex = s"^http://wellcomeimages\\.org/indexplus/image/($miroIDregex)(?:\\.html){0,2}$$".r
+  private val indexPlusURL: Regex =
+    s"^http://wellcomeimages\\.org/indexplus/image/($miroIDregex)(?:\\.html){0,2}$$".r
 
   // Examples:
   //
@@ -32,25 +33,28 @@ trait WellcomeImagesURLParser {
   //    http://wellcomeimages.org/ixbin/hixclient?MIROPAC=V0000492EB
   //    http://wellcomeimages.org/ixbin/hixclient?MIROPAC=V0031553F1
   //
-  private val hixClientURL: Regex = s"^http://wellcomeimages\\.org/ixbin/hixclient\\?MIROPAC=($miroIDregex)$$".r
+  private val hixClientURL: Regex =
+    s"^http://wellcomeimages\\.org/ixbin/hixclient\\?MIROPAC=($miroIDregex)$$".r
 
   // Examples:
   //
   //    http://wellcomeimages.org/ixbinixclient.exe?MIROPAC=V0010851.html.html
   //
-  private val ixbinixClientURL: Regex = s"^http://wellcomeimages\\.org/ixbinixclient\\.exe\\?MIROPAC=($miroIDregex)\\.html\\.html$$".r
+  private val ixbinixClientURL: Regex =
+    s"^http://wellcomeimages\\.org/ixbinixclient\\.exe\\?MIROPAC=($miroIDregex)\\.html\\.html$$".r
 
   // Examples:
   //
   //    http://wellcomeimages.org/ixbinixclient.exe?image=M0009946.html
   //
-  private val altIxbinixClientURL: Regex = s"^http://wellcomeimages\\.org/ixbinixclient\\.exe\\?image=($miroIDregex)\\.html$$".r
+  private val altIxbinixClientURL: Regex =
+    s"^http://wellcomeimages\\.org/ixbinixclient\\.exe\\?image=($miroIDregex)\\.html$$".r
 
   def maybeGetMiroID(url: String): Option[String] = url match {
-    case indexPlusURL(miroID) => Some(miroID)
-    case hixClientURL(miroID) => Some(miroID)
-    case ixbinixClientURL(miroID) => Some(miroID)
+    case indexPlusURL(miroID)        => Some(miroID)
+    case hixClientURL(miroID)        => Some(miroID)
+    case ixbinixClientURL(miroID)    => Some(miroID)
     case altIxbinixClientURL(miroID) => Some(miroID)
-    case _ => None
+    case _                           => None
   }
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParser.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParser.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
+import scala.util.matching.Regex
+
 /** For merging Miro/Sierra works, we look in MARC tag 962 subfield $u.
   *
   * Unfortunately, this doesn't contain just the Miro ID, which is what we
@@ -9,5 +11,23 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
   *
   */
 trait WellcomeImagesURLParser {
-  def maybeGetMiroID(url: String): Option[String] = None
+
+  // Regex for parsing a Miro ID.  Examples of valid IDs, all taken from
+  // the Sierra data:
+  //
+  //    L0046161, V0033167F1, V0032544ECL
+  //
+  private val miroID: Regex = "[A-Z][0-9]{7}[A-Z]{0,3}[0-9]?".r
+
+  // One of the forms of a Wellcome Images URL.  Examples:
+  //
+  //    http://wellcomeimages.org/indexplus/image/L0046161.html
+  //    http://wellcomeimages.org/indexplus/image/L0041574.html.html
+  //
+  private val indexPlusURL: Regex = s"^http://wellcomeimages\\.org/indexplus/image/($miroID)(?:\\.html){0,2}$$".r.anchored
+
+  def maybeGetMiroID(url: String): Option[String] = url match {
+    case indexPlusURL(miroID) => Some(miroID)
+    case _ => None
+  }
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParser.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParser.scala
@@ -24,7 +24,7 @@ trait WellcomeImagesURLParser {
   //    http://wellcomeimages.org/indexplus/image/L0046161.html
   //    http://wellcomeimages.org/indexplus/image/L0041574.html.html
   //
-  private val indexPlusURL: Regex = s"^http://wellcomeimages\\.org/indexplus/image/($miroIDregex)(?:\\.html){0,2}$$".r.anchored
+  private val indexPlusURL: Regex = s"^http://wellcomeimages\\.org/indexplus/image/($miroIDregex)(?:\\.html){0,2}$$".r
 
   // Examples:
   //
@@ -32,11 +32,18 @@ trait WellcomeImagesURLParser {
   //    http://wellcomeimages.org/ixbin/hixclient?MIROPAC=V0000492EB
   //    http://wellcomeimages.org/ixbin/hixclient?MIROPAC=V0031553F1
   //
-  private val hixClientURL: Regex = s"^http://wellcomeimages\\.org/ixbin/hixclient\\?MIROPAC=($miroIDregex)$$".r.anchored
+  private val hixClientURL: Regex = s"^http://wellcomeimages\\.org/ixbin/hixclient\\?MIROPAC=($miroIDregex)$$".r
+
+  // Examples:
+  //
+  //    http://wellcomeimages.org/ixbinixclient.exe?MIROPAC=V0010851.html.html
+  //
+  private val ixbinixClientURL: Regex = s"^http://wellcomeimages\\.org/ixbinixclient\\.exe\\?MIROPAC=($miroIDregex)\\.html\\.html$$".r
 
   def maybeGetMiroID(url: String): Option[String] = url match {
     case indexPlusURL(miroID) => Some(miroID)
     case hixClientURL(miroID) => Some(miroID)
+    case ixbinixClientURL(miroID) => Some(miroID)
     case _ => None
   }
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParser.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParser.scala
@@ -1,0 +1,13 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
+
+/** For merging Miro/Sierra works, we look in MARC tag 962 subfield $u.
+  *
+  * Unfortunately, this doesn't contain just the Miro ID, which is what we
+  * want -- it contains a Wellcome Images URL, and they're a bit inconsistent.
+  * This trait provides a method for extracting the Miro ID from a WI URL,
+  * if possible.
+  *
+  */
+trait WellcomeImagesURLParser {
+  def maybeGetMiroID(url: String): Option[String] = None
+}

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParser.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParser.scala
@@ -17,17 +17,26 @@ trait WellcomeImagesURLParser {
   //
   //    L0046161, V0033167F1, V0032544ECL
   //
-  private val miroID: Regex = "[A-Z][0-9]{7}[A-Z]{0,3}[0-9]?".r
+  private val miroIDregex: Regex = "[A-Z][0-9]{7}[A-Z]{0,3}[0-9]?".r
 
-  // One of the forms of a Wellcome Images URL.  Examples:
+  // Examples:
   //
   //    http://wellcomeimages.org/indexplus/image/L0046161.html
   //    http://wellcomeimages.org/indexplus/image/L0041574.html.html
   //
-  private val indexPlusURL: Regex = s"^http://wellcomeimages\\.org/indexplus/image/($miroID)(?:\\.html){0,2}$$".r.anchored
+  private val indexPlusURL: Regex = s"^http://wellcomeimages\\.org/indexplus/image/($miroIDregex)(?:\\.html){0,2}$$".r.anchored
+
+  // Examples:
+  //
+  //    http://wellcomeimages.org/ixbin/hixclient?MIROPAC=L0076330
+  //    http://wellcomeimages.org/ixbin/hixclient?MIROPAC=V0000492EB
+  //    http://wellcomeimages.org/ixbin/hixclient?MIROPAC=V0031553F1
+  //
+  private val hixClientURL: Regex = s"^http://wellcomeimages\\.org/ixbin/hixclient\\?MIROPAC=($miroIDregex)$$".r.anchored
 
   def maybeGetMiroID(url: String): Option[String] = url match {
     case indexPlusURL(miroID) => Some(miroID)
+    case hixClientURL(miroID) => Some(miroID)
     case _ => None
   }
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParser.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParser.scala
@@ -40,10 +40,17 @@ trait WellcomeImagesURLParser {
   //
   private val ixbinixClientURL: Regex = s"^http://wellcomeimages\\.org/ixbinixclient\\.exe\\?MIROPAC=($miroIDregex)\\.html\\.html$$".r
 
+  // Examples:
+  //
+  //    http://wellcomeimages.org/ixbinixclient.exe?image=M0009946.html
+  //
+  private val altIxbinixClientURL: Regex = s"^http://wellcomeimages\\.org/ixbinixclient\\.exe\\?image=($miroIDregex)\\.html$$".r
+
   def maybeGetMiroID(url: String): Option[String] = url match {
     case indexPlusURL(miroID) => Some(miroID)
     case hixClientURL(miroID) => Some(miroID)
     case ixbinixClientURL(miroID) => Some(miroID)
+    case altIxbinixClientURL(miroID) => Some(miroID)
     case _ => None
   }
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParserTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParserTest.scala
@@ -43,6 +43,12 @@ class WellcomeImagesURLParserTest extends FunSpec with Matchers {
     }
   }
 
+  it("ignores URLs that are unrelated to Wellcome Images") {
+    transformer.maybeGetMiroID(
+      url = "http://film.wellcome.ac.uk:15151/mediaplayer.html?fug_7340-1&pw=524ph=600.html"
+    ) shouldBe None
+  }
+
   val transformer = new WellcomeImagesURLParser {}
 
   private def assertURLPatternParsedCorrectly(createURL: (String) => String) = {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParserTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParserTest.scala
@@ -12,13 +12,25 @@ class WellcomeImagesURLParserTest extends FunSpec with Matchers {
   )
 
   it("indexplus/image URLs with a single '.html'") {
-    miroIDexamples.foreach { miroID =>
-      val url = s"http://wellcomeimages.org/indexplus/image/$miroID.html"
-      assertURLParsedCorrectly(url, miroID = miroID)
+    assertURLTemplateParsedCorrectly { miroID =>
+      s"http://wellcomeimages.org/indexplus/image/$miroID.html"
+    }
+  }
+
+  it("indexplus/image URLs with a double '.html'") {
+    assertURLTemplateParsedCorrectly { miroID =>
+      s"http://wellcomeimages.org/indexplus/image/$miroID.html.html"
     }
   }
 
   val transformer = new WellcomeImagesURLParser {}
+
+  private def assertURLTemplateParsedCorrectly(createURL: (String) => String) = {
+    miroIDexamples.foreach { miroID =>
+      val url = createURL(miroID)
+      assertURLParsedCorrectly(url, miroID = miroID)
+    }
+  }
 
   private def assertURLParsedCorrectly(url: String, miroID: String) = {
     val result = transformer.maybeGetMiroID(url)

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParserTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParserTest.scala
@@ -11,33 +11,41 @@ class WellcomeImagesURLParserTest extends FunSpec with Matchers {
     "V0032544ECL"
   )
 
-  it("indexplus/image URLs with a single '.html'") {
-    assertURLTemplateParsedCorrectly { miroID =>
-      s"http://wellcomeimages.org/indexplus/image/$miroID.html"
+  describe("extracts Miro IDs for known URL patterns") {
+    it("indexplus/image URLs with a single '.html'") {
+      assertURLPatternParsedCorrectly { miroID =>
+        s"http://wellcomeimages.org/indexplus/image/$miroID.html"
+      }
     }
-  }
 
-  it("indexplus/image URLs with a double '.html'") {
-    assertURLTemplateParsedCorrectly { miroID =>
-      s"http://wellcomeimages.org/indexplus/image/$miroID.html.html"
+    it("indexplus/image URLs with a double '.html'") {
+      assertURLPatternParsedCorrectly { miroID =>
+        s"http://wellcomeimages.org/indexplus/image/$miroID.html.html"
+      }
     }
-  }
 
-  it("ixbin/hixclient URLs") {
-    assertURLTemplateParsedCorrectly { miroID =>
-      s"http://wellcomeimages.org/ixbin/hixclient?MIROPAC=$miroID"
+    it("ixbin/hixclient URLs") {
+      assertURLPatternParsedCorrectly { miroID =>
+        s"http://wellcomeimages.org/ixbin/hixclient?MIROPAC=$miroID"
+      }
     }
-  }
 
-  it("ixbinixclient.exe URLs") {
-    assertURLTemplateParsedCorrectly { miroID =>
-      s"http://wellcomeimages.org/ixbinixclient.exe?MIROPAC=$miroID.html.html"
+    it("ixbinixclient.exe URLs") {
+      assertURLPatternParsedCorrectly { miroID =>
+        s"http://wellcomeimages.org/ixbinixclient.exe?MIROPAC=$miroID.html.html"
+      }
+    }
+
+    it("alternative ixbinixclient.exe URLs") {
+      assertURLPatternParsedCorrectly { miroID =>
+        s"http://wellcomeimages.org/ixbinixclient.exe?image=$miroID.html"
+      }
     }
   }
 
   val transformer = new WellcomeImagesURLParser {}
 
-  private def assertURLTemplateParsedCorrectly(createURL: (String) => String) = {
+  private def assertURLPatternParsedCorrectly(createURL: (String) => String) = {
     miroIDexamples.foreach { miroID =>
       val url = createURL(miroID)
       assertURLParsedCorrectly(url, miroID = miroID)

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParserTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParserTest.scala
@@ -23,6 +23,12 @@ class WellcomeImagesURLParserTest extends FunSpec with Matchers {
     }
   }
 
+  it("ixbin/hixclient URLs") {
+    assertURLTemplateParsedCorrectly { miroID =>
+      s"http://wellcomeimages.org/ixbin/hixclient?MIROPAC=$miroID"
+    }
+  }
+
   val transformer = new WellcomeImagesURLParser {}
 
   private def assertURLTemplateParsedCorrectly(createURL: (String) => String) = {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParserTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParserTest.scala
@@ -1,0 +1,25 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
+
+import org.scalatest.{FunSpec, Matchers}
+
+/** All of these test cases are based on real examples from the Sierra data. */
+class WellcomeImagesURLParserTest extends FunSpec with Matchers {
+
+  val miroIDexamples = List(
+    "L0046161",
+    "V0033167F1",
+    "V0032544ECL"
+  )
+
+  it("indexplus/image URLs with a single '.html'") {
+    miroIDexamples.foreach { miroID =>
+      val url = s"http://wellcomeimages.org/indexplus/image/$miroID.html"
+      assertURLParsedCorrectly(url, miroID = miroID)
+    }
+  }
+
+  val transformer = new WellcomeImagesURLParser {}
+
+  private def assertURLParsedCorrectly(url: String, miroID: String) =
+    transformer.maybeGetMiroID(url) shouldBe Some(miroID)
+}

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParserTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParserTest.scala
@@ -45,7 +45,8 @@ class WellcomeImagesURLParserTest extends FunSpec with Matchers {
 
   it("ignores URLs that are unrelated to Wellcome Images") {
     transformer.maybeGetMiroID(
-      url = "http://film.wellcome.ac.uk:15151/mediaplayer.html?fug_7340-1&pw=524ph=600.html"
+      url =
+        "http://film.wellcome.ac.uk:15151/mediaplayer.html?fug_7340-1&pw=524ph=600.html"
     ) shouldBe None
   }
 

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParserTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParserTest.scala
@@ -20,6 +20,11 @@ class WellcomeImagesURLParserTest extends FunSpec with Matchers {
 
   val transformer = new WellcomeImagesURLParser {}
 
-  private def assertURLParsedCorrectly(url: String, miroID: String) =
-    transformer.maybeGetMiroID(url) shouldBe Some(miroID)
+  private def assertURLParsedCorrectly(url: String, miroID: String) = {
+    val result = transformer.maybeGetMiroID(url)
+    if (result.isEmpty) {
+      println(s"$url did not return a Miro ID")
+    }
+    result shouldBe Some(miroID)
+  }
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParserTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/WellcomeImagesURLParserTest.scala
@@ -29,6 +29,12 @@ class WellcomeImagesURLParserTest extends FunSpec with Matchers {
     }
   }
 
+  it("ixbinixclient.exe URLs") {
+    assertURLTemplateParsedCorrectly { miroID =>
+      s"http://wellcomeimages.org/ixbinixclient.exe?MIROPAC=$miroID.html.html"
+    }
+  }
+
   val transformer = new WellcomeImagesURLParser {}
 
   private def assertURLTemplateParsedCorrectly(createURL: (String) => String) = {


### PR DESCRIPTION
A key part of #1408 is being able to extract Miro IDs from Wellcome Images URLs as they've been stored in the Sierra catalogue.

I went through the entire VHS, and extracted every instance of MARC tag 962. It looks like we want subfield $u, so I built a series of regexes that should cover all the Sierra data. This turns out to be moderately fiddly, so I put it in its own trait for testing, and it's a standalone component we can merge immediately.