### PR TITLE
Remove fieldTag from our VarField definition

### DIFF
--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/MarcFields.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/MarcFields.scala
@@ -32,7 +32,6 @@ case class MarcSubfield(
 )
 
 case class VarField(
-  fieldTag: String,
   content: Option[String] = None,
   marcTag: Option[String] = None,
   @JsonKey("ind1") indicator1: Option[String] = None,
@@ -41,9 +40,8 @@ case class VarField(
 )
 
 case object VarField {
-  def apply(fieldTag: String, content: String): VarField =
+  def apply(content: String): VarField =
     VarField(
-      fieldTag = fieldTag,
       content = Some(content),
       marcTag = None,
       indicator1 = None,
@@ -51,13 +49,11 @@ case object VarField {
       subfields = Nil
     )
 
-  def apply(fieldTag: String,
-            marcTag: String,
+  def apply(marcTag: String,
             indicator1: String,
             indicator2: String,
             subfields: List[MarcSubfield]): VarField =
     VarField(
-      fieldTag = fieldTag,
       content = None,
       marcTag = Some(marcTag),
       indicator1 = Some(indicator1),

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/MarcUtils.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/MarcUtils.scala
@@ -13,7 +13,7 @@ trait MarcUtils {
     marcSubfieldTags: List[String]): List[List[MarcSubfield]] =
     bibData.varFields
       .collect {
-        case VarField(_, _, Some(m), _, _, subfields) if m == marcTag =>
+        case VarField(_, Some(m), _, _, subfields) if m == marcTag =>
           subfields.filter { subfield =>
             marcSubfieldTags.contains(subfield.tag)
           }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraProduction.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraProduction.scala
@@ -151,13 +151,7 @@ trait SierraProduction {
     marc264fields: List[VarField]): Boolean =
     marc264fields match {
       case List(
-          VarField(
-            _,
-            _,
-            Some("264"),
-            _,
-            _,
-            List(MarcSubfield("c", content)))) =>
+          VarField(_, Some("264"), _, _, List(MarcSubfield("c", content)))) =>
         content.matches("^©\\d{4}$")
       case _ => false
     }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/MarcGenerators.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/MarcGenerators.scala
@@ -10,7 +10,6 @@ trait MarcGenerators {
                          indicator2: Option[String] = None,
                          subfields: List[MarcSubfield] = List()): VarField =
     VarField(
-      fieldTag = "p",
       marcTag = Some(marcTag),
       indicator1 = None,
       indicator2 = indicator2,

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/MarcFieldTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/MarcFieldTest.scala
@@ -32,7 +32,6 @@ class MarcFieldTest extends FunSpec with Matchers with JsonAssertions {
     }"""
 
     val expectedVarField = VarField(
-      fieldTag = "n",
       marcTag = "008",
       indicator1 = " ",
       indicator2 = " ",
@@ -54,7 +53,6 @@ class MarcFieldTest extends FunSpec with Matchers with JsonAssertions {
     }"""
 
     val expectedVarField = VarField(
-      fieldTag = "c",
       content = "Enjoying an event with enormous eagles"
     )
 


### PR DESCRIPTION
Spotted while working on #2619 – nothing relies on this field (possibly because it’s [Innovative-specific](https://techdocs.iii.com/sierraapi/v2/Content/zReference/objects/varFieldsArray.htm)), so we don’t need to parse it out or pass it around.

[For comparison, there are also fields on bib objects in the Sierra API that we don't serialise in SierraBibData.]