### PR TITLE
Reduce logging in one of our background Lambdas

### DIFF
--- a/monitoring/ecs_dashboard/update_service_list/src/update_service_list.py
+++ b/monitoring/ecs_dashboard/update_service_list/src/update_service_list.py
@@ -144,8 +144,6 @@ def main(event, _):
         'lastUpdated': str(datetime.datetime.utcnow())
     }
 
-    print(f'service_snapshot = {service_snapshot!r}')
-
     s3_client = boto3.client('s3')
 
     response = send_ecs_status_to_s3(
@@ -154,5 +152,4 @@ def main(event, _):
         bucket_name,
         object_key
     )
-
-    print(f'response = {response}')
+    assert response['HTTPStatusCode'] == 200, (service_snapshot, response)

--- a/reindexer/terraform/reindex_worker/service.tf
+++ b/reindexer/terraform/reindex_worker/service.tf
@@ -23,7 +23,7 @@ module "service" {
     # seen issues where we exhaust the HTTP connection pool.  Turning down
     # the parallelism is an attempt to reduce the number of SNS messages in
     # flight, and avoid these errors.
-    sqs_parallelism = 7
+    sqs_parallelism = 5
   }
 
   env_vars_length = 6


### PR DESCRIPTION
This Lambda logs ~9KB every five minutes – not a huge amount, but it’s unnecessary and we never check if it succeeds! So let’s not do that.

Spotted as part of #2632.