### PR TITLE
An empty subfield $a in a contributor field is now handled, not an error

### DIFF
--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraAgents.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraAgents.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
 
 trait SierraAgents {
@@ -11,8 +10,8 @@ trait SierraAgents {
   //  - subfield $a populates the person label
   //  - subfield $b populates the person numeration
   //  - subfield $c populates the person prefixes
-  def getPerson(subfields: List[MarcSubfield]) = {
-    val label = getLabel(subfields)
+  def getPerson(subfields: List[MarcSubfield]): Option[Person] = {
+    val maybeLabel = getLabel(subfields)
 
     // Extract the numeration from subfield $b.  This is also non-repeatable
     // in the MARC spec.
@@ -28,21 +27,24 @@ trait SierraAgents {
     val prefixString =
       if (prefixes.isEmpty) None else Some(prefixes.mkString(" "))
 
-    Person(
-      label = label,
-      prefix = prefixString,
-      numeration = numeration
-    )
+    maybeLabel.map { label =>
+      Person(
+        label = label,
+        prefix = prefixString,
+        numeration = numeration
+      )
+    }
   }
 
   // This is used to construct an Organisation from MARC tags 110 and 710.
   // For all entries:
   //  - Subfield $a is "label"
   //  - Subfield $0 is used to populate "identifiers". The identifier scheme is lc-names.
-  def getOrganisation(subfields: List[MarcSubfield]) = {
-    val label = getLabel(subfields)
-    Organisation(label = label)
-  }
+  //
+  def getOrganisation(subfields: List[MarcSubfield]): Option[Organisation] =
+    getLabel(subfields).map { label =>
+      Organisation(label = label)
+    }
 
   /* Given an agent and the associated MARC subfields, look for instances of subfield $0,
    * which are used for identifiers.
@@ -88,19 +90,12 @@ trait SierraAgents {
     }
   }
 
-  private def getLabel(subfields: List[MarcSubfield]): String = {
+  private def getLabel(subfields: List[MarcSubfield]): Option[String] = {
     // Extract the label from subfield $a.  This is a non-repeatable
     // field in the MARC spec, but we have seen records where it
-    // doesn't appear.
-    val maybeSubfieldA = subfields.collectFirst {
+    // doesn't appear.  In that case, we discard the entire agent.
+    subfields.collectFirst {
       case MarcSubfield("a", content) => content
-    }
-
-    maybeSubfieldA match {
-      case Some(content) => content
-      case None =>
-        throw TransformerException(
-          s"Unable to find subfield $$a? <<$subfields>>")
     }
   }
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraAgents.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraAgents.scala
@@ -13,7 +13,6 @@ trait SierraAgents {
   //
   def getPerson(subfields: List[MarcSubfield]): Option[Person] =
     getLabel(subfields).map { label =>
-
       // Extract the numeration from subfield $b.  This is also non-repeatable
       // in the MARC spec.
       val numeration = subfields.collectFirst {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraAgents.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraAgents.scala
@@ -90,12 +90,11 @@ trait SierraAgents {
     }
   }
 
-  private def getLabel(subfields: List[MarcSubfield]): Option[String] = {
+  private def getLabel(subfields: List[MarcSubfield]): Option[String] =
     // Extract the label from subfield $a.  This is a non-repeatable
     // field in the MARC spec, but we have seen records where it
     // doesn't appear.  In that case, we discard the entire agent.
     subfields.collectFirst {
       case MarcSubfield("a", content) => content
     }
-  }
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraAgents.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraAgents.scala
@@ -10,31 +10,30 @@ trait SierraAgents {
   //  - subfield $a populates the person label
   //  - subfield $b populates the person numeration
   //  - subfield $c populates the person prefixes
-  def getPerson(subfields: List[MarcSubfield]): Option[Person] = {
-    val maybeLabel = getLabel(subfields)
+  //
+  def getPerson(subfields: List[MarcSubfield]): Option[Person] =
+    getLabel(subfields).map { label =>
 
-    // Extract the numeration from subfield $b.  This is also non-repeatable
-    // in the MARC spec.
-    val numeration = subfields.collectFirst {
-      case MarcSubfield("b", content) => content
-    }
+      // Extract the numeration from subfield $b.  This is also non-repeatable
+      // in the MARC spec.
+      val numeration = subfields.collectFirst {
+        case MarcSubfield("b", content) => content
+      }
 
-    // Extract the prefix from subfield $c.  This is a repeatable field, so
-    // we take all instances and join them.
-    val prefixes = subfields.collect {
-      case MarcSubfield("c", content) => content
-    }
-    val prefixString =
-      if (prefixes.isEmpty) None else Some(prefixes.mkString(" "))
+      // Extract the prefix from subfield $c.  This is a repeatable field, so
+      // we take all instances and join them.
+      val prefixes = subfields.collect {
+        case MarcSubfield("c", content) => content
+      }
+      val prefixString =
+        if (prefixes.isEmpty) None else Some(prefixes.mkString(" "))
 
-    maybeLabel.map { label =>
       Person(
         label = label,
         prefix = prefixString,
         numeration = numeration
       )
     }
-  }
 
   // This is used to construct an Organisation from MARC tags 110 and 710.
   // For all entries:

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraContributors.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraContributors.scala
@@ -45,15 +45,18 @@ trait SierraContributors extends MarcUtils with SierraAgents {
       marcSubfieldTags = List("a", "b", "c", "e", "0")
     )
 
-    persons.map { subfields =>
-      val roles = getContributionRoles(subfields)
-      val agent = getPerson(subfields)
+    persons
+      .flatMap { subfields: List[MarcSubfield] =>
+        val roles = getContributionRoles(subfields)
+        val maybePerson = getPerson(subfields)
 
-      Contributor(
-        agent = identify(subfields, agent, "Person"),
-        roles = roles
-      )
-    }
+        maybePerson.map { person =>
+          Contributor(
+            agent = identify(subfields, person, "Person"),
+            roles = roles
+          )
+        }
+      }
   }
 
   /* For a given MARC tag (110 or 710), return a list of all the Contributor[Organisation] instances
@@ -68,15 +71,18 @@ trait SierraContributors extends MarcUtils with SierraAgents {
       marcSubfieldTags = List("a", "b", "c", "e", "0")
     )
 
-    organisations.map { subfields =>
-      val roles = getContributionRoles(subfields)
-      val agent = getOrganisation(subfields)
+    organisations
+      .flatMap { subfields: List[MarcSubfield] =>
+        val roles = getContributionRoles(subfields)
+        val maybeAgent = getOrganisation(subfields)
 
-      Contributor(
-        agent = identify(subfields, agent, "Organisation"),
-        roles = roles
-      )
-    }
+        maybeAgent.map { agent =>
+          Contributor(
+            agent = identify(subfields, agent, "Organisation"),
+            roles = roles
+          )
+        }
+      }
   }
 
   private def getContributionRoles(

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraContributorsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraContributorsTest.scala
@@ -431,7 +431,8 @@ class SierraContributorsTest
         expectedContributors = expectedContributors)
     }
 
-    it("gets the name from MARC tags 110 and 710 subfield $$a in the right order") {
+    it(
+      "gets the name from MARC tags 110 and 710 subfield $$a in the right order") {
       val name1 = "Mary the mallow"
       val name2 = "Mike the mashua"
       val name3 = "Mickey the mozuku"
@@ -564,7 +565,8 @@ class SierraContributorsTest
         expectedContributors = expectedContributors)
     }
 
-    it("does not identify the contributor if there are multiple distinct identifiers in subfield $$0") {
+    it(
+      "does not identify the contributor if there are multiple distinct identifiers in subfield $$0") {
       val name = "Luke the lime"
       val varFields = List(
         createVarFieldWith(

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraContributorsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/SierraContributorsTest.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
@@ -432,8 +431,7 @@ class SierraContributorsTest
         expectedContributors = expectedContributors)
     }
 
-    it(
-      "gets the name from MARC tags 110 and 710 subfield $$a in the right order") {
+    it("gets the name from MARC tags 110 and 710 subfield $$a in the right order") {
       val name1 = "Mary the mallow"
       val name2 = "Mike the mashua"
       val name3 = "Mickey the mozuku"
@@ -566,8 +564,7 @@ class SierraContributorsTest
         expectedContributors = expectedContributors)
     }
 
-    it(
-      "does not identify the contributor if there are multiple distinct identifiers in subfield $$0") {
+    it("does not identify the contributor if there are multiple distinct identifiers in subfield $$0") {
       val name = "Luke the lime"
       val varFields = List(
         createVarFieldWith(
@@ -592,15 +589,22 @@ class SierraContributorsTest
     }
   }
 
-  it("fails the transform if subfield $$a is missing") {
+  // This is based on transformer failures we saw in October 2018 --
+  // records 3069865, 3069866, 3069867, 3069872 all had empty instances of
+  // the 110 field.
+  it("returns an empty list if subfield $$a is missing") {
     val varFields = List(
       createVarFieldWith(
         marcTag = "100",
-        subfields = List()
+        subfields = List(
+          MarcSubfield(tag = "e", content = "")
+        )
       )
     )
 
-    assertTransformFails(varFields)
+    transformAndCheckContributors(
+      varFields = varFields,
+      expectedContributors = List())
   }
 
   private def transformAndCheckContributors(
@@ -609,13 +613,5 @@ class SierraContributorsTest
   ) = {
     val bibData = createSierraBibDataWith(varFields = varFields)
     transformer.getContributors(bibData) shouldBe expectedContributors
-  }
-
-  private def assertTransformFails(varFields: List[VarField]) = {
-    val bibData = createSierraBibDataWith(varFields = varFields)
-
-    intercept[TransformerException] {
-      transformer.getContributors(bibData)
-    }
   }
 }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraPersonSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/sierra/subjects/SierraPersonSubjectsTest.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.sierra.subjects
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
 import uk.ac.wellcome.platform.transformer.sierra.generators.{
   MarcGenerators,
@@ -160,9 +159,9 @@ class SierraPersonSubjectsTest
         concepts = List(Unidentifiable(Person(label = "David Attenborough,")))))
   }
 
-  // This test case shouldn't be possible but we've seen cataloguing errors
-  // elsewhere. For now, we error in those cases so that we are able
-  // to flag cataloguing errors, so error here as well for consistency
+  // There's nothing useful we can do here.  Arguably it's a cataloguing
+  // error, but all the person will do is delete the field, so we can avoid
+  // throwing an error.
   it("errors transforming a subject 600 if subfield a is missing") {
     val sierraBibData = createSierraBibDataWith(
       varFields = List(
@@ -173,9 +172,7 @@ class SierraPersonSubjectsTest
       )
     )
 
-    intercept[TransformerException] {
-      transformer.getSubjectsWithPerson(sierraBibData)
-    }
+    transformer.getSubjectsWithPerson(sierraBibData) shouldBe List()
   }
 
   it(


### PR DESCRIPTION
Resolves #2886.

This is a change to the transformer logic: previously, being asked to inspect a “contributor” field (I think this is MARC tags 100, 100, 600, 610, 700, 710) without subfield $a would cause the transformer to throw an exception, and the record lands on the DLQ.

In practice, this has only occurred when the entire MARC tag is empty.

Since a librarian would just delete the empty field if we told them, let's skip the transformer exception and discard the field here.

(One alternative is to detect if all the subfields are empty, and throw if some of them are populated, but we've never seen that in practice – I feel it's unnecessary. Reviewers, tell me if you disagree.)