### PR TITLE
Populate the mergeCandidates field for single-page Miro/Sierra works

### DIFF
--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
@@ -65,15 +65,13 @@ trait SierraMergeCandidates extends MarcUtils with WellcomeImagesURLParser {
       marcSubfieldTag = "u"
     ).flatten
 
-    val contents = matchingSubfields.map { _.content }
+    val maybeMiroIDs: List[String] = matchingSubfields
+      .map { _.content }
+      .map { maybeGetMiroID(_).get }
+      .distinct
 
-    val maybeMiroID: Option[String] = contents match {
-      case List(url) => Some(maybeGetMiroID(url).get)
-      case _ => None
-    }
-
-    maybeMiroID match {
-      case Some(miroID: String) => List(
+    maybeMiroIDs match {
+      case List(miroID) => List(
         MergeCandidate(
           identifier = SourceIdentifier(
             identifierType = IdentifierType("miro-image-number"),
@@ -82,7 +80,7 @@ trait SierraMergeCandidates extends MarcUtils with WellcomeImagesURLParser {
           )
         )
       )
-      case None => List()
+      case _ => List()
     }
   }
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, SierraBi
 
 import scala.util.matching.Regex
 
-trait SierraMergeCandidates extends MarcUtils {
+trait SierraMergeCandidates extends MarcUtils with WellcomeImagesURLParser {
 
   def getMergeCandidates(sierraBibData: SierraBibData): List[MergeCandidate] =
     get776mergeCandidates(sierraBibData) ++
@@ -59,6 +59,24 @@ trait SierraMergeCandidates extends MarcUtils {
     *
     */
   private def getSinglePageMiroMergeCandidates(sierraBibData: SierraBibData): List[MergeCandidate] = {
-    List()
+    val matchingSubfields: List[MarcSubfield] = getMatchingSubfields(
+      sierraBibData,
+      marcTag = "962",
+      marcSubfieldTag = "u"
+    ).flatten
+
+    val miroID = maybeGetMiroID(matchingSubfields
+      .head
+      .content).get
+
+    List(
+      MergeCandidate(
+        identifier = SourceIdentifier(
+          identifierType = IdentifierType("miro-image-number"),
+          ontologyType = "Work",
+          value = miroID
+        )
+      )
+    )
   }
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
@@ -38,18 +38,24 @@ trait SierraMergeCandidates extends MarcUtils with WellcomeImagesURLParser {
       marcSubfieldTag = "w"
     ).flatten
 
-    matchingSubfields match {
-      case List(MarcSubfield(_, uklwPrefixRegex(bibNumber))) =>
-        List(
-          MergeCandidate(
-            identifier = SourceIdentifier(
-              identifierType = IdentifierType("sierra-system-number"),
-              ontologyType = "Work",
-              value = bibNumber
-            ),
-            reason = Some("Physical/digitised Sierra work")
-          )
+    val maybeBibNumbers: List[Option[String]] = matchingSubfields
+      .map { _.content }
+      .map {
+        case uklwPrefixRegex(bibNumber) => Some(bibNumber)
+        case _ => None
+      }
+
+    maybeBibNumbers match {
+      case List(Some(bibNumber)) => List(
+        MergeCandidate(
+          identifier = SourceIdentifier(
+            identifierType = IdentifierType("sierra-system-number"),
+            ontologyType = "Work",
+            value = bibNumber
+          ),
+          reason = Some("Physical/digitised Sierra work")
         )
+      )
       case _ => List()
     }
   }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
@@ -88,7 +88,8 @@ trait SierraMergeCandidates extends MarcUtils with WellcomeImagesURLParser {
                 identifierType = IdentifierType("miro-image-number"),
                 ontologyType = "Work",
                 value = miroID
-              )
+              ),
+              reason = Some("Single page Miro/Sierra work")
             )
           )
           case _ => List()

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
@@ -31,7 +31,8 @@ trait SierraMergeCandidates extends MarcUtils with WellcomeImagesURLParser {
     * bib number as a merge candidate.
     *
     */
-  private def get776mergeCandidates(sierraBibData: SierraBibData): List[MergeCandidate] = {
+  private def get776mergeCandidates(
+    sierraBibData: SierraBibData): List[MergeCandidate] = {
     val matchingSubfields: List[MarcSubfield] = getMatchingSubfields(
       sierraBibData,
       marcTag = "776",
@@ -42,21 +43,22 @@ trait SierraMergeCandidates extends MarcUtils with WellcomeImagesURLParser {
       .map { _.content }
       .map {
         case uklwPrefixRegex(bibNumber) => Some(bibNumber)
-        case _ => None
+        case _                          => None
       }
       .distinct
 
     maybeBibNumbers match {
-      case List(Some(bibNumber)) => List(
-        MergeCandidate(
-          identifier = SourceIdentifier(
-            identifierType = IdentifierType("sierra-system-number"),
-            ontologyType = "Work",
-            value = bibNumber
-          ),
-          reason = Some("Physical/digitised Sierra work")
+      case List(Some(bibNumber)) =>
+        List(
+          MergeCandidate(
+            identifier = SourceIdentifier(
+              identifierType = IdentifierType("sierra-system-number"),
+              ontologyType = "Work",
+              value = bibNumber
+            ),
+            reason = Some("Physical/digitised Sierra work")
+          )
         )
-      )
       case _ => List()
     }
   }
@@ -70,7 +72,8 @@ trait SierraMergeCandidates extends MarcUtils with WellcomeImagesURLParser {
     *     than one item, we don't know where to put the Miro location).
     *
     */
-  private def getSinglePageMiroMergeCandidates(sierraBibData: SierraBibData): List[MergeCandidate] = {
+  private def getSinglePageMiroMergeCandidates(
+    sierraBibData: SierraBibData): List[MergeCandidate] = {
     sierraBibData.materialType match {
       // The Sierra material type codes we care about are:
       //
@@ -90,16 +93,17 @@ trait SierraMergeCandidates extends MarcUtils with WellcomeImagesURLParser {
           .distinct
 
         maybeMiroIDs match {
-          case List(miroID) => List(
-            MergeCandidate(
-              identifier = SourceIdentifier(
-                identifierType = IdentifierType("miro-image-number"),
-                ontologyType = "Work",
-                value = miroID
-              ),
-              reason = Some("Single page Miro/Sierra work")
+          case List(miroID) =>
+            List(
+              MergeCandidate(
+                identifier = SourceIdentifier(
+                  identifierType = IdentifierType("miro-image-number"),
+                  ontologyType = "Work",
+                  value = miroID
+                ),
+                reason = Some("Single page Miro/Sierra work")
+              )
             )
-          )
           case _ => List()
         }
       }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
@@ -67,7 +67,7 @@ trait SierraMergeCandidates extends MarcUtils with WellcomeImagesURLParser {
 
     val maybeMiroIDs: List[String] = matchingSubfields
       .map { _.content }
-      .map { maybeGetMiroID(_).get }
+      .flatMap { maybeGetMiroID }
       .distinct
 
     maybeMiroIDs match {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
@@ -42,11 +42,12 @@ trait SierraMergeCandidates extends MarcUtils with WellcomeImagesURLParser {
       case List(MarcSubfield(_, uklwPrefixRegex(bibNumber))) =>
         List(
           MergeCandidate(
-            SourceIdentifier(
+            identifier = SourceIdentifier(
               identifierType = IdentifierType("sierra-system-number"),
               ontologyType = "Work",
               value = bibNumber
-            )
+            ),
+            reason = Some("Physical/digitised Sierra work")
           )
         )
       case _ => List()

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
@@ -12,7 +12,8 @@ import scala.util.matching.Regex
 trait SierraMergeCandidates extends MarcUtils {
 
   def getMergeCandidates(sierraBibData: SierraBibData): List[MergeCandidate] =
-    get776mergeCandidates(sierraBibData)
+    get776mergeCandidates(sierraBibData) ++
+      getSinglePageMiroMergeCandidates(sierraBibData)
 
   // This regex matches any string starting with (UkLW), followed by
   // any number of spaces, and then captures everything after the
@@ -46,5 +47,18 @@ trait SierraMergeCandidates extends MarcUtils {
         )
       case _ => List()
     }
+  }
+
+  /** We can merge a single-page Miro and Sierra work if:
+    *
+    *   - The Sierra work has type "Picture" or "Digital images"
+    *   - There's exactly one Miro ID in MARC tag 962 subfield $u
+    *     (if there's more than one Miro ID, we can't do a merge).
+    *   - There's exactly one item on the Sierra record (if there's more
+    *     than one item, we don't know where to put the Miro location).
+    *
+    */
+  private def getSinglePageMiroMergeCandidates(sierraBibData: SierraBibData): List[MergeCandidate] = {
+    List()
   }
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
@@ -44,6 +44,7 @@ trait SierraMergeCandidates extends MarcUtils with WellcomeImagesURLParser {
         case uklwPrefixRegex(bibNumber) => Some(bibNumber)
         case _ => None
       }
+      .distinct
 
     maybeBibNumbers match {
       case List(Some(bibNumber)) => List(

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidates.scala
@@ -65,18 +65,24 @@ trait SierraMergeCandidates extends MarcUtils with WellcomeImagesURLParser {
       marcSubfieldTag = "u"
     ).flatten
 
-    val miroID = maybeGetMiroID(matchingSubfields
-      .head
-      .content).get
+    val contents = matchingSubfields.map { _.content }
 
-    List(
-      MergeCandidate(
-        identifier = SourceIdentifier(
-          identifierType = IdentifierType("miro-image-number"),
-          ontologyType = "Work",
-          value = miroID
+    val maybeMiroID: Option[String] = contents match {
+      case List(url) => Some(maybeGetMiroID(url).get)
+      case _ => None
+    }
+
+    maybeMiroID match {
+      case Some(miroID: String) => List(
+        MergeCandidate(
+          identifier = SourceIdentifier(
+            identifierType = IdentifierType("miro-image-number"),
+            ontologyType = "Work",
+            value = miroID
+          )
         )
       )
-    )
+      case None => List()
+    }
   }
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -610,10 +610,14 @@ class SierraTransformableTransformerTest
     val work = transformDataToUnidentifiedWork(id = id, data = data)
     work.mergeCandidates shouldBe List(
       MergeCandidate(
-        SourceIdentifier(
-          IdentifierType("sierra-system-number"),
-          "Work",
-          mergeCandidateBibNumber)))
+        identifier = SourceIdentifier(
+          identifierType = IdentifierType("sierra-system-number"),
+          ontologyType = "Work",
+          value = mergeCandidateBibNumber
+        ),
+        reason = Some("Physical/digitised Sierra work")
+      )
+    )
   }
 
   it("returns an InvisibleWork if bibData has no title") {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -75,8 +75,17 @@ class SierraMergeCandidatesTest
 
       transformer.getMergeCandidates(sierraData) shouldBe Nil
     }
-  }
 
+    it("does not create a merge candidate if there are multiple distinct instances of 776$$w") {
+      val bibData = createSierraBibDataWith(
+        varFields = create776subfieldsWith(
+          ids = List(s"(UkLW)  $mergeCandidateBibNumber", "(UkLW)b12345678")
+        )
+      )
+
+      transformer.getMergeCandidates(bibData) shouldBe List()
+    }
+  }
 
   describe("single-page Miro/Sierra work") {
     it("extracts a MIRO ID from a URL in MARC tag 962 subfield u") {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -8,6 +8,8 @@ import uk.ac.wellcome.models.work.internal.{
 }
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
+  SierraBibData,
+  SierraMaterialType,
   VarField
 }
 import uk.ac.wellcome.platform.transformer.sierra.generators.{
@@ -102,10 +104,8 @@ class SierraMergeCandidatesTest
   describe("single-page Miro/Sierra work") {
     it("extracts a MIRO ID from a URL in MARC tag 962 subfield u") {
       val miroID = "A0123456"
-      val bibData = createSierraBibDataWith(
-        varFields = create962subfieldsWith(
-          urls = List(s"http://wellcomeimages.org/indexplus/image/$miroID.html")
-        )
+      val bibData = createMiroPictureWith(
+        urls = List(s"http://wellcomeimages.org/indexplus/image/$miroID.html")
       )
 
       transformer.getMergeCandidates(bibData) shouldBe List(
@@ -120,12 +120,10 @@ class SierraMergeCandidatesTest
     }
 
     it("does not put a merge candidate for multiple distinct instances of 962 subfield u") {
-      val bibData = createSierraBibDataWith(
-        varFields = create962subfieldsWith(
-          urls = List(
-            "http://wellcomeimages.org/indexplus/image/A0000001.html",
-            "http://wellcomeimages.org/ixbin/hixclient?MIROPAC=B0000001"
-          )
+      val bibData = createMiroPictureWith(
+        urls = List(
+          "http://wellcomeimages.org/indexplus/image/A0000001.html",
+          "http://wellcomeimages.org/ixbin/hixclient?MIROPAC=B0000001"
         )
       )
 
@@ -134,12 +132,10 @@ class SierraMergeCandidatesTest
 
     it("creates a merge candidate if multiple URLs point to the same Miro ID") {
       val miroID = "C0000001"
-      val bibData = createSierraBibDataWith(
-        varFields = create962subfieldsWith(
-          urls = List(
-            s"http://wellcomeimages.org/indexplus/image/$miroID.html",
-            s"http://wellcomeimages.org/ixbin/hixclient?MIROPAC=$miroID"
-          )
+      val bibData = createMiroPictureWith(
+        urls = List(
+          s"http://wellcomeimages.org/indexplus/image/$miroID.html",
+          s"http://wellcomeimages.org/ixbin/hixclient?MIROPAC=$miroID"
         )
       )
 
@@ -155,10 +151,8 @@ class SierraMergeCandidatesTest
     }
 
     it("does not create a merge candidate if the URL is unrecognised") {
-      val bibData = createSierraBibDataWith(
-        varFields = create962subfieldsWith(
-          urls = List("http://film.wellcome.ac.uk:15151/mediaplayer.html?fug_7340-1&pw=524ph=600.html")
-        )
+      val bibData = createMiroPictureWith(
+        urls = List("http://film.wellcome.ac.uk:15151/mediaplayer.html?fug_7340-1&pw=524ph=600.html")
       )
 
       transformer.getMergeCandidates(bibData) shouldBe List()
@@ -169,6 +163,12 @@ class SierraMergeCandidatesTest
     val sierraData = createSierraBibDataWith(varFields = List())
     transformer.getMergeCandidates(sierraData) shouldBe Nil
   }
+
+  private def createMiroPictureWith(urls: List[String]): SierraBibData =
+    createSierraBibDataWith(
+      materialType = Some(SierraMaterialType(code = "k")),
+      varFields = create962subfieldsWith(urls = urls)
+    )
 
   private def create962subfieldsWith(urls: List[String]): List[VarField] =
     urls.map { url =>

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -153,6 +153,16 @@ class SierraMergeCandidatesTest
         )
       )
     }
+
+    it("does not create a merge candidate if the URL is unrecognised") {
+      val bibData = createSierraBibDataWith(
+        varFields = create962subfieldsWith(
+          urls = List("http://film.wellcome.ac.uk:15151/mediaplayer.html?fug_7340-1&pw=524ph=600.html")
+        )
+      )
+
+      transformer.getMergeCandidates(bibData) shouldBe List()
+    }
   }
 
   it("returns an empty list if there is no MARC tag 776") {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -101,9 +101,10 @@ class SierraMergeCandidatesTest
     }
   }
 
+  val miroID = "A0123456"
+
   describe("single-page Miro/Sierra work") {
     it("extracts a MIRO ID from a URL in MARC tag 962 subfield u") {
-      val miroID = "A0123456"
       val bibData = createMiroPictureWith(
         urls = List(s"http://wellcomeimages.org/indexplus/image/$miroID.html")
       )
@@ -114,7 +115,7 @@ class SierraMergeCandidatesTest
     it("does not put a merge candidate for multiple distinct instances of 962 subfield u") {
       val bibData = createMiroPictureWith(
         urls = List(
-          "http://wellcomeimages.org/indexplus/image/A0000001.html",
+          s"http://wellcomeimages.org/indexplus/image/$miroID.html",
           "http://wellcomeimages.org/ixbin/hixclient?MIROPAC=B0000001"
         )
       )
@@ -123,7 +124,6 @@ class SierraMergeCandidatesTest
     }
 
     it("creates a merge candidate if multiple URLs point to the same Miro ID") {
-      val miroID = "C0000001"
       val bibData = createMiroPictureWith(
         urls = List(
           s"http://wellcomeimages.org/indexplus/image/$miroID.html",
@@ -137,6 +137,39 @@ class SierraMergeCandidatesTest
     it("does not create a merge candidate if the URL is unrecognised") {
       val bibData = createMiroPictureWith(
         urls = List("http://film.wellcome.ac.uk:15151/mediaplayer.html?fug_7340-1&pw=524ph=600.html")
+      )
+
+      transformer.getMergeCandidates(bibData) shouldBe List()
+    }
+
+    it("creates a merge candidate if the material type is 'Picture'") {
+      val bibData = createSierraBibDataWith(
+        materialType = Some(SierraMaterialType(code = "k")),
+        varFields = create962subfieldsWith(
+          urls = List(s"http://wellcomeimages.org/indexplus/image/$miroID.html")
+        )
+      )
+
+      transformer.getMergeCandidates(bibData) shouldBe singleMiroMergeCandidate(miroID)
+    }
+
+    it("creates a merge candidate if the material type is 'Digital Images'") {
+      val bibData = createSierraBibDataWith(
+        materialType = Some(SierraMaterialType(code = "q")),
+        varFields = create962subfieldsWith(
+          urls = List(s"http://wellcomeimages.org/indexplus/image/$miroID.html")
+        )
+      )
+
+      transformer.getMergeCandidates(bibData) shouldBe singleMiroMergeCandidate(miroID)
+    }
+
+    it("does not create a merge candidate if the material type is neither 'Picture' nor 'Digital Images'") {
+      val bibData = createSierraBibDataWith(
+        materialType = Some(SierraMaterialType(code = "x")),
+        varFields = create962subfieldsWith(
+          urls = List(s"http://wellcomeimages.org/indexplus/image/$miroID.html")
+        )
       )
 
       transformer.getMergeCandidates(bibData) shouldBe List()

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -29,13 +29,8 @@ class SierraMergeCandidatesTest
     it("extracts the bib number in 776$$w as a mergeCandidate") {
       val mergeCandidateBibNumber = "b21414440"
       val sierraData = createSierraBibDataWith(
-        varFields = List(
-          createVarFieldWith(
-            marcTag = "776",
-            subfields = List(
-              MarcSubfield(tag = "w", content = s"(UkLW)$mergeCandidateBibNumber")
-            )
-          )
+        varFields = create776subfieldsWith(
+          ids = List(s"(UkLW)$mergeCandidateBibNumber")
         )
       )
 
@@ -50,15 +45,8 @@ class SierraMergeCandidatesTest
     it("strips spaces in tag 776$$w and adds it as a mergeCandidate") {
       val mergeCandidateBibNumber = "b21414440"
       val sierraData = createSierraBibDataWith(
-        varFields = List(
-          createVarFieldWith(
-            marcTag = "776",
-            subfields = List(
-              MarcSubfield(
-                tag = "w",
-                content = s"(UkLW)  $mergeCandidateBibNumber")
-            )
-          )
+        varFields = create776subfieldsWith(
+          ids = List(s"(UkLW)  $mergeCandidateBibNumber")
         )
       )
 
@@ -87,13 +75,8 @@ class SierraMergeCandidatesTest
 
     it("ignores values in 776$$w that aren't prefixed with (UkLW)") {
       val sierraData = createSierraBibDataWith(
-        varFields = List(
-          createVarFieldWith(
-            marcTag = "776",
-            subfields = List(
-              MarcSubfield(tag = "w", content = s"(OCoLC)14322288")
-            )
-          )
+        varFields = create776subfieldsWith(
+          ids = List("(OCoLC)14322288")
         )
       )
 
@@ -178,18 +161,14 @@ class SierraMergeCandidatesTest
 
   it("creates merge candidates for both physical/digital Sierra works and Miro works") {
     val mergeCandidateBibNumber = "b12345678"
+
+    val varFields =
+      create776subfieldsWith(ids = List(s"(UkLW)$mergeCandidateBibNumber")) ++
+      create962subfieldsWith(urls = List(s"http://wellcomeimages.org/indexplus/image/$miroID.html"))
+
     val sierraData = createSierraBibDataWith(
       materialType = Some(SierraMaterialType("k")),
-      varFields = List(
-        createVarFieldWith(
-          marcTag = "776",
-          subfields = List(
-            MarcSubfield(tag = "w", content = s"(UkLW)$mergeCandidateBibNumber")
-          )
-        )
-      ) ++ create962subfieldsWith(
-        urls = List(s"http://wellcomeimages.org/indexplus/image/$miroID.html")
-      )
+      varFields = varFields
     )
 
     transformer.getMergeCandidates(sierraData) shouldBe List(
@@ -216,6 +195,16 @@ class SierraMergeCandidatesTest
         reason = Some("Single page Miro/Sierra work")
       )
     )
+
+  private def create776subfieldsWith(ids: List[String]): List[VarField] =
+    ids.map { idString =>
+      createVarFieldWith(
+        marcTag = "776",
+        subfields = List(
+          MarcSubfield(tag = "w", content = idString)
+        )
+      )
+    }
 
   private def createMiroPictureWith(urls: List[String]): SierraBibData =
     createSierraBibDataWith(

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -131,6 +131,28 @@ class SierraMergeCandidatesTest
 
       transformer.getMergeCandidates(bibData) shouldBe List()
     }
+
+    it("creates a merge candidate if multiple URLs point to the same Miro ID") {
+      val miroID = "C0000001"
+      val bibData = createSierraBibDataWith(
+        varFields = create962subfieldsWith(
+          urls = List(
+            s"http://wellcomeimages.org/indexplus/image/$miroID.html",
+            s"http://wellcomeimages.org/ixbin/hixclient?MIROPAC=$miroID"
+          )
+        )
+      )
+
+      transformer.getMergeCandidates(bibData) shouldBe List(
+        MergeCandidate(
+          identifier = SourceIdentifier(
+            identifierType = IdentifierType("miro-image-number"),
+            ontologyType = "Work",
+            value = miroID
+          )
+        )
+      )
+    }
   }
 
   it("returns an empty list if there is no MARC tag 776") {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -123,6 +123,33 @@ class SierraMergeCandidatesTest
         )
       )
     }
+
+    it("does not put a merge candidate for multiple instances of 962 subfield u") {
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "962",
+            subfields = List(
+              MarcSubfield(
+                tag = "u",
+                content = s"http://wellcomeimages.org/indexplus/image/A0000001.html"
+              )
+            )
+          ),
+          createVarFieldWith(
+            marcTag = "962",
+            subfields = List(
+              MarcSubfield(
+                tag = "u",
+                content = s"http://wellcomeimages.org/ixbin/hixclient?MIROPAC=B0000001"
+              )
+            )
+          )
+        )
+      )
+
+      transformer.getMergeCandidates(bibData) shouldBe List()
+    }
   }
 
   it("returns an empty list if there is no MARC tag 776") {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -176,6 +176,30 @@ class SierraMergeCandidatesTest
     }
   }
 
+  it("creates merge candidates for both physical/digital Sierra works and Miro works") {
+    val mergeCandidateBibNumber = "b12345678"
+    val sierraData = createSierraBibDataWith(
+      materialType = Some(SierraMaterialType("k")),
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "776",
+          subfields = List(
+            MarcSubfield(tag = "w", content = s"(UkLW)$mergeCandidateBibNumber")
+          )
+        )
+      ) ++ create962subfieldsWith(
+        urls = List(s"http://wellcomeimages.org/indexplus/image/$miroID.html")
+      )
+    )
+
+    transformer.getMergeCandidates(sierraData) shouldBe List(
+      MergeCandidate(
+        SourceIdentifier(
+          identifierType = IdentifierType("sierra-system-number"),
+          ontologyType = "Work",
+          value = mergeCandidateBibNumber))) ++ singleMiroMergeCandidate(miroID)
+  }
+
   it("returns an empty list if there is no MARC tag 776 or 962") {
     val sierraData = createSierraBibDataWith(varFields = List())
     transformer.getMergeCandidates(sierraData) shouldBe Nil

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -108,15 +108,7 @@ class SierraMergeCandidatesTest
         urls = List(s"http://wellcomeimages.org/indexplus/image/$miroID.html")
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe List(
-        MergeCandidate(
-          identifier = SourceIdentifier(
-            identifierType = IdentifierType("miro-image-number"),
-            ontologyType = "Work",
-            value = miroID
-          )
-        )
-      )
+      transformer.getMergeCandidates(bibData) shouldBe singleMiroMergeCandidate(miroID)
     }
 
     it("does not put a merge candidate for multiple distinct instances of 962 subfield u") {
@@ -139,15 +131,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe List(
-        MergeCandidate(
-          identifier = SourceIdentifier(
-            identifierType = IdentifierType("miro-image-number"),
-            ontologyType = "Work",
-            value = miroID
-          )
-        )
-      )
+      transformer.getMergeCandidates(bibData) shouldBe singleMiroMergeCandidate(miroID)
     }
 
     it("does not create a merge candidate if the URL is unrecognised") {
@@ -159,10 +143,21 @@ class SierraMergeCandidatesTest
     }
   }
 
-  it("returns an empty list if there is no MARC tag 776") {
+  it("returns an empty list if there is no MARC tag 776 or 962") {
     val sierraData = createSierraBibDataWith(varFields = List())
     transformer.getMergeCandidates(sierraData) shouldBe Nil
   }
+
+  private def singleMiroMergeCandidate(miroID: String): List[MergeCandidate] =
+    List(
+      MergeCandidate(
+        identifier = SourceIdentifier(
+          identifierType = IdentifierType("miro-image-number"),
+          ontologyType = "Work",
+          value = miroID
+        )
+      )
+    )
 
   private def createMiroPictureWith(urls: List[String]): SierraBibData =
     createSierraBibDataWith(

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -124,7 +124,7 @@ class SierraMergeCandidatesTest
       )
     }
 
-    it("does not put a merge candidate for multiple instances of 962 subfield u") {
+    it("does not put a merge candidate for multiple distinct instances of 962 subfield u") {
       val bibData = createSierraBibDataWith(
         varFields = List(
           createVarFieldWith(

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -76,7 +76,8 @@ class SierraMergeCandidatesTest
       transformer.getMergeCandidates(sierraData) shouldBe Nil
     }
 
-    it("does not create a merge candidate if there are multiple distinct instances of 776$$w") {
+    it(
+      "does not create a merge candidate if there are multiple distinct instances of 776$$w") {
       val bibData = createSierraBibDataWith(
         varFields = create776subfieldsWith(
           ids = List(s"(UkLW)  $mergeCandidateBibNumber", "(UkLW)b12345678")
@@ -86,7 +87,8 @@ class SierraMergeCandidatesTest
       transformer.getMergeCandidates(bibData) shouldBe List()
     }
 
-    it("creates a merge candidate if there are multiple 776$$w for the same value") {
+    it(
+      "creates a merge candidate if there are multiple 776$$w for the same value") {
       val bibData = createSierraBibDataWith(
         varFields = create776subfieldsWith(
           ids = List(
@@ -108,10 +110,12 @@ class SierraMergeCandidatesTest
         urls = List(s"http://wellcomeimages.org/indexplus/image/$miroID.html")
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe singleMiroMergeCandidate(miroID)
+      transformer.getMergeCandidates(bibData) shouldBe singleMiroMergeCandidate(
+        miroID)
     }
 
-    it("does not put a merge candidate for multiple distinct instances of 962 subfield u") {
+    it(
+      "does not put a merge candidate for multiple distinct instances of 962 subfield u") {
       val bibData = createMiroPictureWith(
         urls = List(
           s"http://wellcomeimages.org/indexplus/image/$miroID.html",
@@ -130,12 +134,14 @@ class SierraMergeCandidatesTest
         )
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe singleMiroMergeCandidate(miroID)
+      transformer.getMergeCandidates(bibData) shouldBe singleMiroMergeCandidate(
+        miroID)
     }
 
     it("does not create a merge candidate if the URL is unrecognised") {
       val bibData = createMiroPictureWith(
-        urls = List("http://film.wellcome.ac.uk:15151/mediaplayer.html?fug_7340-1&pw=524ph=600.html")
+        urls = List(
+          "http://film.wellcome.ac.uk:15151/mediaplayer.html?fug_7340-1&pw=524ph=600.html")
       )
 
       transformer.getMergeCandidates(bibData) shouldBe List()
@@ -149,7 +155,8 @@ class SierraMergeCandidatesTest
         )
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe singleMiroMergeCandidate(miroID)
+      transformer.getMergeCandidates(bibData) shouldBe singleMiroMergeCandidate(
+        miroID)
     }
 
     it("creates a merge candidate if the material type is 'Digital Images'") {
@@ -160,10 +167,12 @@ class SierraMergeCandidatesTest
         )
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe singleMiroMergeCandidate(miroID)
+      transformer.getMergeCandidates(bibData) shouldBe singleMiroMergeCandidate(
+        miroID)
     }
 
-    it("does not create a merge candidate if the material type is neither 'Picture' nor 'Digital Images'") {
+    it(
+      "does not create a merge candidate if the material type is neither 'Picture' nor 'Digital Images'") {
       val bibData = createSierraBibDataWith(
         materialType = Some(SierraMaterialType(code = "x")),
         varFields = create962subfieldsWith(
@@ -175,10 +184,12 @@ class SierraMergeCandidatesTest
     }
   }
 
-  it("creates merge candidates for both physical/digital Sierra works and Miro works") {
+  it(
+    "creates merge candidates for both physical/digital Sierra works and Miro works") {
     val varFields =
       create776subfieldsWith(ids = List(s"(UkLW)$mergeCandidateBibNumber")) ++
-      create962subfieldsWith(urls = List(s"http://wellcomeimages.org/indexplus/image/$miroID.html"))
+        create962subfieldsWith(urls =
+          List(s"http://wellcomeimages.org/indexplus/image/$miroID.html"))
 
     val sierraData = createSierraBibDataWith(
       materialType = Some(SierraMaterialType("k")),
@@ -197,7 +208,8 @@ class SierraMergeCandidatesTest
     transformer.getMergeCandidates(sierraData) shouldBe Nil
   }
 
-  private def physicalAndDigitalSierraMergeCandidate(bibNumber: String): List[MergeCandidate] =
+  private def physicalAndDigitalSierraMergeCandidate(
+    bibNumber: String): List[MergeCandidate] =
     List(
       MergeCandidate(
         identifier = SourceIdentifier(

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -85,6 +85,21 @@ class SierraMergeCandidatesTest
 
       transformer.getMergeCandidates(bibData) shouldBe List()
     }
+
+    it("creates a merge candidate if there are multiple 776$$w for the same value") {
+      val bibData = createSierraBibDataWith(
+        varFields = create776subfieldsWith(
+          ids = List(
+            s"(UkLW)  $mergeCandidateBibNumber",
+            s"(UkLW)  $mergeCandidateBibNumber",
+            s"(UkLW)$mergeCandidateBibNumber",
+          )
+        )
+      )
+
+      transformer.getMergeCandidates(bibData) shouldBe
+        physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber)
+    }
   }
 
   describe("single-page Miro/Sierra work") {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -6,7 +6,10 @@ import uk.ac.wellcome.models.work.internal.{
   MergeCandidate,
   SourceIdentifier
 }
-import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  VarField
+}
 import uk.ac.wellcome.platform.transformer.sierra.generators.{
   MarcGenerators,
   SierraDataGenerators
@@ -100,16 +103,8 @@ class SierraMergeCandidatesTest
     it("extracts a MIRO ID from a URL in MARC tag 962 subfield u") {
       val miroID = "A0123456"
       val bibData = createSierraBibDataWith(
-        varFields = List(
-          createVarFieldWith(
-            marcTag = "962",
-            subfields = List(
-              MarcSubfield(
-                tag = "u",
-                content = s"http://wellcomeimages.org/indexplus/image/$miroID.html"
-              )
-            )
-          )
+        varFields = create962subfieldsWith(
+          urls = List(s"http://wellcomeimages.org/indexplus/image/$miroID.html")
         )
       )
 
@@ -126,24 +121,10 @@ class SierraMergeCandidatesTest
 
     it("does not put a merge candidate for multiple distinct instances of 962 subfield u") {
       val bibData = createSierraBibDataWith(
-        varFields = List(
-          createVarFieldWith(
-            marcTag = "962",
-            subfields = List(
-              MarcSubfield(
-                tag = "u",
-                content = s"http://wellcomeimages.org/indexplus/image/A0000001.html"
-              )
-            )
-          ),
-          createVarFieldWith(
-            marcTag = "962",
-            subfields = List(
-              MarcSubfield(
-                tag = "u",
-                content = s"http://wellcomeimages.org/ixbin/hixclient?MIROPAC=B0000001"
-              )
-            )
+        varFields = create962subfieldsWith(
+          urls = List(
+            "http://wellcomeimages.org/indexplus/image/A0000001.html",
+            "http://wellcomeimages.org/ixbin/hixclient?MIROPAC=B0000001"
           )
         )
       )
@@ -156,4 +137,14 @@ class SierraMergeCandidatesTest
     val sierraData = createSierraBibDataWith(varFields = List())
     transformer.getMergeCandidates(sierraData) shouldBe Nil
   }
+
+  private def create962subfieldsWith(urls: List[String]): List[VarField] =
+    urls.map { url =>
+      createVarFieldWith(
+        marcTag = "962",
+        subfields = List(
+          MarcSubfield(tag = "u", content = url)
+        )
+      )
+    }
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -96,6 +96,35 @@ class SierraMergeCandidatesTest
     }
   }
 
+  describe("single-page Miro/Sierra work") {
+    it("extracts a MIRO ID from a URL in MARC tag 962 subfield u") {
+      val miroID = "A0123456"
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "962",
+            subfields = List(
+              MarcSubfield(
+                tag = "u",
+                content = s"http://wellcomeimages.org/indexplus/image/$miroID.html"
+              )
+            )
+          )
+        )
+      )
+
+      transformer.getMergeCandidates(bibData) shouldBe List(
+        MergeCandidate(
+          identifier = SourceIdentifier(
+            identifierType = IdentifierType("miro-image-number"),
+            ontologyType = "Work",
+            value = miroID
+          )
+        )
+      )
+    }
+  }
+
   it("returns an empty list if there is no MARC tag 776") {
     val sierraData = createSierraBibDataWith(varFields = List())
     transformer.getMergeCandidates(sierraData) shouldBe Nil

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -26,6 +26,7 @@ class SierraMergeCandidatesTest
   val transformer = new SierraMergeCandidates {}
 
   val mergeCandidateBibNumber = "b21414440"
+  val miroID = "A0123456"
 
   describe("physical/digital Sierra work") {
     it("extracts the bib number in 776$$w as a mergeCandidate") {
@@ -76,7 +77,6 @@ class SierraMergeCandidatesTest
     }
   }
 
-  val miroID = "A0123456"
 
   describe("single-page Miro/Sierra work") {
     it("extracts a MIRO ID from a URL in MARC tag 962 subfield u") {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -188,7 +188,8 @@ class SierraMergeCandidatesTest
           identifierType = IdentifierType("miro-image-number"),
           ontologyType = "Work",
           value = miroID
-        )
+        ),
+        reason = Some("Single page Miro/Sierra work")
       )
     )
 

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -19,82 +19,85 @@ class SierraMergeCandidatesTest
     with SierraDataGenerators {
 
   val transformer = new SierraMergeCandidates {}
-  it("extracts the bib number in 776$$w and adds it as a mergeCandidate") {
-    val mergeCandidateBibNumber = "b21414440"
-    val sierraData = createSierraBibDataWith(
-      varFields = List(
-        createVarFieldWith(
-          marcTag = "776",
-          subfields = List(
-            MarcSubfield(tag = "w", content = s"(UkLW)$mergeCandidateBibNumber")
+
+  describe("physical/digital Sierra work") {
+    it("extracts the bib number in 776$$w as a mergeCandidate") {
+      val mergeCandidateBibNumber = "b21414440"
+      val sierraData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "776",
+            subfields = List(
+              MarcSubfield(tag = "w", content = s"(UkLW)$mergeCandidateBibNumber")
+            )
           )
         )
       )
-    )
 
-    transformer.getMergeCandidates(sierraData) shouldBe List(
-      MergeCandidate(
-        SourceIdentifier(
-          IdentifierType("sierra-system-number"),
-          "Work",
-          mergeCandidateBibNumber)))
-  }
+      transformer.getMergeCandidates(sierraData) shouldBe List(
+        MergeCandidate(
+          SourceIdentifier(
+            IdentifierType("sierra-system-number"),
+            "Work",
+            mergeCandidateBibNumber)))
+    }
 
-  it("strips spaces in tag 776$$w and adds it as a mergeCandidate") {
-    val mergeCandidateBibNumber = "b21414440"
-    val sierraData = createSierraBibDataWith(
-      varFields = List(
-        createVarFieldWith(
-          marcTag = "776",
-          subfields = List(
-            MarcSubfield(
-              tag = "w",
-              content = s"(UkLW)  $mergeCandidateBibNumber")
+    it("strips spaces in tag 776$$w and adds it as a mergeCandidate") {
+      val mergeCandidateBibNumber = "b21414440"
+      val sierraData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "776",
+            subfields = List(
+              MarcSubfield(
+                tag = "w",
+                content = s"(UkLW)  $mergeCandidateBibNumber")
+            )
           )
         )
       )
-    )
 
-    transformer.getMergeCandidates(sierraData) shouldBe List(
-      MergeCandidate(
-        SourceIdentifier(
-          IdentifierType("sierra-system-number"),
-          "Work",
-          mergeCandidateBibNumber)))
+      transformer.getMergeCandidates(sierraData) shouldBe List(
+        MergeCandidate(
+          SourceIdentifier(
+            IdentifierType("sierra-system-number"),
+            "Work",
+            mergeCandidateBibNumber)))
+    }
+
+    it("returns an empty list if MARC tag 776 does not contain a subfield w") {
+      val sierraData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "776",
+            subfields = List(
+              MarcSubfield(tag = "a", content = s"blah blah")
+            )
+          )
+        )
+      )
+
+      transformer.getMergeCandidates(sierraData) shouldBe Nil
+    }
+
+    it("ignores values in 776$$w that aren't prefixed with (UkLW)") {
+      val sierraData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "776",
+            subfields = List(
+              MarcSubfield(tag = "w", content = s"(OCoLC)14322288")
+            )
+          )
+        )
+      )
+
+      transformer.getMergeCandidates(sierraData) shouldBe Nil
+    }
   }
 
-  it("returns an empty list if there is no marc tag 776") {
+  it("returns an empty list if there is no MARC tag 776") {
     val sierraData = createSierraBibDataWith(varFields = List())
-    transformer.getMergeCandidates(sierraData) shouldBe Nil
-  }
-
-  it("returns an empty list if marc tag 776 does not contain a subfield w") {
-    val sierraData = createSierraBibDataWith(
-      varFields = List(
-        createVarFieldWith(
-          marcTag = "776",
-          subfields = List(
-            MarcSubfield(tag = "a", content = s"blah blah")
-          )
-        )
-      )
-    )
-
-    transformer.getMergeCandidates(sierraData) shouldBe Nil
-  }
-
-  it("ignores values in 776$$w that aren't prefixed with (UkLW)") {
-    val sierraData = createSierraBibDataWith(
-      varFields = List(
-        createVarFieldWith(
-          marcTag = "776",
-          subfields = List(
-            MarcSubfield(tag = "w", content = s"(OCoLC)14322288")
-          )
-        )
-      )
-    )
-
     transformer.getMergeCandidates(sierraData) shouldBe Nil
   }
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -34,12 +34,8 @@ class SierraMergeCandidatesTest
         )
       )
 
-      transformer.getMergeCandidates(sierraData) shouldBe List(
-        MergeCandidate(
-          SourceIdentifier(
-            IdentifierType("sierra-system-number"),
-            "Work",
-            mergeCandidateBibNumber)))
+      transformer.getMergeCandidates(sierraData) shouldBe
+        physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber)
     }
 
     it("strips spaces in tag 776$$w and adds it as a mergeCandidate") {
@@ -50,12 +46,8 @@ class SierraMergeCandidatesTest
         )
       )
 
-      transformer.getMergeCandidates(sierraData) shouldBe List(
-        MergeCandidate(
-          SourceIdentifier(
-            IdentifierType("sierra-system-number"),
-            "Work",
-            mergeCandidateBibNumber)))
+      transformer.getMergeCandidates(sierraData) shouldBe
+        physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber)
     }
 
     it("returns an empty list if MARC tag 776 does not contain a subfield w") {
@@ -171,18 +163,29 @@ class SierraMergeCandidatesTest
       varFields = varFields
     )
 
-    transformer.getMergeCandidates(sierraData) shouldBe List(
-      MergeCandidate(
-        SourceIdentifier(
-          identifierType = IdentifierType("sierra-system-number"),
-          ontologyType = "Work",
-          value = mergeCandidateBibNumber))) ++ singleMiroMergeCandidate(miroID)
+    val expectedMergeCandidates =
+      physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber) ++
+        singleMiroMergeCandidate(miroID)
+
+    transformer.getMergeCandidates(sierraData) shouldBe expectedMergeCandidates
   }
 
   it("returns an empty list if there is no MARC tag 776 or 962") {
     val sierraData = createSierraBibDataWith(varFields = List())
     transformer.getMergeCandidates(sierraData) shouldBe Nil
   }
+
+  private def physicalAndDigitalSierraMergeCandidate(bibNumber: String): List[MergeCandidate] =
+    List(
+      MergeCandidate(
+        identifier = SourceIdentifier(
+          identifierType = IdentifierType("sierra-system-number"),
+          ontologyType = "Work",
+          value = bibNumber
+        ),
+        reason = Some("Physical/digitised Sierra work")
+      )
+    )
 
   private def singleMiroMergeCandidate(miroID: String): List[MergeCandidate] =
     List(

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraMergeCandidatesTest.scala
@@ -25,9 +25,10 @@ class SierraMergeCandidatesTest
 
   val transformer = new SierraMergeCandidates {}
 
+  val mergeCandidateBibNumber = "b21414440"
+
   describe("physical/digital Sierra work") {
     it("extracts the bib number in 776$$w as a mergeCandidate") {
-      val mergeCandidateBibNumber = "b21414440"
       val sierraData = createSierraBibDataWith(
         varFields = create776subfieldsWith(
           ids = List(s"(UkLW)$mergeCandidateBibNumber")
@@ -39,7 +40,6 @@ class SierraMergeCandidatesTest
     }
 
     it("strips spaces in tag 776$$w and adds it as a mergeCandidate") {
-      val mergeCandidateBibNumber = "b21414440"
       val sierraData = createSierraBibDataWith(
         varFields = create776subfieldsWith(
           ids = List(s"(UkLW)  $mergeCandidateBibNumber")
@@ -152,8 +152,6 @@ class SierraMergeCandidatesTest
   }
 
   it("creates merge candidates for both physical/digital Sierra works and Miro works") {
-    val mergeCandidateBibNumber = "b12345678"
-
     val varFields =
       create776subfieldsWith(ids = List(s"(UkLW)$mergeCandidateBibNumber")) ++
       create962subfieldsWith(urls = List(s"http://wellcomeimages.org/indexplus/image/$miroID.html"))


### PR DESCRIPTION
This implements the rules described in https://github.com/wellcometrust/platform/issues/1408 for deciding if a Sierra work should be merged with a Miro work:

> * Sierra work of type Picture or Digital images
> * Sierra has a Miro ID that can be extracted from 962
> * There is only one Miro ID in 962 (there can be multiple, if so do not merge any of them)

and populates the mergeCandidates field with the Miro ID, if appropriate.

Along the way, I did a bunch of refactoring in 776$w. In particular:

* There was no test that distinct values in 776$w would mean we didn't set a merge candidate, now there is. (We already had the correct behaviour, just not the test.)
* If the same ID appears multiple times in 776$w but in different forms, we can still do something sensible with it. (I'd written this test for Miro, seemed like a natural fit.)
* Both single-page Miro/Sierra and physical/digital Sierra include a reason on the merge candidate, as future-proof against looking at a merge candidate and asking “why is this here”?

Once this is done, I’ll open a separate PR to use this value in the merger, and actually perform the merge.