### PR TITLE
Tweaks to our Travis short-circuit logic + caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,10 +61,10 @@ cache:
 
     - archive/commmon/target
     - archive/archivist/target
-    - archive/registrar/target
-    - archive/progress/target
     - archive/notifier/target
-
+    - archive/progress_async/target
+    - archive/progress_http/target
+    - archive/registrar/target
 
 # Based on instructions from
 # https://www.scala-sbt.org/1.0/docs/Travis-CI-with-sbt.html#Caching

--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -22,6 +22,7 @@ from travistooling.decisions import (
     IgnoredFileFormat,
     IgnoredPath,
     InsignificantFile,
+    PythonChangeAndIsScalaApp,
     ScalaChangeAndIsScalaApp,
     ScalaChangeAndNotScalaApp,
     SignificantFile,
@@ -186,6 +187,12 @@ def does_file_affect_build_task(path, task):
         and task != "travis-format"
     ):
         raise ExclusivelyAffectsAnotherTask("travis-format")
+
+    # Changes to Python files only affect Scala apps.
+    if path.endswith(".py"):
+        for project in PROJECTS:
+            if task.startswith(project.name) and (project.type == "sbt_app"):
+                raise PythonChangeAndIsScalaApp()
 
     # If we can't decide if a file affects a build job, we assume it's
     # significant and run the job just-in-case.

--- a/travistooling/decisions.py
+++ b/travistooling/decisions.py
@@ -58,6 +58,10 @@ class CheckedByTravisLambda(SignificantFile):
     message = "File format is checked by the travis-lambda task"
 
 
+class PythonChangeAndIsScalaApp(InsignificantFile):
+    message = "Changes to Python files don't affect Scala apps"
+
+
 class ScalaChangeAndIsScalaApp(SignificantFile):
     message = "Changes to Scala common libs affect Scala apps"
 

--- a/travistooling/tests/test_decisionmaker.py
+++ b/travistooling/tests/test_decisionmaker.py
@@ -15,6 +15,7 @@ from travistooling.decisions import (
     ExclusivelyAffectsThisTask,
     IgnoredFileFormat,
     IgnoredPath,
+    PythonChangeAndIsScalaApp,
     ScalaChangeAndIsScalaApp,
     ScalaChangeAndNotScalaApp,
     UnrecognisedFile,
@@ -313,6 +314,9 @@ from travistooling.decisions import (
             ExclusivelyAffectsAnotherTask,
             False,
         ),
+        # Chnages to Python files shouldn't trigger a Scala app
+        ("shared_conftest.py", "ingestor-test", PythonChangeAndIsScalaApp, False),
+        ("shared_conftest.py", "loris-test", UnrecognisedFile, True),
     ],
 )
 def test_does_file_affect_build_task(path, task, exc_class, is_significant):


### PR DESCRIPTION
* Make sure we cache artefacts for both flavours of the progress service
* Changes to Python files (e.g. shared_conftest.py) should never trigger Scala changes – this bit me a few PRs back