### PR TITLE
Archive API bag ingest format 

### DIFF
--- a/archive/archive_api/src/request_new_ingest.py
+++ b/archive/archive_api/src/request_new_ingest.py
@@ -23,7 +23,7 @@ def create_archive_bag_message(guid, bag_url, callback_url):
 
     message = {
         'archiveRequestId': guid,
-        'bagLocation': {
+        'zippedBagLocation': {
             'namespace': bucket,
             'key': key
         }

--- a/archive/archive_api/src/test_archive_api.py
+++ b/archive/archive_api/src/test_archive_api.py
@@ -124,7 +124,7 @@ class TestRequestNewIngest:
         assert len(sns_messages) == 1
         message = sns_messages[0][':message']
 
-        assert message['bagLocation'] == {
+        assert message['zippedBagLocation'] == {
             'namespace': 'example-bukkit',
             'key': 'helloworld.zip'
         }

--- a/archive/archive_api/src/test_request_new_ingest.py
+++ b/archive/archive_api/src/test_request_new_ingest.py
@@ -19,7 +19,7 @@ def test_creates_bag_message_without_callback_url(guid):
     )
     assert resp == {
         'archiveRequestId': guid,
-        'bagLocation': {
+        'zippedBagLocation': {
             'namespace': 'example-bukkit',
             'key': 'foo/bar.zip'
         }


### PR DESCRIPTION
### What is this PR trying to achieve?
Update the API to use the bag request ingest message format to the new format expected by the archivist (`bagLocation` now `zippedBagLocation`).

Update the message format sent by the API and the `trigger_archive_bag` script.

part of #2634 

