### PR TITLE
One Lambda does one thing…

### DIFF
--- a/archive/archive_report_ingest_status/src/archive_report_ingest_status.py
+++ b/archive/archive_report_ingest_status/src/archive_report_ingest_status.py
@@ -98,6 +98,12 @@ def join_url(path_segments):
 def main(event, context=None, dynamodb_resource=None, sns_client=None):
     logger.debug('received %r', event)
 
+    request_method = event['request_method']
+    if request_method != 'GET':
+        raise ValueError(
+            'Expected request_method=GET, got %r' % request_method
+        )
+
     request_method = event.get('request_method', 'POST')
 
     if request_method.upper() == 'POST':

--- a/archive/archive_report_ingest_status/src/archive_report_ingest_status.py
+++ b/archive/archive_report_ingest_status/src/archive_report_ingest_status.py
@@ -4,99 +4,32 @@ Receives a message to ingest a bag giving the URL and publishes the archive even
 """
 
 import os
-import uuid
 
 import boto3
 import daiquiri
 
-from urllib.parse import urlparse
 from wellcome_aws_utils.lambda_utils import log_on_error
-from wellcome_aws_utils.sns_utils import publish_sns_message
 
 daiquiri.setup(level=os.environ.get('LOG_LEVEL', 'INFO'))
 logger = daiquiri.getLogger()
 
 
-def post_ingest_request(event, sns_client):
-    topic_arn = os.environ['TOPIC_ARN']
-
-    request = event['body']
-    path = event.get('path', '')
-
-    try:
-        upload_url = request['uploadUrl']
-        callback_url = request.get('callbackUrl', None)
-    except TypeError:
-        raise TypeError(f"[BadRequest] Invalid request not json: {request}")
-    except KeyError as keyError:
-        raise KeyError(f"[BadRequest] Invalid request missing '{keyError.args[0]}' in {request}")
-
-    ingest_request_id = str(uuid.uuid4())
-    logger.debug('ingest_request_id: %r', ingest_request_id)
-
-    message = archive_bag_message(ingest_request_id, upload_url, callback_url)
-    logger.debug(f"sns-message: {message}")
-
-    topic_name = topic_arn.split(":")[-1]
-
-    sns_client = sns_client or boto3.client('sns')
-
-    publish_sns_message(
-        sns_client=sns_client,
-        topic_arn=topic_arn,
-        message=message,
-        subject=f"source: archive_ingest ({topic_name})"
-    )
-    logger.debug(f"published: {message} to {topic_arn}")
-
-    return {
-        'id': ingest_request_id,
-        'location': join_url((path, ingest_request_id))
-    }
-
-
-def get_ingest_status(event, dynamodb_resource):
-    dynamodb_resource = dynamodb_resource or boto3.resource('dynamodb')
-    table_name = os.environ['TABLE_NAME']
-    id = event['id']
-
+def get_ingest_status(event, dynamodb_resource, table_name):
+    guid = event['id']
     table = dynamodb_resource.Table(table_name)
 
     item = table.get_item(
-        Key={'id': id}
+        Key={'id': guid}
     )
     return item['Item']
-
-
-def archive_bag_message(archive_request_id, bag_url, callback_url):
-    """
-    Generates bag archive messages.
-    """
-    url = urlparse(bag_url)
-    if url.scheme == 's3':
-        bucket = url.netloc
-        key = url.path.lstrip('/')
-        msg = {
-            'archiveRequestId': archive_request_id,
-            'bagLocation': {
-                'namespace': bucket,
-                'key': key
-            }
-        }
-        if callback_url:
-            msg['callbackUrl'] = callback_url
-        return msg
-    else:
-        raise ValueError(f"[BadRequest] Unrecognised url scheme: {bag_url}")
-
-
-def join_url(path_segments):
-    return '/' + '/'.join(path_segment.strip('/') for path_segment in path_segments)
 
 
 @log_on_error
 def main(event, context=None, dynamodb_resource=None, sns_client=None):
     logger.debug('received %r', event)
+
+    table_name = os.environ['TABLE_NAME']
+    dynamodb_resource = dynamodb_resource or boto3.resource('dynamodb')
 
     request_method = event['request_method']
     if request_method != 'GET':
@@ -104,9 +37,4 @@ def main(event, context=None, dynamodb_resource=None, sns_client=None):
             'Expected request_method=GET, got %r' % request_method
         )
 
-    request_method = event.get('request_method', 'POST')
-
-    if request_method.upper() == 'POST':
-        return post_ingest_request(event, sns_client)
-    elif request_method.upper() == 'GET':
-        return get_ingest_status(event, dynamodb_resource)
+    return get_ingest_status(event, dynamodb_resource, table_name=table_name)

--- a/archive/archive_report_ingest_status/src/archive_report_ingest_status.py
+++ b/archive/archive_report_ingest_status/src/archive_report_ingest_status.py
@@ -1,6 +1,36 @@
 # -*- encoding: utf-8 -*-
 """
