### PR TITLE
Callback when completed or failed

### DIFF
--- a/archive/progress_async/src/main/scala/uk/ac/wellcome/platform/archive/progress_async/flows/CallbackNotificationFlow.scala
+++ b/archive/progress_async/src/main/scala/uk/ac/wellcome/platform/archive/progress_async/flows/CallbackNotificationFlow.scala
@@ -13,6 +13,7 @@ import uk.ac.wellcome.platform.archive.common.models.CallbackNotification
 import uk.ac.wellcome.platform.archive.common.progress.models.progress.Progress
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.progress.models.progress.Callback.Pending
+import uk.ac.wellcome.platform.archive.common.progress.models.progress.Progress.{Completed, Failed}
 
 object CallbackNotificationFlow extends Logging {
   import CallbackNotification._
@@ -35,9 +36,9 @@ object CallbackNotificationFlow extends Logging {
     }
 
     Flow[Progress].flatMapConcat {
-      case progress @ Progress(id, _, _, Some(callback), _, _, _, _, _) =>
+      case progress @ Progress(id, _, _, Some(callback), progressStatus, _, _, _, _) =>
         callback.status match {
-          case Pending =>
+          case Pending if List(Completed, Failed) contains progressStatus =>
             notifyFlow(progress, id, callback.uri)
           case _ => Source.single(())
         }

--- a/archive/progress_async/src/main/scala/uk/ac/wellcome/platform/archive/progress_async/flows/CallbackNotificationFlow.scala
+++ b/archive/progress_async/src/main/scala/uk/ac/wellcome/platform/archive/progress_async/flows/CallbackNotificationFlow.scala
@@ -13,7 +13,10 @@ import uk.ac.wellcome.platform.archive.common.models.CallbackNotification
 import uk.ac.wellcome.platform.archive.common.progress.models.progress.Progress
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.progress.models.progress.Callback.Pending
-import uk.ac.wellcome.platform.archive.common.progress.models.progress.Progress.{Completed, Failed}
+import uk.ac.wellcome.platform.archive.common.progress.models.progress.Progress.{
+  Completed,
+  Failed
+}
 
 object CallbackNotificationFlow extends Logging {
   import CallbackNotification._
@@ -36,7 +39,16 @@ object CallbackNotificationFlow extends Logging {
     }
 
     Flow[Progress].flatMapConcat {
-      case progress @ Progress(id, _, _, Some(callback), progressStatus, _, _, _, _) =>
+      case progress @ Progress(
+            id,
+            _,
+            _,
+            Some(callback),
+            progressStatus,
+            _,
+            _,
+            _,
+            _) =>
         callback.status match {
           case Pending if List(Completed, Failed) contains progressStatus =>
             notifyFlow(progress, id, callback.uri)


### PR DESCRIPTION
### What is this PR trying to achieve?

Make callbacks when the progress status is Completed or Failed and the callback status is Pending.  This fixes a problem that has arisen because callback status is now separated from the processing status leading to multiple callbacks.

However this change still assumes only one message is sent with the final status change, which should also be fixed.
