### PR TITLE
Implement filters for workType

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -227,6 +227,11 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
         |To search for any of these special characters, they should be escaped with \.""".stripMargin,
         required = false
       )
+      .queryParam[String](
+        "workType",
+        "Filter by the workType of the searched works",
+        required = false
+      )
       .parameter(includeSwaggerParam)
     // Deliberately undocumented: we have an 'index' query param that
     // allows the user to pick which Elasticsearch index to use.  This is

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -107,6 +107,7 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
       case Some(queryString) =>
         worksService.searchWorks(
           queryString,
+          workType = request.workType,
           pageSize = pageSize,
           pageNumber = request.page,
           indexName = request._index
@@ -114,6 +115,7 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
         )
       case None =>
         worksService.listWorks(
+          workType = request.workType,
           pageSize = pageSize,
           pageNumber = request.page,
           indexName = request._index

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
@@ -18,6 +18,7 @@ trait MultipleResultsRequest[W <: WorksIncludes] extends ApiRequest {
   val pageSize: Option[Int]
   val include: Option[W]
   val query: Option[String]
+  val workType: Option[String]
   val _index: Option[String]
   val request: Request
 }
@@ -27,6 +28,7 @@ case class V1MultipleResultsRequest(
   @Min(1) @Max(100) @QueryParam pageSize: Option[Int],
   @QueryParam includes: Option[V1WorksIncludes],
   @QueryParam query: Option[String],
+  @QueryParam workType: Option[String],
   @QueryParam _index: Option[String],
   request: Request
 ) extends MultipleResultsRequest[V1WorksIncludes] {
@@ -38,6 +40,7 @@ case class V2MultipleResultsRequest(
   @Min(1) @Max(100) @QueryParam pageSize: Option[Int],
   @QueryParam include: Option[V2WorksIncludes],
   @QueryParam query: Option[String],
+  @QueryParam workType: Option[String],
   @QueryParam _index: Option[String],
   request: Request
 ) extends MultipleResultsRequest[V2WorksIncludes]

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -61,7 +61,8 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient,
           .from(from)
       }
 
-  private def buildQuery(queryString: Option[String], workType: Option[String]): BoolQueryDefinition = {
+  private def buildQuery(queryString: Option[String],
+                         workType: Option[String]): BoolQueryDefinition = {
     val queries = List(
       queryString.map { simpleStringQuery }
     ).flatten

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -31,7 +31,12 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient,
     elasticClient
       .execute {
         search(s"$indexName/$documentType")
-          .query(termQuery("type", "IdentifiedWork"))
+          .query(
+            buildQuery(
+              queryString = None,
+              workType = workType
+            )
+          )
           .sortBy(fieldSort(sortByField))
           .limit(limit)
           .from(from)

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -60,7 +60,8 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient,
           .from(from)
       }
 
-  private def buildQuery(queryString: Option[String], workType: Option[String]): BoolQueryDefinition = {
+  private def buildQuery(queryString: Option[String],
+                         workType: Option[String]): BoolQueryDefinition = {
     val maybeQueries = List(
       queryString.map { simpleStringQuery },
       workType.map { termQuery("workType.id", _) }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -24,6 +24,7 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient,
       }
 
   def listResults(sortByField: String,
+                  workType: Option[String] = None,
                   indexName: String,
                   limit: Int = 10,
                   from: Int = 0): Future[SearchResponse] =
@@ -37,6 +38,7 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient,
       }
 
   def simpleStringQueryResults(queryString: String,
+                               workType: Option[String] = None,
                                limit: Int = 10,
                                from: Int = 0,
                                indexName: String): Future[SearchResponse] =

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -32,6 +32,7 @@ class WorksService @Inject()(
     searchService
       .listResults(
         sortByField = "canonicalId",
+        workType = workType,
         limit = pageSize,
         from = (pageNumber - 1) * pageSize,
         indexName = indexName
@@ -53,6 +54,7 @@ class WorksService @Inject()(
     searchService
       .simpleStringQueryResults(
         query,
+        workType = workType,
         limit = pageSize,
         from = (pageNumber - 1) * pageSize,
         indexName = indexName

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -26,6 +26,7 @@ class WorksService @Inject()(
       }
 
   def listWorks(indexName: String,
+                workType: Option[String] = None,
                 pageSize: Int = apiConfig.defaultPageSize,
                 pageNumber: Int = 1): Future[ResultList] =
     searchService
@@ -45,6 +46,7 @@ class WorksService @Inject()(
       }
 
   def searchWorks(query: String,
+                  workType: Option[String] = None,
                   indexName: String,
                   pageSize: Int = apiConfig.defaultPageSize,
                   pageNumber: Int = 1): Future[ResultList] =

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/responses/ResultListResponseTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/responses/ResultListResponseTest.scala
@@ -26,6 +26,7 @@ class ResultListResponseTest extends FunSpec with Matchers {
     pageSize = Some(displayResultList.pageSize),
     includes = None,
     query = None,
+    workType = None,
     _index = None,
     request = Request(method = Method.Get, uri = requestUri)
   )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -31,12 +31,12 @@ class ElasticsearchServiceTest
 
         withElasticsearchService(indexName = indexName, itemType = itemType) {
           searchService =>
-            val searchResultFuture = searchService.simpleStringQueryResults(
+            val searchResponseFuture = searchService.simpleStringQueryResults(
               queryString = "Aegean",
               indexName = indexName
             )
 
-            whenReady(searchResultFuture) { response =>
+            whenReady(searchResponseFuture) { response =>
               searchResponseToWorks(response) shouldBe List(work1)
             }
         }
@@ -59,13 +59,13 @@ class ElasticsearchServiceTest
 
         withElasticsearchService(indexName = indexName, itemType = itemType) {
           searchService =>
-            val searchResultFuture = searchService.simpleStringQueryResults(
+            val searchResponseFuture = searchService.simpleStringQueryResults(
               queryString = "artichokes",
               workType = Some("b"),
               indexName = indexName
             )
 
-            whenReady(searchResultFuture) { response =>
+            whenReady(searchResponseFuture) { response =>
               searchResponseToWorks(response) shouldBe List(workWithCorrectWorkType)
             }
         }
@@ -214,19 +214,14 @@ class ElasticsearchServiceTest
   ) = {
     withElasticsearchService(indexName = indexName, itemType = itemType) {
       searchService =>
-        val searchResultFuture = searchService.listResults(
+        val searchResponseFuture = searchService.listResults(
           sortByField = "canonicalId",
           indexName = indexName,
           limit = limit,
           from = from
         )
-        whenReady(searchResultFuture) { result =>
-          result.hits should have size expectedWorks.length
-          val returnedWorks = result.hits.hits
-            .map { h: SearchHit =>
-              jsonToIdentifiedBaseWork(h.sourceAsString)
-            }
-          returnedWorks.toList should contain theSameElementsAs expectedWorks
+        whenReady(searchResponseFuture) { response =>
+          searchResponseToWorks(response) should contain theSameElementsAs expectedWorks
         }
     }
   }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -196,6 +196,29 @@ class ElasticsearchServiceTest
         )
       }
     }
+
+    it("filters list results by workType") {
+      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+        val workWithCorrectWorkType = createIdentifiedWorkWith(
+          title = "Animated artichokes", workType = Some(WorkType(id = "b", label = "Books"))
+        )
+        val workWithWrongTitle = createIdentifiedWorkWith(
+          title = "Bouncing bananas", workType = Some(WorkType(id = "b", label = "Books"))
+        )
+        val workWithWrongWorkType = createIdentifiedWorkWith(
+          title = "Animated artichokes", workType = Some(WorkType(id = "m", label = "Manuscripts"))
+        )
+
+        insertIntoElasticsearch(indexName, itemType, workWithCorrectWorkType, workWithWrongTitle, workWithWrongWorkType)
+
+        assertSliceIsCorrect(
+          indexName = indexName,
+          limit = 10,
+          from = 0,
+          expectedWorks = List(workWithCorrectWorkType)
+        )
+      }
+    }
   }
 
   private def populateElasticsearch(indexName: String): List[IdentifiedWork] = {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -43,7 +43,7 @@ class ElasticsearchServiceTest
       }
     }
 
-    it("finds results when filtering by workType") {
+    it("filters search results by workType") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
         val workWithCorrectWorkType = createIdentifiedWorkWith(
           title = "Animated artichokes", workType = Some(WorkType(id = "b", label = "Books"))

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -5,7 +5,11 @@ import com.sksamuel.elastic4s.http.search.{SearchHit, SearchResponse}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, IdentifiedWork, WorkType}
+import uk.ac.wellcome.models.work.internal.{
+  IdentifiedBaseWork,
+  IdentifiedWork,
+  WorkType
+}
 import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.api.fixtures.ElasticsearchServiceFixture
 
@@ -46,16 +50,24 @@ class ElasticsearchServiceTest
     it("filters search results by workType") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
         val workWithCorrectWorkType = createIdentifiedWorkWith(
-          title = "Animated artichokes", workType = Some(WorkType(id = "b", label = "Books"))
+          title = "Animated artichokes",
+          workType = Some(WorkType(id = "b", label = "Books"))
         )
         val workWithWrongTitle = createIdentifiedWorkWith(
-          title = "Bouncing bananas", workType = Some(WorkType(id = "b", label = "Books"))
+          title = "Bouncing bananas",
+          workType = Some(WorkType(id = "b", label = "Books"))
         )
         val workWithWrongWorkType = createIdentifiedWorkWith(
-          title = "Animated artichokes", workType = Some(WorkType(id = "m", label = "Manuscripts"))
+          title = "Animated artichokes",
+          workType = Some(WorkType(id = "m", label = "Manuscripts"))
         )
 
-        insertIntoElasticsearch(indexName, itemType, workWithCorrectWorkType, workWithWrongTitle, workWithWrongWorkType)
+        insertIntoElasticsearch(
+          indexName,
+          itemType,
+          workWithCorrectWorkType,
+          workWithWrongTitle,
+          workWithWrongWorkType)
 
         withElasticsearchService(indexName = indexName, itemType = itemType) {
           searchService =>
@@ -66,7 +78,8 @@ class ElasticsearchServiceTest
             )
 
             whenReady(searchResponseFuture) { response =>
-              searchResponseToWorks(response) shouldBe List(workWithCorrectWorkType)
+              searchResponseToWorks(response) shouldBe List(
+                workWithCorrectWorkType)
             }
         }
       }
@@ -200,16 +213,24 @@ class ElasticsearchServiceTest
     it("filters list results by workType") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
         val work1 = createIdentifiedWorkWith(
-          title = "Animated artichokes", workType = Some(WorkType(id = "b", label = "Books"))
+          title = "Animated artichokes",
+          workType = Some(WorkType(id = "b", label = "Books"))
         )
         val work2 = createIdentifiedWorkWith(
-          title = "Bouncing bananas", workType = Some(WorkType(id = "b", label = "Books"))
+          title = "Bouncing bananas",
+          workType = Some(WorkType(id = "b", label = "Books"))
         )
         val workWithWrongWorkType = createIdentifiedWorkWith(
-          title = "Animated artichokes", workType = Some(WorkType(id = "m", label = "Manuscripts"))
+          title = "Animated artichokes",
+          workType = Some(WorkType(id = "m", label = "Manuscripts"))
         )
 
-        insertIntoElasticsearch(indexName, itemType, work1, work2, workWithWrongWorkType)
+        insertIntoElasticsearch(
+          indexName,
+          itemType,
+          work1,
+          work2,
+          workWithWrongWorkType)
 
         assertSliceIsCorrect(
           workType = Some("b"),
@@ -251,12 +272,11 @@ class ElasticsearchServiceTest
         }
     }
 
-  private def searchResponseToWorks(response: SearchResponse): List[IdentifiedBaseWork] =
-    response
-      .hits
-      .hits
-      .map { h: SearchHit => jsonToIdentifiedBaseWork(h.sourceAsString) }
-      .toList
+  private def searchResponseToWorks(
+    response: SearchResponse): List[IdentifiedBaseWork] =
+    response.hits.hits.map { h: SearchHit =>
+      jsonToIdentifiedBaseWork(h.sourceAsString)
+    }.toList
 
   private def jsonToIdentifiedBaseWork(document: String): IdentifiedBaseWork =
     fromJson[IdentifiedBaseWork](document).get

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -80,20 +80,28 @@ class WorksServiceTest
 
     it("filters records by workType") {
       val work1 = createIdentifiedWorkWith(
-        title = "Animated artichokes", workType = Some(WorkType(id = "b", label = "Books"))
+        title = "Animated artichokes",
+        workType = Some(WorkType(id = "b", label = "Books"))
       )
       val work2 = createIdentifiedWorkWith(
-        title = "Bouncing bananas", workType = Some(WorkType(id = "b", label = "Books"))
+        title = "Bouncing bananas",
+        workType = Some(WorkType(id = "b", label = "Books"))
       )
       val workWithWrongWorkType = createIdentifiedWorkWith(
-        title = "Animated artichokes", workType = Some(WorkType(id = "m", label = "Manuscripts"))
+        title = "Animated artichokes",
+        workType = Some(WorkType(id = "m", label = "Manuscripts"))
       )
 
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
         withElasticsearchService(indexName = indexName, itemType = itemType) {
           searchService =>
             withWorksService(searchService) { worksService =>
-              insertIntoElasticsearch(indexName, itemType, work1, work2, workWithWrongWorkType)
+              insertIntoElasticsearch(
+                indexName,
+                itemType,
+                work1,
+                work2,
+                workWithWrongWorkType)
 
               val future = worksService.listWorks(
                 indexName = indexName,
@@ -101,7 +109,9 @@ class WorksServiceTest
               )
 
               whenReady(future) { resultList =>
-                resultList.results should contain theSameElementsAs List(work1, work2)
+                resultList.results should contain theSameElementsAs List(
+                  work1,
+                  work2)
               }
             }
         }
@@ -219,20 +229,28 @@ class WorksServiceTest
 
     it("filters searches by workType") {
       val matchingWork = createIdentifiedWorkWith(
-        title = "Animated artichokes", workType = Some(WorkType(id = "b", label = "Books"))
+        title = "Animated artichokes",
+        workType = Some(WorkType(id = "b", label = "Books"))
       )
       val workWithWrongTitle = createIdentifiedWorkWith(
-        title = "Bouncing bananas", workType = Some(WorkType(id = "b", label = "Books"))
+        title = "Bouncing bananas",
+        workType = Some(WorkType(id = "b", label = "Books"))
       )
       val workWithWrongWorkType = createIdentifiedWorkWith(
-        title = "Animated artichokes", workType = Some(WorkType(id = "m", label = "Manuscripts"))
+        title = "Animated artichokes",
+        workType = Some(WorkType(id = "m", label = "Manuscripts"))
       )
 
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
         withElasticsearchService(indexName = indexName, itemType = itemType) {
           searchService =>
             withWorksService(searchService) { worksService =>
-              insertIntoElasticsearch(indexName, itemType, matchingWork, workWithWrongTitle, workWithWrongWorkType)
+              insertIntoElasticsearch(
+                indexName,
+                itemType,
+                matchingWork,
+                workWithWrongTitle,
+                workWithWrongWorkType)
 
               val searchForEmu = worksService.searchWorks(
                 query = "artichokes",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -18,165 +18,171 @@ class WorksServiceTest
 
   val itemType = "work"
 
-  it("gets records in Elasticsearch") {
-    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withElasticsearchService(indexName = indexName, itemType = itemType) {
-        searchService =>
-          withWorksService(searchService) { worksService =>
-            val works = createIdentifiedWorks(count = 2)
+  describe("listWorks") {
+    it("gets records in Elasticsearch") {
+      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+        withElasticsearchService(indexName = indexName, itemType = itemType) {
+          searchService =>
+            withWorksService(searchService) { worksService =>
+              val works = createIdentifiedWorks(count = 2)
 
-            insertIntoElasticsearch(indexName, itemType, works: _*)
+              insertIntoElasticsearch(indexName, itemType, works: _*)
 
-            val future = worksService.listWorks(indexName = indexName)
+              val future = worksService.listWorks(indexName = indexName)
 
-            whenReady(future) { resultList =>
-              resultList.results should contain theSameElementsAs works
+              whenReady(future) { resultList =>
+                resultList.results should contain theSameElementsAs works
+              }
             }
-          }
+        }
+      }
+    }
+
+    it("returns 0 pages when no results are available") {
+      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+        withElasticsearchService(indexName = indexName, itemType = itemType) {
+          searchService =>
+            withWorksService(searchService) { worksService =>
+              val displayWorksFuture =
+                worksService.listWorks(indexName = indexName, pageSize = 10)
+
+              whenReady(displayWorksFuture) { works =>
+                works.totalResults shouldBe 0
+              }
+            }
+        }
+      }
+    }
+
+    it("returns an empty result set when asked for a page that does not exist") {
+      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+        withElasticsearchService(indexName = indexName, itemType = itemType) {
+          searchService =>
+            withWorksService(searchService) { worksService =>
+              val works = createIdentifiedWorks(count = 3)
+
+              insertIntoElasticsearch(indexName, itemType, works: _*)
+
+              val displayWorksFuture =
+                worksService.listWorks(
+                  indexName = indexName,
+                  pageSize = 1,
+                  pageNumber = 4)
+
+              whenReady(displayWorksFuture) { receivedWorks =>
+                receivedWorks.results shouldBe empty
+              }
+            }
+        }
       }
     }
   }
 
-  it("gets a DisplayWork by id") {
-    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withElasticsearchService(indexName = indexName, itemType = itemType) {
-        searchService =>
-          withWorksService(searchService) { worksService =>
-            val work = createIdentifiedWork
+  describe("findWorkById") {
+    it("gets a DisplayWork by id") {
+      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+        withElasticsearchService(indexName = indexName, itemType = itemType) {
+          searchService =>
+            withWorksService(searchService) { worksService =>
+              val work = createIdentifiedWork
 
-            insertIntoElasticsearch(indexName, itemType, work)
+              insertIntoElasticsearch(indexName, itemType, work)
 
-            val recordsFuture =
-              worksService.findWorkById(
-                canonicalId = work.canonicalId,
+              val recordsFuture =
+                worksService.findWorkById(
+                  canonicalId = work.canonicalId,
+                  indexName = indexName
+                )
+
+              whenReady(recordsFuture) { records =>
+                records.isDefined shouldBe true
+                records.get shouldBe work
+              }
+            }
+        }
+      }
+    }
+
+    it("returns a future of None if it cannot get a record by id") {
+      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+        withElasticsearchService(indexName = indexName, itemType = itemType) {
+          searchService =>
+            withWorksService(searchService) { worksService =>
+              val recordsFuture = worksService.findWorkById(
+                canonicalId = "1234",
                 indexName = indexName
               )
 
-            whenReady(recordsFuture) { records =>
-              records.isDefined shouldBe true
-              records.get shouldBe work
+              whenReady(recordsFuture) { record =>
+                record shouldBe None
+              }
             }
-          }
+        }
       }
     }
   }
 
-  it("only finds results that match a query if doing a full-text search") {
-    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withElasticsearchService(indexName = indexName, itemType = itemType) {
-        searchService =>
-          withWorksService(searchService) { worksService =>
-            val workDodo = createIdentifiedWorkWith(
-              title = "A drawing of a dodo"
-            )
-            val workMouse = createIdentifiedWorkWith(
-              title = "A mezzotint of a mouse"
-            )
+  describe("searchWorks") {
+    it("only finds results that match a query if doing a full-text search") {
+      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+        withElasticsearchService(indexName = indexName, itemType = itemType) {
+          searchService =>
+            withWorksService(searchService) { worksService =>
+              val workDodo = createIdentifiedWorkWith(
+                title = "A drawing of a dodo"
+              )
+              val workMouse = createIdentifiedWorkWith(
+                title = "A mezzotint of a mouse"
+              )
 
-            insertIntoElasticsearch(indexName, itemType, workDodo, workMouse)
+              insertIntoElasticsearch(indexName, itemType, workDodo, workMouse)
 
-            val searchForCat = worksService.searchWorks(
-              query = "cat",
-              indexName = indexName
-            )
+              val searchForCat = worksService.searchWorks(
+                query = "cat",
+                indexName = indexName
+              )
 
-            whenReady(searchForCat) { works =>
-              works.results should have size 0
+              whenReady(searchForCat) { works =>
+                works.results should have size 0
+              }
+
+              val searchForDodo = worksService.searchWorks(
+                query = "dodo",
+                indexName = indexName
+              )
+
+              whenReady(searchForDodo) { works =>
+                works.results should have size 1
+                works.results.head shouldBe workDodo
+              }
             }
-
-            val searchForDodo = worksService.searchWorks(
-              query = "dodo",
-              indexName = indexName
-            )
-
-            whenReady(searchForDodo) { works =>
-              works.results should have size 1
-              works.results.head shouldBe workDodo
-            }
-          }
+        }
       }
     }
-  }
 
-  it("returns a future of None if it cannot get a record by id") {
-    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withElasticsearchService(indexName = indexName, itemType = itemType) {
-        searchService =>
-          withWorksService(searchService) { worksService =>
-            val recordsFuture = worksService.findWorkById(
-              canonicalId = "1234",
-              indexName = indexName
-            )
+    it(
+      "doesn't throw an exception if passed an invalid query string for full-text search") {
+      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+        withElasticsearchService(indexName = indexName, itemType = itemType) {
+          searchService =>
+            withWorksService(searchService) { worksService =>
+              val workEmu = createIdentifiedWorkWith(
+                title = "An etching of an emu"
+              )
+              insertIntoElasticsearch(indexName, itemType, workEmu)
 
-            whenReady(recordsFuture) { record =>
-              record shouldBe None
+              val searchForEmu = worksService.searchWorks(
+                query =
+                  "emu \"unmatched quotes are a lexical error in the Elasticsearch parser",
+                indexName = indexName
+              )
+
+              whenReady(searchForEmu) { works =>
+                works.results should have size 1
+                works.results.head shouldBe workEmu
+              }
             }
-          }
-      }
-    }
-  }
-
-  it("returns 0 pages when no results are available") {
-    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withElasticsearchService(indexName = indexName, itemType = itemType) {
-        searchService =>
-          withWorksService(searchService) { worksService =>
-            val displayWorksFuture =
-              worksService.listWorks(indexName = indexName, pageSize = 10)
-
-            whenReady(displayWorksFuture) { works =>
-              works.totalResults shouldBe 0
-            }
-          }
-      }
-    }
-  }
-
-  it("returns an empty result set when asked for a page that does not exist") {
-    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withElasticsearchService(indexName = indexName, itemType = itemType) {
-        searchService =>
-          withWorksService(searchService) { worksService =>
-            val works = createIdentifiedWorks(count = 3)
-
-            insertIntoElasticsearch(indexName, itemType, works: _*)
-
-            val displayWorksFuture =
-              worksService.listWorks(
-                indexName = indexName,
-                pageSize = 1,
-                pageNumber = 4)
-
-            whenReady(displayWorksFuture) { receivedWorks =>
-              receivedWorks.results shouldBe empty
-            }
-          }
-      }
-    }
-  }
-
-  it(
-    "doesn't throw an exception if passed an invalid query string for full-text search") {
-    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withElasticsearchService(indexName = indexName, itemType = itemType) {
-        searchService =>
-          withWorksService(searchService) { worksService =>
-            val workEmu = createIdentifiedWorkWith(
-              title = "An etching of an emu"
-            )
-            insertIntoElasticsearch(indexName, itemType, workEmu)
-
-            val searchForEmu = worksService.searchWorks(
-              query =
-                "emu \"unmatched quotes are a lexical error in the Elasticsearch parser",
-              indexName = indexName
-            )
-
-            whenReady(searchForEmu) { works =>
-              works.results should have size 1
-              works.results.head shouldBe workEmu
-            }
-          }
+        }
       }
     }
   }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1FiltersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1FiltersTest.scala
@@ -1,5 +1,160 @@
 package uk.ac.wellcome.platform.api.works.v1
 
-class ApiV1FiltersTest {
+import com.twitter.finagle.http.Status
+import com.twitter.finatra.http.EmbeddedHttpServer
+import uk.ac.wellcome.models.work.internal._
 
+class ApiV1FiltersTest extends ApiV1WorksTestBase {
+
+  describe("listing works") {
+    it("ignores works with no workType") {
+      withV1Api {
+        case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+          val noWorkTypeWorks = (1 to 3).map { _ => createIdentifiedWorkWith(workType = None) }
+          val matchingWork = createIdentifiedWorkWith(workType = Some(WorkType(id = "b", label = "Books")))
+
+          val works = noWorkTypeWorks :+ matchingWork
+          insertIntoElasticsearch(indexNameV1, itemType, works: _*)
+
+          eventually {
+            server.httpGet(
+              path = s"/$apiPrefix/works?workType=b",
+              andExpect = Status.Ok,
+              withJsonBody =
+                s"""
+                   |{
+                   |  ${resultList(apiPrefix, totalResults = 1)},
+                   |  "results": [
+                   |    {
+                   |      "type": "Work",
+                   |      "id": "${matchingWork.canonicalId}",
+                   |      "title": "${matchingWork.title}",
+                   |      "workType": ${workType(matchingWork.workType.get)},
+                   |      "creators": [ ],
+                   |      "subjects": [ ],
+                   |      "genres": [ ],
+                   |      "publishers": [ ],
+                   |      "placesOfPublication": [ ]
+                   |    }
+                   |  ]
+                   |}
+          """.stripMargin
+            )
+          }
+      }
+    }
+
+    it("filters out works with a different workType") {
+      withV1Api {
+        case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+          val wrongWorkTypeWorks = (1 to 3).map { _ => createIdentifiedWorkWith(workType = Some(WorkType(id = "m", label = "Manuscripts"))) }
+          val matchingWork = createIdentifiedWorkWith(workType = Some(WorkType(id = "b", label = "Books")))
+
+          val works = wrongWorkTypeWorks :+ matchingWork
+          insertIntoElasticsearch(indexNameV1, itemType, works: _*)
+
+          eventually {
+            server.httpGet(
+              path = s"/$apiPrefix/works?workType=b",
+              andExpect = Status.Ok,
+              withJsonBody =
+                s"""
+                   |{
+                   |  ${resultList(apiPrefix, totalResults = 1)},
+                   |  "results": [
+                   |    {
+                   |      "type": "Work",
+                   |      "id": "${matchingWork.canonicalId}",
+                   |      "title": "${matchingWork.title}",
+                   |      "workType": ${workType(matchingWork.workType.get)},
+                   |      "creators": [ ],
+                   |      "subjects": [ ],
+                   |      "genres": [ ],
+                   |      "publishers": [ ],
+                   |      "placesOfPublication": [ ]
+                   |    }
+                   |  ]
+                   |}
+          """.stripMargin
+            )
+          }
+      }
+    }
+  }
+
+  describe("searching works") {
+    it("ignores works with no workType") {
+      withV1Api {
+        case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+          val noWorkTypeWorks = (1 to 3).map { _ => createIdentifiedWorkWith(title = "Amazing aubergines", workType = None) }
+          val matchingWork = createIdentifiedWorkWith(title = "Amazing aubergines", workType = Some(WorkType(id = "b", label = "Books")))
+
+          val works = noWorkTypeWorks :+ matchingWork
+          insertIntoElasticsearch(indexNameV1, itemType, works: _*)
+
+          eventually {
+            server.httpGet(
+              path = s"/$apiPrefix/works?query=aubergines&workType=b",
+              andExpect = Status.Ok,
+              withJsonBody =
+                s"""
+                   |{
+                   |  ${resultList(apiPrefix, totalResults = 1)},
+                   |  "results": [
+                   |    {
+                   |      "type": "Work",
+                   |      "id": "${matchingWork.canonicalId}",
+                   |      "title": "${matchingWork.title}",
+                   |      "workType": ${workType(matchingWork.workType.get)},
+                   |      "creators": [ ],
+                   |      "subjects": [ ],
+                   |      "genres": [ ],
+                   |      "publishers": [ ],
+                   |      "placesOfPublication": [ ]
+                   |    }
+                   |  ]
+                   |}
+          """.stripMargin
+            )
+          }
+      }
+    }
+
+    it("filters out works with a different workType") {
+      withV1Api {
+        case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+          val wrongWorkTypeWorks = (1 to 3).map { _ => createIdentifiedWorkWith(title = "Bouncing bananas", workType = Some(WorkType(id = "m", label = "Manuscripts"))) }
+          val matchingWork = createIdentifiedWorkWith(title = "Bouncing bananas", workType = Some(WorkType(id = "b", label = "Books")))
+
+          val works = wrongWorkTypeWorks :+ matchingWork
+          insertIntoElasticsearch(indexNameV1, itemType, works: _*)
+
+          eventually {
+            server.httpGet(
+              path = s"/$apiPrefix/works?query=bananas&workType=b",
+              andExpect = Status.Ok,
+              withJsonBody =
+                s"""
+                   |{
+                   |  ${resultList(apiPrefix, totalResults = 1)},
+                   |  "results": [
+                   |    {
+                   |      "type": "Work",
+                   |      "id": "${matchingWork.canonicalId}",
+                   |      "title": "${matchingWork.title}",
+                   |      "workType": ${workType(matchingWork.workType.get)},
+                   |      "creators": [ ],
+                   |      "subjects": [ ],
+                   |      "genres": [ ],
+                   |      "publishers": [ ],
+                   |      "placesOfPublication": [ ]
+                   |    }
+                   |  ]
+                   |}
+          """.stripMargin
+            )
+          }
+      }
+    }
+  }
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1FiltersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1FiltersTest.scala
@@ -1,0 +1,5 @@
+package uk.ac.wellcome.platform.api.works.v1
+
+class ApiV1FiltersTest {
+
+}

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1FiltersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1FiltersTest.scala
@@ -9,9 +9,17 @@ class ApiV1FiltersTest extends ApiV1WorksTestBase {
   describe("listing works") {
     it("ignores works with no workType") {
       withV1Api {
-        case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-          val noWorkTypeWorks = (1 to 3).map { _ => createIdentifiedWorkWith(workType = None) }
-          val matchingWork = createIdentifiedWorkWith(workType = Some(WorkType(id = "b", label = "Books")))
+        case (
+            apiPrefix,
+            indexNameV1,
+            _,
+            itemType,
+            server: EmbeddedHttpServer) =>
+          val noWorkTypeWorks = (1 to 3).map { _ =>
+            createIdentifiedWorkWith(workType = None)
+          }
+          val matchingWork = createIdentifiedWorkWith(
+            workType = Some(WorkType(id = "b", label = "Books")))
 
           val works = noWorkTypeWorks :+ matchingWork
           insertIntoElasticsearch(indexNameV1, itemType, works: _*)
@@ -20,8 +28,7 @@ class ApiV1FiltersTest extends ApiV1WorksTestBase {
             server.httpGet(
               path = s"/$apiPrefix/works?workType=b",
               andExpect = Status.Ok,
-              withJsonBody =
-                s"""
+              withJsonBody = s"""
                    |{
                    |  ${resultList(apiPrefix, totalResults = 1)},
                    |  "results": [
@@ -46,9 +53,18 @@ class ApiV1FiltersTest extends ApiV1WorksTestBase {
 
     it("filters out works with a different workType") {
       withV1Api {
-        case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-          val wrongWorkTypeWorks = (1 to 3).map { _ => createIdentifiedWorkWith(workType = Some(WorkType(id = "m", label = "Manuscripts"))) }
-          val matchingWork = createIdentifiedWorkWith(workType = Some(WorkType(id = "b", label = "Books")))
+        case (
+            apiPrefix,
+            indexNameV1,
+            _,
+            itemType,
+            server: EmbeddedHttpServer) =>
+          val wrongWorkTypeWorks = (1 to 3).map { _ =>
+            createIdentifiedWorkWith(
+              workType = Some(WorkType(id = "m", label = "Manuscripts")))
+          }
+          val matchingWork = createIdentifiedWorkWith(
+            workType = Some(WorkType(id = "b", label = "Books")))
 
           val works = wrongWorkTypeWorks :+ matchingWork
           insertIntoElasticsearch(indexNameV1, itemType, works: _*)
@@ -57,8 +73,7 @@ class ApiV1FiltersTest extends ApiV1WorksTestBase {
             server.httpGet(
               path = s"/$apiPrefix/works?workType=b",
               andExpect = Status.Ok,
-              withJsonBody =
-                s"""
+              withJsonBody = s"""
                    |{
                    |  ${resultList(apiPrefix, totalResults = 1)},
                    |  "results": [
@@ -85,9 +100,20 @@ class ApiV1FiltersTest extends ApiV1WorksTestBase {
   describe("searching works") {
     it("ignores works with no workType") {
       withV1Api {
-        case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-          val noWorkTypeWorks = (1 to 3).map { _ => createIdentifiedWorkWith(title = "Amazing aubergines", workType = None) }
-          val matchingWork = createIdentifiedWorkWith(title = "Amazing aubergines", workType = Some(WorkType(id = "b", label = "Books")))
+        case (
+            apiPrefix,
+            indexNameV1,
+            _,
+            itemType,
+            server: EmbeddedHttpServer) =>
+          val noWorkTypeWorks = (1 to 3).map { _ =>
+            createIdentifiedWorkWith(
+              title = "Amazing aubergines",
+              workType = None)
+          }
+          val matchingWork = createIdentifiedWorkWith(
+            title = "Amazing aubergines",
+            workType = Some(WorkType(id = "b", label = "Books")))
 
           val works = noWorkTypeWorks :+ matchingWork
           insertIntoElasticsearch(indexNameV1, itemType, works: _*)
@@ -96,8 +122,7 @@ class ApiV1FiltersTest extends ApiV1WorksTestBase {
             server.httpGet(
               path = s"/$apiPrefix/works?query=aubergines&workType=b",
               andExpect = Status.Ok,
-              withJsonBody =
-                s"""
+              withJsonBody = s"""
                    |{
                    |  ${resultList(apiPrefix, totalResults = 1)},
                    |  "results": [
@@ -122,9 +147,20 @@ class ApiV1FiltersTest extends ApiV1WorksTestBase {
 
     it("filters out works with a different workType") {
       withV1Api {
-        case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-          val wrongWorkTypeWorks = (1 to 3).map { _ => createIdentifiedWorkWith(title = "Bouncing bananas", workType = Some(WorkType(id = "m", label = "Manuscripts"))) }
-          val matchingWork = createIdentifiedWorkWith(title = "Bouncing bananas", workType = Some(WorkType(id = "b", label = "Books")))
+        case (
+            apiPrefix,
+            indexNameV1,
+            _,
+            itemType,
+            server: EmbeddedHttpServer) =>
+          val wrongWorkTypeWorks = (1 to 3).map { _ =>
+            createIdentifiedWorkWith(
+              title = "Bouncing bananas",
+              workType = Some(WorkType(id = "m", label = "Manuscripts")))
+          }
+          val matchingWork = createIdentifiedWorkWith(
+            title = "Bouncing bananas",
+            workType = Some(WorkType(id = "b", label = "Books")))
 
           val works = wrongWorkTypeWorks :+ matchingWork
           insertIntoElasticsearch(indexNameV1, itemType, works: _*)
@@ -133,8 +169,7 @@ class ApiV1FiltersTest extends ApiV1WorksTestBase {
             server.httpGet(
               path = s"/$apiPrefix/works?query=bananas&workType=b",
               andExpect = Status.Ok,
-              withJsonBody =
-                s"""
+              withJsonBody = s"""
                    |{
                    |  ${resultList(apiPrefix, totalResults = 1)},
                    |  "results": [

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
@@ -9,9 +9,17 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
   describe("listing works") {
     it("ignores works with no workType") {
       withV2Api {
-        case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-          val noWorkTypeWorks = (1 to 3).map { _ => createIdentifiedWorkWith(workType = None) }
-          val matchingWork = createIdentifiedWorkWith(workType = Some(WorkType(id = "b", label = "Books")))
+        case (
+            apiPrefix,
+            _,
+            indexNameV2,
+            itemType,
+            server: EmbeddedHttpServer) =>
+          val noWorkTypeWorks = (1 to 3).map { _ =>
+            createIdentifiedWorkWith(workType = None)
+          }
+          val matchingWork = createIdentifiedWorkWith(
+            workType = Some(WorkType(id = "b", label = "Books")))
 
           val works = noWorkTypeWorks :+ matchingWork
           insertIntoElasticsearch(indexNameV2, itemType, works: _*)
@@ -20,8 +28,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             server.httpGet(
               path = s"/$apiPrefix/works?workType=b",
               andExpect = Status.Ok,
-              withJsonBody =
-                s"""
+              withJsonBody = s"""
                    |{
                    |  ${resultList(apiPrefix, totalResults = 1)},
                    |  "results": [
@@ -41,9 +48,18 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("filters out works with a different workType") {
       withV2Api {
-        case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-          val wrongWorkTypeWorks = (1 to 3).map { _ => createIdentifiedWorkWith(workType = Some(WorkType(id = "m", label = "Manuscripts"))) }
-          val matchingWork = createIdentifiedWorkWith(workType = Some(WorkType(id = "b", label = "Books")))
+        case (
+            apiPrefix,
+            _,
+            indexNameV2,
+            itemType,
+            server: EmbeddedHttpServer) =>
+          val wrongWorkTypeWorks = (1 to 3).map { _ =>
+            createIdentifiedWorkWith(
+              workType = Some(WorkType(id = "m", label = "Manuscripts")))
+          }
+          val matchingWork = createIdentifiedWorkWith(
+            workType = Some(WorkType(id = "b", label = "Books")))
 
           val works = wrongWorkTypeWorks :+ matchingWork
           insertIntoElasticsearch(indexNameV2, itemType, works: _*)
@@ -52,8 +68,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             server.httpGet(
               path = s"/$apiPrefix/works?workType=b",
               andExpect = Status.Ok,
-              withJsonBody =
-                s"""
+              withJsonBody = s"""
                    |{
                    |  ${resultList(apiPrefix, totalResults = 1)},
                    |  "results": [
@@ -75,9 +90,20 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
   describe("searching works") {
     it("ignores works with no workType") {
       withV2Api {
-        case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-          val noWorkTypeWorks = (1 to 3).map { _ => createIdentifiedWorkWith(title = "Amazing aubergines", workType = None) }
-          val matchingWork = createIdentifiedWorkWith(title = "Amazing aubergines", workType = Some(WorkType(id = "b", label = "Books")))
+        case (
+            apiPrefix,
+            _,
+            indexNameV2,
+            itemType,
+            server: EmbeddedHttpServer) =>
+          val noWorkTypeWorks = (1 to 3).map { _ =>
+            createIdentifiedWorkWith(
+              title = "Amazing aubergines",
+              workType = None)
+          }
+          val matchingWork = createIdentifiedWorkWith(
+            title = "Amazing aubergines",
+            workType = Some(WorkType(id = "b", label = "Books")))
 
           val works = noWorkTypeWorks :+ matchingWork
           insertIntoElasticsearch(indexNameV2, itemType, works: _*)
@@ -86,8 +112,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             server.httpGet(
               path = s"/$apiPrefix/works?query=aubergines&workType=b",
               andExpect = Status.Ok,
-              withJsonBody =
-                s"""
+              withJsonBody = s"""
                    |{
                    |  ${resultList(apiPrefix, totalResults = 1)},
                    |  "results": [
@@ -107,9 +132,20 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("filters out works with a different workType") {
       withV2Api {
-        case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-          val wrongWorkTypeWorks = (1 to 3).map { _ => createIdentifiedWorkWith(title = "Bouncing bananas", workType = Some(WorkType(id = "m", label = "Manuscripts"))) }
-          val matchingWork = createIdentifiedWorkWith(title = "Bouncing bananas", workType = Some(WorkType(id = "b", label = "Books")))
+        case (
+            apiPrefix,
+            _,
+            indexNameV2,
+            itemType,
+            server: EmbeddedHttpServer) =>
+          val wrongWorkTypeWorks = (1 to 3).map { _ =>
+            createIdentifiedWorkWith(
+              title = "Bouncing bananas",
+              workType = Some(WorkType(id = "m", label = "Manuscripts")))
+          }
+          val matchingWork = createIdentifiedWorkWith(
+            title = "Bouncing bananas",
+            workType = Some(WorkType(id = "b", label = "Books")))
 
           val works = wrongWorkTypeWorks :+ matchingWork
           insertIntoElasticsearch(indexNameV2, itemType, works: _*)
@@ -118,8 +154,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             server.httpGet(
               path = s"/$apiPrefix/works?query=bananas&workType=b",
               andExpect = Status.Ok,
-              withJsonBody =
-                s"""
+              withJsonBody = s"""
                    |{
                    |  ${resultList(apiPrefix, totalResults = 1)},
                    |  "results": [

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
@@ -1,0 +1,140 @@
+package uk.ac.wellcome.platform.api.works.v2
+
+import com.twitter.finagle.http.Status
+import com.twitter.finatra.http.EmbeddedHttpServer
+import uk.ac.wellcome.models.work.internal._
+
+class ApiV2FiltersTest extends ApiV2WorksTestBase {
+
+  describe("listing works") {
+    it("ignores works with no workType") {
+      withV2Api {
+        case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+          val noWorkTypeWorks = (1 to 3).map { _ => createIdentifiedWorkWith(workType = None) }
+          val matchingWork = createIdentifiedWorkWith(workType = Some(WorkType(id = "b", label = "Books")))
+
+          val works = noWorkTypeWorks :+ matchingWork
+          insertIntoElasticsearch(indexNameV2, itemType, works: _*)
+
+          eventually {
+            server.httpGet(
+              path = s"/$apiPrefix/works?workType=b",
+              andExpect = Status.Ok,
+              withJsonBody =
+                s"""
+                   |{
+                   |  ${resultList(apiPrefix, totalResults = 1)},
+                   |  "results": [
+                   |    {
+                   |      "type": "Work",
+                   |      "id": "${matchingWork.canonicalId}",
+                   |      "title": "${matchingWork.title}",
+                   |      "workType": ${workType(matchingWork.workType.get)}
+                   |    }
+                   |  ]
+                   |}
+          """.stripMargin
+            )
+          }
+      }
+    }
+
+    it("filters out works with a different workType") {
+      withV2Api {
+        case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+          val wrongWorkTypeWorks = (1 to 3).map { _ => createIdentifiedWorkWith(workType = Some(WorkType(id = "m", label = "Manuscripts"))) }
+          val matchingWork = createIdentifiedWorkWith(workType = Some(WorkType(id = "b", label = "Books")))
+
+          val works = wrongWorkTypeWorks :+ matchingWork
+          insertIntoElasticsearch(indexNameV2, itemType, works: _*)
+
+          eventually {
+            server.httpGet(
+              path = s"/$apiPrefix/works?workType=b",
+              andExpect = Status.Ok,
+              withJsonBody =
+                s"""
+                   |{
+                   |  ${resultList(apiPrefix, totalResults = 1)},
+                   |  "results": [
+                   |    {
+                   |      "type": "Work",
+                   |      "id": "${matchingWork.canonicalId}",
+                   |      "title": "${matchingWork.title}",
+                   |      "workType": ${workType(matchingWork.workType.get)}
+                   |    }
+                   |  ]
+                   |}
+          """.stripMargin
+            )
+          }
+      }
+    }
+  }
+
+  describe("searching works") {
+    it("ignores works with no workType") {
+      withV2Api {
+        case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+          val noWorkTypeWorks = (1 to 3).map { _ => createIdentifiedWorkWith(title = "Amazing aubergines", workType = None) }
+          val matchingWork = createIdentifiedWorkWith(title = "Amazing aubergines", workType = Some(WorkType(id = "b", label = "Books")))
+
+          val works = noWorkTypeWorks :+ matchingWork
+          insertIntoElasticsearch(indexNameV2, itemType, works: _*)
+
+          eventually {
+            server.httpGet(
+              path = s"/$apiPrefix/works?query=aubergines&workType=b",
+              andExpect = Status.Ok,
+              withJsonBody =
+                s"""
+                   |{
+                   |  ${resultList(apiPrefix, totalResults = 1)},
+                   |  "results": [
+                   |    {
+                   |      "type": "Work",
+                   |      "id": "${matchingWork.canonicalId}",
+                   |      "title": "${matchingWork.title}",
+                   |      "workType": ${workType(matchingWork.workType.get)}
+                   |    }
+                   |  ]
+                   |}
+          """.stripMargin
+            )
+          }
+      }
+    }
+
+    it("filters out works with a different workType") {
+      withV2Api {
+        case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+          val wrongWorkTypeWorks = (1 to 3).map { _ => createIdentifiedWorkWith(title = "Bouncing bananas", workType = Some(WorkType(id = "m", label = "Manuscripts"))) }
+          val matchingWork = createIdentifiedWorkWith(title = "Bouncing bananas", workType = Some(WorkType(id = "b", label = "Books")))
+
+          val works = wrongWorkTypeWorks :+ matchingWork
+          insertIntoElasticsearch(indexNameV2, itemType, works: _*)
+
+          eventually {
+            server.httpGet(
+              path = s"/$apiPrefix/works?query=bananas&workType=b",
+              andExpect = Status.Ok,
+              withJsonBody =
+                s"""
+                   |{
+                   |  ${resultList(apiPrefix, totalResults = 1)},
+                   |  "results": [
+                   |    {
+                   |      "type": "Work",
+                   |      "id": "${matchingWork.canonicalId}",
+                   |      "title": "${matchingWork.title}",
+                   |      "workType": ${workType(matchingWork.workType.get)}
+                   |    }
+                   |  ]
+                   |}
+          """.stripMargin
+            )
+          }
+      }
+    }
+  }
+}


### PR DESCRIPTION
While waiting for the Tandem Vault APIs to stabilise, I started working on this, and it fell out rather neatly. Closes #2798.

Note: the filter is implemented on both the V1 and the V2 APIs because that’s easiest and I couldn’t see a reason not to, but it wouldn’t be much more complicated to make it V2 only. @jtweed – thoughts?