### PR TITLE
Use function currying to reduce repetition in {Works,Elasticsearch}Service

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -105,12 +105,12 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
       pageNumber = request.page
     )
 
-    val curriedSearch: (WorksSearchOptions) => Future[ResultList] = request.query match {
+    def searchFunction: (WorksSearchOptions) => Future[ResultList] = request.query match {
       case Some(queryString) => worksService.searchWorks(queryString)
       case None => worksService.listWorks
     }
 
-    curriedSearch(worksSearchOptions)
+    searchFunction(worksSearchOptions)
   }
 
   private def generateSingleWorkResponse[T <: DisplayWork](

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -105,10 +105,11 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
       pageNumber = request.page
     )
 
-    def searchFunction: (WorksSearchOptions) => Future[ResultList] = request.query match {
-      case Some(queryString) => worksService.searchWorks(queryString)
-      case None => worksService.listWorks
-    }
+    def searchFunction: (WorksSearchOptions) => Future[ResultList] =
+      request.query match {
+        case Some(queryString) => worksService.searchWorks(queryString)
+        case None              => worksService.listWorks
+      }
 
     searchFunction(worksSearchOptions)
   }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -33,13 +33,15 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient,
         get(canonicalId).from(s"$indexName/$documentType")
       }
 
-  def listResults(sortByField: String): (ElasticsearchQueryOptions) => Future[SearchResponse] =
+  def listResults(sortByField: String)
+    : (ElasticsearchQueryOptions) => Future[SearchResponse] =
     executeSearch(
       maybeQueryString = None,
       sortByField = Some(sortByField)
     )
 
-  def simpleStringQueryResults(queryString: String): (ElasticsearchQueryOptions) => Future[SearchResponse] =
+  def simpleStringQueryResults(queryString: String)
+    : (ElasticsearchQueryOptions) => Future[SearchResponse] =
     executeSearch(
       maybeQueryString = Some(queryString),
       sortByField = None
@@ -60,7 +62,7 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient,
     val sortDefinitions: List[FieldSortDefinition] =
       sortByField match {
         case Some(fieldName) => List(fieldSort(fieldName))
-        case None => List()
+        case None            => List()
       }
 
     val searchDefinition: SearchDefinition =
@@ -74,9 +76,9 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient,
       .execute { searchDefinition }
   }
 
