### PR TITLE
add extra logging for matcher version conflict failures 

### DIFF
--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiver.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiver.scala
@@ -5,7 +5,7 @@ import com.google.inject.Inject
 import com.twitter.inject.Logging
 import uk.ac.wellcome.messaging.sns.SNSWriter
 import uk.ac.wellcome.platform.matcher.matcher.WorkMatcher
-import uk.ac.wellcome.platform.matcher.models.VersionExpectedConflictException
+import uk.ac.wellcome.platform.matcher.models.{VersionExpectedConflictException, VersionUnexpectedConflictException}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.message.MessageStream
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
@@ -29,8 +29,8 @@ class MatcherMessageReceiver @Inject()(
         subject = s"source: ${this.getClass.getSimpleName}.processMessage"
       )
     } yield ()).recover {
-      case e: VersionExpectedConflictException =>
-        debug(s"Not matching work due to version: ${e.getMessage}")
+      case e @ (_: VersionExpectedConflictException | _: VersionUnexpectedConflictException)  =>
+        debug(s"Not matching work due to version conflict exception: ${e.getMessage}")
     }
   }
 

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiver.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiver.scala
@@ -5,7 +5,10 @@ import com.google.inject.Inject
 import com.twitter.inject.Logging
 import uk.ac.wellcome.messaging.sns.SNSWriter
 import uk.ac.wellcome.platform.matcher.matcher.WorkMatcher
-import uk.ac.wellcome.platform.matcher.models.{VersionExpectedConflictException, VersionUnexpectedConflictException}
+import uk.ac.wellcome.platform.matcher.models.{
+  VersionExpectedConflictException,
+  VersionUnexpectedConflictException
+}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.message.MessageStream
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
@@ -29,8 +32,10 @@ class MatcherMessageReceiver @Inject()(
         subject = s"source: ${this.getClass.getSimpleName}.processMessage"
       )
     } yield ()).recover {
-      case e @ (_: VersionExpectedConflictException | _: VersionUnexpectedConflictException)  =>
-        debug(s"Not matching work due to version conflict exception: ${e.getMessage}")
+      case e @ (_: VersionExpectedConflictException |
+          _: VersionUnexpectedConflictException) =>
+        debug(
+          s"Not matching work due to version conflict exception: ${e.getMessage}")
     }
   }
 

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
@@ -24,13 +24,13 @@ object WorkGraphUpdater extends Logging {
       case Some(WorkNode(_, existingVersion, _, _))
           if existingVersion > workUpdate.version =>
         val versionConflictMessage =
-          s"${workUpdate.workId} v${workUpdate.version} is not newer than existing work v$existingVersion"
+          s"update failed, work:${workUpdate.workId} v${workUpdate.version} is not newer than existing work v$existingVersion"
         debug(versionConflictMessage)
         throw VersionExpectedConflictException(versionConflictMessage)
       case Some(WorkNode(_, existingVersion, linkedIds, _))
           if existingVersion == workUpdate.version && workUpdate.referencedWorkIds != linkedIds.toSet =>
         val versionConflictMessage =
-          s"${workUpdate.workId} v${workUpdate.version} exists with different content!"
+          s"update failed, work:${workUpdate.workId} v${workUpdate.version} already exists with different content! update-ids:${workUpdate.referencedWorkIds} != existing-ids:${linkedIds.toSet}"
         error(versionConflictMessage)
         throw VersionUnexpectedConflictException(versionConflictMessage)
       case _ => doUpdate(workUpdate, existingGraph)

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -184,7 +184,7 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
       val existingVersion = 3
       val updateVersion = 1
 
-      intercept[VersionExpectedConflictException] {
+      val thrown = intercept[VersionExpectedConflictException] {
         WorkGraphUpdater
           .update(
             workUpdate = WorkUpdate("A", updateVersion, Set("B")),
@@ -192,6 +192,7 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
               WorkGraph(Set(WorkNode("A", existingVersion, Nil, "A")))
           )
       }
+      thrown.message shouldBe "update failed, work:A v1 is not newer than existing work v3"
     }
 
     it(
@@ -218,7 +219,7 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
       val existingVersion = 2
       val updateVersion = 2
 
-      intercept[VersionUnexpectedConflictException] {
+      val thrown = intercept[VersionUnexpectedConflictException] {
         WorkGraphUpdater
           .update(
             workUpdate = WorkUpdate("A", updateVersion, Set("A")),
@@ -228,6 +229,7 @@ class WorkGraphUpdaterTest extends FunSpec with Matchers with MatcherFixtures {
                 WorkNode("B", 0, List(), hashed_AB)))
           )
       }
+      thrown.message shouldBe "update failed, work:A v2 already exists with different content! update-ids:Set(A) != existing-ids:Set(B)"
     }
   }
 


### PR DESCRIPTION
### What is this PR trying to achieve?
logs details for matcher version conflict failures
do not log stack traces
