### PR TITLE
Support reindexing the sierra_items VHS

### DIFF
--- a/reindexer/terraform/locals.tf
+++ b/reindexer/terraform/locals.tf
@@ -1,6 +1,7 @@
 locals {
-  vhs_sierra_table_name = "${data.terraform_remote_state.catalogue_pipeline_data.vhs_sierra_table_name}"
-  vhs_miro_table_name   = "${data.terraform_remote_state.catalogue_pipeline_data.vhs_miro_table_name}"
+  vhs_sierra_table_name       = "${data.terraform_remote_state.catalogue_pipeline_data.vhs_sierra_table_name}"
+  vhs_miro_table_name         = "${data.terraform_remote_state.catalogue_pipeline_data.vhs_miro_table_name}"
+  vhs_sierra_items_table_name = "${data.terraform_remote_state.catalogue_pipeline_data.vhs_sierra_items_table_name}"
 
   vpc_id          = "${data.terraform_remote_state.shared_infra.catalogue_vpc_id}"
   private_subnets = "${data.terraform_remote_state.shared_infra.catalogue_private_subnets}"

--- a/reindexer/terraform/main.tf
+++ b/reindexer/terraform/main.tf
@@ -25,3 +25,17 @@ module "sierra_reindexer" {
   service_egress_security_group_id = "${aws_security_group.service_egress_security_group.id}"
   namespace_id                     = "${aws_service_discovery_private_dns_namespace.namespace.id}"
 }
+
+module "sierra_items_reindexer" {
+  source = "./reindex_worker"
+
+  namespace      = "sierra_items"
+  vhs_table_name = "${local.vhs_sierra_table_name}"
+
+  reindex_worker_container_image = "${local.reindex_worker_container_image}"
+
+  ecs_cluster_name                 = "${aws_ecs_cluster.cluster.name}"
+  ecs_cluster_id                   = "${aws_ecs_cluster.cluster.id}"
+  service_egress_security_group_id = "${aws_security_group.service_egress_security_group.id}"
+  namespace_id                     = "${aws_service_discovery_private_dns_namespace.namespace.id}"
+}

--- a/reindexer/terraform/outputs.tf
+++ b/reindexer/terraform/outputs.tf
@@ -5,3 +5,7 @@ output "miro_topic_name" {
 output "sierra_topic_name" {
   value = "${module.sierra_reindexer.hybrid_records_topic_name}"
 }
+
+output "sierra_items_topic_name" {
+  value = "${module.sierra_items_reindexer.hybrid_records_topic_name}"
+}

--- a/reindexer/terraform/reindex_worker/service.tf
+++ b/reindexer/terraform/reindex_worker/service.tf
@@ -17,7 +17,6 @@ module "service" {
     reindex_requests_topic_arn = "${module.hybrid_records_topic.arn}"
     metrics_namespace          = "reindex_worker-${var.namespace}"
     dynamo_table_name          = "${var.vhs_table_name}"
-    dynamo_table_index         = "reindexTracker"
 
     # The reindex worker has to send lots of SNS notifications, and we've
     # seen issues where we exhaust the HTTP connection pool.  Turning down
@@ -26,7 +25,7 @@ module "service" {
     sqs_parallelism = 5
   }
 
-  env_vars_length = 6
+  env_vars_length = 5
 
   ecs_cluster_name = "${var.ecs_cluster_name}"
   ecs_cluster_id   = "${var.ecs_cluster_id}"

--- a/reindexer/trigger_reindex.py
+++ b/reindexer/trigger_reindex.py
@@ -143,9 +143,6 @@ def main():
         print("Checking pipeline is clear...")
         check_tables_are_clear()
 
-    print("Checking pipeline is clear...")
-    check_tables_are_clear()
-
     print(f"Triggering a reindex in {source_name}")
 
     post_to_slack(source_name=source_name, reason=reason, total_segments=total_segments)

--- a/reindexer/trigger_reindex.py
+++ b/reindexer/trigger_reindex.py
@@ -3,7 +3,7 @@
 """
 Create/update reindex shards in the reindex shard tracker table.
 
-Usage: trigger_reindex.py --source=<SOURCE_NAME> --reason=<REASON> --total_segments=<COUNT>
+Usage: trigger_reindex.py --source=<SOURCE_NAME> --reason=<REASON> --total_segments=<COUNT> [--skip-pipeline-checks]
        trigger_reindex.py -h | --help
 
 Options:
@@ -11,6 +11,8 @@ Options:
   --reason=<REASON>         An explanation of why you're running this reindex.
                             This will be printed in the Slack alert.
   --total_segments=<COUNT>  How many segments to divide the VHS table into.
+  --skip-pipeline-checks    Don't check if the pipeline tables are clear
+                            before running.
   -h --help                 Print this help message
 
 """
@@ -135,6 +137,11 @@ def main():
     source_name = args["--source"]
     reason = args["--reason"]
     total_segments = int(args["--total_segments"])
+    skip_pipeline_checks = args["--skip-pipeline-checks"]
+
+    if not skip_pipeline_checks:
+        print("Checking pipeline is clear...")
+        check_tables_are_clear()
 
     print("Checking pipeline is clear...")
     check_tables_are_clear()

--- a/sierra_adapter/terraform/item_merger/queues.tf
+++ b/sierra_adapter/terraform/item_merger/queues.tf
@@ -4,6 +4,7 @@ module "updates_queue" {
   aws_region  = "${var.aws_region}"
   account_id  = "${var.account_id}"
   topic_names = ["${var.updates_topic_name}"]
+
   topic_names = [
     "${var.updates_topic_name}",
     "${var.reindexed_items_topic_name}",

--- a/sierra_adapter/terraform/item_merger/queues.tf
+++ b/sierra_adapter/terraform/item_merger/queues.tf
@@ -4,6 +4,10 @@ module "updates_queue" {
   aws_region  = "${var.aws_region}"
   account_id  = "${var.account_id}"
   topic_names = ["${var.updates_topic_name}"]
+  topic_names = [
+    "${var.updates_topic_name}",
+    "${var.reindexed_items_topic_name}",
+  ]
 
   # Ensure that messages are spread around -- if the merger has an error
   # (for example, hitting DynamoDB write limits), we don't retry too quickly.

--- a/sierra_adapter/terraform/item_merger/variables.tf
+++ b/sierra_adapter/terraform/item_merger/variables.tf
@@ -24,3 +24,5 @@ variable "interservice_security_group_id" {}
 variable "service_egress_security_group_id" {}
 
 variable "sierra_items_bucket" {}
+
+variable "reindexed_items_topic_name" {}

--- a/sierra_adapter/terraform/locals.tf
+++ b/sierra_adapter/terraform/locals.tf
@@ -8,4 +8,6 @@ locals {
   vhs_full_access_policy = "${data.terraform_remote_state.catalogue_pipeline_data.vhs_sierra_full_access_policy}"
   vhs_table_name         = "${data.terraform_remote_state.catalogue_pipeline_data.vhs_sierra_table_name}"
   vhs_bucket_name        = "${data.terraform_remote_state.catalogue_pipeline_data.vhs_sierra_bucket_name}"
+
+  reindexed_items_topic_name = "${data.terraform_remote_state.reindexer.sierra_items_topic_name}"
 }

--- a/sierra_adapter/terraform/pipeline_items.tf
+++ b/sierra_adapter/terraform/pipeline_items.tf
@@ -76,7 +76,8 @@ module "items_merger" {
 
   merged_dynamo_table_name = "${local.vhs_table_name}"
 
-  updates_topic_name = "${module.items_to_dynamo.topic_name}"
+  updates_topic_name         = "${module.items_to_dynamo.topic_name}"
+  reindexed_items_topic_name = "${local.reindexed_items_topic_name}"
 
   cluster_name = "${aws_ecs_cluster.cluster.name}"
   vpc_id       = "${local.vpc_id}"

--- a/sierra_adapter/terraform/terraform.tf
+++ b/sierra_adapter/terraform/terraform.tf
@@ -28,3 +28,13 @@ data "terraform_remote_state" "catalogue_pipeline_data" {
     region = "eu-west-1"
   }
 }
+
+data "terraform_remote_state" "reindexer" {
+  backend = "s3"
+
+  config {
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/reindexer.tfstate"
+    region = "eu-west-1"
+  }
+}


### PR DESCRIPTION
These changes allow us to run a reindex on the sierra_items VHS, for example if the sierra_item_merger fails and loses records. It doesn't modify the item merger itself.

Part of #2691. Spun out of #2719.