-
-  private def buildQuery(maybeQueryString: Option[String],
-                         workTypeFilter: Option[String]): BoolQueryDefinition = {
+  private def buildQuery(
+    maybeQueryString: Option[String],
+    workTypeFilter: Option[String]): BoolQueryDefinition = {
     val queries = List(
       maybeQueryString.map { simpleStringQuery }
     ).flatten

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -14,10 +14,10 @@ import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
 import scala.concurrent.Future
 
 case class ElasticsearchQueryOptions(
-  workTypeFilter: Option[String] = None,
+  workTypeFilter: Option[String],
   indexName: String,
-  limit: Int = 10,
-  from: Int = 10
+  limit: Int,
+  from: Int
 )
 
 @Singleton

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -45,8 +45,8 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient,
       sortByField = None
     )
 
-  /** Given a set of query options, but a SearchDefinition for Elasticsearch
-    * using the elastic4s query DSL.
+  /** Given a set of query options, build a SearchDefinition for Elasticsearch
+    * using the elastic4s query DSL, then execute the search.
     */
   private def executeSearch(
     maybeQueryString: Option[String],

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -18,7 +18,8 @@ case class WorksSearchOptions(
 )
 
 @Singleton
-class WorksService @Inject()(searchService: ElasticsearchService)(implicit ec: ExecutionContext) {
+class WorksService @Inject()(searchService: ElasticsearchService)(
+  implicit ec: ExecutionContext) {
 
   def findWorkById(canonicalId: String,
                    indexName: String): Future[Option[IdentifiedBaseWork]] =
@@ -32,15 +33,19 @@ class WorksService @Inject()(searchService: ElasticsearchService)(implicit ec: E
 
   def listWorks(worksSearchOptions: WorksSearchOptions): Future[ResultList] =
     searchService
-      .listResults(sortByField = "canonicalId")(toElasticsearchQueryOptions(worksSearchOptions))
+      .listResults(sortByField = "canonicalId")(
+        toElasticsearchQueryOptions(worksSearchOptions))
       .map { createResultList }
 
-  def searchWorks(query: String)(worksSearchOptions: WorksSearchOptions): Future[ResultList] =
+  def searchWorks(query: String)(
+    worksSearchOptions: WorksSearchOptions): Future[ResultList] =
     searchService
-      .simpleStringQueryResults(query)(toElasticsearchQueryOptions(worksSearchOptions))
+      .simpleStringQueryResults(query)(
+        toElasticsearchQueryOptions(worksSearchOptions))
       .map { createResultList }
 
-  private def toElasticsearchQueryOptions(worksSearchOptions: WorksSearchOptions): ElasticsearchQueryOptions =
+  private def toElasticsearchQueryOptions(
+    worksSearchOptions: WorksSearchOptions): ElasticsearchQueryOptions =
     ElasticsearchQueryOptions(
       workTypeFilter = worksSearchOptions.workTypeFilter,
       indexName = worksSearchOptions.indexName,
@@ -54,11 +59,11 @@ class WorksService @Inject()(searchService: ElasticsearchService)(implicit ec: E
       totalResults = searchResponse.totalHits
     )
 
-  private def searchResponseToWorks(searchResponse: SearchResponse): List[IdentifiedWork] =
-    searchResponse
-      .hits.hits
-      .map { h: SearchHit => jsonTo[IdentifiedWork](h.sourceAsString)}
-      .toList
+  private def searchResponseToWorks(
+    searchResponse: SearchResponse): List[IdentifiedWork] =
+    searchResponse.hits.hits.map { h: SearchHit =>
+      jsonTo[IdentifiedWork](h.sourceAsString)
+    }.toList
 
   private def jsonTo[T <: IdentifiedBaseWork](document: String)(
     implicit decoder: Decoder[T]): T =

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -11,10 +11,10 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 case class WorksSearchOptions(
-  workTypeFilter: Option[String] = None,
+  workTypeFilter: Option[String],
   indexName: String,
-  pageSize: Int = 10,
-  pageNumber: Int = 1
+  pageSize: Int,
+  pageNumber: Int
 )
 
 @Singleton

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -5,7 +5,7 @@ import com.sksamuel.elastic4s.http.search.{SearchHit, SearchResponse}
 import io.circe.Decoder
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, IdentifiedWork}
-import uk.ac.wellcome.platform.api.models.{ApiConfig, ResultList}
+import uk.ac.wellcome.platform.api.models.ResultList
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -18,9 +18,7 @@ case class WorksSearchOptions(
 )
 
 @Singleton
-class WorksService @Inject()(
-  apiConfig: ApiConfig,
-  searchService: ElasticsearchService)(implicit ec: ExecutionContext) {
+class WorksService @Inject()(searchService: ElasticsearchService)(implicit ec: ExecutionContext) {
 
   def findWorkById(canonicalId: String,
                    indexName: String): Future[Option[IdentifiedBaseWork]] =

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/WorksServiceFixture.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/WorksServiceFixture.scala
@@ -1,25 +1,15 @@
 package uk.ac.wellcome.platform.api.fixtures
 
-import org.scalatest.{Assertion, Suite}
+import org.scalatest.Suite
 import uk.ac.wellcome.platform.api.services.{ElasticsearchService, WorksService}
-import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.test.fixtures.TestWith
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait WorksServiceFixture { this: Suite =>
-  def withWorksService(searchService: ElasticsearchService)(
-    testWith: TestWith[WorksService, Assertion]) = {
-    val worksService = new WorksService(
-      apiConfig = ApiConfig(
-        host = "example.org",
-        scheme = "https",
-        defaultPageSize = 10,
-        pathPrefix = "/catalogue/works",
-        contextSuffix = "/conext.json"
-      ),
-      searchService = searchService
-    )
+  def withWorksService[R](searchService: ElasticsearchService)(
+    testWith: TestWith[WorksService, R]): R = {
+    val worksService = new WorksService(searchService = searchService)
     testWith(worksService)
   }
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -35,7 +35,8 @@ class ElasticsearchServiceTest
 
         assertSearchResultsAreCorrect(
           queryString = "Aegean",
-          queryOptions = createElasticsearchQueryOptionsWith(indexName = indexName),
+          queryOptions =
+            createElasticsearchQueryOptionsWith(indexName = indexName),
           expectedWorks = List(work1)
         )
       }
@@ -108,7 +109,8 @@ class ElasticsearchServiceTest
 
         insertIntoElasticsearch(indexName, itemType, work1, work2, work3)
 
-        val queryOptions = createElasticsearchQueryOptionsWith(indexName = indexName)
+        val queryOptions =
+          createElasticsearchQueryOptionsWith(indexName = indexName)
 
         assertListResultsAreCorrect(
           queryOptions = queryOptions,
@@ -211,7 +213,8 @@ class ElasticsearchServiceTest
         val works = visibleWorks ++ invisibleWorks
         insertIntoElasticsearch(indexName, itemType, works: _*)
 
-        val queryOptions = createElasticsearchQueryOptionsWith(indexName = indexName)
+        val queryOptions =
+          createElasticsearchQueryOptionsWith(indexName = indexName)
 
         assertListResultsAreCorrect(
           queryOptions = queryOptions,
@@ -268,28 +271,30 @@ class ElasticsearchServiceTest
     queryOptions: ElasticsearchQueryOptions,
     expectedWorks: List[IdentifiedWork]
   ): Assertion =
-    withElasticsearchService(indexName = queryOptions.indexName, itemType = itemType) {
-      searchService =>
-        val searchResponseFuture = searchService
-          .simpleStringQueryResults(queryString)(queryOptions)
+    withElasticsearchService(
+      indexName = queryOptions.indexName,
+      itemType = itemType) { searchService =>
+      val searchResponseFuture = searchService
+        .simpleStringQueryResults(queryString)(queryOptions)
 
-        whenReady(searchResponseFuture) { response =>
-          searchResponseToWorks(response) should contain theSameElementsAs expectedWorks
-        }
+      whenReady(searchResponseFuture) { response =>
+        searchResponseToWorks(response) should contain theSameElementsAs expectedWorks
+      }
     }
 
   private def assertListResultsAreCorrect(
     queryOptions: ElasticsearchQueryOptions,
     expectedWorks: Seq[IdentifiedWork]
   ): Assertion =
-    withElasticsearchService(indexName = queryOptions.indexName, itemType = itemType) {
-      searchService =>
-        val listResponseFuture = searchService
-          .listResults(sortByField = "canonicalId")(queryOptions)
+    withElasticsearchService(
+      indexName = queryOptions.indexName,
+      itemType = itemType) { searchService =>
+      val listResponseFuture = searchService
+        .listResults(sortByField = "canonicalId")(queryOptions)
 
-        whenReady(listResponseFuture) { response =>
-          searchResponseToWorks(response) should contain theSameElementsAs expectedWorks
-        }
+      whenReady(listResponseFuture) { response =>
+        searchResponseToWorks(response) should contain theSameElementsAs expectedWorks
+      }
     }
 
   private def createElasticsearchQueryOptionsWith(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -35,7 +35,7 @@ class ElasticsearchServiceTest
 
         assertSearchResultsAreCorrect(
           queryString = "Aegean",
-          queryOptions = ElasticsearchQueryOptions(indexName = indexName),
+          queryOptions = createElasticsearchQueryOptionsWith(indexName = indexName),
           expectedWorks = List(work1)
         )
       }
@@ -65,7 +65,7 @@ class ElasticsearchServiceTest
 
         assertSearchResultsAreCorrect(
           queryString = "artichokes",
-          queryOptions = ElasticsearchQueryOptions(
+          queryOptions = createElasticsearchQueryOptionsWith(
             workTypeFilter = Some("b"),
             indexName = indexName
           ),
@@ -108,7 +108,7 @@ class ElasticsearchServiceTest
 
         insertIntoElasticsearch(indexName, itemType, work1, work2, work3)
 
-        val queryOptions = ElasticsearchQueryOptions(indexName = indexName)
+        val queryOptions = createElasticsearchQueryOptionsWith(indexName = indexName)
 
         assertListResultsAreCorrect(
           queryOptions = queryOptions,
@@ -125,7 +125,7 @@ class ElasticsearchServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
         val works = populateElasticsearch(indexName)
 
-        val queryOptions = ElasticsearchQueryOptions(
+        val queryOptions = createElasticsearchQueryOptionsWith(
           indexName = indexName,
           limit = works.length + 1
         )
@@ -141,7 +141,7 @@ class ElasticsearchServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
         val works = populateElasticsearch(indexName)
 
-        val queryOptions = ElasticsearchQueryOptions(
+        val queryOptions = createElasticsearchQueryOptionsWith(
           indexName = indexName,
           limit = 4
         )
@@ -157,7 +157,7 @@ class ElasticsearchServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
         val works = populateElasticsearch(indexName)
 
-        val queryOptions = ElasticsearchQueryOptions(
+        val queryOptions = createElasticsearchQueryOptionsWith(
           indexName = indexName,
           limit = 4,
           from = 3
@@ -174,7 +174,7 @@ class ElasticsearchServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
         val works = populateElasticsearch(indexName)
 
-        val queryOptions = ElasticsearchQueryOptions(
+        val queryOptions = createElasticsearchQueryOptionsWith(
           indexName = indexName,
           limit = 7,
           from = 5
@@ -191,7 +191,7 @@ class ElasticsearchServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
         val works = populateElasticsearch(indexName)
 
-        val queryOptions = ElasticsearchQueryOptions(
+        val queryOptions = createElasticsearchQueryOptionsWith(
           indexName = indexName,
           from = works.length * 2
         )
@@ -211,7 +211,7 @@ class ElasticsearchServiceTest
         val works = visibleWorks ++ invisibleWorks
         insertIntoElasticsearch(indexName, itemType, works: _*)
 
-        val queryOptions = ElasticsearchQueryOptions(indexName = indexName)
+        val queryOptions = createElasticsearchQueryOptionsWith(indexName = indexName)
 
         assertListResultsAreCorrect(
           queryOptions = queryOptions,
@@ -242,7 +242,7 @@ class ElasticsearchServiceTest
           work2,
           workWithWrongWorkType)
 
-        val queryOptions = ElasticsearchQueryOptions(
+        val queryOptions = createElasticsearchQueryOptionsWith(
           workTypeFilter = Some("b"),
           indexName = indexName
         )
@@ -291,6 +291,19 @@ class ElasticsearchServiceTest
           searchResponseToWorks(response) should contain theSameElementsAs expectedWorks
         }
     }
+
+  private def createElasticsearchQueryOptionsWith(
+    workTypeFilter: Option[String] = None,
+    indexName: String,
+    limit: Int = 10,
+    from: Int = 0
+  ): ElasticsearchQueryOptions =
+    ElasticsearchQueryOptions(
+      workTypeFilter = workTypeFilter,
+      indexName = indexName,
+      limit = limit,
+      from = from
+    )
 
   private def searchResponseToWorks(
     response: SearchResponse): List[IdentifiedBaseWork] =

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -183,7 +183,7 @@ class WorksServiceTest
               insertIntoElasticsearch(indexName, itemType, workDodo, workMouse)
 
               val searchForCat = worksService.searchWorks(query = "cat")(
-                WorksSearchOptions(indexName = indexName)
+                createWorksSearchOptionsWith(indexName = indexName)
               )
 
               whenReady(searchForCat) { works =>

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -46,7 +46,8 @@ class WorksServiceTest
         withElasticsearchService(indexName = indexName, itemType = itemType) {
           searchService =>
             withWorksService(searchService) { worksService =>
-              val future = worksService.listWorks(createWorksSearchOptionsWith(indexName = indexName))
+              val future = worksService.listWorks(
+                createWorksSearchOptionsWith(indexName = indexName))
 
               whenReady(future) { works =>
                 works.totalResults shouldBe 0
@@ -214,9 +215,8 @@ class WorksServiceTest
               )
               insertIntoElasticsearch(indexName, itemType, workEmu)
 
-              val searchForEmu = worksService.searchWorks(
-                query =
-                  "emu \"unmatched quotes are a lexical error in the Elasticsearch parser")(
+              val searchForEmu = worksService.searchWorks(query =
+                "emu \"unmatched quotes are a lexical error in the Elasticsearch parser")(
                 createWorksSearchOptionsWith(indexName = indexName)
               )
 
@@ -254,8 +254,7 @@ class WorksServiceTest
                 workWithWrongTitle,
                 workWithWrongWorkType)
 
-              val searchForEmu = worksService.searchWorks(
-                query = "artichokes")(
+              val searchForEmu = worksService.searchWorks(query = "artichokes")(
                 createWorksSearchOptionsWith(
                   workTypeFilter = Some("b"),
                   indexName = indexName

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -29,7 +29,9 @@ class WorksServiceTest
 
               insertIntoElasticsearch(indexName, itemType, works: _*)
 
-              val future = worksService.listWorks(indexName = indexName)
+              val future = worksService.listWorks(
+                WorksSearchOptions(indexName = indexName)
+              )
 
               whenReady(future) { resultList =>
                 resultList.results should contain theSameElementsAs works
@@ -44,10 +46,9 @@ class WorksServiceTest
         withElasticsearchService(indexName = indexName, itemType = itemType) {
           searchService =>
             withWorksService(searchService) { worksService =>
-              val displayWorksFuture =
-                worksService.listWorks(indexName = indexName, pageSize = 10)
+              val future = worksService.listWorks(WorksSearchOptions(indexName = indexName))
 
-              whenReady(displayWorksFuture) { works =>
+              whenReady(future) { works =>
                 works.totalResults shouldBe 0
               }
             }
@@ -64,13 +65,14 @@ class WorksServiceTest
 
               insertIntoElasticsearch(indexName, itemType, works: _*)
 
-              val displayWorksFuture =
-                worksService.listWorks(
+              val future = worksService.listWorks(
+                WorksSearchOptions(
                   indexName = indexName,
-                  pageSize = 1,
-                  pageNumber = 4)
+                  pageNumber = 4
+                )
+              )
 
-              whenReady(displayWorksFuture) { receivedWorks =>
+              whenReady(future) { receivedWorks =>
                 receivedWorks.results shouldBe empty
               }
             }
@@ -104,8 +106,10 @@ class WorksServiceTest
                 workWithWrongWorkType)
 
               val future = worksService.listWorks(
-                indexName = indexName,
-                workType = Some("b")
+                WorksSearchOptions(
+                  workTypeFilter = Some("b"),
+                  indexName = indexName
+                )
               )
 
               whenReady(future) { resultList =>
@@ -178,18 +182,16 @@ class WorksServiceTest
 
               insertIntoElasticsearch(indexName, itemType, workDodo, workMouse)
 
-              val searchForCat = worksService.searchWorks(
-                query = "cat",
-                indexName = indexName
+              val searchForCat = worksService.searchWorks(query = "cat")(
+                WorksSearchOptions(indexName = indexName)
               )
 
               whenReady(searchForCat) { works =>
                 works.results should have size 0
               }
 
-              val searchForDodo = worksService.searchWorks(
-                query = "dodo",
-                indexName = indexName
+              val searchForDodo = worksService.searchWorks(query = "dodo")(
+                WorksSearchOptions(indexName = indexName)
               )
 
               whenReady(searchForDodo) { works =>
@@ -214,8 +216,8 @@ class WorksServiceTest
 
               val searchForEmu = worksService.searchWorks(
                 query =
-                  "emu \"unmatched quotes are a lexical error in the Elasticsearch parser",
-                indexName = indexName
+                  "emu \"unmatched quotes are a lexical error in the Elasticsearch parser")(
+                WorksSearchOptions(indexName = indexName)
               )
 
               whenReady(searchForEmu) { works =>
@@ -253,9 +255,11 @@ class WorksServiceTest
                 workWithWrongWorkType)
 
               val searchForEmu = worksService.searchWorks(
-                query = "artichokes",
-                workType = Some("b"),
-                indexName = indexName
+                query = "artichokes")(
+                WorksSearchOptions(
+                  workTypeFilter = Some("b"),
+                  indexName = indexName
+                )
               )
 
               whenReady(searchForEmu) { works =>

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -30,7 +30,7 @@ class WorksServiceTest
               insertIntoElasticsearch(indexName, itemType, works: _*)
 
               val future = worksService.listWorks(
-                WorksSearchOptions(indexName = indexName)
+                createWorksSearchOptionsWith(indexName = indexName)
               )
 
               whenReady(future) { resultList =>
@@ -46,7 +46,7 @@ class WorksServiceTest
         withElasticsearchService(indexName = indexName, itemType = itemType) {
           searchService =>
             withWorksService(searchService) { worksService =>
-              val future = worksService.listWorks(WorksSearchOptions(indexName = indexName))
+              val future = worksService.listWorks(createWorksSearchOptionsWith(indexName = indexName))
 
               whenReady(future) { works =>
                 works.totalResults shouldBe 0
@@ -66,7 +66,7 @@ class WorksServiceTest
               insertIntoElasticsearch(indexName, itemType, works: _*)
 
               val future = worksService.listWorks(
-                WorksSearchOptions(
+                createWorksSearchOptionsWith(
                   indexName = indexName,
                   pageNumber = 4
                 )
@@ -106,7 +106,7 @@ class WorksServiceTest
                 workWithWrongWorkType)
 
               val future = worksService.listWorks(
-                WorksSearchOptions(
+                createWorksSearchOptionsWith(
                   workTypeFilter = Some("b"),
                   indexName = indexName
                 )
@@ -191,7 +191,7 @@ class WorksServiceTest
               }
 
               val searchForDodo = worksService.searchWorks(query = "dodo")(
-                WorksSearchOptions(indexName = indexName)
+                createWorksSearchOptionsWith(indexName = indexName)
               )
 
               whenReady(searchForDodo) { works =>
@@ -217,7 +217,7 @@ class WorksServiceTest
               val searchForEmu = worksService.searchWorks(
                 query =
                   "emu \"unmatched quotes are a lexical error in the Elasticsearch parser")(
-                WorksSearchOptions(indexName = indexName)
+                createWorksSearchOptionsWith(indexName = indexName)
               )
 
               whenReady(searchForEmu) { works =>
@@ -256,7 +256,7 @@ class WorksServiceTest
 
               val searchForEmu = worksService.searchWorks(
                 query = "artichokes")(
-                WorksSearchOptions(
+                createWorksSearchOptionsWith(
                   workTypeFilter = Some("b"),
                   indexName = indexName
                 )
@@ -270,4 +270,17 @@ class WorksServiceTest
       }
     }
   }
+
+  private def createWorksSearchOptionsWith(
+    workTypeFilter: Option[String] = None,
+    indexName: String,
+    pageSize: Int = 10,
+    pageNumber: Int = 1
+  ): WorksSearchOptions =
+    WorksSearchOptions(
+      workTypeFilter = workTypeFilter,
+      indexName = indexName,
+      pageSize = pageSize,
+      pageNumber = pageNumber
+    )
 }


### PR DESCRIPTION
Follows #2897.

Since @jtweed pointed out we have a quite a bit of repetition in these two services, and that’s going to make adding new filters harder, I had a stab at cleaning it up. I wanted to try currying and partial functions again, and I think it’s finally “clicked”.

This patch:

* Introduces two new case classes `WorksSearchOptions` and `ElasticsearchQueryOptions`, which absorb the shared logic of things like filters, page size, index name, and so on
* Modifies the list/search methods in the services to use currying, so you pass the options separately from method-specific config
* Updates tests and so on to match

Separate from #2897 because we can add workType filtering without fixing the repetition, and I think this is substantial enough to merit its own review.

It won’t run in Travis until we merge the original PR, but I've run tests locally and it’s all green. 💚 