### PR TITLE
Add a switch for the "PDM" licence type

### DIFF
--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
@@ -36,6 +36,7 @@ trait MiroLicenses {
           case "CC-BY"       => License_CCBY
           case "CC-BY-NC"    => License_CCBYNC
           case "CC-BY-NC-ND" => License_CCBYNCND
+          case "PDM"         => License_PDM
 
           // These mappings are defined in Christy's document
           case "Academics" => License_CCBYNC


### PR DESCRIPTION
Required for #2790 – we have a bunch of Miro records that now have a PDM in the `image_use_restrictions`, which is causing this match statement to fail.