### PR TITLE
Return catalogue error responses on non-works pages

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/ContextHelper.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/ContextHelper.scala
@@ -4,6 +4,7 @@ import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.platform.api.models.ApiConfig
 
 object ContextHelper {
-  def buildContextUri(apiConfig: ApiConfig, version: ApiVersions.Value) =
+  def buildContextUri(apiConfig: ApiConfig,
+                      version: ApiVersions.Value = ApiVersions.default) =
     s"${apiConfig.scheme}://${apiConfig.host}${apiConfig.pathPrefix}/$version${apiConfig.contextSuffix}"
 }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
@@ -9,26 +9,42 @@ import com.twitter.finatra.http.filters.{
   TraceIdMDCFilter
 }
 import com.twitter.finatra.http.routing.HttpRouter
+import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.modules.DisplayJacksonModule
 import uk.ac.wellcome.finatra.akka.ExecutionContextModule
 import uk.ac.wellcome.finatra.elasticsearch.{
   ElasticClientModule,
   ElasticConfigModule
 }
+import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
 import uk.ac.wellcome.platform.api.controllers._
 import uk.ac.wellcome.platform.api.finatra.exceptions.{
   CaseClassMappingExceptionWrapper,
   ElasticsearchResponseExceptionMapper,
   GeneralExceptionMapper
 }
+import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error}
 import uk.ac.wellcome.platform.api.modules.ApiConfigModule
+import uk.ac.wellcome.platform.api.responses.ResultResponse
 
 object ServerMain extends Server
 
 @Singleton
-class AlexController @Inject() extends Controller {
+class AlexController @Inject()(apiConfig: ApiConfig) extends Controller {
+  val contextUri: String = buildContextUri(
+    apiConfig = apiConfig,
+    version = ApiVersions.default
+  )
+
   get("/:*") { request: Request =>
-    response.notFound.json(Map("message" -> "ok"))
+    val result = Error(
+      variant = "http-404",
+      description = Some(s"Page not found for URL ${request.uri}")
+    )
+
+    response.notFound.json(
+      ResultResponse(context = contextUri, result = DisplayError(result))
+    )
   }
 }
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
@@ -1,52 +1,28 @@
 package uk.ac.wellcome.platform.api
 
-import com.google.inject.{Inject, Singleton}
 import com.twitter.finagle.http.{Request, Response}
-import com.twitter.finatra.http.{Controller, HttpServer}
+import com.twitter.finatra.http.HttpServer
 import com.twitter.finatra.http.filters.{
   CommonFilters,
   LoggingMDCFilter,
   TraceIdMDCFilter
 }
 import com.twitter.finatra.http.routing.HttpRouter
-import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.modules.DisplayJacksonModule
 import uk.ac.wellcome.finatra.akka.ExecutionContextModule
 import uk.ac.wellcome.finatra.elasticsearch.{
   ElasticClientModule,
   ElasticConfigModule
 }
-import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
 import uk.ac.wellcome.platform.api.controllers._
 import uk.ac.wellcome.platform.api.finatra.exceptions.{
   CaseClassMappingExceptionWrapper,
   ElasticsearchResponseExceptionMapper,
   GeneralExceptionMapper
 }
-import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error}
 import uk.ac.wellcome.platform.api.modules.ApiConfigModule
-import uk.ac.wellcome.platform.api.responses.ResultResponse
 
 object ServerMain extends Server
