### PR TITLE
Add the @context field to every response from the Archive API

### DIFF
--- a/archive/archive_api/src/archive_api.py
+++ b/archive/archive_api/src/archive_api.py
@@ -7,9 +7,12 @@ from flask import Flask
 from flask_restplus import Api
 
 import config
+from responses import ContextResponse
 from progress_manager import ProgressManager
 
 app = Flask(__name__)
+app.response_class = ContextResponse
+
 api = Api(
     app,
     version="0.1",

--- a/archive/archive_api/src/models.py
+++ b/archive/archive_api/src/models.py
@@ -68,7 +68,6 @@ IngestRequest = api.model(
 Error = api.model(
     "Error",
     {
-        "@context": fields.String(description="Context URL"),
         "errorType": fields.String(description="The type of error", enum=["http"]),
         "httpStatus": fields.Integer(description="The HTTP response status code"),
         "label": fields.String(

--- a/archive/archive_api/src/responses.py
+++ b/archive/archive_api/src/responses.py
@@ -14,6 +14,7 @@ class ContextResponse(Response):
     For an explanation of how this works/is used, read
     https://blog.miguelgrinberg.com/post/customizing-the-flask-response-class
     """
+
     context_url = "https://api.wellcomecollection.org/storage/v1/context.json"
 
     def __init__(self, response, *args, **kwargs):
@@ -22,7 +23,7 @@ class ContextResponse(Response):
         @context parameter, then repack it.
         """
         if isinstance(response, ClosingIterator):
-            response = b''.join([char for char in response])
+            response = b"".join([char for char in response])
 
         # Some requests (e.g. POST /ingests) return an empty response body,
         # so we shouldn't try to add a parameter.

--- a/archive/archive_api/src/responses.py
+++ b/archive/archive_api/src/responses.py
@@ -1,0 +1,24 @@
+# -*- encoding: utf-8
+
+from flask import Response, jsonify
+
+
+class ContextResponse(Response):
+    """
+    This class adds the "@context" parameter to JSON responses before
+    they're sent to the user.
+
+    For an explanation of how this works/is used, read
+    https://blog.miguelgrinberg.com/post/customizing-the-flask-response-class
+    """
+
+    @classmethod
+    def force_type(cls, rv, environ=None):
+        # All of our endpoints should be returning a dictionary to be
+        # serialised as JSON.
+        assert isinstance(rv, dict)
+
+        assert "@context" not in rv
+        rv["@context"] = "https://api.wellcomecollection.org/storage/v1/context.json"
+
+        return super(ContextResponse, cls).force_type(jsonify(rv), environ)

--- a/archive/archive_api/src/responses.py
+++ b/archive/archive_api/src/responses.py
@@ -1,5 +1,7 @@
 # -*- encoding: utf-8
 
+import json
+
 from flask import Response, jsonify
 
 
@@ -11,6 +13,20 @@ class ContextResponse(Response):
     For an explanation of how this works/is used, read
     https://blog.miguelgrinberg.com/post/customizing-the-flask-response-class
     """
+    context_url = "https://api.wellcomecollection.org/storage/v1/context.json"
+
+    def __init__(self, response, **kwargs):
+        # Here we unmarshal the response as provided by Flask-RESTPlus, add
+        # the @context parameter, then repack it.
+        rv = json.loads(response)
+
+        # The @context may already be provided if we've been through the
+        # force_type method below.
+        if "@context" in rv:
+            return super(ContextResponse, self).__init__(response, **kwargs)
+        else:
+            rv["@context"] = self.context_url
+            return super(ContextResponse, self).__init__(json.dumps(rv), **kwargs)
 
     @classmethod
     def force_type(cls, rv, environ=None):
@@ -18,7 +34,7 @@ class ContextResponse(Response):
         # serialised as JSON.
         assert isinstance(rv, dict)
 
-        assert "@context" not in rv
-        rv["@context"] = "https://api.wellcomecollection.org/storage/v1/context.json"
+        assert "@context" not in rv, rv
+        rv["@context"] = cls.context_url
 
         return super(ContextResponse, cls).force_type(jsonify(rv), environ)

--- a/archive/archive_api/src/tests/test_archive_api.py
+++ b/archive/archive_api/src/tests/test_archive_api.py
@@ -14,7 +14,7 @@ class TestReportIngestStatus:
         assert resp.status_code == 200
         assert json.loads(resp.data) == {
             "@context": "https://api.wellcomecollection.org/storage/v1/context.json",
-            "progress": lookup_id
+            "progress": lookup_id,
         }
 
     def test_lookup_missing_item_is_404(self, client):
@@ -49,7 +49,7 @@ class TestBags:
         assert resp.status_code == 200
         assert json.loads(resp.data) == {
             "@context": "https://api.wellcomecollection.org/storage/v1/context.json",
-            "id": guid
+            "id": guid,
         }
 
     def test_lookup_missing_item_is_404(self, client, guid):

--- a/archive/archive_api/src/tests/test_archive_api.py
+++ b/archive/archive_api/src/tests/test_archive_api.py
@@ -12,7 +12,10 @@ class TestReportIngestStatus:
         lookup_id = "F423966E-A5E5-4D91-B321-88B90D1B5154"
         resp = client.get(f"/storage/v1/ingests/{lookup_id}")
         assert resp.status_code == 200
-        assert json.loads(resp.data) == {"progress": lookup_id}
+        assert json.loads(resp.data) == {
+            "@context": "https://api.wellcomecollection.org/storage/v1/context.json",
+            "progress": lookup_id
+        }
 
     def test_lookup_missing_item_is_404(self, client):
         lookup_id = "bad_status-404"

--- a/archive/archive_api/src/tests/test_archive_api.py
+++ b/archive/archive_api/src/tests/test_archive_api.py
@@ -47,7 +47,10 @@ class TestBags:
 
         resp = client.get(f"/storage/v1/bags/{guid}")
         assert resp.status_code == 200
-        assert json.loads(resp.data) == {"id": guid}
+        assert json.loads(resp.data) == {
+            "@context": "https://api.wellcomecollection.org/storage/v1/context.json",
+            "id": guid
+        }
 
     def test_lookup_missing_item_is_404(self, client, guid):
         resp = client.get(f"/storage/v1/bags/{guid}")

--- a/archive/archive_api/src/tests/test_archive_api.py
+++ b/archive/archive_api/src/tests/test_archive_api.py
@@ -210,7 +210,7 @@ class TestReportHealthStatus:
     def test_get_healthcheck_endpoint_is_200_OK(self, client):
         resp = client.get("/storage/v1/healthcheck")
         assert resp.status_code == 200
-        assert json.loads(resp.data) == {"status": "OK"}
+        assert json.loads(resp.data)["status"] == "OK"
 
 
 def ingests_post(upload_url=None, callback_url=None):

--- a/archive/archive_api/src/views.py
+++ b/archive/archive_api/src/views.py
@@ -87,7 +87,7 @@ class IngestResource(Resource):
         """Get the current status of an ingest request"""
         try:
             result = progress_manager.lookup_progress(id=id)
-            return jsonify(result)
+            return result
         except ProgressNotFoundError as error:
             raise NotFoundError(f"Invalid id: No ingest found for id={id!r}")
 
@@ -123,7 +123,6 @@ def route_report_healthcheck_status():
 @api.errorhandler(Exception)
 def default_error_handler(error):
     error_response = {
-        "@context": "https://api.wellcomecollection.org/storage/v1/context.json",
         "errorType": "http",
         "httpStatus": getattr(error, "code", 500),
         "label": getattr(error, "name", "Internal Server Error"),
@@ -137,4 +136,4 @@ def default_error_handler(error):
             )
         else:
             error_response["description"] = getattr(error, "description", str(error))
-    return jsonify(error_response), error_response["httpStatus"]
+    return error_response, error_response["httpStatus"]

--- a/archive/archive_api/src/views.py
+++ b/archive/archive_api/src/views.py
@@ -115,7 +115,7 @@ class BagResource(Resource):
 
 @app.route("/storage/v1/healthcheck")
 def route_report_healthcheck_status():
-    return jsonify({"status": "OK"})
+    return {"status": "OK"}
 
 
 # TODO: There's no testing of the error handling; we should fix that!

--- a/docs/rfcs/001-merger_matcher/README.md
+++ b/docs/rfcs/001-merger_matcher/README.md
@@ -1,6 +1,6 @@
 # RFC 001: Matcher architecture
 
-**Last updated: 07 September 2018.**
+**Last updated: 11 September 2018.**
 
 ## Background
 

--- a/docs/rfcs/001-merger_matcher/README.md
+++ b/docs/rfcs/001-merger_matcher/README.md
@@ -1,6 +1,6 @@
 # RFC 001: Matcher architecture
 
-**Last updated: 11 September 2018.**
+**Last updated: 04 October 2018.**
 
 ## Background
 

--- a/docs/rfcs/002-archival_storage/README.md
+++ b/docs/rfcs/002-archival_storage/README.md
@@ -109,7 +109,7 @@ Content-Type: application/json
     "type": "IngestType"
   },
   "uploadUrl": "s3://source-bucket/source-path/source-bag.zip",
-  "callbackUrl": "https://workflow.wellcomecollection.org/callback?id=b1234567",
+  "callbackUrl": "https://workflow.wellcomecollection.org/callback?id=b1234567"
 }
 ```
 

--- a/docs/rfcs/002-archival_storage/README.md
+++ b/docs/rfcs/002-archival_storage/README.md
@@ -1,6 +1,6 @@
 # RFC 002: Archival Storage Service
 
-**Last updated: 01 October 2018.**
+**Last updated: 04 October 2018.**
 
 ## Problem statement
 

--- a/docs/rfcs/003-asset_access/README.md
+++ b/docs/rfcs/003-asset_access/README.md
@@ -1,6 +1,6 @@
 # RFC 003: Asset Access
 
-**Last updated: 07 September 2018.**
+**Last updated: 11 September 2018.**
 
 ## Background
 

--- a/docs/rfcs/003-asset_access/README.md
+++ b/docs/rfcs/003-asset_access/README.md
@@ -1,6 +1,6 @@
 # RFC 003: Asset Access
 
-**Last updated: 11 September 2018.**
+**Last updated: 04 October 2018.**
 
 ## Background
 

--- a/docs/rfcs/004-mets_adapter/README.md
+++ b/docs/rfcs/004-mets_adapter/README.md
@@ -1,6 +1,6 @@
 # RFC 004: METS Adapter
 
-**Last updated: 07 September 2018.**
+**Last updated: 11 September 2018.**
 
 ## Background
 

--- a/docs/rfcs/004-mets_adapter/README.md
+++ b/docs/rfcs/004-mets_adapter/README.md
@@ -1,6 +1,6 @@
 # RFC 004: METS Adapter
 
-**Last updated: 11 September 2018.**
+**Last updated: 04 October 2018.**
 
 ## Background
 

--- a/docs/rfcs/005-reporting_pipeline/README.md
+++ b/docs/rfcs/005-reporting_pipeline/README.md
@@ -1,6 +1,6 @@
 # RFC 005: Reporting Pipeline
 
-**Last updated: 11 September 2018.**
+**Last updated: 04 October 2018.**
 
 ## Background
 

--- a/docs/rfcs/005-reporting_pipeline/README.md
+++ b/docs/rfcs/005-reporting_pipeline/README.md
@@ -1,6 +1,6 @@
 # RFC 005: Reporting Pipeline
 
-**Last updated: 07 September 2018.**
+**Last updated: 11 September 2018.**
 
 ## Background
 

--- a/docs/rfcs/006-reindexer-architecture/README.md
+++ b/docs/rfcs/006-reindexer-architecture/README.md
@@ -1,6 +1,6 @@
 # RFC 006: Reindexer architecture
 
-**Last updated: 11 September 2018.**
+**Last updated: 04 October 2018.**
 
 ## Problem statement
 

--- a/docs/rfcs/006-reindexer-architecture/README.md
+++ b/docs/rfcs/006-reindexer-architecture/README.md
@@ -1,6 +1,6 @@
 # RFC 006: Reindexer architecture
 
-**Last updated: 07 September 2018.**
+**Last updated: 11 September 2018.**
 
 ## Problem statement
 

--- a/docs/rfcs/007-goobi_upload/README.md
+++ b/docs/rfcs/007-goobi_upload/README.md
@@ -1,6 +1,6 @@
 # RFC 007: Goobi Upload
 
-**Last updated: 11 September 2018.**
+**Last updated: 04 October 2018.**
 
 ## Problem statement
 

--- a/docs/rfcs/007-goobi_upload/README.md
+++ b/docs/rfcs/007-goobi_upload/README.md
@@ -1,6 +1,6 @@
 # RFC 007: Goobi Upload
 
-**Last updated: 07 September 2018.**
+**Last updated: 11 September 2018.**
 
 ## Problem statement
 


### PR DESCRIPTION
This uses [a custom Response class](https://blog.miguelgrinberg.com/post/customizing-the-flask-response-class) to ensure that we always include the `@context` parameter on our responses (even if it doesn't go anywhere yet!).

Importantly, it means we can keep this parameter out of our internal models, and never have to worry about it.