### PR TITLE
Ingests API creates progress record during ingest request

### DIFF
--- a/archive/archive_api/src/archive_api.py
+++ b/archive/archive_api/src/archive_api.py
@@ -1,6 +1,8 @@
 # -*- encoding: utf-8
 
 import os
+from urllib.parse import urlparse
+import uuid
 
 import daiquiri
 from flask import Flask
@@ -9,6 +11,11 @@ from werkzeug.exceptions import BadRequest as BadRequestError
 
 from report_ingest_status import report_ingest_status
 from request_new_ingest import send_new_ingest_request
+
+from create_ingest_progress import (
+    IngestProgress,
+    create_ingest_progress
+)
 
 app = Flask(__name__)
 app.config.from_object('config.ProductionConfig')
@@ -39,17 +46,41 @@ def route_request_new_ingest():
 
     try:
         request_data = request.get_json()
+        validateType(request_data['type'])
+        validateIngestType(request_data['ingestType'])
         upload_url = request_data['uploadUrl']
+        callback_url = request_data.get('callbackUrl')
     except BadRequestError:
         raise BadRequestError('Invalid json in request')
-    except KeyError:
-        raise BadRequestError('No uploadUrl parameter in request')
+    except KeyError as key_error:
+        raise BadRequestError(f'No {key_error.args[0]} parameter in request')
+    except ValueError as value_error:
+        raise BadRequestError(f'Invalid {value_error} parameter in request')
 
-    callback_url = request_data.get('callbackUrl')
+    # TODO: There is quite a lot of request validation logic which should be moved out
+    try:
+        validateUrl(upload_url, allowed_schemes=['s3'], allow_fragment=False)
+    except ValueError:
+        raise BadRequestError(f"Invalid url in uploadUrl: {upload_url}")
+
+    if callback_url:
+        try:
+            validateUrl(callback_url, allowed_schemes=['http', 'https'])
+        except ValueError:
+            raise BadRequestError(f"Invalid url in callbackUrl: {callback_url}")
+
+    ingest_request_id = str(uuid.uuid4())
+    logger.debug('ingest_request_id=%r', ingest_request_id)
+
+    create_ingest_progress(
+        IngestProgress(ingest_request_id, upload_url, callback_url),
+        app.config['DYNAMODB_RESOURCE'],
+        app.config['DYNAMODB_TABLE_NAME'])
 
     ingest_request_id = send_new_ingest_request(
         sns_client=app.config['SNS_CLIENT'],
         topic_arn=app.config['SNS_TOPIC_ARN'],
+        ingest_request_id=ingest_request_id,
         upload_url=upload_url,
         callback_url=callback_url
     )
@@ -64,7 +95,34 @@ def route_request_new_ingest():
     # Now we set the Location response header.  There's no way to do this
     # without constructing our own Response object, so that's what we do
     # here.  See https://stackoverflow.com/q/25860304/1558022
-    resp = make_response(location, 202)
+    resp = make_response('', 202)
     resp.headers['Location'] = location
-
     return resp
+
+
+@app.errorhandler(BadRequestError)
+def bad_request_error(error):
+    return jsonify(status=400, message=error.description), 400
+
+
+def validateType(type_value):
+    if type_value != 'Ingest':
+        raise ValueError(f'type: {type_value}')
+
+
+def validateIngestType(ingest_type_value):
+    if ingest_type_value != {'id': 'create', 'type': 'IngestType'}:
+        raise ValueError(f'ingestType: {ingest_type_value}')
+
+
+def validateUrl(url, allowed_schemes=None, allow_fragment=True):
+    """
+    Validates the passed string is a URL, optionally checking against allowed schemes and
+    whether a fragment is allowed
+    """
+    parsed_url = urlparse(url)
+    invalid = any(not p for p in [parsed_url.scheme, parsed_url.netloc, parsed_url.path])
+    invalid = invalid or (allowed_schemes and parsed_url.scheme not in allowed_schemes)
+    invalid = invalid or (not allow_fragment and bool(parsed_url.fragment))
+    if invalid:
+        raise ValueError(f"Invalid url:{url}")