-
-@Singleton
-class AlexController @Inject()(apiConfig: ApiConfig) extends Controller {
-  val contextUri: String = buildContextUri(
-    apiConfig = apiConfig,
-    version = ApiVersions.default
-  )
-
-  get("/:*") { request: Request =>
-    val result = Error(
-      variant = "http-404",
-      description = Some(s"Page not found for URL ${request.uri}")
-    )
-
-    response.notFound.json(
-      ResultResponse(context = contextUri, result = DisplayError(result))
-    )
-  }
-}
 
 class Server extends HttpServer {
   override val name = "uk.ac.wellcome.platform.api Platformapi"
@@ -69,7 +45,7 @@ class Server extends HttpServer {
       .add[DocsController]
       .add[V1WorksController]
       .add[V2WorksController]
-      .add[AlexController]
+      .add[MissingPathController]
       .exceptionMapper[GeneralExceptionMapper]
       .exceptionMapper[CaseClassMappingExceptionWrapper]
       .exceptionMapper[ElasticsearchResponseExceptionMapper]

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
@@ -1,7 +1,8 @@
 package uk.ac.wellcome.platform.api
 
+import com.google.inject.{Inject, Singleton}
 import com.twitter.finagle.http.{Request, Response}
-import com.twitter.finatra.http.HttpServer
+import com.twitter.finatra.http.{Controller, HttpServer}
 import com.twitter.finatra.http.filters.{
   CommonFilters,
   LoggingMDCFilter,
@@ -24,6 +25,13 @@ import uk.ac.wellcome.platform.api.modules.ApiConfigModule
 
 object ServerMain extends Server
 
+@Singleton
+class AlexController @Inject() extends Controller {
+  get("/:*") { request: Request =>
+    response.notFound.json(Map("message" -> "ok"))
+  }
+}
+
 class Server extends HttpServer {
   override val name = "uk.ac.wellcome.platform.api Platformapi"
   override val modules = Seq(
@@ -45,6 +53,7 @@ class Server extends HttpServer {
       .add[DocsController]
       .add[V1WorksController]
       .add[V2WorksController]
+      .add[AlexController]
       .exceptionMapper[GeneralExceptionMapper]
       .exceptionMapper[CaseClassMappingExceptionWrapper]
       .exceptionMapper[ElasticsearchResponseExceptionMapper]

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MissingPathController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MissingPathController.scala
@@ -1,0 +1,28 @@
+package uk.ac.wellcome.platform.api.controllers
+
+import com.google.inject.{Inject, Singleton}
+import com.twitter.finagle.http.Request
+import com.twitter.finatra.http.Controller
+import uk.ac.wellcome.display.models.ApiVersions
+import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
+import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error}
+import uk.ac.wellcome.platform.api.responses.ResultResponse
+
+@Singleton
+class MissingPathController @Inject()(apiConfig: ApiConfig) extends Controller {
+  val contextUri: String = buildContextUri(
+    apiConfig = apiConfig,
+    version = ApiVersions.default
+  )
+
+  get("/:*") { request: Request =>
+    val result = Error(
+      variant = "http-404",
+      description = Some(s"Page not found for URL ${request.uri}")
+    )
+
+    response.notFound.json(
+      ResultResponse(context = contextUri, result = DisplayError(result))
+    )
+  }
+}

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MissingPathController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MissingPathController.scala
@@ -8,6 +8,15 @@ import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
 import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error}
 import uk.ac.wellcome.platform.api.responses.ResultResponse
 
+/** This controller returns a 404 to any requests for an undefined path.
+  *
+  * Note: it does this by defining a wildcard route for all paths.
+  * Since Finatra resolves routes in the order they're declared, this
+  * controller must be used last, or it will break other routes.
+  *
+  * More info: https://twitter.github.io/finatra/user-guide/http/controllers.html#wildcard-parameter
+  *
+  */
 @Singleton
 class MissingPathController @Inject()(apiConfig: ApiConfig) extends Controller {
   val contextUri: String = buildContextUri(

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MissingPathController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MissingPathController.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.api.controllers
 import com.google.inject.{Inject, Singleton}
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
-import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
 import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error}
 import uk.ac.wellcome.platform.api.responses.ResultResponse
@@ -19,10 +18,7 @@ import uk.ac.wellcome.platform.api.responses.ResultResponse
   */
 @Singleton
 class MissingPathController @Inject()(apiConfig: ApiConfig) extends Controller {
-  val contextUri: String = buildContextUri(
-    apiConfig = apiConfig,
-    version = ApiVersions.default
-  )
+  val contextUri: String = buildContextUri(apiConfig = apiConfig)
 
   get("/:*") { request: Request =>
     val result = Error(

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MissingPathController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MissingPathController.scala
@@ -13,7 +13,9 @@ import uk.ac.wellcome.platform.api.responses.ResultResponse
   * Since Finatra resolves routes in the order they're declared, this
   * controller must be used last, or it will break other routes.
   *
-  * More info: https://twitter.github.io/finatra/user-guide/http/controllers.html#wildcard-parameter
+  * More info:
+  *   https://twitter.github.io/finatra/user-guide/http/controllers.html#wildcard-parameter
+  *   https://alexwlchan.net/2018/10/finatra-404/
   *
   */
 @Singleton

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/ApiConfig.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/ApiConfig.scala
@@ -4,7 +4,6 @@ case class ApiConfig(
   host: String,
   scheme: String,
   defaultPageSize: Int,
-  name: String,
   pathPrefix: String,
   contextSuffix: String
 )

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/modules/ApiConfigModule.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/modules/ApiConfigModule.scala
@@ -31,7 +31,6 @@ object ApiConfigModule extends TwitterModule {
       host = host(),
       scheme = scheme(),
       defaultPageSize = defaultPageSize(),
-      name = apiName(),
       pathPrefix = pathPrefix(),
       contextSuffix = contextSuffix()
     )

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -20,7 +20,7 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient,
                      indexName: String): Future[GetResponse] =
     elasticClient
       .execute {
-        get(canonicalId).from(s"${indexName}/$documentType")
+        get(canonicalId).from(s"$indexName/$documentType")
       }
 
   def listResults(sortByField: String,
@@ -29,7 +29,7 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient,
                   from: Int = 0): Future[SearchResponse] =
     elasticClient
       .execute {
-        search(s"${indexName}/$documentType")
+        search(s"$indexName/$documentType")
           .query(termQuery("type", "IdentifiedWork"))
           .sortBy(fieldSort(sortByField))
           .limit(limit)
@@ -42,7 +42,7 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient,
                                indexName: String): Future[SearchResponse] =
     elasticClient
       .execute {
-        search(s"${indexName}/$documentType")
+        search(s"$indexName/$documentType")
           .query(
             must(
               simpleStringQuery(queryString),

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/WorksServiceFixture.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/WorksServiceFixture.scala
@@ -15,7 +15,6 @@ trait WorksServiceFixture { this: Suite =>
         host = "example.org",
         scheme = "https",
         defaultPageSize = 10,
-        name = "testing",
         pathPrefix = "/catalogue/works",
         contextSuffix = "/conext.json"
       ),

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
@@ -4,12 +4,8 @@ import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.apache.commons.io.IOUtils
 import uk.ac.wellcome.display.models.ApiVersions
-import uk.ac.wellcome.display.models.v1.DisplayV1SerialisationTestBase
 
-class ApiContextTest
-    extends ApiWorksTestBase
-    with DisplayV1SerialisationTestBase {
-
+class ApiContextTest extends ApiWorksTestBase {
   it("returns a context for all versions") {
     ApiVersions.values.toList.foreach { version: ApiVersions.Value =>
       withApiFixtures(apiVersion = version) {
@@ -22,5 +18,4 @@ class ApiContextTest
       }
     }
   }
-
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
@@ -12,9 +12,9 @@ class ApiErrorsTest extends ApiWorksTestBase {
       server.httpGet(
         path = "/catalogue/v567/works",
         andExpect = Status.NotFound,
-        withJsonBody = badRequest(
+        withJsonBody = notFound(
           s"catalogue/${ApiVersions.default.toString}",
-          "v567 is not a valid API version")
+          "Page not found for URL /catalogue/v567/works")
       )
     }
   }
@@ -24,9 +24,9 @@ class ApiErrorsTest extends ApiWorksTestBase {
       server.httpGet(
         path = "/foo/bar",
         andExpect = Status.NotFound,
-        withJsonBody = badRequest(
+        withJsonBody = notFound(
           s"catalogue/${ApiVersions.default.toString}",
-          "v567 is not a valid API version")
+          "Page not found for URL /foo/bar")
       )
     }
   }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
@@ -8,15 +8,26 @@ import uk.ac.wellcome.test.fixtures.TestWith
 class ApiErrorsTest extends ApiWorksTestBase {
 
   it("returns a Not Found error if you try to get an API version") {
-    withServer(indexNameV1 = "not-important", indexNameV2 = "not-important") {
-      server =>
-        server.httpGet(
-          path = "/catalogue/v567/works",
-          andExpect = Status.NotFound,
-          withJsonBody = badRequest(
-            s"catalogue/${ApiVersions.default.toString}",
-            "v567 is not a valid API version")
-        )
+    withServer { server =>
+      server.httpGet(
+        path = "/catalogue/v567/works",
+        andExpect = Status.NotFound,
+        withJsonBody = badRequest(
+          s"catalogue/${ApiVersions.default.toString}",
+          "v567 is not a valid API version")
+      )
+    }
+  }
+
+  it("returns a Not Found error if you try to get an unrecognised path") {
+    withServer { server =>
+      server.httpGet(
+        path = "/foo/bar",
+        andExpect = Status.NotFound,
+        withJsonBody = badRequest(
+          s"catalogue/${ApiVersions.default.toString}",
+          "v567 is not a valid API version")
+      )
     }
   }
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
@@ -1,0 +1,27 @@
+package uk.ac.wellcome.platform.api.works
+
+import com.twitter.finagle.http.Status
+import com.twitter.finatra.http.EmbeddedHttpServer
+import uk.ac.wellcome.display.models.ApiVersions
+import uk.ac.wellcome.test.fixtures.TestWith
+
+class ApiErrorsTest extends ApiWorksTestBase {
+
+  it("returns a Not Found error if you try to get an API version") {
+    withServer(indexNameV1 = "not-important", indexNameV2 = "not-important") {
+      server =>
+        server.httpGet(
+          path = "/catalogue/v567/works",
+          andExpect = Status.NotFound,
+          withJsonBody = badRequest(
+            s"catalogue/${ApiVersions.default.toString}",
+            "v567 is not a valid API version")
+        )
+    }
+  }
+
+  private def withServer[R](testWith: TestWith[EmbeddedHttpServer, R]): R =
+    withServer(indexNameV1 = "index-v1", indexNameV2 = "index-v2") { server =>
+      testWith(server)
+    }
+}

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.api.works
 import com.sksamuel.elastic4s.Indexable
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.FunSpec
-import uk.ac.wellcome.display.models.{ApiVersions, DisplaySerialisationTestBase}
+import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
@@ -14,7 +14,6 @@ import uk.ac.wellcome.test.fixtures.TestWith
 trait ApiWorksTestBase
     extends FunSpec
     with ElasticsearchFixtures
-    with DisplaySerialisationTestBase
     with WorksGenerators {
 
   implicit object IdentifiedWorkIndexable extends Indexable[IdentifiedWork] {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.api.works.v1
 
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
-import uk.ac.wellcome.display.models.ApiVersions
 
 class ApiV1ErrorsTest extends ApiV1WorksTestBase {
 
@@ -274,19 +273,6 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
             "Only the first 10000 works are available in the API.")
         )
 
-    }
-  }
-
-  it("returns a Not Found error if you try to get a version that doesn't exist") {
-    withServer(indexNameV1 = "not-important", indexNameV2 = "not-important") {
-      server =>
-        server.httpGet(
-          path = "/catalogue/v567/works?pageSize=100&page=101",
-          andExpect = Status.NotFound,
-          withJsonBody = badRequest(
-            s"catalogue/${ApiVersions.default.toString}",
-            "v567 is not a valid API version")
-        )
     }
   }
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
@@ -277,9 +277,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
     }
   }
 
-  // TODO figure out what the correct behaviour should be in this case
-  ignore(
-    "returns a Not Found error if you try to get a version that doesn't exist") {
+  it("returns a Not Found error if you try to get a version that doesn't exist") {
     withServer(indexNameV1 = "not-important", indexNameV2 = "not-important") {
       server =>
         server.httpGet(

--- a/catalogue_api/terraform/outputs.tf
+++ b/catalogue_api/terraform/outputs.tf
@@ -1,11 +1,3 @@
-output "romulus_app_uri" {
-  value = "${local.romulus_app_uri}"
-}
-
-output "remus_app_uri" {
-  value = "${local.remus_app_uri}"
-}
-
 output "snapshots_bucket_arn" {
   value = "${module.data_api.snapshots_bucket_arn}"
 }


### PR DESCRIPTION
Resolves #2874. This ensures that a request for any page – not just one of our defined paths – will return a full JSON body, and not an empty response.

Plus a few bits of refactoring, but nothing major.