### PR TITLE
Improve Slack error reports from the snapshot scheduler

### DIFF
--- a/catalogue_api/terraform/data_api/outputs.tf
+++ b/catalogue_api/terraform/data_api/outputs.tf
@@ -1,0 +1,3 @@
+output "snapshots_bucket_arn" {
+  value = "${aws_s3_bucket.public_data.arn}"
+}

--- a/catalogue_api/terraform/outputs.tf
+++ b/catalogue_api/terraform/outputs.tf
@@ -5,3 +5,7 @@ output "romulus_app_uri" {
 output "remus_app_uri" {
   value = "${local.remus_app_uri}"
 }
+
+output "snapshots_bucket_arn" {
+  value = "${module.data_api.snapshots_bucket_arn}"
+}

--- a/monitoring/ecs.tf
+++ b/monitoring/ecs.tf
@@ -1,0 +1,3 @@
+resource "aws_ecs_cluster" "cluster" {
+  name = "monitoring"
+}

--- a/monitoring/locals.tf
+++ b/monitoring/locals.tf
@@ -10,7 +10,7 @@ locals {
   dlq_alarm_arn              = "${data.terraform_remote_state.shared_infra.dlq_alarm_arn}"
 
   bucket_alb_logs_id      = "${data.terraform_remote_state.shared_infra.bucket_alb_logs_id}"
-  ecs_services_cluster_id = "${data.terraform_remote_state.catalogue_pipeline.cluster_name}"
+  ecs_services_cluster_id = "${aws_ecs_cluster.cluster.name}"
 
   terraform_apply_topic_name  = "${data.terraform_remote_state.shared_infra.terraform_apply_topic_name}"
   cloudfront_errors_topic_arn = "${data.terraform_remote_state.loris.cloudfront_errors_topic_arn}"

--- a/monitoring/post_to_slack/iam_policy_document.tf
+++ b/monitoring/post_to_slack/iam_policy_document.tf
@@ -8,4 +8,14 @@ data "aws_iam_policy_document" "cloudwatch_allow_filterlogs" {
       "*",
     ]
   }
+
+  statement {
+    actions = [
+      "s3:ListObjects",
+    ]
+
+    resources = [
+      "${local.snapshots_bucket_arn}/*"
+    ]
+  }
 }

--- a/monitoring/post_to_slack/iam_policy_document.tf
+++ b/monitoring/post_to_slack/iam_policy_document.tf
@@ -11,11 +11,13 @@ data "aws_iam_policy_document" "cloudwatch_allow_filterlogs" {
 
   statement {
     actions = [
-      "s3:ListObjects",
+      "s3:Head*",
+      "s3:List*",
     ]
 
     resources = [
-      "${local.snapshots_bucket_arn}/*"
+      "${local.snapshots_bucket_arn}/",
+      "${local.snapshots_bucket_arn}/*",
     ]
   }
 }

--- a/monitoring/post_to_slack/locals.tf
+++ b/monitoring/post_to_slack/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  snapshots_bucket_arn = "${data.terraform_remote_state.catalogue_api.snapshots_bucket_arn}"
+}

--- a/monitoring/post_to_slack/src/platform_alarms.py
+++ b/monitoring/post_to_slack/src/platform_alarms.py
@@ -220,4 +220,14 @@ def get_human_message(alarm_name, state_reason):
         else:
             return f'There were {error_count} errors in the {lambda_name} Lambda.'
 
+    # The snapshot generator queue filling up suggests the snapshot
+    # generator isn't running correctly.  In that case, we can be helpful
+    # and tell the user when the last snapshot was taken.
+    if alarm_name == 'snapshot_scheduler_queue_not_empty':
+        error_count = threshold.actual_value
+        if error_count == 1:
+            return 'The snapshot generator queue has 1 unprocessed item.'
+        else:
+            return f'The snapshot generator queue has {error_count} unprocessed items.'
+
     return state_reason

--- a/monitoring/post_to_slack/src/post_to_slack.py
+++ b/monitoring/post_to_slack/src/post_to_slack.py
@@ -24,6 +24,7 @@ from platform_alarms import (
     is_critical_error,
     simplify_message
 )
+from snapshot_reports import pprint_timedelta
 
 
 @attr.s
@@ -146,21 +147,6 @@ def to_bitly(sess, url, access_token):
         return url
 
 
