### PR TITLE
Cap the maximum parallelism in the Akka default dispatcher

### DIFF
--- a/sierra_adapter/sierra_item_merger/src/main/resources/application.conf
+++ b/sierra_adapter/sierra_item_merger/src/main/resources/application.conf
@@ -1,0 +1,9 @@
+akka {
+  actor {
+    default-dispatcher {
+      fork-join-executor {
+        parallelism-max = 50
+      }
+    }
+  }
+}


### PR DESCRIPTION
An attempt to fix the Sierra item merger. I’m going to publish this, then kick off a reindex with #2769 and see what happens.

Fixes #2691, maybe.