### PR TITLE
Create VPC endpoints for S3

### DIFF
--- a/data_science/terraform/network.tf
+++ b/data_science/terraform/network.tf
@@ -4,3 +4,8 @@ module "network" {
   cidr_block = "${var.vpc_cidr_block}"
   az_count   = "2"
 }
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id       = "${module.network.vpc_id}"
+  service_name = "com.amazonaws.${var.aws_region}.s3"
+}

--- a/monitoring/network.tf
+++ b/monitoring/network.tf
@@ -5,6 +5,11 @@ module "network" {
   az_count   = "2"
 }
 
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id       = "${module.network.vpc_id}"
+  service_name = "com.amazonaws.${var.aws_region}.s3"
+}
+
 resource "aws_service_discovery_private_dns_namespace" "namespace" {
   name = "${local.namespace}"
   vpc  = "${module.network.vpc_id}"

--- a/shared_infra/vpcs.tf
+++ b/shared_infra/vpcs.tf
@@ -4,3 +4,8 @@ module "catalogue_vpc" {
   cidr_block = "10.100.0.0/16"
   az_count   = "3"
 }
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id       = "${module.catalogue_vpc.vpc_id}"
+  service_name = "com.amazonaws.${var.aws_region}.s3"
+}


### PR DESCRIPTION
One of the big line items on this month’s EC2 bill was NatGateway:

<table>
<tr>
<td colspan="2"><b>Amazon Elastic Compute Cloud NatGateway</b></td><th>$1,228.35</th>
</tr><tr>
<td>$0.048 per GB Data Processed by NAT Gateways</td><td>20,504.592 GB</td><td>$984.22</td>
</tr><tr>
<td>$0.048 per NAT Gateway Hour</td><td>5,086 Hrs</td><td>$244.13</td></tr>
</table>

Oof.

This creates a VPC endpoint for S3 in all three of our Terraform-defined VPCs, which should mean these charges are slightly gentler next month.

This change is already applied.