-def pretty_time_delta(seconds):
-    seconds = int(seconds)
-    days, seconds = divmod(seconds, 86400)
-    hours, seconds = divmod(seconds, 3600)
-    minutes, seconds = divmod(seconds, 60)
-    if days > 0:
-        return '%dd %dh %dm %ds' % (days, hours, minutes, seconds)
-    elif hours > 0:
-        return '%dh %dm %ds' % (hours, minutes, seconds)
-    elif minutes > 0:
-        return '%dm %ds' % (minutes, seconds)
-    else:
-        return '%ds' % (seconds,)
-
-
 def get_latest_snapshots():
     """
     Try to return a string that describes the latest snapshots.
@@ -190,8 +176,8 @@ def get_latest_snapshots():
         v2_diff = now - v2
 
         return '\n'.join([
-            f'v1: {pretty_time_delta(v1_diff.seconds)} ago ({v1.isoformat()})',
-            f'v2: {pretty_time_delta(v2_diff.seconds)} ago ({v2.isoformat()})',
+            f'v1: {pprint_timedelta(v1_diff.seconds)} ago ({v1.isoformat()})',
+            f'v2: {pprint_timedelta(v2_diff.seconds)} ago ({v2.isoformat()})',
         ])
 
     except KeyError:

--- a/monitoring/post_to_slack/src/snapshot_reports.py
+++ b/monitoring/post_to_slack/src/snapshot_reports.py
@@ -48,6 +48,9 @@ def get_snapshot_report():
 
     for version in ['v1', 'v2']:
         try:
+            # Yes, this makes a bunch of hard-coded assumptions about the
+            # way the bucket is laid out.  It's a quick-win helper for
+            # bug diagnosis, not a prod API.
             s3_object = s3.head_object(
                 Bucket='wellcomecollection-data-public',
                 Key=f'catalogue/{version}/works.json.gz'
@@ -58,5 +61,7 @@ def get_snapshot_report():
             lines.append(
                 f'{version}: {pprint_timedelta(seconds)} ago {last_modified_date.isoformat()}'
             )
+        except Exception:
+            pass
 
     return '\n'.join(lines)

--- a/monitoring/post_to_slack/src/snapshot_reports.py
+++ b/monitoring/post_to_slack/src/snapshot_reports.py
@@ -1,0 +1,35 @@
+# -*- encoding: utf-8
+
+import datetime as dt
+
+
+def pprint_timedelta(seconds):
+    """
+    Returns a pretty-printed summary of a duration as seconds.
+
+    e.g. "1h", "2d 3h", "1m 4s".
+
+    """
+    days, seconds = divmod(seconds, 86400)
+    hours, seconds = divmod(seconds, 3600)
+    minutes, seconds = divmod(seconds, 60)
+
+    if days > 0:
+        if hours == 0:
+            return '%dd' % days
+        else:
+            return '%dd %dh' % (days, hours)
+
+    elif hours > 0:
+        if minutes == 0:
+            return '%dh' % hours
+        else:
+            return '%dh %dm' % (hours, minutes)
+
+    elif minutes > 0:
+        if seconds == 0:
+            return '%dm' % minutes
+        else:
+            return '%dm %ds' % (minutes, seconds)
+    else:
+        return '%ds' % seconds

--- a/monitoring/post_to_slack/src/snapshot_reports.py
+++ b/monitoring/post_to_slack/src/snapshot_reports.py
@@ -59,7 +59,7 @@ def get_snapshot_report():
             last_modified_date = s3_object['LastModified'].replace(tzinfo=None)
             seconds = (now - last_modified_date).seconds
             lines.append(
-                f'{version}: {pprint_timedelta(seconds)} ago {last_modified_date.isoformat()}'
+                f'{version}: {pprint_timedelta(seconds)} ago ({last_modified_date.isoformat()})'
             )
         except Exception:
             pass

--- a/monitoring/post_to_slack/src/test_platform_alarms.py
+++ b/monitoring/post_to_slack/src/test_platform_alarms.py
@@ -170,6 +170,17 @@ def test_simplify_message(message, expected):
     ),
 
     (
+        'snapshot_scheduler_queue_not_empty',
+        'Threshold Crossed: 1 datapoint [1.0 (23/09/18 11:30:00)] was greater than the threshold (0.0).',
+        'The snapshot generator queue has 1 unprocessed item.'
+    ),
+    (
+        'snapshot_scheduler_queue_not_empty',
+        'Threshold Crossed: 1 datapoint [4.0 (23/09/18 11:30:00)] was greater than the threshold (2.0).',
+        'The snapshot generator queue has 4 unprocessed items.'
+    ),
+
+    (
         'unrecognised-alarm-name',
         'Threshold Crossed: 1 datapoint [1.0 (01/01/01 12:00:00)] was less than the threshold (0.0).',
         'Threshold Crossed: 1 datapoint [1.0 (01/01/01 12:00:00)] was less than the threshold (0.0).',

--- a/monitoring/post_to_slack/src/test_snapshot_reports.py
+++ b/monitoring/post_to_slack/src/test_snapshot_reports.py
@@ -1,0 +1,21 @@
+# -*- encoding: utf-8
+
+import pytest
+
+from snapshot_reports import pprint_timedelta
+
+
+@pytest.mark.parametrize('seconds, expected_string', [
+    (1, '1s'),
+    (15, '15s'),
+    (60, '1m'),
+    (67, '1m 7s'),
+    (3600, '1h'),
+    (3660, '1h 1m'),
+    (3661, '1h 1m'),
+    (86400, '1d'),
+    (90000, '1d 1h'),
+    (90010, '1d 1h'),
+])
+def test_pprint_timedelta(seconds, expected_string):
+    assert pprint_timedelta(seconds) == expected_string

--- a/monitoring/post_to_slack/terraform.tf
+++ b/monitoring/post_to_slack/terraform.tf
@@ -1,0 +1,9 @@
+data "terraform_remote_state" "catalogue_api" {
+  backend = "s3"
+
+  config {
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/catalogue_api.tfstate"
+    region = "eu-west-1"
+  }
+}

--- a/monitoring/terraform.tf
+++ b/monitoring/terraform.tf
@@ -9,16 +9,6 @@ terraform {
   }
 }
 
-data "terraform_remote_state" "catalogue_pipeline" {
-  backend = "s3"
-
-  config {
-    bucket = "wellcomecollection-platform-infra"
-    key    = "terraform/catalogue_pipeline.tfstate"
-    region = "eu-west-1"
-  }
-}
-
 data "terraform_remote_state" "loris" {
   backend = "s3"
 


### PR DESCRIPTION
Part of #2676.

In particular, the Slack alarms now give a more helpful message and include the dates of the last two snapshots (if available):

![screen shot 2018-09-24 at 11 44 14](https://user-images.githubusercontent.com/301220/45948264-327de300-bfef-11e8-991f-52c31e08d87a.png)

For example, here we can see that the queue is filling up, but a snapshot was created yesterday – so the snapshot generator hasn't stalled.