--- a/archive/archive_api/src/create_ingest_progress.py
+++ b/archive/archive_api/src/create_ingest_progress.py
@@ -1,0 +1,61 @@
+# -*- encoding: utf-8
+
+from uuid import UUID
+from datetime import (datetime, timezone)
+from botocore.exceptions import ClientError
+
+
+class IngestProgress(object):
+    static_fields = {
+        '@context': 'https://api.wellcomecollection.org/storage/v1/context.json',
+        'type': 'Ingest',
+        'description': 'Ingest requested',
+        'ingestType': {'id': 'create', 'type': 'IngestType'}
+    }
+
+    def __init__(self, id, bag_url, callback_url=None):
+        self.validateId(id)
+        self.id = id
+
+        self.uploadUrl = bag_url
+
+        if callback_url:
+            self.callbackUrl = callback_url
+
+        self.createdDate = self.nowIsoFormatted()
+        self.lastModifiedDate = self.nowIsoFormatted()
+
+    def validateId(self, id):
+        try:
+            UUID(id)
+        except ValueError:
+            raise ValueError(f"Cannot create IngestProgress, invalid id '{id}'.")
+
+    def dict_with_static_data(self):
+        """
+        Merges dynamic fields with static fields to create a dict
+        representing initialised progress data.
+        """
+        return {**self.__dict__, **self.static_fields}
+
+    def nowIsoFormatted(self):
+        """
+        Creates an ISO 8601 date string *with* timezone
+          Timezone is '+00:00' rather than 'Z'
+        """
+        return datetime.now(timezone.utc).isoformat()
+
+
+def create_ingest_progress(ingest_progress, dynamodb_resource, table_name):
+    """
+    Creates an ingest progress record
+    """
+    table = dynamodb_resource.Table(table_name)
+    try:
+        table.put_item(
+            Item=ingest_progress.dict_with_static_data(),
+            ConditionExpression='attribute_not_exists(id)'
+        )
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
+            raise ValueError(f"Cannot create IngestProgress, id already exists '{ingest_progress.id}'.")

--- a/archive/archive_api/src/request_new_ingest.py
+++ b/archive/archive_api/src/request_new_ingest.py
@@ -1,7 +1,6 @@
 # -*- encoding: utf-8
 
 from urllib.parse import urlparse
-import uuid
 
 import daiquiri
 from wellcome_aws_utils.sns_utils import publish_sns_message
@@ -36,15 +35,11 @@ def create_archive_bag_message(guid, bag_url, callback_url):
     return message
 
 
-def send_new_ingest_request(sns_client, topic_arn, upload_url, callback_url):
+def send_new_ingest_request(sns_client, topic_arn, ingest_request_id, upload_url, callback_url):
     """
     Create a new ingest request, and send a notification to SNS.
 
-    Returns the ID of the new ingest request.
     """