-Receives a message to ingest a bag giving the URL and publishes the archive event to an SNS topic.
+This Lambda receives a GET request to return the state of an ingest.
+
+Quoting from RFC 002 at commit ea310c1 on master:
+
+    Request:
+
+    GET /ingests/xx-xx-xx-xx
+
+    Response:
+
+    {
+      "@context": "https://api.wellcomecollection.org/storage/v1/context.json",
+      "id": "{guid}",
+      "type": "Ingest",
+      "ingestType": {
+        "id": "create",
+        "type": "IngestType"
+      },
+      "uploadUrl": "s3://source-bucket/source-path/source-bag.zip",
+      "callbackUrl": "https://workflow.wellcomecollection.org/callback?id=b1234567",
+      "bag": {
+        "id": "{id}",
+        "type": "Bag"
+      },
+      "result": {
+        "id": "success",
+        "type": "IngestResult"
+      },
+      "events": [ ... ]
+    }
+
 """
 
 import os

--- a/archive/archive_report_ingest_status/src/conftest.py
+++ b/archive/archive_report_ingest_status/src/conftest.py
@@ -1,0 +1,46 @@
+# -*- encoding: utf-8
+
+import os
+import random
+
+import pytest
+
+
+@pytest.fixture()
+def table_name():
+    return 'archive_report_ingest_status--table-%d' % random.randint(0, 10000)
+
+
+@pytest.yield_fixture(autouse=True)
+def run_around_tests(dynamodb_client, table_name):
+    os.environ.update({'TABLE_NAME': table_name})
+
+    create_table(dynamodb_client, table_name)
+    yield
+    dynamodb_client.delete_table(TableName=table_name)
+
+
+def create_table(dynamodb_client, table_name):
+    try:
+        dynamodb_client.create_table(
+            TableName=table_name,
+            KeySchema=[
+                {
+                    'AttributeName': 'id',
+                    'KeyType': 'HASH'
+                }
+            ],
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'id',
+                    'AttributeType': 'S'
+                }
+            ],
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 1,
+                'WriteCapacityUnits': 1
+            }
+        )
+        dynamodb_client.get_waiter('table_exists').wait(TableName=table_name)
+    except dynamodb_client.exceptions.ResourceInUseException:
+        pass

--- a/archive/archive_report_ingest_status/src/conftest.py
+++ b/archive/archive_report_ingest_status/src/conftest.py
@@ -14,10 +14,14 @@ def table_name():
 @pytest.yield_fixture(autouse=True)
 def run_around_tests(dynamodb_client, table_name):
     os.environ.update({'TABLE_NAME': table_name})
-
     create_table(dynamodb_client, table_name)
     yield
     dynamodb_client.delete_table(TableName=table_name)
+
+    try:
+        del os.environ['TABLE_NAME']
+    except KeyError:
+        pass
 
 
 def create_table(dynamodb_client, table_name):

--- a/archive/archive_report_ingest_status/src/docker-compose.yml
+++ b/archive/archive_report_ingest_status/src/docker-compose.yml
@@ -1,9 +1,4 @@
-sns:
-  image: wellcome/fake-sns
-  ports:
-    - "9292:9292"
-
 dynamodb:
-  image: peopleperhour/dynamodb
+  image: "peopleperhour/dynamodb"
   ports:
     - "8000:8000"

--- a/archive/archive_report_ingest_status/src/test_archive_report_ingest_status.py
+++ b/archive/archive_report_ingest_status/src/test_archive_report_ingest_status.py
@@ -1,144 +1,42 @@
 # -*- encoding: utf-8 -*-
 
-import os
-from uuid import UUID
+import uuid
 
-import pytest
-
-import archive_report_ingest_status as archive_ingest
+import archive_report_ingest_status as report_ingest_status
 
 
-TABLE_NAME = 'archive-storage-progress-table'
+def test_get_returns_status(dynamodb_resource, table_name):
+    guid = str(uuid.uuid4())
 
+    table = dynamodb_resource.Table(table_name)
+    table.put_item(Item={'id': guid})
 
-def test_post_sends_location_to_sns(sns_client, topic_arn):
-    request = ingest_request(upload_url='s3://wellcomecollection-assets-archive-ingest/test-bag.zip')
-
-    response = archive_ingest.main(event=request, sns_client=sns_client)
-
-    id = str(UUID(response['id']))
-    assert id
-
-    assert response['location'] == f"/ingests/{id}"
-
-    messages = sns_client.list_messages()
-    assert len(messages) == 1
-    assert messages[0][':message'] == {
-        'archiveRequestId': id,
-        'bagLocation': {
-            'namespace': 'wellcomecollection-assets-archive-ingest',
-            'key': 'test-bag.zip'
-        }
-    }
-
-
-def test_get_returns_status(dynamodb_resource):
-    os.environ['TABLE_NAME'] = TABLE_NAME
-
-    id = '245e3de7-5453-4ce1-a3ce-bd111753b1cf'
-    table = dynamodb_resource.Table(TABLE_NAME)
-    table.put_item(Item={'id': id, 'a': 'b'})
-
-    request = {
+    event = {
         'request_method': 'GET',
-        'id': id
+        'id': guid
     }
 
-    response = archive_ingest.main(event=request, dynamodb_resource=dynamodb_resource)
-    assert response['a'] == 'b'
+    response = report_ingest_status.main(
+        event=event,
+        dynamodb_resource=dynamodb_resource
+    )
+    assert response['id'] == guid
 
 
-def test_sends_request_to_sns_with_callback(sns_client, topic_arn):
-    request = ingest_request(upload_url='s3://wellcomecollection-assets-archive-ingest/test-bag.zip',
-                             callback_url='https://workflow.wellcomecollection.org/callback?id=b1234567')
+def test_get_includes_other_dynamodb_metadata(dynamodb_resource, table_name):
+    guid = str(uuid.uuid4())
+    item = {'id': guid, 'fooKey': 'barValue'}
 
-    response = archive_ingest.main(event=request, sns_client=sns_client)
+    table = dynamodb_resource.Table(table_name)
+    table.put_item(Item=item)
 
-    actual_id = str(UUID(response['id']))
-    assert actual_id
-
-    messages = sns_client.list_messages()
-    assert len(messages) == 1
-    assert messages[0][':message'] == {
-        'archiveRequestId': actual_id,
-        'bagLocation': {
-            'namespace': 'wellcomecollection-assets-archive-ingest',
-            'key': 'test-bag.zip'
-        },
-        'callbackUrl': 'https://workflow.wellcomecollection.org/callback?id=b1234567'
+    event = {
+        'request_method': 'GET',
+        'id': guid
     }
 
-
-def test_invalid_url_fails(sns_client):
-    request = ingest_request('invalidUrl')
-
-    with pytest.raises(ValueError, match="\[BadRequest\] Unrecognised url scheme: invalid"):
-        archive_ingest.main(event=request, sns_client=sns_client)
-
-    assert len(sns_client.list_messages()) == 0
-
-
-def test_missing_url_fails(sns_client):
-    request = {"body": {'unknownKey': 'aValue'}}
-
-    with pytest.raises(KeyError,
-                       match="\[BadRequest\] Invalid request missing 'uploadUrl' in {'unknownKey': 'aValue'}"):
-        archive_ingest.main(event=request, sns_client=sns_client)
-
-    assert len(sns_client.list_messages()) == 0
-
-
-def test_invalid_json_fails(sns_client):
-    request = {"body": "not_json"}
-
-    with pytest.raises(TypeError, match="\[BadRequest\] Invalid request not json: not_json"):
-        archive_ingest.main(event=request, sns_client=sns_client)
-
-    assert len(sns_client.list_messages()) == 0
-
-
-def ingest_request(upload_url, callback_url=None):
-    body = {
-        'uploadUrl': upload_url
-    }
-    if callback_url:
-        body['callbackUrl'] = callback_url
-    return {
-        'body': body,
-        'path': '/ingests/'
-    }
-
-
-@pytest.yield_fixture(autouse=True)
-def run_around_tests(dynamodb_client):
-    os.environ['TABLE_NAME'] = TABLE_NAME
-
-    create_table(dynamodb_client, TABLE_NAME)
-    yield
-    dynamodb_client.delete_table(TableName=TABLE_NAME)
-
-
-def create_table(dynamodb_client, table_name):
-    try:
-        dynamodb_client.create_table(
-            TableName=table_name,
-            KeySchema=[
-                {
-                    'AttributeName': 'id',
-                    'KeyType': 'HASH'
-                }
-            ],
-            AttributeDefinitions=[
-                {
-                    'AttributeName': 'id',
-                    'AttributeType': 'S'
-                }
-            ],
-            ProvisionedThroughput={
-                'ReadCapacityUnits': 1,
-                'WriteCapacityUnits': 1
-            }
-        )
-        dynamodb_client.get_waiter('table_exists').wait(TableName=table_name)
-    except dynamodb_client.exceptions.ResourceInUseException:
-        pass
+    response = report_ingest_status.main(
+        event=event,
+        dynamodb_resource=dynamodb_resource
+    )
+    assert response == item

--- a/archive/archive_report_ingest_status/src/test_archive_report_ingest_status.py
+++ b/archive/archive_report_ingest_status/src/test_archive_report_ingest_status.py
@@ -2,6 +2,8 @@
 
 import uuid
 
+import pytest
+
 import archive_report_ingest_status as report_ingest_status
 
 
@@ -40,3 +42,12 @@ def test_get_includes_other_dynamodb_metadata(dynamodb_resource, table_name):
         dynamodb_resource=dynamodb_resource
     )
     assert response == item
+
+
+def test_fails_if_called_with_post_event():
+    event = {
+        'request_method': 'POST'
+    }
+
+    with pytest.raises(AssertionError, match='Expected request_method=GET'):
+        report_ingest_status.main(event=event)

--- a/archive/archive_report_ingest_status/src/test_archive_report_ingest_status.py
+++ b/archive/archive_report_ingest_status/src/test_archive_report_ingest_status.py
@@ -49,5 +49,5 @@ def test_fails_if_called_with_post_event():
         'request_method': 'POST'
     }
 
-    with pytest.raises(AssertionError, match='Expected request_method=GET'):
+    with pytest.raises(ValueError, match='Expected request_method=GET'):
         report_ingest_status.main(event=event)


### PR DESCRIPTION
Following up #2563, this modifies the report_ingest_status Lambda to only respond to GET requests. It also adds some new tests and better error handling, and I’ve refactored the internals now it only has a single path.

There’s an outstanding question about how we return different status codes through the Lambda, but I’ll save that for a separate PR.