### PR TITLE
Wait longer before declaring the snapshot scheduler broken

### DIFF
--- a/catalogue_api/terraform/data_api/queues.tf
+++ b/catalogue_api/terraform/data_api/queues.tf
@@ -19,7 +19,7 @@ resource "aws_cloudwatch_metric_alarm" "snapshot_scheduler_queue_not_empty" {
   evaluation_periods  = 1
   metric_name         = "ApproximateNumberOfMessagesVisible"
   namespace           = "AWS/SQS"
-  period              = 60
+  period              = 3600
   threshold           = 2
   statistic           = "Average"
 

--- a/data_api/Makefile
+++ b/data_api/Makefile
@@ -10,10 +10,9 @@ SBT_NO_DOCKER_LIBRARIES =
 ECS_TASKS   =
 LAMBDAS     = snapshot_scheduler
 
-TF_NAME     = data_api
-TF_PATH     = $(STACK_ROOT)/terraform
-TF_IS_PUBLIC_FACING = true
-
+TF_NAME     =
+TF_PATH     =
+TF_IS_PUBLIC_FACING =
 
 
 $(val $(call stack_setup))


### PR DESCRIPTION
Possible fix for #2676.

For reasons I don’t fully understand, sometimes Lambdas can be invoked more than once in response to an event (e.g. a CloudWatch cron task) – and our Lambda is being invoked twice, seemingly regularly. That trips the queue alarm, but it clears shortly afterward when the snapshot generator runs.

This doesn't fix the at-least-once-invocation problem, but it should clean up the alarms – we wait an hour before declaring it not to have run, not a minute. Since this alarm is already at least 24 hours late to reporting a problem, this isn't as big a problem as it might first appear.