-    ingest_request_id = str(uuid.uuid4())
-    logger.debug('ingest_request_id=%r', ingest_request_id)
-
     message = create_archive_bag_message(
         guid=ingest_request_id,
         bag_url=upload_url,

--- a/archive/archive_api/src/test_archive_api.py
+++ b/archive/archive_api/src/test_archive_api.py
@@ -32,12 +32,120 @@ class TestRequestNewIngest:
     """
 
     upload_url = 's3://example-bukkit/helloworld.zip'
+    callback_url = 'https://example.com/post?callback'
 
     def test_request_new_ingest_is_202(self, client):
         resp = client.post(
             f'/ingests',
-            json={'uploadUrl': self.upload_url})
+            json=ingests_post(self.upload_url))
         assert resp.status_code == 202
+        assert resp.data == b''
+
+    def test_no_type_is_badrequest(self, client):
+        resp = client.post(f'/ingests', json={})
+        assert resp.status_code == 400
+        assert b'No type parameter' in resp.data
+
+    def test_invalid_type_is_badrequest(self, client):
+        resp = client.post(f'/ingests', json={'type': 'UnexpectedType'})
+        assert resp.status_code == 400
+        assert b'Invalid type: UnexpectedType parameter' in resp.data
+
+    def test_no_ingest_type_is_badrequest(self, client):
+        resp = client.post(f'/ingests', json={'type': 'Ingest'})
+        assert resp.status_code == 400
+        assert b'No ingestType parameter' in resp.data
+
+    def test_invalid_ingest_type_is_badrequest(self, client):
+        resp = client.post(f'/ingests', json={'type': 'Ingest',
+                                              'ingestType': {'type': 'UnexpectedIngestType'}})
+        assert resp.status_code == 400
+        assert b"Invalid ingestType: {'type': 'UnexpectedIngestType'} parameter" in resp.data
+
+    def test_no_uploadurl_is_badrequest(self, client):
+        resp = client.post(f'/ingests', json=ingests_post())
+        assert resp.status_code == 400
+        assert b'No uploadUrl parameter' in resp.data
+
+    def test_invalid_uploadurl_is_badrequest(self, client):
+        resp = client.post(f'/ingests', json=ingests_post('not-a-url'))
+        assert resp.status_code == 400
+        assert b"Invalid url in uploadUrl: not-a-url" in resp.data
+
+    def test_invalid_scheme_uploadurl_is_badrequest(self, client):
+        resp = client.post(f'/ingests', json=ingests_post('ftp://example-bukkit/helloworld.zip'))
+        assert resp.status_code == 400
+        assert b"Invalid url in uploadUrl: ftp://example-bukkit/helloworld.zip" in resp.data
+
+    def test_uploadurl_with_fragments_is_badrequest(self, client):
+        resp = client.post(f'/ingests', json=ingests_post('s3://example-bukkit/helloworld.zip#fragment'))
+        assert resp.status_code == 400
+        assert b"Invalid url in uploadUrl: s3://example-bukkit/helloworld.zip#fragment" in resp.data
+
+    def test_invalid_callback_url_is_badrequest(self, client):
+        resp = client.post(f'/ingests', json=ingests_post(self.upload_url, 'not-a-url'))
+        assert resp.status_code == 400
+        assert b"Invalid url in callbackUrl: not-a-url" in resp.data
+
+    def test_invalid_scheme_callback_url_is_badrequest(self, client):
+        resp = client.post(f'/ingests', json=ingests_post(self.upload_url, 's3://example.com'))
+        assert resp.status_code == 400
+        assert b"Invalid url in callbackUrl: s3://example.com" in resp.data
+
+    def test_request_allows_fragment_in_callback(self, client):
+        resp = client.post(f'/ingests', json=ingests_post(self.upload_url, f'{self.callback_url}#fragment'))
+        assert resp.status_code == 202
+
+    def test_request_new_ingest_has_location_header(self, client):
+        resp = client.post(f'/ingests', json=ingests_post(self.upload_url))
+        assert 'Location' in resp.headers
+
+        # TODO: This might need revisiting when we deploy the app behind
+        # an ALB and these paths are no longer correct.
+        assert resp.headers['Location'].startswith('http://localhost/ingests/')
+
+    def test_successful_request_sends_to_sns(self, client, sns_client):
+        resp = client.post(f'/ingests', json=ingests_post(self.upload_url))
+
+        sns_messages = sns_client.list_messages()
+        assert len(sns_messages) == 1
+        message = sns_messages[0][':message']
+
+        assert message['bagLocation'] == {
+            'namespace': 'example-bukkit',
+            'key': 'helloworld.zip'
+        }
+
+        # This checks that the request ID sent to SNS is the same as
+        # the one we've been given to look up the request later.
+        assert resp.headers['Location'].endswith(message['archiveRequestId'])
+
+    def test_successful_request_sends_to_sns_with_callback(self, client, sns_client):
+        client.post(f'/ingests', json=ingests_post(self.upload_url, self.callback_url))
+
+        sns_messages = sns_client.list_messages()
+        assert len(sns_messages) == 1
+        message = sns_messages[0][':message']
+
+        assert 'callbackUrl' in message
+        assert message['callbackUrl'] == self.callback_url
+
+    def test_successful_request_creates_progress(self, client, dynamodb_resource, table_name):
+        response = client.post(f'/ingests', json=ingests_post(self.upload_url, self.callback_url))
+
+        assert 'Location' in response.headers
+        request_id = response.headers['Location'].split('/')[-1]
+
+        table = dynamodb_resource.Table(table_name)
+        dynamo_response = table.get_item(Key={'id': request_id})
+        assert 'Item' in dynamo_response
+        progress = dynamo_response['Item']
+        assert progress['uploadUrl'] == self.upload_url
+        assert progress['callbackUrl'] == self.callback_url
+
+    def test_get_against_request_endpoint_is_405(self, client):
+        resp = client.get('/ingests')
+        assert resp.status_code == 405
 
     def test_request_not_json_is_badrequest(self, client):
         resp = client.post(
@@ -55,53 +163,6 @@ class TestRequestNewIngest:
         assert resp.status_code == 400
         assert b'Mimetype expected to be application/json' in resp.data
 
-    def test_no_uploadurl_is_badrequest(self, client):
-        resp = client.post(f'/ingests', json={})
-        assert resp.status_code == 400
-        assert b'No uploadUrl parameter' in resp.data
-
-    def test_request_new_ingest_has_location_header(self, client):
-        resp = client.post(f'/ingests', json={'uploadUrl': self.upload_url})
-        assert 'Location' in resp.headers
-
-        # TODO: This might need revisiting when we deploy the app behind
-        # an ALB and these paths are no longer correct.
-        assert resp.headers['Location'].startswith('http://localhost/ingests/')
-
-    def test_successful_request_sends_to_sns(self, client, sns_client):
-        resp = client.post(f'/ingests', json={'uploadUrl': self.upload_url})
-
-        sns_messages = sns_client.list_messages()
-        assert len(sns_messages) == 1
-        message = sns_messages[0][':message']
-
-        assert message['bagLocation'] == {
-            'namespace': 'example-bukkit',
-            'key': 'helloworld.zip'
-        }
-
-        # This checks that the request ID sent to SNS is the same as
-        # the one we've been given to look up the request later.
-        assert resp.headers['Location'].endswith(message['archiveRequestId'])
-
-    def test_successful_request_sends_to_sns_with_callback(self, client, sns_client):
-        callback_url = 'https://example.com/post?callback'
-        client.post(f'/ingests', json={
-            'uploadUrl': self.upload_url,
-            'callbackUrl': callback_url
-        })
-
-        sns_messages = sns_client.list_messages()
-        assert len(sns_messages) == 1
-        message = sns_messages[0][':message']
-
-        assert 'callbackUrl' in message
-        assert message['callbackUrl'] == callback_url
-
-    def test_get_against_request_endpoint_is_405(self, client):
-        resp = client.get('/ingests')
-        assert resp.status_code == 405
-
 
 class TestReportHealthStatus:
     """
@@ -112,3 +173,18 @@ class TestReportHealthStatus:
         resp = client.get(f'/healthcheck')
         assert resp.status_code == 200
         assert json.loads(resp.data) == {'status': 'OK'}
+
+
+def ingests_post(upload_url=None, callback_url=None):
+    request = {
+        "type": "Ingest",
+        "ingestType": {
+            "id": "create",
+            "type": "IngestType"
+        }
+    }
+    if upload_url:
+        request.update({'uploadUrl': upload_url})
+    if callback_url:
+        request.update({'callbackUrl': callback_url})
+    return request

--- a/archive/archive_api/src/test_archive_api.py
+++ b/archive/archive_api/src/test_archive_api.py
@@ -49,7 +49,7 @@ class TestRequestNewIngest:
     def test_invalid_type_is_badrequest(self, client):
         resp = client.post(f'/ingests', json={'type': 'UnexpectedType'})
         assert resp.status_code == 400
-        assert b'Invalid type: UnexpectedType parameter' in resp.data
+        assert b"Expected 'type'='Ingest', got 'UnexpectedType' in request" in resp.data
 
     def test_no_ingest_type_is_badrequest(self, client):
         resp = client.post(f'/ingests', json={'type': 'Ingest'})
@@ -60,7 +60,9 @@ class TestRequestNewIngest:
         resp = client.post(f'/ingests', json={'type': 'Ingest',
                                               'ingestType': {'type': 'UnexpectedIngestType'}})
         assert resp.status_code == 400
-        assert b"Invalid ingestType: {'type': 'UnexpectedIngestType'} parameter" in resp.data
+        assert b"Expected 'ingestType'={'id': 'create', 'type': 'IngestType'}," \
+               b" got {'type': 'UnexpectedIngestType'} in request" \
+               in resp.data
 
     def test_no_uploadurl_is_badrequest(self, client):
         resp = client.post(f'/ingests', json=ingests_post())
@@ -70,27 +72,27 @@ class TestRequestNewIngest:
     def test_invalid_uploadurl_is_badrequest(self, client):
         resp = client.post(f'/ingests', json=ingests_post('not-a-url'))
         assert resp.status_code == 400
-        assert b"Invalid url in uploadUrl: not-a-url" in resp.data
+        assert b"Invalid uploadUrl:'not-a-url', is not a complete url" in resp.data
 
     def test_invalid_scheme_uploadurl_is_badrequest(self, client):
         resp = client.post(f'/ingests', json=ingests_post('ftp://example-bukkit/helloworld.zip'))
         assert resp.status_code == 400
-        assert b"Invalid url in uploadUrl: ftp://example-bukkit/helloworld.zip" in resp.data
+        assert b"Invalid uploadUrl:'ftp://example-bukkit/helloworld.zip', 'ftp' is not one of the supported schemes (['s3'])" in resp.data
 
     def test_uploadurl_with_fragments_is_badrequest(self, client):
         resp = client.post(f'/ingests', json=ingests_post('s3://example-bukkit/helloworld.zip#fragment'))
         assert resp.status_code == 400
-        assert b"Invalid url in uploadUrl: s3://example-bukkit/helloworld.zip#fragment" in resp.data
+        assert b"Invalid uploadUrl:'s3://example-bukkit/helloworld.zip#fragment', 'fragment' fragment is not supported" in resp.data
 
     def test_invalid_callback_url_is_badrequest(self, client):
         resp = client.post(f'/ingests', json=ingests_post(self.upload_url, 'not-a-url'))
         assert resp.status_code == 400
-        assert b"Invalid url in callbackUrl: not-a-url" in resp.data
+        assert b"Invalid callbackUrl:'not-a-url', is not a complete url" in resp.data
 
     def test_invalid_scheme_callback_url_is_badrequest(self, client):
         resp = client.post(f'/ingests', json=ingests_post(self.upload_url, 's3://example.com'))
         assert resp.status_code == 400
-        assert b"Invalid url in callbackUrl: s3://example.com" in resp.data
+        assert b"Invalid callbackUrl:'s3://example.com', 's3' is not one of the supported schemes (['http', 'https'])" in resp.data
 
     def test_request_allows_fragment_in_callback(self, client):
         resp = client.post(f'/ingests', json=ingests_post(self.upload_url, f'{self.callback_url}#fragment'))

--- a/archive/archive_api/src/test_create_ingest_progress.py
+++ b/archive/archive_api/src/test_create_ingest_progress.py
@@ -1,0 +1,106 @@
+# -*- encoding: utf-8
+
+import pytest
+from datetime import (datetime, timezone, timedelta)
+
+from create_ingest_progress import (
+    IngestProgress,
+    create_ingest_progress
+)
+
+bag_url = 's3://example-bukkit/foo/bar.zip'
+callback_url = 'https://example.com/post?callback'
+
+
+def test_creates_ingest_progress_without_callback(dynamodb_resource, table_name, guid):
+    create_ingest_progress(
+        IngestProgress(guid, bag_url),
+        dynamodb_resource,
+        table_name)
+
+    expected_item = initialised_progress_item(guid, bag_url)
+
+    assert_stored_progress(expected_item, dynamodb_resource, table_name)
+
+
+def test_creates_ingest_progress_with_callback(dynamodb_resource, table_name, guid):
+    create_ingest_progress(
+        IngestProgress(guid, bag_url, callback_url),
+        dynamodb_resource,
+        table_name)
+
+    expected_item = initialised_progress_item(guid, bag_url, callback_url)
+
+    assert_stored_progress(expected_item, dynamodb_resource, table_name)
+
+
+def test_raises_if_id_is_invalid(dynamodb_resource, table_name):
+    with pytest.raises(ValueError, match="Cannot create IngestProgress, invalid id ''."):
+        create_ingest_progress(
+            IngestProgress("", bag_url, callback_url),
+            dynamodb_resource,
+            table_name)
+
+
+def test_raises_if_id_is_already_saved(dynamodb_resource, table_name, guid):
+    with pytest.raises(ValueError, match=f"Cannot create IngestProgress, id already exists '{guid}'."):
+        create_ingest_progress(
+            IngestProgress(guid, bag_url, callback_url),
+            dynamodb_resource,
+            table_name)
+
+        create_ingest_progress(
+            IngestProgress(guid, bag_url, callback_url),
+            dynamodb_resource,
+            table_name)
+
+
+def initialised_progress_item(guid, upload_url, callback_url=None):
+    item = {
+        '@context': 'https://api.wellcomecollection.org/storage/v1/context.json',
+        'id': guid,
+        'type': 'Ingest',
+        'ingestType': {
+            'id': 'create',
+            'type': 'IngestType'
+        },
+        'uploadUrl': upload_url,
+        'description': 'Ingest requested',
+        'createdDate': '@recent',
+        'lastModifiedDate': '@recent'
+    }
+    if callback_url is not None:
+        item.update({'callbackUrl': callback_url})
+    return item
+
+
+def assert_stored_progress(expected_item, dynamodb_resource, table_name):
+    table = dynamodb_resource.Table(table_name)
+    result = table.get_item(Key={'id': expected_item['id']})
+    saved_item = result['Item']
+
+    assert_dynamic_fields(saved_item, expected_item)
+    assert saved_item == expected_item
+
+
+def assert_dynamic_fields(actual_dict, expected_dict):
+    for key, value in expected_dict.items():
+        if value == '@recent':
+            try:
+                date_str = actual_dict.get(key, "")
+                assert_iso_date_is_recent(date_str)
+            except ValueError:
+                raise ValueError(f"Expected recent ISO date {key}: '{date_str}' in {actual_dict}")
+            expected_dict[key] = actual_dict[key]
+
+
+def assert_iso_date_is_recent(actual_date_str, seconds_delta=1):
+    # We expect a UTC ISO 8601 time with a timezone portion that includes colons.
+    # Python < 3.7 strptime('%z') cannot parse the colons so replace +00:00 with a timezone
+    # that can be parsed ('+0000').
+    #
+    # This step should *not* be needed in python >= 3.7
+    actual_date_str = actual_date_str.replace('+00:00', '+0000')
+
+    actual_date = datetime.strptime(actual_date_str, '%Y-%m-%dT%H:%M:%S.%f%z')
+    assert datetime.now(timezone.utc) - actual_date < timedelta(seconds=seconds_delta)


### PR DESCRIPTION
### What is this PR trying to achieve?
When a request for ingest is received create the progress record so it is immediately available for status query.

Validate the ingest request as requested in #2626 

part of #2626
