### PR TITLE
Get our ACM certificate ARNs from Terraform, not variables

### DIFF
--- a/catalogue_api/terraform/data_api.tf
+++ b/catalogue_api/terraform/data_api.tf
@@ -15,8 +15,6 @@ module "data_api" {
   infra_bucket = "${var.infra_bucket}"
   key_name     = "${var.key_name}"
 
-  data_acm_cert_arn = "${var.data_acm_cert_arn}"
-
   es_cluster_credentials = "${var.es_cluster_credentials}"
 
   es_config_snapshot = "${local.prod_es_config}"

--- a/catalogue_api/terraform/data_api/cloudfront.tf
+++ b/catalogue_api/terraform/data_api/cloudfront.tf
@@ -1,3 +1,9 @@
+data "aws_acm_certificate" "data_wc_org" {
+  domain   = "data.wellcomecollection.org"
+  statuses = ["ISSUED"]
+  provider = "aws.us_east_1"
+}
+
 resource "aws_cloudfront_distribution" "data_api" {
   origin {
     domain_name = "${aws_s3_bucket.public_data.bucket_domain_name}"
@@ -43,7 +49,7 @@ resource "aws_cloudfront_distribution" "data_api" {
   price_class = "PriceClass_100"
 
   viewer_certificate {
-    acm_certificate_arn      = "${var.data_acm_cert_arn}"
+    acm_certificate_arn      = "${data.aws_acm_certificate.data_wc_org.arn}"
     minimum_protocol_version = "TLSv1"
     ssl_support_method       = "sni-only"
   }

--- a/catalogue_api/terraform/data_api/provider.tf
+++ b/catalogue_api/terraform/data_api/provider.tf
@@ -1,1 +1,6 @@
 data "aws_caller_identity" "current" {}
+
+provider "aws" {
+  region = "us-east-1"
+  alias  = "us_east_1"
+}

--- a/catalogue_api/terraform/data_api/variables.tf
+++ b/catalogue_api/terraform/data_api/variables.tf
@@ -8,10 +8,6 @@ variable "key_name" {
   description = "Name of AWS key pair"
 }
 
-variable "data_acm_cert_arn" {
-  description = "ARN for the data ssl cert"
-}
-
 variable "es_cluster_credentials" {
   description = "Credentials for the Elasticsearch cluster"
   type        = "map"

--- a/catalogue_api/terraform/variables.tf
+++ b/catalogue_api/terraform/variables.tf
@@ -92,7 +92,3 @@ variable "es_config_remus" {
     doc_type = "work"
   }
 }
-
-variable "data_acm_cert_arn" {
-  description = "ARN for the data ssl cert"
-}

--- a/loris/terraform/cloudfront.tf
+++ b/loris/terraform/cloudfront.tf
@@ -1,3 +1,9 @@
+data "aws_acm_certificate" "iiif_wc_org" {
+  domain   = "iiif.wellcomecollection.org"
+  statuses = ["ISSUED"]
+  provider = "aws.us_east_1"
+}
+
 resource "aws_cloudfront_distribution" "loris" {
   origin {
     domain_name = "iiif-origin.wellcomecollection.org"
@@ -41,7 +47,7 @@ resource "aws_cloudfront_distribution" "loris" {
   price_class = "PriceClass_100"
 
   viewer_certificate {
-    acm_certificate_arn      = "${var.iiif_acm_cert_arn}"
+    acm_certificate_arn      = "${data.aws_acm_certificate.iiif_wc_org.arn}"
     minimum_protocol_version = "TLSv1"
     ssl_support_method       = "sni-only"
   }

--- a/loris/terraform/variables.tf
+++ b/loris/terraform/variables.tf
@@ -3,22 +3,6 @@ variable "aws_region" {
   default     = "eu-west-1"
 }
 
-# We can't look up the ARN of our IIIF ACM certificate using the Terraform
-# data providers because most of our infrastructure runs in eu-west-1, but
-# the certificate for CloudFront has to live in us-east-1.
-#
-# Quoting http://docs.aws.amazon.com/acm/latest/userguide/acm-regions.html:
-#
-#     To use an ACM Certificate with Amazon CloudFront, you must request or
-#     import the certificate in the US East (N. Virginia) region.
-#     ACM Certificates in this region that are associated with a CloudFront
-#     distribution are distributed to all the geographic locations configured
-#     for that distribution.
-#
-variable "iiif_acm_cert_arn" {
-  description = "ARN of ACM cert for iiif API (in us-east-1) for CloudFront"
-}
-
 variable "release_ids" {
   description = "Release tags for platform apps"
   type        = "map"


### PR DESCRIPTION
A tiny optimisation spotted on a code read. Now we have the "us_east_1" provider alias, we can look this up directly rather than passing it around in variables.

(It turns out the variable with the Loris ACM certificate ARN was actually out-of-date, so running anything in the Loris stack would fail to deploy!)