### PR TITLE
Improve the quality of error responses in the Archive API

### DIFF
--- a/archive/archive_api/src/archive_api.py
+++ b/archive/archive_api/src/archive_api.py
@@ -8,6 +8,7 @@ from flask_restplus import Api
 
 from apis import bags_api, ingests_api
 import config
+import models
 from responses import ContextResponse
 from progress_manager import ProgressManager
 
@@ -39,6 +40,29 @@ app.config["PROGRESS_MANAGER"] = ProgressManager(
 
 api.add_namespace(bags_api)
 api.add_namespace(ingests_api)
+
+
+# TODO: There's no testing of the error handling; we should fix that!
+@app.errorhandler(Exception)
+@api.errorhandler(Exception)
+@bags_api.errorhandler(Exception)
+@ingests_api.errorhandler(Exception)
+@api.marshal_with(models.Error, skip_none=True)
+def default_error_handler(error):
+    error_response = {
+        "httpStatus": getattr(error, "code", 500),
+        "label": getattr(error, "name", "Internal Server Error"),
+    }
+    logger.warn(error)
+    if error_response["httpStatus"] != 500:
+        if hasattr(error, "data"):
+            error_response["description"] = ", ".join(
+                error.data.get("errors", {}).values()
+            )
+        else:
+            error_response["description"] = getattr(error, "description", str(error))
+    return error_response, error_response["httpStatus"]
+
 
 # We can't move this import to the top because the views need the ``api``
 # instance defined in this file.

--- a/archive/archive_api/src/archive_api.py
+++ b/archive/archive_api/src/archive_api.py
@@ -42,7 +42,6 @@ api.add_namespace(bags_api)
 api.add_namespace(ingests_api)
 
 
-# TODO: There's no testing of the error handling; we should fix that!
 @app.errorhandler(Exception)
 @api.errorhandler(Exception)
 @bags_api.errorhandler(Exception)

--- a/archive/archive_api/src/archive_api.py
+++ b/archive/archive_api/src/archive_api.py
@@ -58,6 +58,20 @@ def default_error_handler(error):
             error_response["description"] = ", ".join(
                 error.data.get("errors", {}).values()
             )
+
+            # The ``data`` attribute is set on ``ValidationError`` if
+            # the user sends a model that doesn't validate.  If we pass this
+            # attribute along to the Flask-RESTPlus error handlers, they
+            # discard our custom response and use the "data" value instead.
+            #
+            # So we delete the ``data`` attribute here, and then Flask-RESTPlus
+            # leaves our custom error model alone.
+            #
+            # For more details, see
+            # https://github.com/noirbizarre/flask-restplus/issues/530
+            #
+            del error.data
+
         else:
             error_response["description"] = getattr(error, "description", str(error))
     return error_response, error_response["httpStatus"]

--- a/archive/archive_api/src/config.py
+++ b/archive/archive_api/src/config.py
@@ -13,6 +13,10 @@ class ArchiveAPIConfig(object):
     S3_CLIENT = boto3.client("s3")
     PROGRESS_MANAGER_SESSION = requests.Session()
 
+    # Disable Flask-RESTPlus including the "message" field on errors.
+    # See https://flask-restplus.readthedocs.io/en/stable/errors.html
+    ERROR_INCLUDE_MESSAGE = False
+
     def __init__(self, development=False):
         try:
             if development:

--- a/archive/archive_api/src/models.py
+++ b/archive/archive_api/src/models.py
@@ -4,7 +4,9 @@ from flask_restplus import Model, fields
 
 
 def fieldType(name, **kwargs):
-    return fields.String(description="Type of the object", enum=[name], default=name, **kwargs)
+    return fields.String(
+        description="Type of the object", enum=[name], default=name, **kwargs
+    )
 
 
 # Example of a valid request from the RFC:
@@ -66,7 +68,9 @@ IngestRequest = Model(
 Error = Model(
     "Error",
     {
-        "errorType": fields.String(description="The type of error", enum=["http"], default="http"),
+        "errorType": fields.String(
+            description="The type of error", enum=["http"], default="http"
+        ),
         "httpStatus": fields.Integer(description="The HTTP response status code"),
         "label": fields.String(
             description="The title or other short name of the error"

--- a/archive/archive_api/src/models.py
+++ b/archive/archive_api/src/models.py
@@ -4,7 +4,7 @@ from flask_restplus import Model, fields
 
 
 def fieldType(name, **kwargs):
-    return fields.String(description="Type of the object", enum=[name], **kwargs)
+    return fields.String(description="Type of the object", enum=[name], default=name, **kwargs)
 
 
 # Example of a valid request from the RFC:
@@ -66,7 +66,7 @@ IngestRequest = Model(
 Error = Model(
     "Error",
     {
-        "errorType": fields.String(description="The type of error", enum=["http"]),
+        "errorType": fields.String(description="The type of error", enum=["http"], default="http"),
         "httpStatus": fields.Integer(description="The HTTP response status code"),
         "label": fields.String(
             description="The title or other short name of the error"

--- a/archive/archive_api/src/tests/apis/helpers.py
+++ b/archive/archive_api/src/tests/apis/helpers.py
@@ -29,12 +29,9 @@ def assert_is_error_response(resp, status, description=None):
 
     actual_resp = json.loads(resp.data)
     if actual_resp != expected_resp:
-        import difflib
-        print('\n'.join(difflib.context_diff(
-            json.dumps(actual_resp, indent=2, sort_keys=True).splitlines(),
-            json.dumps(expected_resp, indent=2, sort_keys=True).splitlines(),
-            fromfile='actual_resp',
-            tofile='expected_resp'
-        )))
+        print('***  actual response  ***')
+        print(json.dumps(actual_resp, indent=2, sort_keys=True))
+        print('*** expected response ***')
+        print(json.dumps(expected_resp, indent=2, sort_keys=True))
 
     assert actual_resp == expected_resp

--- a/archive/archive_api/src/tests/apis/helpers.py
+++ b/archive/archive_api/src/tests/apis/helpers.py
@@ -29,9 +29,9 @@ def assert_is_error_response(resp, status, description=None):
 
     actual_resp = json.loads(resp.data)
     if actual_resp != expected_resp:
-        print('***  actual response  ***')
+        print("***  actual response  ***")
         print(json.dumps(actual_resp, indent=2, sort_keys=True))
-        print('*** expected response ***')
+        print("*** expected response ***")
         print(json.dumps(expected_resp, indent=2, sort_keys=True))
 
     assert actual_resp == expected_resp

--- a/archive/archive_api/src/tests/apis/helpers.py
+++ b/archive/archive_api/src/tests/apis/helpers.py
@@ -1,0 +1,31 @@
+# -*- encoding: utf-8
+
+import json
+
+
+def assert_is_error_response(resp, status, description=None):
+    """
+    Constructs an error response to match against API responses.
+    """
+    assert resp.status_code == status
+
+    labels = {
+        400: "Bad Request",
+        404: "Not Found",
+        405: "Method Not Allowed",
+        500: "Internal Server Error",
+    }
+
+    expected_resp = {
+        "errorType": "http",
+        "httpStatus": status,
+        "label": labels[status],
+        "type": "Error",
+        "@context": "https://api.wellcomecollection.org/storage/v1/context.json",
+    }
+
+    if description is not None:
+        expected_resp["description"] = description
+
+    actual_resp = json.loads(resp.data)
+    assert actual_resp == expected_resp

--- a/archive/archive_api/src/tests/apis/helpers.py
+++ b/archive/archive_api/src/tests/apis/helpers.py
@@ -28,4 +28,13 @@ def assert_is_error_response(resp, status, description=None):
         expected_resp["description"] = description
 
     actual_resp = json.loads(resp.data)
+    if actual_resp != expected_resp:
+        import difflib
+        print('\n'.join(difflib.context_diff(
+            json.dumps(actual_resp, indent=2, sort_keys=True).splitlines(),
+            json.dumps(expected_resp, indent=2, sort_keys=True).splitlines(),
+            fromfile='actual_resp',
+            tofile='expected_resp'
+        )))
+
     assert actual_resp == expected_resp

--- a/archive/archive_api/src/tests/apis/test_bags.py
+++ b/archive/archive_api/src/tests/apis/test_bags.py
@@ -6,12 +6,7 @@ from helpers import assert_is_error_response
 
 
 def test_returns_a_present_bag(
-    client,
-    dynamodb_resource,
-    table_name_bag,
-    s3_client,
-    bucket_bag,
-    guid
+    client, dynamodb_resource, table_name_bag, s3_client, bucket_bag, guid
 ):
     stored_bag = {"id": guid}
 
@@ -27,15 +22,13 @@ def test_returns_a_present_bag(
 
     rv = json.loads(resp.data)
     assert rv["id"] == guid
-    assert rv["@context"] == "https://api.wellcomecollection.org/storage/v1/context.json"
+    assert (
+        rv["@context"] == "https://api.wellcomecollection.org/storage/v1/context.json"
+    )
 
 
 def test_returns_500_if_s3_object_missing(
-    client,
-    dynamodb_resource,
-    table_name_bag,
-    bucket_bag,
-    guid
+    client, dynamodb_resource, table_name_bag, bucket_bag, guid
 ):
     stored_bag = {"id": guid}
 
@@ -49,15 +42,10 @@ def test_returns_500_if_s3_object_missing(
 
 
 def test_returns_500_if_malformed_dynamodb(
-    client,
-    dynamodb_resource,
-    table_name_bag,
-    guid
+    client, dynamodb_resource, table_name_bag, guid
 ):
     table = dynamodb_resource.Table(table_name_bag)
-    table.put_item(
-        Item={"id": guid, "location": {"k_y": guid, "n_m_s_c_e": "bukkit"}}
-    )
+    table.put_item(Item={"id": guid, "location": {"k_y": guid, "n_m_s_c_e": "bukkit"}})
 
     resp = client.get(f"/storage/v1/bags/{guid}")
     assert_is_error_response(resp, status=500)
@@ -65,9 +53,13 @@ def test_returns_500_if_malformed_dynamodb(
 
 def test_returns_404_if_no_such_bag(client, guid):
     resp = client.get(f"/storage/v1/bags/{guid}")
-    assert_is_error_response(resp, status=404, description=f"Invalid id: No bag found for id='{guid}'")
+    assert_is_error_response(
+        resp, status=404, description=f"Invalid id: No bag found for id='{guid}'"
+    )
 
 
 def test_returns_405_if_try_to_post(client):
     resp = client.post(f"/storage/v1/bags/123")
-    assert_is_error_response(resp, status=405, description="The method is not allowed for the requested URL.")
+    assert_is_error_response(
+        resp, status=405, description="The method is not allowed for the requested URL."
+    )

--- a/archive/archive_api/src/tests/apis/test_bags.py
+++ b/archive/archive_api/src/tests/apis/test_bags.py
@@ -2,6 +2,8 @@
 
 import json
 
+from helpers import assert_is_error_response
+
 
 def test_lookup_bag(
     client, dynamodb_resource, s3_client, guid, bucket_bag, table_name_bag
@@ -25,5 +27,8 @@ def test_lookup_bag(
 
 def test_lookup_missing_item_is_404(client, guid):
     resp = client.get(f"/storage/v1/bags/{guid}")
-    assert resp.status_code == 404
-    assert (b"Invalid id: No bag found for id=%r" % guid) in resp.data
+    assert_is_error_response(
+        resp,
+        status=404,
+        description="Invalid id: No bag found for id=%r" % guid
+    )

--- a/archive/archive_api/src/tests/apis/test_bags.py
+++ b/archive/archive_api/src/tests/apis/test_bags.py
@@ -5,8 +5,13 @@ import json
 from helpers import assert_is_error_response
 
 
-def test_lookup_bag(
-    client, dynamodb_resource, s3_client, guid, bucket_bag, table_name_bag
+def test_returns_a_present_bag(
+    client,
+    dynamodb_resource,
+    table_name_bag,
+    s3_client,
+    bucket_bag,
+    guid
 ):
     stored_bag = {"id": guid}
 
@@ -19,16 +24,51 @@ def test_lookup_bag(
 
     resp = client.get(f"/storage/v1/bags/{guid}")
     assert resp.status_code == 200
-    assert json.loads(resp.data) == {
-        "@context": "https://api.wellcomecollection.org/storage/v1/context.json",
-        "id": guid,
-    }
+
+    rv = json.loads(resp.data)
+    assert rv["id"] == guid
+    assert rv["@context"] == "https://api.wellcomecollection.org/storage/v1/context.json"
+    assert rv["type"] == "Bag"
 
 
-def test_lookup_missing_item_is_404(client, guid):
-    resp = client.get(f"/storage/v1/bags/{guid}")
-    assert_is_error_response(
-        resp,
-        status=404,
-        description="Invalid id: No bag found for id=%r" % guid
+def test_returns_500_if_s3_object_missing(
+    client,
+    dynamodb_resource,
+    table_name_bag,
+    bucket_bag,
+    guid
+):
+    stored_bag = {"id": guid}
+
+    table = dynamodb_resource.Table(table_name_bag)
+    table.put_item(
+        Item={"id": guid, "location": {"key": guid, "namespace": bucket_bag}}
     )
+
+    resp = client.get(f"/storage/v1/bags/{guid}")
+    assert_is_error_response(resp, status=500)
+
+
+def test_returns_500_if_malformed_dynamodb(
+    client,
+    dynamodb_resource,
+    table_name_bag,
+    guid
+):
+    table = dynamodb_resource.Table(table_name_bag)
+    table.put_item(
+        Item={"id": guid, "location": {"k_y": guid, "n_m_s_c_e": "bukkit"}}
+    )
+
+    resp = client.get(f"/storage/v1/bags/{guid}")
+    assert_is_error_response(resp, status=500)
+
+
+def test_returns_404_if_no_such_bag(client, guid):
+    resp = client.get(f"/storage/v1/bags/{guid}")
+    assert_is_error_response(resp, status=404, description=f"No bag found for id='{guid}'")
+
+
+def test_returns_405_if_try_to_post(client):
+    resp = client.post(f"/storage/v1/bags/123")
+    assert_is_error_response(resp, status=405, description="The method is not allowed for the requested URL.")

--- a/archive/archive_api/src/tests/apis/test_bags.py
+++ b/archive/archive_api/src/tests/apis/test_bags.py
@@ -30,8 +30,6 @@ def test_returns_a_present_bag(
 def test_returns_500_if_s3_object_missing(
     client, dynamodb_resource, table_name_bag, bucket_bag, guid
 ):
-    stored_bag = {"id": guid}
-
     table = dynamodb_resource.Table(table_name_bag)
     table.put_item(
         Item={"id": guid, "location": {"key": guid, "namespace": bucket_bag}}

--- a/archive/archive_api/src/tests/apis/test_bags.py
+++ b/archive/archive_api/src/tests/apis/test_bags.py
@@ -28,7 +28,6 @@ def test_returns_a_present_bag(
     rv = json.loads(resp.data)
     assert rv["id"] == guid
     assert rv["@context"] == "https://api.wellcomecollection.org/storage/v1/context.json"
-    assert rv["type"] == "Bag"
 
 
 def test_returns_500_if_s3_object_missing(
@@ -66,7 +65,7 @@ def test_returns_500_if_malformed_dynamodb(
 
 def test_returns_404_if_no_such_bag(client, guid):
     resp = client.get(f"/storage/v1/bags/{guid}")
-    assert_is_error_response(resp, status=404, description=f"No bag found for id='{guid}'")
+    assert_is_error_response(resp, status=404, description=f"Invalid id: No bag found for id='{guid}'")
 
 
 def test_returns_405_if_try_to_post(client):

--- a/archive/archive_api/src/tests/apis/test_ingests.py
+++ b/archive/archive_api/src/tests/apis/test_ingests.py
@@ -7,7 +7,7 @@ import pytest
 from helpers import assert_is_error_response
 
 
-class TestGET:
+class TestGETIngests:
     """
     Tests for the GET /ingests/<guid> endpoint.
     """
@@ -39,7 +39,7 @@ class TestGET:
         )
 
 
-class TestPOST:
+class TestPOSTIngests:
     """
     Tests for the POST /ingests endpoint.
     """

--- a/archive/archive_api/src/tests/apis/test_ingests.py
+++ b/archive/archive_api/src/tests/apis/test_ingests.py
@@ -57,21 +57,19 @@ class TestPOST:
         assert_is_error_response(
             resp,
             status=400,
-            description="'type' is a required property"
+            description="'ingestType' is a required property, 'type' is a required property, 'uploadUrl' is a required property"
         )
-
-        assert b in resp.data
 
     def test_invalid_type_is_badrequest(self, client):
         resp = client.post("/storage/v1/ingests", json={"type": "UnexpectedType"})
         assert_is_error_response(
             resp,
             status=400,
-            description="'UnexpectedType' is not one of ['Ingest']"
+            description="'ingestType' is a required property, 'uploadUrl' is a required property, 'UnexpectedType' is not one of ['Ingest']"
         )
 
     def test_no_ingest_type_is_badrequest(self, client):
-        resp = client.post("/storage/v1/ingests", json={"type": "Ingest"})
+        resp = client.post("/storage/v1/ingests", json={"type": "Ingest", "uploadUrl": "http://example.net"})
         assert_is_error_response(
             resp,
             status=400,
@@ -86,7 +84,8 @@ class TestPOST:
         assert_is_error_response(
             resp,
             status=400,
-            description="'UnexpectedIngestType' is not one of ['IngestType']"
+            # TODO: Really?  You want an ID?
+            description="'uploadUrl' is a required property, 'id' is a required property, 'UnexpectedIngestType' is not one of ['IngestType']"
         )
 
     def test_no_uploadurl_is_badrequest(self, client):
@@ -102,7 +101,7 @@ class TestPOST:
         assert_is_error_response(
             resp,
             status=400,
-            description="Invalid uploadUrl:'not-a-url', is not a complete URL"
+            description="Invalid uploadUrl:'not-a-url', is not a complete URL, '' is not a supported scheme ['s3']"
         )
 
     def test_invalid_scheme_uploadurl_is_badrequest(self, client):
@@ -135,7 +134,7 @@ class TestPOST:
         assert_is_error_response(
             resp,
             status=400,
-            description="Invalid callbackUrl:'not-a-url', is not a complete URL"
+            description="Invalid callbackUrl:'not-a-url', is not a complete URL, '' is not a supported scheme ['http', 'https']"
         )
 
     def test_invalid_scheme_callback_url_is_badrequest(self, client):

--- a/archive/archive_api/src/tests/apis/test_ingests.py
+++ b/archive/archive_api/src/tests/apis/test_ingests.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from helpers import assert_is_error_response
 
 
@@ -42,125 +44,108 @@ class TestPOST:
     Tests for the POST /ingests endpoint.
     """
 
-    upload_url = "s3://example-bukkit/helloworld.zip"
-    callback_url = "https://example.com/post?callback"
-
-    def test_request_new_ingest_is_201(self, client):
-        resp = client.post(
-            "/storage/v1/ingests", json=_create_ingest_request(self.upload_url)
-        )
+    def test_request_new_ingest_is_201(self, client, ingest_request):
+        resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert resp.status_code == 201
         assert resp.data == b""
 
-    def test_no_type_is_badrequest(self, client):
-        resp = client.post("/storage/v1/ingests", json={})
+    def test_no_type_is_badrequest(self, client, ingest_request):
+        del ingest_request["type"]
+        resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(
             resp,
             status=400,
-            description="'ingestType' is a required property, 'type' is a required property, 'uploadUrl' is a required property"
+            description="'type' is a required property"
         )
 
-    def test_invalid_type_is_badrequest(self, client):
-        resp = client.post("/storage/v1/ingests", json={"type": "UnexpectedType"})
+    def test_invalid_type_is_badrequest(self, client, ingest_request):
+        ingest_request["type"] = "UnexpectedType"
+        resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(
             resp,
             status=400,
-            description="'ingestType' is a required property, 'uploadUrl' is a required property, 'UnexpectedType' is not one of ['Ingest']"
+            description="'UnexpectedType' is not one of ['Ingest']"
         )
 
-    def test_no_ingest_type_is_badrequest(self, client):
-        resp = client.post("/storage/v1/ingests", json={"type": "Ingest", "uploadUrl": "http://example.net"})
+    def test_no_ingest_type_is_badrequest(self, client, ingest_request):
+        del ingest_request["ingestType"]
+        resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(
             resp,
             status=400,
             description="'ingestType' is a required property"
         )
 
-    def test_invalid_ingest_type_is_badrequest(self, client):
-        resp = client.post(
-            "/storage/v1/ingests",
-            json={"type": "Ingest", "ingestType": {"type": "UnexpectedIngestType"}},
-        )
+    def test_invalid_ingest_type_is_badrequest(self, client, ingest_request):
+        ingest_request["ingestType"] = {"type": "UnexpectedIngestType"}
+        resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(
             resp,
             status=400,
-            # TODO: Really?  You want an ID?
-            description="'uploadUrl' is a required property, 'id' is a required property, 'UnexpectedIngestType' is not one of ['IngestType']"
+            description="'UnexpectedIngestType' is not one of ['IngestType']"
         )
 
-    def test_no_uploadurl_is_badrequest(self, client):
-        resp = client.post("/storage/v1/ingests", json=_create_ingest_request())
+    def test_no_uploadurl_is_badrequest(self, client, ingest_request):
+        del ingest_request["uploadUrl"]
+        resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(
             resp,
             status=400,
             description="'uploadUrl' is a required property"
         )
 
-    def test_invalid_uploadurl_is_badrequest(self, client):
-        resp = client.post("/storage/v1/ingests", json=_create_ingest_request("not-a-url"))
+    def test_invalid_uploadurl_is_badrequest(self, client, ingest_request):
+        ingest_request["uploadUrl"] = "not-a-url"
+        resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(
             resp,
             status=400,
             description="Invalid uploadUrl:'not-a-url', is not a complete URL, '' is not a supported scheme ['s3']"
         )
 
-    def test_invalid_scheme_uploadurl_is_badrequest(self, client):
-        resp = client.post(
-            "/storage/v1/ingests",
-            json=_create_ingest_request("ftp://example-bukkit/helloworld.zip"),
-        )
+    def test_invalid_scheme_uploadurl_is_badrequest(self, client, ingest_request):
+        ingest_request["uploadUrl"] = "ftp://example-bukkit/helloworld.zip"
+        resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(
             resp,
             status=400,
             description="Invalid uploadUrl:'ftp://example-bukkit/helloworld.zip', 'ftp' is not a supported scheme ['s3']"
         )
 
-    def test_uploadurl_with_fragments_is_badrequest(self, client):
-        resp = client.post(
-            "/storage/v1/ingests",
-            json=_create_ingest_request("s3://example-bukkit/helloworld.zip#fragment"),
-        )
+    def test_uploadurl_with_fragments_is_badrequest(self, client, ingest_request):
+        ingest_request["uploadUrl"] = "s3://example-bukkit/helloworld.zip#fragment"
+        resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(
             resp,
             status=400,
             description="Invalid uploadUrl:'s3://example-bukkit/helloworld.zip#fragment', 'fragment' fragment is not allowed"
         )
 
-    def test_invalid_callback_url_is_badrequest(self, client):
-        resp = client.post(
-            "/storage/v1/ingests",
-            json=_create_ingest_request(self.upload_url, "not-a-url"),
-        )
+    def test_invalid_callback_url_is_badrequest(self, client, ingest_request):
+        ingest_request["callbackUrl"] = "not-a-url"
+        resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(
             resp,
             status=400,
             description="Invalid callbackUrl:'not-a-url', is not a complete URL, '' is not a supported scheme ['http', 'https']"
         )
 
-    def test_invalid_scheme_callback_url_is_badrequest(self, client):
-        resp = client.post(
-            "/storage/v1/ingests",
-            json=_create_ingest_request(self.upload_url, "s3://example.com"),
-        )
+    def test_invalid_scheme_callback_url_is_badrequest(self, client, ingest_request):
+        ingest_request["callbackUrl"] = "s3://example.com"
+        resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(
             resp,
             status=400,
             description="Invalid callbackUrl:'s3://example.com', 's3' is not a supported scheme ['http', 'https']"
         )
 
-    def test_request_allows_fragment_in_callback(self, client):
-        resp = client.post(
-            "/storage/v1/ingests",
-            json=_create_ingest_request(
-                self.upload_url, f"{self.callback_url}#fragment"
-            ),
-        )
+    def test_request_allows_fragment_in_callback(self, client, ingest_request):
+        ingest_request["callbackUrl"] += "#fragment"
+        resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert resp.status_code == 201
 
-    def test_request_new_ingest_has_location_header(self, client):
-        resp = client.post(
-            "/storage/v1/ingests", json=_create_ingest_request(self.upload_url)
-        )
+    def test_request_new_ingest_has_location_header(self, client, ingest_request):
+        resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert "Location" in resp.headers
 
         # TODO: This might need revisiting when we deploy the app behind
@@ -168,14 +153,15 @@ class TestPOST:
         new_location = resp.headers["Location"]
         assert new_location.startswith("http://localhost/storage/v1/ingests/")
 
-    def test_successful_request_sends_to_sns(self, client, sns_client):
-        resp = client.post(
-            "/storage/v1/ingests", json=_create_ingest_request(self.upload_url)
-        )
+    def test_successful_request_sends_to_sns(self, client, sns_client, ingest_request):
+        del ingest_request["callbackUrl"]
+        resp = client.post("/storage/v1/ingests", json=ingest_request)
 
         sns_messages = sns_client.list_messages()
         assert len(sns_messages) == 1
         message = sns_messages[0][":message"]
+
+        assert "archiveCompleteCallbackUrl" not in message
 
         assert message["zippedBagLocation"] == {
             "namespace": "example-bukkit",
@@ -186,18 +172,15 @@ class TestPOST:
         # the one we've been given to look up the request later.
         assert resp.headers["Location"].endswith(message["archiveRequestId"])
 
-    def test_successful_request_sends_to_sns_with_callback(self, client, sns_client):
-        client.post(
-            "/storage/v1/ingests",
-            json=_create_ingest_request(self.upload_url, self.callback_url),
-        )
+    def test_successful_request_sends_to_sns_with_callback(self, client, sns_client, ingest_request):
+        client.post("/storage/v1/ingests", json=ingest_request)
 
         sns_messages = sns_client.list_messages()
         assert len(sns_messages) == 1
         message = sns_messages[0][":message"]
 
         assert "archiveCompleteCallbackUrl" in message
-        assert message["archiveCompleteCallbackUrl"] == self.callback_url
+        assert message["archiveCompleteCallbackUrl"] == ingest_request["callbackUrl"]
 
         resp = client.get("/storage/v1/ingests")
         assert_is_error_response(
@@ -219,10 +202,14 @@ class TestPOST:
         )
 
 
-def _create_ingest_request(upload_url=None, callback_url=None):
-    request = {"type": "Ingest", "ingestType": {"id": "create", "type": "IngestType"}}
-    if upload_url:
-        request["uploadUrl"] = upload_url
-    if callback_url:
-        request["callbackUrl"] = callback_url
-    return request
+@pytest.fixture
+def ingest_request():
+    return {
+        "type": "Ingest",
+        "ingestType": {
+            "id": "create",
+            "type": "IngestType"
+        },
+        "uploadUrl": "s3://example-bukkit/helloworld.zip",
+        "callbackUrl": "https://example.com/post?callback"
+    }

--- a/archive/archive_api/src/tests/apis/test_ingests.py
+++ b/archive/archive_api/src/tests/apis/test_ingests.py
@@ -27,7 +27,7 @@ class TestGETIngests:
         assert_is_error_response(
             resp,
             status=404,
-            description="Invalid id: No ingest found for id=%r" % lookup_id
+            description="Invalid id: No ingest found for id=%r" % lookup_id,
         )
 
     def test_post_against_lookup_endpoint_is_405(self, client, guid):
@@ -35,7 +35,7 @@ class TestGETIngests:
         assert_is_error_response(
             resp,
             status=405,
-            description="The method is not allowed for the requested URL."
+            description="The method is not allowed for the requested URL.",
         )
 
 
@@ -53,48 +53,41 @@ class TestPOSTIngests:
         del ingest_request["type"]
         resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(
-            resp,
-            status=400,
-            description="'type' is a required property"
+            resp, status=400, description="'type' is a required property"
         )
 
     def test_invalid_type_is_badrequest(self, client, ingest_request):
         ingest_request["type"] = "UnexpectedType"
         resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(
-            resp,
-            status=400,
-            description="'UnexpectedType' is not one of ['Ingest']"
+            resp, status=400, description="'UnexpectedType' is not one of ['Ingest']"
         )
 
     def test_no_ingest_type_is_badrequest(self, client, ingest_request):
         del ingest_request["ingestType"]
         resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(
-            resp,
-            status=400,
-            description="'ingestType' is a required property"
+            resp, status=400, description="'ingestType' is a required property"
         )
 
-    @pytest.mark.parametrize('ingest_type,error_description', [
-        (
-            {"id": "create", "type": "UnexpectedIngestType"},
-            "'UnexpectedIngestType' is not one of ['IngestType']"
-        ),
-        (
-            {"id": "destroy", "type": "IngestType"},
-            "'destroy' is not one of ['create']"
-        ),
-        (
-            {"type": "IngestType"},
-            "'id' is a required property"
-        ),
-        (
-            {"id": "create"},
-            "'type' is a required property"
-        ),
-    ])
-    def test_invalid_ingest_type_is_badrequest(self, client, ingest_request, ingest_type, error_description):
+    @pytest.mark.parametrize(
+        "ingest_type,error_description",
+        [
+            (
+                {"id": "create", "type": "UnexpectedIngestType"},
+                "'UnexpectedIngestType' is not one of ['IngestType']",
+            ),
+            (
+                {"id": "destroy", "type": "IngestType"},
+                "'destroy' is not one of ['create']",
+            ),
+            ({"type": "IngestType"}, "'id' is a required property"),
+            ({"id": "create"}, "'type' is a required property"),
+        ],
+    )
+    def test_invalid_ingest_type_is_badrequest(
+        self, client, ingest_request, ingest_type, error_description
+    ):
         ingest_request["ingestType"] = ingest_type
         resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(resp, status=400, description=error_description)
@@ -103,26 +96,29 @@ class TestPOSTIngests:
         del ingest_request["uploadUrl"]
         resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(
-            resp,
-            status=400,
-            description="'uploadUrl' is a required property"
+            resp, status=400, description="'uploadUrl' is a required property"
         )
 
-    @pytest.mark.parametrize('upload_url,error_description', [
-        (
-            "not-a-url",
-            "Invalid uploadUrl:'not-a-url', is not a complete URL, '' is not a supported scheme ['s3']"
-        ),
-        (
-            "ftp://example-bukkit/helloworld.zip",
-            "Invalid uploadUrl:'ftp://example-bukkit/helloworld.zip', 'ftp' is not a supported scheme ['s3']"
-        ),
-        (
-            "s3://example-bukkit/helloworld.zip#fragment",
-            "Invalid uploadUrl:'s3://example-bukkit/helloworld.zip#fragment', 'fragment' fragment is not allowed"
-        ),
-    ])
-    def test_invalid_uploadurl_is_badrequest(self, client, ingest_request, upload_url, error_description):
+    @pytest.mark.parametrize(
+        "upload_url,error_description",
+        [
+            (
+                "not-a-url",
+                "Invalid uploadUrl:'not-a-url', is not a complete URL, '' is not a supported scheme ['s3']",
+            ),
+            (
+                "ftp://example-bukkit/helloworld.zip",
+                "Invalid uploadUrl:'ftp://example-bukkit/helloworld.zip', 'ftp' is not a supported scheme ['s3']",
+            ),
+            (
+                "s3://example-bukkit/helloworld.zip#fragment",
+                "Invalid uploadUrl:'s3://example-bukkit/helloworld.zip#fragment', 'fragment' fragment is not allowed",
+            ),
+        ],
+    )
+    def test_invalid_uploadurl_is_badrequest(
+        self, client, ingest_request, upload_url, error_description
+    ):
         ingest_request["uploadUrl"] = upload_url
         resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(resp, status=400, description=error_description)
@@ -132,17 +128,22 @@ class TestPOSTIngests:
         resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert resp.status_code == 201
 
-    @pytest.mark.parametrize('callback_url,error_description', [
-        (
-            "not-a-url",
-            "Invalid callbackUrl:'not-a-url', is not a complete URL, '' is not a supported scheme ['http', 'https']"
-        ),
-        (
-            "s3://example.com",
-            "Invalid callbackUrl:'s3://example.com', 's3' is not a supported scheme ['http', 'https']"
-        ),
-    ])
-    def test_invalid_callback_url_is_badrequest(self, client, ingest_request, callback_url, error_description):
+    @pytest.mark.parametrize(
+        "callback_url,error_description",
+        [
+            (
+                "not-a-url",
+                "Invalid callbackUrl:'not-a-url', is not a complete URL, '' is not a supported scheme ['http', 'https']",
+            ),
+            (
+                "s3://example.com",
+                "Invalid callbackUrl:'s3://example.com', 's3' is not a supported scheme ['http', 'https']",
+            ),
+        ],
+    )
+    def test_invalid_callback_url_is_badrequest(
+        self, client, ingest_request, callback_url, error_description
+    ):
         ingest_request["callbackUrl"] = callback_url
         resp = client.post("/storage/v1/ingests", json=ingest_request)
         assert_is_error_response(resp, status=400, description=error_description)
@@ -180,7 +181,9 @@ class TestPOSTIngests:
         # the one we've been given to look up the request later.
         assert resp.headers["Location"].endswith(message["archiveRequestId"])
 
-    def test_successful_request_sends_to_sns_with_callback(self, client, sns_client, ingest_request):
+    def test_successful_request_sends_to_sns_with_callback(
+        self, client, sns_client, ingest_request
+    ):
         client.post("/storage/v1/ingests", json=ingest_request)
 
         sns_messages = sns_client.list_messages()
@@ -194,7 +197,7 @@ class TestPOSTIngests:
         assert_is_error_response(
             resp,
             status=405,
-            description="The method is not allowed for the requested URL."
+            description="The method is not allowed for the requested URL.",
         )
 
     def test_request_not_json_is_badrequest(self, client):
@@ -206,7 +209,7 @@ class TestPOSTIngests:
         assert_is_error_response(
             resp,
             status=400,
-            description="The browser (or proxy) sent a request that this server could not understand."
+            description="The browser (or proxy) sent a request that this server could not understand.",
         )
 
 
@@ -214,10 +217,7 @@ class TestPOSTIngests:
 def ingest_request():
     return {
         "type": "Ingest",
-        "ingestType": {
-            "id": "create",
-            "type": "IngestType"
-        },
+        "ingestType": {"id": "create", "type": "IngestType"},
         "uploadUrl": "s3://example-bukkit/helloworld.zip",
-        "callbackUrl": "https://example.com/post?callback"
+        "callbackUrl": "https://example.com/post?callback",
     }

--- a/archive/archive_api/src/tests/cassettes/test_archive_api.json
+++ b/archive/archive_api/src/tests/cassettes/test_archive_api.json
@@ -340,6 +340,65 @@
       "request": {
         "body": {
           "encoding": "utf-8",
+          "string": "uploadUrl=s3%3A%2F%2Fexample-bukkit%2Fhelloworld.zip"
+        },
+        "headers": {
+          "User-Agent": [
+            "python-requests/2.19.1"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Accept": [
+            "*/*"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "52"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ]
+        },
+        "method": "POST",
+        "uri": "http://docker.for.mac.localhost:6000/progress"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Content-Type": [
+            "text/html; charset=utf-8"
+          ],
+          "Location": [
+            "http://docker.for.mac.localhost:6000/progress/b4c8b161-5c1b-4493-86ba-ca1fc324f380"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Server": [
+            "Werkzeug/0.14.1 Python/3.6.1"
+          ],
+          "Date": [
+            "Thu, 04 Oct 2018 10:16:21 GMT"
+          ]
+        },
+        "status": {
+          "code": 201,
+          "message": "CREATED"
+        },
+        "url": "http://docker.for.mac.localhost:6000/progress"
+      },
+      "recorded_at": "2018-10-04T10:16:21"
+    },
+    {
+      "request": {
+        "body": {
+          "encoding": "utf-8",
           "string": "uploadUrl=s3%3A%2F%2Fexample-bukkit%2Fhelloworld.zip&callbackUrl=https%3A%2F%2Fexample.com%2Fpost%3Fcallback"
         },
         "headers": {

--- a/archive/archive_api/src/views.py
+++ b/archive/archive_api/src/views.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8
 
-from archive_api import app, api, logger
+from archive_api import app
 
 
 progress_manager = app.config["PROGRESS_MANAGER"]
@@ -9,24 +9,3 @@ progress_manager = app.config["PROGRESS_MANAGER"]
 @app.route("/storage/v1/healthcheck")
 def route_report_healthcheck_status():
     return {"status": "OK"}
-
-
-# TODO: There's no testing of the error handling; we should fix that!
-@app.errorhandler(Exception)
-@api.errorhandler(Exception)
-def default_error_handler(error):
-    error_response = {
-        "errorType": "http",
-        "httpStatus": getattr(error, "code", 500),
-        "label": getattr(error, "name", "Internal Server Error"),
-        "type": "Error",
-    }
-    logger.warn(error)
-    if error_response["httpStatus"] != 500:
-        if hasattr(error, "data"):
-            error_response["description"] = ", ".join(
-                error.data.get("errors", {}).values()
-            )
-        else:
-            error_response["description"] = getattr(error, "description", str(error))
-    return error_response, error_response["httpStatus"]


### PR DESCRIPTION
This PR significantly ups the error handling in the Archive API. In particular:

* The tests now assert on the structure of our error responses, and not just the presence of particular strings
* There are additional tests for error cases that weren't covered previously
* The default error handler actually works, where previously it would be applied inconsistently

Follows #2752. Spun out of #2748.