### PR TITLE
Save mapping of old guid to new ID as we bag

### DIFF
--- a/archive/bagger/src/aws.py
+++ b/archive/bagger/src/aws.py
@@ -35,6 +35,12 @@ def save_mets_to_side(b_number, local_tmp_file):
     client.upload_file(local_tmp_file, settings.DROP_BUCKET_NAME_METS_ONLY, key)
 
 
+def save_id_map(b_number, id_map):
+    s3_path = "_idmaps/{0}.json".format(b_number)
+    obj = get_s3().Object(settings.DROP_BUCKET_NAME_METS_ONLY, s3_path)
+    obj.put(Body=json.dumps(id_map, indent=4))
+
+
 def log_processing_error(message):
     s3_path = "{0}.json".format(message["identifier"])
     obj = get_s3().Object(settings.DROP_BUCKET_NAME_ERRORS, s3_path)

--- a/archive/bagger/src/bagger.py
+++ b/archive/bagger/src/bagger.py
@@ -6,6 +6,7 @@ and no I/O operations happen, other than on METS files.
 
 import sys
 import os
+import collections
 import shutil
 import logging
 import bagit
@@ -24,6 +25,7 @@ logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 def bag_from_identifier(identifier, skip_file_download):
     b_number = identifiers.normalise_b_number(identifier)
     bag_details = bag_assembly.prepare_bag_dir(b_number)
+    id_map = collections.OrderedDict()
     mets_path = "{0}{1}.xml".format(bag_details["mets_partial_path"], b_number)
     logging.info("process METS or anchor file at %s", mets_path)
     tree = load_xml(mets_path)
@@ -82,7 +84,7 @@ def bag_from_identifier(identifier, skip_file_download):
             manif_struct_div = mets.get_logical_struct_div(mf_root)
             link_to_anchor = mets.get_file_pointer_link(manif_struct_div)
             logging.info("{0} should be link back to anchor".format(link_to_anchor))
-            process_manifestation(mf_root, bag_details, skip_file_download)
+            process_manifestation(mf_root, bag_details, skip_file_download, id_map)
             # not os separator, this is in the METS; always /
             parts = rel_path[0].split("/")
             manifestation_file = os.path.join(bag_details["directory"], *parts)
@@ -91,12 +93,14 @@ def bag_from_identifier(identifier, skip_file_download):
             aws.save_mets_to_side(b_number, manifestation_file)
 
     elif mets.is_manifestation(struct_type):
-        process_manifestation(root, bag_details, skip_file_download)
+        process_manifestation(root, bag_details, skip_file_download, id_map)
         tree.write(root_mets_file, encoding="utf-8", xml_declaration=True)
         aws.save_mets_to_side(b_number, root_mets_file)
 
     else:
         raise ValueError("Unknown struct type: " + struct_type)
+
+    aws.save_id_map(b_number, id_map)
 
     if skip_file_download:
         print(b_number)
@@ -110,9 +114,9 @@ def bag_from_identifier(identifier, skip_file_download):
     logging.info("Finished {0}".format(b_number))
 
 
-def process_manifestation(root, bag_details, skip_file_download):
+def process_manifestation(root, bag_details, skip_file_download, id_map):
     mets.remove_deliverable_unit(root)
-    tech_md.remodel_file_technical_metadata(root)
+    tech_md.remodel_file_technical_metadata(root, id_map)
     mets.remodel_file_section(root)
     assets, alto = mets.get_physical_file_maps(root)
     files.process_assets(root, bag_details, assets, skip_file_download)

--- a/archive/bagger/src/tech_md.py
+++ b/archive/bagger/src/tech_md.py
@@ -19,7 +19,7 @@ def add_premis_significant_prop(premis_file, p_type, value):
     value_el.text = value
 
 
-def remodel_file_technical_metadata(root):
+def remodel_file_technical_metadata(root, id_map):
     logging.info("transforming Tessella techMD")
     x_path = ".//mets:xmlData[tessella:File]"
     tessella_file_xmldata = root.findall(x_path, namespaces)
@@ -37,8 +37,9 @@ def remodel_file_technical_metadata(root):
 
         file_name = tessella_file.find("tessella:FileName", namespaces).text
         add_premis_identifier(premis_file, "local", file_name)
-        checksum = tessella_file.find("tessella:ID", namespaces).text
-        add_premis_identifier(premis_file, "uuid", checksum)
+        uuid = tessella_file.find("tessella:ID", namespaces).text
+        add_premis_identifier(premis_file, "uuid", uuid)
+        id_map[uuid] = file_name
 
         file_properties = tessella_file.findall("tessella:FileProperty", namespaces)
         to_copy = mappings.SIGNIFICANT_PROPERTIES.keys()


### PR DESCRIPTION
### What is this PR trying to achieve?
Although the information is in the METS, it would be very useful to have a simple map of old asset IDs to new asset IDs, for each  b number. This PR produces that as a side-effect of the bagging process.

### Who is this change for?
Anyone trying to migrate 35m images.
