### PR TITLE
Redirect top level endpoints to documentation

### DIFF
--- a/infra_critical/terraform/alb.tf
+++ b/infra_critical/terraform/alb.tf
@@ -7,4 +7,7 @@ module "load_balancer" {
   public_subnets = "${local.public_subnets}"
 
   certificate_domain = "api.wellcomecollection.org"
+
+  top_level_host = "developers.wellcomecollection.org"
+  top_level_path = "/developers"
 }

--- a/infra_critical/terraform/load_balancer/main.tf
+++ b/infra_critical/terraform/load_balancer/main.tf
@@ -14,12 +14,12 @@ resource "aws_alb_listener" "https" {
   certificate_arn   = "${data.aws_acm_certificate.certificate.arn}"
 
   default_action {
-    type = "fixed-response"
+    type = "redirect"
 
-    fixed_response {
-      content_type = "text/plain"
-      message_body = "Not Found"
-      status_code  = "404"
+    redirect {
+      host        = "${var.top_level_host}"
+      path        = "${var.top_level_path}"
+      status_code = "HTTP_301"
     }
   }
 }

--- a/infra_critical/terraform/load_balancer/variables.tf
+++ b/infra_critical/terraform/load_balancer/variables.tf
@@ -5,3 +5,6 @@ variable "public_subnets" {
 variable "vpc_id" {}
 variable "certificate_domain" {}
 variable "name" {}
+
+variable "top_level_host" {}
+variable "top_level_path" {}

--- a/loris/terraform/provider.tf
+++ b/loris/terraform/provider.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "1.25.0"
+  version = "1.33.0"
 }
 
 provider "aws" {

--- a/loris/terraform/service/variables.tf
+++ b/loris/terraform/service/variables.tf
@@ -18,10 +18,6 @@ variable "healthcheck_path" {
   default = "/image/"
 }
 
-variable "path_pattern" {
-  default = "/*"
-}
-
 variable "ebs_container_path" {
   default = "/mnt/loris"
 }


### PR DESCRIPTION
This patch moves api.wc.org and iiif.wc.org to redirect to the appropriate part of our developer docs. data.wellcomecollection.org doesn't 301 because it's serving an HTML page doing a \<meta>/JavaScript-based redirect instead, and I can't be bothered to do more load balancer fiddling for it.

Resolves #579.

```console
$ curl --head https://api.wellcomecollection.org/
HTTP/1.1 301 Moved Permanently
Server: awselb/2.0
Date: Tue, 02 Oct 2018 14:51:12 GMT
Content-Type: text/html
Content-Length: 150
Connection: keep-alive
Location: https://developers.wellcomecollection.org:443/developers

$ curl --head https://iiif.wellcomecollection.org/
HTTP/1.1 301 Moved Permanently
Content-Type: text/html
Content-Length: 150
Connection: keep-alive
Server: awselb/2.0
Date: Tue, 02 Oct 2018 14:46:47 GMT
Location: https://developers.wellcomecollection.org:443/iiif
Age: 269
X-Cache: Hit from cloudfront
Via: 1.1 c9d4d8710ea2ee7404e993c5ad34736e.cloudfront.net (CloudFront)
X-Amz-Cf-Id: snqVMrh5cexGdyDR7s-SAupu7qxZ3iORIR2TM5isgvd2dpqJ80xIWw==
```