### PR TITLE
Clean materialType when extracting into case classes

### DIFF
--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -21,6 +21,7 @@ import uk.ac.wellcome.platform.transformer.sierra.transformers.sierra.subjects.{
   SierraConceptSubjects,
   SierraPersonSubjects
 }
+import uk.ac.wellcome.platform.transformer.sierra.source.SierraMaterialType._
 
 import scala.util.{Failure, Success, Try}
 

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraMaterialType.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraMaterialType.scala
@@ -1,3 +1,14 @@
 package uk.ac.wellcome.platform.transformer.sierra.source
 
+import io.circe.Decoder
+
 case class SierraMaterialType(code: String)
+
+object SierraMaterialType {
+  implicit val decoder = Decoder.instance[SierraMaterialType](cursor =>
+    for {
+      id <- cursor.downField("code").as[String]
+    } yield {
+      SierraMaterialType(id.trim)
+    })
+}

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraMaterialType.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraMaterialType.scala
@@ -10,5 +10,5 @@ object SierraMaterialType {
       id <- cursor.downField("code").as[String]
     } yield {
       SierraMaterialType(id.trim)
-    })
+  })
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraWorkType.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraWorkType.scala
@@ -23,6 +23,6 @@ trait SierraWorkType {
    */
   def getWorkType(bibData: SierraBibData): Option[WorkType] =
     bibData.materialType.map { t =>
-      SierraMaterialTypes.fromCode(t.code.trim)
+      SierraMaterialTypes.fromCode(t.code)
     }
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -4,7 +4,11 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraGenerators
-import uk.ac.wellcome.models.transformable.sierra.{SierraBibNumber, SierraBibRecord, SierraItemRecord}
+import uk.ac.wellcome.models.transformable.sierra.{
+  SierraBibNumber,
+  SierraBibRecord,
+  SierraItemRecord
+}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
@@ -65,18 +69,20 @@ class SierraTransformableTransformerTest
          |}
         """.stripMargin
 
-    val bibRecord = createSierraBibRecordWith(id = id, data = data )
-
+    val bibRecord = createSierraBibRecordWith(id = id, data = data)
 
     val expectedWorkType = WorkType(
       id = "k",
       label = "Pictures"
     )
 
-    val triedWork = transformer.transform(createSierraTransformableWith(id, Some(bibRecord)), 1)
+    val triedWork = transformer.transform(
+      createSierraTransformableWith(id, Some(bibRecord)),
+      1)
     triedWork.isSuccess shouldBe true
 
-    triedWork.get.asInstanceOf[UnidentifiedWork].workType shouldBe Some(expectedWorkType)
+    triedWork.get.asInstanceOf[UnidentifiedWork].workType shouldBe Some(
+      expectedWorkType)
   }
 
   it("extracts information from items") {
@@ -682,7 +688,8 @@ class SierraTransformableTransformerTest
     )
   }
 
-  it("extracts merge candidates from 962 subfield $$u if material type is k followed by spaces") {
+  it(
+    "extracts merge candidates from 962 subfield $$u if material type is k followed by spaces") {
     val id = createSierraBibNumber
     val miroId = "V0021476"
     val data =

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -4,11 +4,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraGenerators
-import uk.ac.wellcome.models.transformable.sierra.{
-  SierraBibNumber,
-  SierraBibRecord,
-  SierraItemRecord
-}
+import uk.ac.wellcome.models.transformable.sierra.{SierraBibNumber, SierraBibRecord, SierraItemRecord}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
@@ -54,6 +50,33 @@ class SierraTransformableTransformerTest
       .map { _.asInstanceOf[Identifiable[Item]].sourceIdentifier }
 
     actualIdentifiers should contain theSameElementsAs expectedIdentifiers
+  }
+
+  it("trims whitespace from the materialType code") {
+    val id = createSierraBibNumber
+    val title = "Hi Diddle Dee Dee"
+
+    val data =
+      s"""
+         |{
+         | "id": "$id",
+         | "title": "$title",
+         | "materialType": {"code":"k  "}
+         |}
+        """.stripMargin
+
+    val bibRecord = createSierraBibRecordWith(id = id, data = data )
+
+
+    val expectedWorkType = WorkType(
+      id = "k",
+      label = "Pictures"
+    )
+
+    val triedWork = transformer.transform(createSierraTransformableWith(id, Some(bibRecord)), 1)
+    triedWork.isSuccess shouldBe true
+
+    triedWork.get.asInstanceOf[UnidentifiedWork].workType shouldBe Some(expectedWorkType)
   }
 
   it("extracts information from items") {
@@ -616,6 +639,84 @@ class SierraTransformableTransformerTest
           value = mergeCandidateBibNumber
         ),
         reason = Some("Physical/digitised Sierra work")
+      )
+    )
+  }
+
+  it("extracts merge candidates from 962 subfield $$u if material type is k") {
+    val id = createSierraBibNumber
+    val miroId = "V0021476"
+    val data =
+      s"""
+         | {
+         |   "id": "$id",
+         |   "title": "Loosely lamenting the lemons of London",
+         |   "varFields": [
+         |     {
+         |       "fieldTag": "",
+         |       "marcTag": "962",
+         |       "ind1": " ",
+         |       "ind2": " ",
+         |       "subfields": [
+         |         {
+         |           "tag": "u",
+         |           "content": "http://wellcomeimages.org/indexplus/image/$miroId.html"
+         |         }
+         |       ]
+         |     }
+         |   ],
+         |   "materialType": {"code": "k"}
+         | }
+      """.stripMargin
+
+    val work = transformDataToUnidentifiedWork(id = id, data = data)
+    work.mergeCandidates shouldBe List(
+      MergeCandidate(
+        identifier = SourceIdentifier(
+          identifierType = IdentifierType("miro-image-number"),
+          ontologyType = "Work",
+          value = miroId
+        ),
+        reason = Some("Single page Miro/Sierra work")
+      )
+    )
+  }
+
+  it("extracts merge candidates from 962 subfield $$u if material type is k followed by spaces") {
+    val id = createSierraBibNumber
+    val miroId = "V0021476"
+    val data =
+      s"""
+         | {
+         |   "id": "$id",
+         |   "title": "Loosely lamenting the lemons of London",
+         |   "varFields": [
+         |     {
+         |       "fieldTag": "",
+         |       "marcTag": "962",
+         |       "ind1": " ",
+         |       "ind2": " ",
+         |       "subfields": [
+         |         {
+         |           "tag": "u",
+         |           "content": "http://wellcomeimages.org/indexplus/image/$miroId.html"
+         |         }
+         |       ]
+         |     }
+         |   ],
+         |   "materialType": {"code": "k  "}
+         | }
+      """.stripMargin
+
+    val work = transformDataToUnidentifiedWork(id = id, data = data)
+    work.mergeCandidates shouldBe List(
+      MergeCandidate(
+        identifier = SourceIdentifier(
+          identifierType = IdentifierType("miro-image-number"),
+          ontologyType = "Work",
+          value = miroId
+        ),
+        reason = Some("Single page Miro/Sierra work")
       )
     )
   }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraWorkTypeTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraWorkTypeTest.scala
@@ -29,19 +29,4 @@ class SierraWorkTypeTest
 
     transformer.getWorkType(bibData = bibData) shouldBe Some(expectedWorkType)
   }
-
-  it("trims whitespace from the materialType code") {
-    val bibData = createSierraBibDataWith(
-      materialType = Some(
-        SierraMaterialType(code = "a  ")
-      )
-    )
-
-    val expectedWorkType = WorkType(
-      id = "a",
-      label = "Books"
-    )
-
-    transformer.getWorkType(bibData = bibData) shouldBe Some(expectedWorkType)
-  }
 }


### PR DESCRIPTION
So that whenever we use material types we know that we don't have hanging spaces around