### PR TITLE
Pass around the ES documentType as a parameter, not a single bit of configuration

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
@@ -24,6 +24,7 @@ class V1WorksController @Inject()(
       V1WorksIncludes](
       apiConfig = apiConfig,
       indexName = elasticConfig.indexV1name,
+      documentType = elasticConfig.documentType,
       worksService = worksService
     ) {
   implicit protected val swagger = ApiV1Swagger

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
@@ -24,6 +24,7 @@ class V2WorksController @Inject()(
       V2WorksIncludes](
       apiConfig = apiConfig,
       indexName = elasticConfig.indexV2name,
+      documentType = elasticConfig.documentType,
       worksService = worksService
     ) {
   implicit protected val swagger = ApiV2Swagger

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -6,7 +6,6 @@ import io.swagger.models.parameters.QueryParameter
 import io.swagger.models.properties.StringProperty
 import io.swagger.models.{Operation, Swagger}
 import uk.ac.wellcome.display.models._
-import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
 import uk.ac.wellcome.platform.api.models._
@@ -15,7 +14,7 @@ import uk.ac.wellcome.platform.api.responses.{
   ResultListResponse,
   ResultResponse
 }
-import uk.ac.wellcome.platform.api.services.{WorksSearchOptions, WorksService}
+import uk.ac.wellcome.platform.api.services.{ElasticsearchDocumentOptions, WorksSearchOptions, WorksService}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -82,14 +81,16 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
     } { request: S =>
       val includes = request.include.getOrElse(emptyWorksIncludes)
 
+      val documentOptions = ElasticsearchDocumentOptions(
+        indexName = request._index.getOrElse(indexName),
+        documentType = documentType
+      )
+
       val contextUri =
         buildContextUri(apiConfig = apiConfig, version = version)
       for {
         maybeWork <- worksService.findWorkById(
-          canonicalId = request.id,
-          indexName = request._index.getOrElse(indexName),
-          documentType = documentType
-        )
+          canonicalId = request.id)(documentOptions)
       } yield
         generateSingleWorkResponse(
           maybeWork,
@@ -101,21 +102,24 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
   }
 
   private def getWorkList(request: M, pageSize: Int): Future[ResultList] = {
+    val documentOptions = ElasticsearchDocumentOptions(
+      indexName = request._index.getOrElse(indexName),
+      documentType = documentType
+    )
+
     val worksSearchOptions = WorksSearchOptions(
       workTypeFilter = request.workType,
-      documentType = documentType,
-      indexName = request._index.getOrElse(indexName),
       pageSize = pageSize,
       pageNumber = request.page
     )
 
-    def searchFunction: (WorksSearchOptions) => Future[ResultList] =
+    def searchFunction: (ElasticsearchDocumentOptions, WorksSearchOptions) => Future[ResultList] =
       request.query match {
         case Some(queryString) => worksService.searchWorks(queryString)
         case None              => worksService.listWorks
       }
 
-    searchFunction(worksSearchOptions)
+    searchFunction(documentOptions, worksSearchOptions)
   }
 
   private def generateSingleWorkResponse[T <: DisplayWork](

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -14,7 +14,11 @@ import uk.ac.wellcome.platform.api.responses.{
   ResultListResponse,
   ResultResponse
 }
-import uk.ac.wellcome.platform.api.services.{ElasticsearchDocumentOptions, WorksSearchOptions, WorksService}
+import uk.ac.wellcome.platform.api.services.{
+  ElasticsearchDocumentOptions,
+  WorksSearchOptions,
+  WorksService
+}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -89,8 +93,8 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
       val contextUri =
         buildContextUri(apiConfig = apiConfig, version = version)
       for {
-        maybeWork <- worksService.findWorkById(
-          canonicalId = request.id)(documentOptions)
+        maybeWork <- worksService.findWorkById(canonicalId = request.id)(
+          documentOptions)
       } yield
         generateSingleWorkResponse(
           maybeWork,
@@ -113,7 +117,8 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
       pageNumber = request.page
     )
 
-    def searchFunction: (ElasticsearchDocumentOptions, WorksSearchOptions) => Future[ResultList] =
+    def searchFunction: (ElasticsearchDocumentOptions,
+                         WorksSearchOptions) => Future[ResultList] =
       request.query match {
         case Some(queryString) => worksService.searchWorks(queryString)
         case None              => worksService.listWorks

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -9,25 +9,23 @@ import com.sksamuel.elastic4s.searches.SearchDefinition
 import com.sksamuel.elastic4s.searches.queries.BoolQueryDefinition
 import com.sksamuel.elastic4s.searches.queries.term.TermQueryDefinition
 import com.sksamuel.elastic4s.searches.sort.FieldSortDefinition
-import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
 
 import scala.concurrent.Future
 
 case class ElasticsearchQueryOptions(
   workTypeFilter: Option[String],
+  documentType: String,
   indexName: String,
   limit: Int,
   from: Int
 )
 
 @Singleton
-class ElasticsearchService @Inject()(elasticClient: HttpClient,
-                                     elasticConfig: DisplayElasticConfig) {
-
-  val documentType: String = elasticConfig.documentType
+class ElasticsearchService @Inject()(elasticClient: HttpClient) {
 
   def findResultById(canonicalId: String,
-                     indexName: String): Future[GetResponse] =
+                     indexName: String,
+                     documentType: String): Future[GetResponse] =
     elasticClient
       .execute {
         get(canonicalId).from(s"$indexName/$documentType")
@@ -66,7 +64,7 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient,
       }
 
     val searchDefinition: SearchDefinition =
-      search(s"${queryOptions.indexName}/$documentType")
+      search(s"${queryOptions.indexName}/${queryOptions.documentType}")
         .query(queryDefinition)
         .sortBy(sortDefinitions)
         .limit(queryOptions.limit)

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -26,19 +26,25 @@ case class ElasticsearchQueryOptions(
 @Singleton
 class ElasticsearchService @Inject()(elasticClient: HttpClient) {
 
-  def findResultById(canonicalId: String)(documentOptions: ElasticsearchDocumentOptions): Future[GetResponse] =
+  def findResultById(canonicalId: String)(
+    documentOptions: ElasticsearchDocumentOptions): Future[GetResponse] =
     elasticClient
       .execute {
-        get(canonicalId).from(s"${documentOptions.indexName}/${documentOptions.documentType}")
+        get(canonicalId).from(
+          s"${documentOptions.indexName}/${documentOptions.documentType}")
       }
 
-  def listResults(sortByField: String): (ElasticsearchDocumentOptions, ElasticsearchQueryOptions) => Future[SearchResponse] =
+  def listResults(sortByField: String)
+    : (ElasticsearchDocumentOptions,
+       ElasticsearchQueryOptions) => Future[SearchResponse] =
     executeSearch(
       maybeQueryString = None,
       sortByField = Some(sortByField)
     )
 
-  def simpleStringQueryResults(queryString: String): (ElasticsearchDocumentOptions, ElasticsearchQueryOptions) => Future[SearchResponse] =
+  def simpleStringQueryResults(queryString: String)
+    : (ElasticsearchDocumentOptions,
+       ElasticsearchQueryOptions) => Future[SearchResponse] =
     executeSearch(
       maybeQueryString = Some(queryString),
       sortByField = None
@@ -50,7 +56,8 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient) {
   private def executeSearch(
     maybeQueryString: Option[String],
     sortByField: Option[String]
-  )(documentOptions: ElasticsearchDocumentOptions, queryOptions: ElasticsearchQueryOptions): Future[SearchResponse] = {
+  )(documentOptions: ElasticsearchDocumentOptions,
+    queryOptions: ElasticsearchQueryOptions): Future[SearchResponse] = {
     val queryDefinition = buildQuery(
       maybeQueryString = maybeQueryString,
       workTypeFilter = queryOptions.workTypeFilter

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -20,7 +20,9 @@ case class WorksSearchOptions(
 class WorksService @Inject()(searchService: ElasticsearchService)(
   implicit ec: ExecutionContext) {
 
-  def findWorkById(canonicalId: String)(documentOptions: ElasticsearchDocumentOptions): Future[Option[IdentifiedBaseWork]] =
+  def findWorkById(canonicalId: String)(
+    documentOptions: ElasticsearchDocumentOptions)
+    : Future[Option[IdentifiedBaseWork]] =
     searchService
       .findResultById(canonicalId)(documentOptions)
       .map { result =>
@@ -29,14 +31,21 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
         else None
       }
 
-  def listWorks(documentOptions: ElasticsearchDocumentOptions, worksSearchOptions: WorksSearchOptions): Future[ResultList] =
+  def listWorks(documentOptions: ElasticsearchDocumentOptions,
+                worksSearchOptions: WorksSearchOptions): Future[ResultList] =
     searchService
-      .listResults(sortByField = "canonicalId")(documentOptions, toElasticsearchQueryOptions(worksSearchOptions))
+      .listResults(sortByField = "canonicalId")(
+        documentOptions,
+        toElasticsearchQueryOptions(worksSearchOptions))
       .map { createResultList }
 
-  def searchWorks(query: String)(documentOptions: ElasticsearchDocumentOptions, worksSearchOptions: WorksSearchOptions): Future[ResultList] =
+  def searchWorks(query: String)(
+    documentOptions: ElasticsearchDocumentOptions,
+    worksSearchOptions: WorksSearchOptions): Future[ResultList] =
     searchService
-      .simpleStringQueryResults(query)(documentOptions, toElasticsearchQueryOptions(worksSearchOptions))
+      .simpleStringQueryResults(query)(
+        documentOptions,
+        toElasticsearchQueryOptions(worksSearchOptions))
       .map { createResultList }
 
   private def toElasticsearchQueryOptions(

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -12,6 +12,7 @@ import scala.util.{Failure, Success}
 
 case class WorksSearchOptions(
   workTypeFilter: Option[String],
+  documentType: String,
   indexName: String,
   pageSize: Int,
   pageNumber: Int
@@ -22,9 +23,10 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
   implicit ec: ExecutionContext) {
 
   def findWorkById(canonicalId: String,
-                   indexName: String): Future[Option[IdentifiedBaseWork]] =
+                   indexName: String,
+                   documentType: String): Future[Option[IdentifiedBaseWork]] =
     searchService
-      .findResultById(canonicalId, indexName = indexName)
+      .findResultById(canonicalId, indexName = indexName, documentType = documentType)
       .map { result =>
         if (result.exists)
           Some(jsonTo[IdentifiedBaseWork](result.sourceAsString))
@@ -48,6 +50,7 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
     worksSearchOptions: WorksSearchOptions): ElasticsearchQueryOptions =
     ElasticsearchQueryOptions(
       workTypeFilter = worksSearchOptions.workTypeFilter,
+      documentType = worksSearchOptions.documentType,
       indexName = worksSearchOptions.indexName,
       limit = worksSearchOptions.pageSize,
       from = (worksSearchOptions.pageNumber - 1) * worksSearchOptions.pageSize

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ElasticsearchServiceFixture.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ElasticsearchServiceFixture.scala
@@ -1,23 +1,15 @@
 package uk.ac.wellcome.platform.api.fixtures
 
-import org.scalatest.{Assertion, Suite}
-import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
+import org.scalatest.Suite
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.platform.api.services.ElasticsearchService
 import uk.ac.wellcome.test.fixtures.TestWith
 
 trait ElasticsearchServiceFixture extends ElasticsearchFixtures {
   this: Suite =>
-  def withElasticsearchService(indexName: String, itemType: String)(
-    testWith: TestWith[ElasticsearchService, Assertion]) = {
-    val searchService = new ElasticsearchService(
-      elasticClient = elasticClient,
-      elasticConfig = DisplayElasticConfig(
-        documentType = itemType,
-        indexV1name = indexName,
-        indexV2name = indexName
-      )
-    )
+  def withElasticsearchService[R](
+    testWith: TestWith[ElasticsearchService, R]): R = {
+    val searchService = new ElasticsearchService(elasticClient = elasticClient)
     testWith(searchService)
   }
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -82,18 +82,17 @@ class ElasticsearchServiceTest
 
         insertIntoElasticsearch(indexName, itemType, work)
 
-        withElasticsearchService {
-          searchService =>
-            val documentOptions = createElasticsearchDocumentOptionsWith(indexName)
+        withElasticsearchService { searchService =>
+          val documentOptions = createElasticsearchDocumentOptionsWith(indexName)
 
-            val searchResultFuture: Future[GetResponse] =
-              searchService.findResultById(
-                canonicalId = work.canonicalId)(documentOptions)
+          val searchResultFuture: Future[GetResponse] =
+            searchService.findResultById(
+              canonicalId = work.canonicalId)(documentOptions)
 
-            whenReady(searchResultFuture) { result =>
-              val returnedWork = jsonToIdentifiedBaseWork(result.sourceAsString)
-              returnedWork shouldBe work
-            }
+          whenReady(searchResultFuture) { result =>
+            val returnedWork = jsonToIdentifiedBaseWork(result.sourceAsString)
+            returnedWork shouldBe work
+          }
         }
       }
     }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -83,12 +83,13 @@ class ElasticsearchServiceTest
 
         insertIntoElasticsearch(indexName, itemType, work)
 
-        withElasticsearchService(indexName = indexName, itemType = itemType) {
+        withElasticsearchService {
           searchService =>
             val searchResultFuture: Future[GetResponse] =
               searchService.findResultById(
                 canonicalId = work.canonicalId,
-                indexName = indexName
+                indexName = indexName,
+                documentType = itemType
               )
 
             whenReady(searchResultFuture) { result =>
@@ -271,9 +272,7 @@ class ElasticsearchServiceTest
     queryOptions: ElasticsearchQueryOptions,
     expectedWorks: List[IdentifiedWork]
   ): Assertion =
-    withElasticsearchService(
-      indexName = queryOptions.indexName,
-      itemType = itemType) { searchService =>
+    withElasticsearchService { searchService =>
       val searchResponseFuture = searchService
         .simpleStringQueryResults(queryString)(queryOptions)
 
@@ -286,9 +285,7 @@ class ElasticsearchServiceTest
     queryOptions: ElasticsearchQueryOptions,
     expectedWorks: Seq[IdentifiedWork]
   ): Assertion =
-    withElasticsearchService(
-      indexName = queryOptions.indexName,
-      itemType = itemType) { searchService =>
+    withElasticsearchService { searchService =>
       val listResponseFuture = searchService
         .listResults(sortByField = "canonicalId")(queryOptions)
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -302,6 +302,7 @@ class ElasticsearchServiceTest
   ): ElasticsearchQueryOptions =
     ElasticsearchQueryOptions(
       workTypeFilter = workTypeFilter,
+      documentType = itemType,
       indexName = indexName,
       limit = limit,
       from = from

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -83,11 +83,12 @@ class ElasticsearchServiceTest
         insertIntoElasticsearch(indexName, itemType, work)
 
         withElasticsearchService { searchService =>
-          val documentOptions = createElasticsearchDocumentOptionsWith(indexName)
+          val documentOptions =
+            createElasticsearchDocumentOptionsWith(indexName)
 
           val searchResultFuture: Future[GetResponse] =
-            searchService.findResultById(
-              canonicalId = work.canonicalId)(documentOptions)
+            searchService.findResultById(canonicalId = work.canonicalId)(
+              documentOptions)
 
           whenReady(searchResultFuture) { result =>
             val returnedWork = jsonToIdentifiedBaseWork(result.sourceAsString)
@@ -259,7 +260,8 @@ class ElasticsearchServiceTest
   private def assertSearchResultsAreCorrect(
     indexName: String,
     queryString: String,
-    queryOptions: ElasticsearchQueryOptions = createElasticsearchQueryOptionsWith(),
+    queryOptions: ElasticsearchQueryOptions =
+      createElasticsearchQueryOptionsWith(),
     expectedWorks: List[IdentifiedWork]
   ): Assertion =
     withElasticsearchService { searchService =>
@@ -275,7 +277,8 @@ class ElasticsearchServiceTest
 
   private def assertListResultsAreCorrect(
     indexName: String,
-    queryOptions: ElasticsearchQueryOptions = createElasticsearchQueryOptionsWith(),
+    queryOptions: ElasticsearchQueryOptions =
+      createElasticsearchQueryOptionsWith(),
     expectedWorks: Seq[IdentifiedWork]
   ): Assertion =
     withElasticsearchService { searchService =>
@@ -289,7 +292,8 @@ class ElasticsearchServiceTest
       }
     }
 
-  private def createElasticsearchDocumentOptionsWith(indexName: String): ElasticsearchDocumentOptions =
+  private def createElasticsearchDocumentOptionsWith(
+    indexName: String): ElasticsearchDocumentOptions =
     ElasticsearchDocumentOptions(
       indexName = indexName,
       documentType = itemType

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -22,7 +22,7 @@ class WorksServiceTest
   describe("listWorks") {
     it("gets records in Elasticsearch") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService(indexName = indexName, itemType = itemType) {
+        withElasticsearchService {
           searchService =>
             withWorksService(searchService) { worksService =>
               val works = createIdentifiedWorks(count = 2)
@@ -43,7 +43,7 @@ class WorksServiceTest
 
     it("returns 0 pages when no results are available") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService(indexName = indexName, itemType = itemType) {
+        withElasticsearchService {
           searchService =>
             withWorksService(searchService) { worksService =>
               val future = worksService.listWorks(
@@ -59,7 +59,7 @@ class WorksServiceTest
 
     it("returns an empty result set when asked for a page that does not exist") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService(indexName = indexName, itemType = itemType) {
+        withElasticsearchService {
           searchService =>
             withWorksService(searchService) { worksService =>
               val works = createIdentifiedWorks(count = 3)
@@ -96,7 +96,7 @@ class WorksServiceTest
       )
 
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService(indexName = indexName, itemType = itemType) {
+        withElasticsearchService {
           searchService =>
             withWorksService(searchService) { worksService =>
               insertIntoElasticsearch(
@@ -127,7 +127,7 @@ class WorksServiceTest
   describe("findWorkById") {
     it("gets a DisplayWork by id") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService(indexName = indexName, itemType = itemType) {
+        withElasticsearchService {
           searchService =>
             withWorksService(searchService) { worksService =>
               val work = createIdentifiedWork
@@ -151,7 +151,7 @@ class WorksServiceTest
 
     it("returns a future of None if it cannot get a record by id") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService(indexName = indexName, itemType = itemType) {
+        withElasticsearchService {
           searchService =>
             withWorksService(searchService) { worksService =>
               val recordsFuture = worksService.findWorkById(
@@ -171,7 +171,7 @@ class WorksServiceTest
   describe("searchWorks") {
     it("only finds results that match a query if doing a full-text search") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService(indexName = indexName, itemType = itemType) {
+        withElasticsearchService {
           searchService =>
             withWorksService(searchService) { worksService =>
               val workDodo = createIdentifiedWorkWith(
@@ -207,7 +207,7 @@ class WorksServiceTest
     it(
       "doesn't throw an exception if passed an invalid query string for full-text search") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService(indexName = indexName, itemType = itemType) {
+        withElasticsearchService {
           searchService =>
             withWorksService(searchService) { worksService =>
               val workEmu = createIdentifiedWorkWith(
@@ -244,7 +244,7 @@ class WorksServiceTest
       )
 
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService(indexName = indexName, itemType = itemType) {
+        withElasticsearchService {
           searchService =>
             withWorksService(searchService) { worksService =>
               insertIntoElasticsearch(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -22,61 +22,58 @@ class WorksServiceTest
   describe("listWorks") {
     it("gets records in Elasticsearch") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService {
-          searchService =>
-            withWorksService(searchService) { worksService =>
-              val works = createIdentifiedWorks(count = 2)
+        withElasticsearchService { searchService =>
+          withWorksService(searchService) { worksService =>
+            val works = createIdentifiedWorks(count = 2)
 
-              insertIntoElasticsearch(indexName, itemType, works: _*)
+            insertIntoElasticsearch(indexName, itemType, works: _*)
 
-              val future = worksService.listWorks(
-                createWorksSearchOptionsWith(indexName = indexName)
-              )
+            val future = worksService.listWorks(
+              createWorksSearchOptionsWith(indexName = indexName)
+            )
 
-              whenReady(future) { resultList =>
-                resultList.results should contain theSameElementsAs works
-              }
+            whenReady(future) { resultList =>
+              resultList.results should contain theSameElementsAs works
             }
+          }
         }
       }
     }
 
     it("returns 0 pages when no results are available") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService {
-          searchService =>
-            withWorksService(searchService) { worksService =>
-              val future = worksService.listWorks(
-                createWorksSearchOptionsWith(indexName = indexName))
+        withElasticsearchService {  searchService =>
+          withWorksService(searchService) { worksService =>
+            val future = worksService.listWorks(
+              createWorksSearchOptionsWith(indexName = indexName))
 
-              whenReady(future) { works =>
-                works.totalResults shouldBe 0
-              }
+            whenReady(future) { works =>
+              works.totalResults shouldBe 0
             }
+          }
         }
       }
     }
 
     it("returns an empty result set when asked for a page that does not exist") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService {
-          searchService =>
-            withWorksService(searchService) { worksService =>
-              val works = createIdentifiedWorks(count = 3)
+        withElasticsearchService { searchService =>
+          withWorksService(searchService) { worksService =>
+            val works = createIdentifiedWorks(count = 3)
 
-              insertIntoElasticsearch(indexName, itemType, works: _*)
+            insertIntoElasticsearch(indexName, itemType, works: _*)
 
-              val future = worksService.listWorks(
-                createWorksSearchOptionsWith(
-                  indexName = indexName,
-                  pageNumber = 4
-                )
+            val future = worksService.listWorks(
+              createWorksSearchOptionsWith(
+                indexName = indexName,
+                pageNumber = 4
               )
+            )
 
-              whenReady(future) { receivedWorks =>
-                receivedWorks.results shouldBe empty
-              }
+            whenReady(future) { receivedWorks =>
+              receivedWorks.results shouldBe empty
             }
+          }
         }
       }
     }
@@ -96,29 +93,28 @@ class WorksServiceTest
       )
 
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService {
-          searchService =>
-            withWorksService(searchService) { worksService =>
-              insertIntoElasticsearch(
-                indexName,
-                itemType,
-                work1,
-                work2,
-                workWithWrongWorkType)
+        withElasticsearchService { searchService =>
+          withWorksService(searchService) { worksService =>
+            insertIntoElasticsearch(
+              indexName,
+              itemType,
+              work1,
+              work2,
+              workWithWrongWorkType)
 
-              val future = worksService.listWorks(
-                createWorksSearchOptionsWith(
-                  workTypeFilter = Some("b"),
-                  indexName = indexName
-                )
+            val future = worksService.listWorks(
+              createWorksSearchOptionsWith(
+                workTypeFilter = Some("b"),
+                indexName = indexName
               )
+            )
 
-              whenReady(future) { resultList =>
-                resultList.results should contain theSameElementsAs List(
-                  work1,
-                  work2)
-              }
+            whenReady(future) { resultList =>
+              resultList.results should contain theSameElementsAs List(
+                work1,
+                work2)
             }
+          }
         }
       }
     }
@@ -127,42 +123,40 @@ class WorksServiceTest
   describe("findWorkById") {
     it("gets a DisplayWork by id") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService {
-          searchService =>
-            withWorksService(searchService) { worksService =>
-              val work = createIdentifiedWork
+        withElasticsearchService { searchService =>
+          withWorksService(searchService) { worksService =>
+            val work = createIdentifiedWork
 
-              insertIntoElasticsearch(indexName, itemType, work)
+            insertIntoElasticsearch(indexName, itemType, work)
 
-              val recordsFuture =
-                worksService.findWorkById(
-                  canonicalId = work.canonicalId,
-                  indexName = indexName
-                )
+            val recordsFuture =
+              worksService.findWorkById(
+                canonicalId = work.canonicalId,
+                indexName = indexName
+              )
 
-              whenReady(recordsFuture) { records =>
-                records.isDefined shouldBe true
-                records.get shouldBe work
-              }
+            whenReady(recordsFuture) { records =>
+              records.isDefined shouldBe true
+              records.get shouldBe work
             }
+          }
         }
       }
     }
 
     it("returns a future of None if it cannot get a record by id") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService {
-          searchService =>
-            withWorksService(searchService) { worksService =>
-              val recordsFuture = worksService.findWorkById(
-                canonicalId = "1234",
-                indexName = indexName
-              )
+        withElasticsearchService { searchService =>
+          withWorksService(searchService) { worksService =>
+            val recordsFuture = worksService.findWorkById(
+              canonicalId = "1234",
+              indexName = indexName
+            )
 
-              whenReady(recordsFuture) { record =>
-                record shouldBe None
-              }
+            whenReady(recordsFuture) { record =>
+              record shouldBe None
             }
+          }
         }
       }
     }
@@ -171,35 +165,34 @@ class WorksServiceTest
   describe("searchWorks") {
     it("only finds results that match a query if doing a full-text search") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService {
-          searchService =>
-            withWorksService(searchService) { worksService =>
-              val workDodo = createIdentifiedWorkWith(
-                title = "A drawing of a dodo"
-              )
-              val workMouse = createIdentifiedWorkWith(
-                title = "A mezzotint of a mouse"
-              )
+        withElasticsearchService { searchService =>
+          withWorksService(searchService) { worksService =>
+            val workDodo = createIdentifiedWorkWith(
+              title = "A drawing of a dodo"
+            )
+            val workMouse = createIdentifiedWorkWith(
+              title = "A mezzotint of a mouse"
+            )
 
-              insertIntoElasticsearch(indexName, itemType, workDodo, workMouse)
+            insertIntoElasticsearch(indexName, itemType, workDodo, workMouse)
 
-              val searchForCat = worksService.searchWorks(query = "cat")(
-                createWorksSearchOptionsWith(indexName = indexName)
-              )
+            val searchForCat = worksService.searchWorks(query = "cat")(
+              createWorksSearchOptionsWith(indexName = indexName)
+            )
 
-              whenReady(searchForCat) { works =>
-                works.results should have size 0
-              }
-
-              val searchForDodo = worksService.searchWorks(query = "dodo")(
-                createWorksSearchOptionsWith(indexName = indexName)
-              )
-
-              whenReady(searchForDodo) { works =>
-                works.results should have size 1
-                works.results.head shouldBe workDodo
-              }
+            whenReady(searchForCat) { works =>
+              works.results should have size 0
             }
+
+            val searchForDodo = worksService.searchWorks(query = "dodo")(
+              createWorksSearchOptionsWith(indexName = indexName)
+            )
+
+            whenReady(searchForDodo) { works =>
+              works.results should have size 1
+              works.results.head shouldBe workDodo
+            }
+          }
         }
       }
     }
@@ -207,24 +200,23 @@ class WorksServiceTest
     it(
       "doesn't throw an exception if passed an invalid query string for full-text search") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService {
-          searchService =>
-            withWorksService(searchService) { worksService =>
-              val workEmu = createIdentifiedWorkWith(
-                title = "An etching of an emu"
-              )
-              insertIntoElasticsearch(indexName, itemType, workEmu)
+        withElasticsearchService { searchService =>
+          withWorksService(searchService) { worksService =>
+            val workEmu = createIdentifiedWorkWith(
+              title = "An etching of an emu"
+            )
+            insertIntoElasticsearch(indexName, itemType, workEmu)
 
-              val searchForEmu = worksService.searchWorks(query =
-                "emu \"unmatched quotes are a lexical error in the Elasticsearch parser")(
-                createWorksSearchOptionsWith(indexName = indexName)
-              )
+            val searchForEmu = worksService.searchWorks(query =
+              "emu \"unmatched quotes are a lexical error in the Elasticsearch parser")(
+              createWorksSearchOptionsWith(indexName = indexName)
+            )
 
-              whenReady(searchForEmu) { works =>
-                works.results should have size 1
-                works.results.head shouldBe workEmu
-              }
+            whenReady(searchForEmu) { works =>
+              works.results should have size 1
+              works.results.head shouldBe workEmu
             }
+          }
         }
       }
     }
@@ -244,27 +236,27 @@ class WorksServiceTest
       )
 
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService {
-          searchService =>
-            withWorksService(searchService) { worksService =>
-              insertIntoElasticsearch(
-                indexName,
-                itemType,
-                matchingWork,
-                workWithWrongTitle,
-                workWithWrongWorkType)
+        withElasticsearchService { searchService =>
+          withWorksService(searchService) { worksService =>
+            insertIntoElasticsearch(
+              indexName,
+              itemType,
+              matchingWork,
+              workWithWrongTitle,
+              workWithWrongWorkType)
 
-              val searchForEmu = worksService.searchWorks(query = "artichokes")(
-                createWorksSearchOptionsWith(
-                  workTypeFilter = Some("b"),
-                  indexName = indexName
-                )
+            val searchForEmu = worksService.searchWorks(
+              query = "artichokes")(
+              createWorksSearchOptionsWith(
+                workTypeFilter = Some("b"),
+                indexName = indexName
               )
+            )
 
-              whenReady(searchForEmu) { works =>
-                works.results shouldBe List(matchingWork)
-              }
+            whenReady(searchForEmu) { works =>
+              works.results shouldBe List(matchingWork)
             }
+          }
         }
       }
     }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -29,7 +29,8 @@ class WorksServiceTest
             insertIntoElasticsearch(indexName, itemType, works: _*)
 
             val future = worksService.listWorks(
-              documentOptions = createElasticsearchDocumentOptionsWith(indexName = indexName),
+              documentOptions =
+                createElasticsearchDocumentOptionsWith(indexName = indexName),
               worksSearchOptions = createWorksSearchOptions
             )
 
@@ -43,10 +44,11 @@ class WorksServiceTest
 
     it("returns 0 pages when no results are available") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-        withElasticsearchService {  searchService =>
+        withElasticsearchService { searchService =>
           withWorksService(searchService) { worksService =>
             val future = worksService.listWorks(
-              documentOptions = createElasticsearchDocumentOptionsWith(indexName = indexName),
+              documentOptions =
+                createElasticsearchDocumentOptionsWith(indexName = indexName),
               worksSearchOptions = createWorksSearchOptions
             )
 
@@ -67,7 +69,8 @@ class WorksServiceTest
             insertIntoElasticsearch(indexName, itemType, works: _*)
 
             val future = worksService.listWorks(
-              documentOptions = createElasticsearchDocumentOptionsWith(indexName = indexName),
+              documentOptions =
+                createElasticsearchDocumentOptionsWith(indexName = indexName),
               worksSearchOptions = createWorksSearchOptionsWith(pageNumber = 4)
             )
 
@@ -104,8 +107,10 @@ class WorksServiceTest
               workWithWrongWorkType)
 
             val future = worksService.listWorks(
-              documentOptions = createElasticsearchDocumentOptionsWith(indexName = indexName),
-              worksSearchOptions = createWorksSearchOptionsWith(workTypeFilter = Some("b"))
+              documentOptions =
+                createElasticsearchDocumentOptionsWith(indexName = indexName),
+              worksSearchOptions =
+                createWorksSearchOptionsWith(workTypeFilter = Some("b"))
             )
 
             whenReady(future) { resultList =>
@@ -128,9 +133,11 @@ class WorksServiceTest
 
             insertIntoElasticsearch(indexName, itemType, work)
 
-            val documentOptions = createElasticsearchDocumentOptionsWith(indexName = indexName)
+            val documentOptions =
+              createElasticsearchDocumentOptionsWith(indexName = indexName)
 
-            val recordsFuture = worksService.findWorkById(canonicalId = work.canonicalId)(documentOptions)
+            val recordsFuture = worksService.findWorkById(
+              canonicalId = work.canonicalId)(documentOptions)
 
             whenReady(recordsFuture) { records =>
               records.isDefined shouldBe true
@@ -145,9 +152,11 @@ class WorksServiceTest
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
         withElasticsearchService { searchService =>
           withWorksService(searchService) { worksService =>
-            val documentOptions = createElasticsearchDocumentOptionsWith(indexName = indexName)
+            val documentOptions =
+              createElasticsearchDocumentOptionsWith(indexName = indexName)
 
-            val recordsFuture = worksService.findWorkById(canonicalId = "1234")(documentOptions)
+            val recordsFuture =
+              worksService.findWorkById(canonicalId = "1234")(documentOptions)
 
             whenReady(recordsFuture) { record =>
               record shouldBe None
@@ -173,7 +182,8 @@ class WorksServiceTest
             insertIntoElasticsearch(indexName, itemType, workDodo, workMouse)
 
             val searchForCat = worksService.searchWorks(query = "cat")(
-              documentOptions = createElasticsearchDocumentOptionsWith(indexName = indexName),
+              documentOptions =
+                createElasticsearchDocumentOptionsWith(indexName = indexName),
               worksSearchOptions = createWorksSearchOptions
             )
 
@@ -182,7 +192,8 @@ class WorksServiceTest
             }
 
             val searchForDodo = worksService.searchWorks(query = "dodo")(
-              documentOptions = createElasticsearchDocumentOptionsWith(indexName = indexName),
+              documentOptions =
+                createElasticsearchDocumentOptionsWith(indexName = indexName),
               worksSearchOptions = createWorksSearchOptions
             )
 
@@ -205,10 +216,10 @@ class WorksServiceTest
             )
             insertIntoElasticsearch(indexName, itemType, workEmu)
 
-            val searchForEmu = worksService.searchWorks(
-              query =
-                "emu \"unmatched quotes are a lexical error in the Elasticsearch parser")(
-              documentOptions = createElasticsearchDocumentOptionsWith(indexName = indexName),
+            val searchForEmu = worksService.searchWorks(query =
+              "emu \"unmatched quotes are a lexical error in the Elasticsearch parser")(
+              documentOptions =
+                createElasticsearchDocumentOptionsWith(indexName = indexName),
               worksSearchOptions = createWorksSearchOptions
             )
 
@@ -245,10 +256,11 @@ class WorksServiceTest
               workWithWrongTitle,
               workWithWrongWorkType)
 
-            val searchForEmu = worksService.searchWorks(
-              query = "artichokes")(
-              documentOptions = createElasticsearchDocumentOptionsWith(indexName = indexName),
-              worksSearchOptions = createWorksSearchOptionsWith(workTypeFilter = Some("b"))
+            val searchForEmu = worksService.searchWorks(query = "artichokes")(
+              documentOptions =
+                createElasticsearchDocumentOptionsWith(indexName = indexName),
+              worksSearchOptions =
+                createWorksSearchOptionsWith(workTypeFilter = Some("b"))
             )
 
             whenReady(searchForEmu) { works =>
@@ -260,7 +272,8 @@ class WorksServiceTest
     }
   }
 
-  private def createElasticsearchDocumentOptionsWith(indexName: String): ElasticsearchDocumentOptions =
+  private def createElasticsearchDocumentOptionsWith(
+    indexName: String): ElasticsearchDocumentOptions =
     ElasticsearchDocumentOptions(
       indexName = indexName,
       documentType = itemType
@@ -277,5 +290,6 @@ class WorksServiceTest
       pageNumber = pageNumber
     )
 
-  private def createWorksSearchOptions: WorksSearchOptions = createWorksSearchOptionsWith()
+  private def createWorksSearchOptions: WorksSearchOptions =
+    createWorksSearchOptionsWith()
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -132,7 +132,8 @@ class WorksServiceTest
             val recordsFuture =
               worksService.findWorkById(
                 canonicalId = work.canonicalId,
-                indexName = indexName
+                indexName = indexName,
+                documentType = itemType
               )
 
             whenReady(recordsFuture) { records =>
@@ -150,7 +151,8 @@ class WorksServiceTest
           withWorksService(searchService) { worksService =>
             val recordsFuture = worksService.findWorkById(
               canonicalId = "1234",
-              indexName = indexName
+              indexName = indexName,
+              documentType = itemType
             )
 
             whenReady(recordsFuture) { record =>
@@ -270,6 +272,7 @@ class WorksServiceTest
   ): WorksSearchOptions =
     WorksSearchOptions(
       workTypeFilter = workTypeFilter,
+      documentType = itemType,
       indexName = indexName,
       pageSize = pageSize,
       pageNumber = pageNumber


### PR DESCRIPTION
While working on #2900, it was bugging me that the ElasticsearchService knows about the documentType from config, but the indexName on a per-request basis. It would be more consistent if both parameters were passed at runtime, when we actually do the query – so this patch does that.

Additionally, this cleans up an inconsistency with the get ID/list/search endpoints – now they all get the indexName/documentType configuration the same way, not in two different ways.

So now we have two classes:

* ElasticsearchDocumentOptions – index name and document type. Stuff we care about, but which should be invisible to the end user.
* ElasticsearchQueryOptions – anything we might present as an external option, e.g. page size, work type filter