### PR TITLE
Break out message-writing logic from SNSWriter

### DIFF
--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -8,7 +8,12 @@ import com.amazonaws.services.sns.AmazonSNS
 import com.google.inject.Inject
 import grizzled.slf4j.Logging
 import io.circe.Encoder
-import uk.ac.wellcome.messaging.sns.{PublishAttempt, SNSConfig, SNSMessageWriter, SNSWriter}
+import uk.ac.wellcome.messaging.sns.{
+  PublishAttempt,
+  SNSConfig,
+  SNSMessageWriter,
+  SNSWriter
+}
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.{KeyPrefix, ObjectStore}
 import uk.ac.wellcome.json.JsonUtil._

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageWriter.scala
@@ -8,7 +8,7 @@ import com.amazonaws.services.sns.AmazonSNS
 import com.google.inject.Inject
 import grizzled.slf4j.Logging
 import io.circe.Encoder
-import uk.ac.wellcome.messaging.sns.{PublishAttempt, SNSConfig, SNSWriter}
+import uk.ac.wellcome.messaging.sns.{PublishAttempt, SNSConfig, SNSMessageWriter, SNSWriter}
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.{KeyPrefix, ObjectStore}
 import uk.ac.wellcome.json.JsonUtil._
@@ -27,8 +27,10 @@ class MessageWriter[T] @Inject()(
 )(implicit objectStore: ObjectStore[T], ec: ExecutionContext)
     extends Logging {
 
+  private val snsMessageWriter = new SNSMessageWriter(snsClient = snsClient)
+
   private val sns = new SNSWriter(
-    snsClient = snsClient,
+    snsMessageWriter = snsMessageWriter,
     snsConfig = messageConfig.snsConfig
   )
 

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/PublishAttempt.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/PublishAttempt.scala
@@ -1,0 +1,3 @@
+package uk.ac.wellcome.messaging.sns
+
+case class PublishAttempt(id: Either[Throwable, String])

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSMessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSMessageWriter.scala
@@ -1,0 +1,42 @@
+package uk.ac.wellcome.messaging.sns
+
+import com.amazonaws.services.sns.AmazonSNS
+import com.amazonaws.services.sns.model.PublishRequest
+import com.google.inject.Inject
+import grizzled.slf4j.Logging
+import io.circe.Encoder
+import uk.ac.wellcome.json.JsonUtil._
+
+import scala.concurrent.{ExecutionContext, Future, blocking}
+
+/** Writes messages to SNS.  This class can write to a different topic on
+  * every request.
+  *
+  */
+class SNSMessageWriter @Inject() (snsClient: AmazonSNS)(implicit ec: ExecutionContext) extends Logging {
+  def writeMessage(message: String, topicArn: String, subject: String): Future[PublishAttempt] =
+    Future {
+      blocking {
+        debug(s"Publishing message $message to $topicArn")
+        snsClient.publish(
+          new PublishRequest(topicArn, message, subject))
+      }
+    }.map { publishResult =>
+      debug(
+        s"Published message $message to $topicArn (${publishResult.getMessageId})")
+      PublishAttempt(Right(message))
+    }
+      .recover {
+        case e: Throwable =>
+          error("Failed to publish message", e)
+          throw e
+      }
+
+  def writeMessage[T](message: T, topicArn: String, subject: String)(
+    implicit encoder: Encoder[T]): Future[PublishAttempt] =
+    writeMessage(
+      message = toJson[T](message).get,
+      topicArn = topicArn,
+      subject = subject
+    )
+}

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSMessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSMessageWriter.scala
@@ -14,7 +14,7 @@ import scala.concurrent.{ExecutionContext, Future, blocking}
   *
   */
 class SNSMessageWriter @Inject() (snsClient: AmazonSNS)(implicit ec: ExecutionContext) extends Logging {
-  def writeMessage(message: String, topicArn: String, subject: String): Future[PublishAttempt] =
+  def writeMessage(message: String, subject: String, topicArn: String): Future[PublishAttempt] =
     Future {
       blocking {
         debug(s"Publishing message $message to $topicArn")
@@ -32,7 +32,7 @@ class SNSMessageWriter @Inject() (snsClient: AmazonSNS)(implicit ec: ExecutionCo
           throw e
       }
 
-  def writeMessage[T](message: T, topicArn: String, subject: String)(
+  def writeMessage[T](message: T, subject: String, topicArn: String)(
     implicit encoder: Encoder[T]): Future[PublishAttempt] =
     writeMessage(
       message = toJson[T](message).get,

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
@@ -11,6 +11,10 @@ import scala.concurrent.{blocking, ExecutionContext, Future}
 
 case class PublishAttempt(id: Either[Throwable, String])
 
+/** Writes messages to SNS.  This class is configured with a single topic in
+  * `snsConfig`, and writes to the same topic on every request.
+  *
+  */
 class SNSWriter @Inject()(snsClient: AmazonSNS, snsConfig: SNSConfig)(
   implicit ec: ExecutionContext)
     extends Logging {

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
@@ -10,7 +10,8 @@ import scala.concurrent.Future
   * `snsConfig`, and writes to the same topic on every request.
   *
   */
-class SNSWriter @Inject()(snsMessageWriter: SNSMessageWriter, snsConfig: SNSConfig)
+class SNSWriter @Inject()(snsMessageWriter: SNSMessageWriter,
+                          snsConfig: SNSConfig)
     extends Logging {
 
   def writeMessage(message: String, subject: String): Future[PublishAttempt] =

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
@@ -1,47 +1,30 @@
 package uk.ac.wellcome.messaging.sns
 
-import com.amazonaws.services.sns.AmazonSNS
-import com.amazonaws.services.sns.model.PublishRequest
 import com.google.inject.Inject
 import grizzled.slf4j.Logging
 import io.circe.Encoder
-import uk.ac.wellcome.json.JsonUtil._
 
-import scala.concurrent.{blocking, ExecutionContext, Future}
+import scala.concurrent.Future
 
 /** Writes messages to SNS.  This class is configured with a single topic in
   * `snsConfig`, and writes to the same topic on every request.
   *
   */
-class SNSWriter @Inject()(snsClient: AmazonSNS, snsConfig: SNSConfig)(
-  implicit ec: ExecutionContext)
+class SNSWriter @Inject()(snsMessageWriter: SNSMessageWriter, snsConfig: SNSConfig)
     extends Logging {
 
   def writeMessage(message: String, subject: String): Future[PublishAttempt] =
-    Future {
-      blocking {
-        debug(s"Publishing message $message to ${snsConfig.topicArn}")
-        snsClient.publish(
-          toPublishRequest(message = message, subject = subject))
-      }
-    }.map { publishResult =>
-        debug(
-          s"Published message $message to ${snsConfig.topicArn} (${publishResult.getMessageId})")
-        PublishAttempt(Right(message))
-      }
-      .recover {
-        case e: Throwable =>
-          error("Failed to publish message", e)
-          throw e
-      }
+    snsMessageWriter.writeMessage(
+      message = message,
+      subject = subject,
+      topicArn = snsConfig.topicArn
+    )
 
   def writeMessage[T](message: T, subject: String)(
     implicit encoder: Encoder[T]): Future[PublishAttempt] =
-    writeMessage(
-      message = toJson[T](message).get,
-      subject = subject
+    snsMessageWriter.writeMessage[T](
+      message = message,
+      subject = subject,
+      topicArn = snsConfig.topicArn
     )
-
-  private def toPublishRequest(message: String, subject: String) =
-    new PublishRequest(snsConfig.topicArn, message, subject)
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
@@ -9,8 +9,6 @@ import uk.ac.wellcome.json.JsonUtil._
 
 import scala.concurrent.{blocking, ExecutionContext, Future}
 
-case class PublishAttempt(id: Either[Throwable, String])
-
 /** Writes messages to SNS.  This class is configured with a single topic in
   * `snsConfig`, and writes to the same topic on every request.
   *

--- a/sbt_common/messaging/src/test/resources/logback-test.xml
+++ b/sbt_common/messaging/src/test/resources/logback-test.xml
@@ -2,5 +2,5 @@
   <include resource="base-logback-test.xml"/>
 
   <logger name="uk.ac.wellcome.messaging.message.MessageWriter" level="WARN"/>
-  <logger name="uk.ac.wellcome.messaging.sns.SNSWriter" level="WARN"/>
+  <logger name="uk.ac.wellcome.messaging.sns.SNSMessageWriter" level="WARN"/>
 </configuration>

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
@@ -6,7 +6,12 @@ import io.circe.generic.extras.JsonKey
 import io.circe.{yaml, Decoder, Json, ParsingFailure}
 import org.scalatest.Matchers
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sns.{SNSClientFactory, SNSConfig, SNSMessageWriter, SNSWriter}
+import uk.ac.wellcome.messaging.sns.{
+  SNSClientFactory,
+  SNSConfig,
+  SNSMessageWriter,
+  SNSWriter
+}
 import uk.ac.wellcome.test.fixtures._
 
 import scala.language.higherKinds


### PR DESCRIPTION
A bit of speculative refactoring for #2865 while I wait for scripts to run.

Our current SNSWriter is tied to the idea that it publishes to a single topic – if we want Harrison to be able to reindex to a different topic, we could either create even more services configured with new topics, or break this assumption. The latter seems easier, so this patch:

* Adds a new class which takes the topic ARN as a parameter:

    ```scala
    class SNSMessageWriter {
        def writeMessage(message: String,
                         subject: String,
                         topicArn: String): Future[PublishAttempt] = ...
    }
    ```

* Modifies SNSWriter to use the new class when sending messages.

There should be no change to existing services, but it would a future patch to send to different topics within the same reindexer service.

[Note: I have no spare local CPU capacity, so this patch is currently untested.]