### PR TITLE
${local.code_is_correct == "true" ? make_amendment : leave_unchanged}$

### DIFF
--- a/catalogue_api/terraform/api_pins.tf
+++ b/catalogue_api/terraform/api_pins.tf
@@ -1,7 +1,7 @@
 locals {
-  production_api       = "romulus"
-  pinned_remus_api     = ""
-  pinned_remus_nginx   = ""
-  pinned_romulus_api   = "7de3c580dc0778fe436b4fe3516ca5a9d0468e3f"
-  pinned_romulus_nginx = "3dd8a423123e1d175dd44520fcf03435a5fc92c8"
+  production_api       = "remus"
+  pinned_remus_api     = "488c405a2c44fde1eef28f10bb505f4c1af8009f"
+  pinned_remus_nginx   = "3dd8a423123e1d175dd44520fcf03435a5fc92c8"
+  pinned_romulus_api   = ""
+  pinned_romulus_nginx = ""
 }

--- a/catalogue_api/terraform/services.tf
+++ b/catalogue_api/terraform/services.tf
@@ -1,9 +1,9 @@
 locals {
-  romulus_api_release_id   = "${local.pinned_romulus_api == "" ? local.pinned_romulus_api : var.release_ids["api"]}"
-  romulus_nginx_release_id = "${local.pinned_romulus_nginx == "" ? local.pinned_romulus_nginx : var.release_ids["nginx_api-delta"]}"
+  romulus_api_release_id   = "${local.pinned_romulus_api != "" ? local.pinned_romulus_api : var.release_ids["api"]}"
+  romulus_nginx_release_id = "${local.pinned_romulus_nginx != "" ? local.pinned_romulus_nginx : var.release_ids["nginx_api-delta"]}"
 
-  remus_api_release_id   = "${local.pinned_remus_api == "" ? local.pinned_remus_api : var.release_ids["api"]}"
-  remus_nginx_release_id = "${local.pinned_remus_nginx == "" ? local.pinned_remus_nginx : var.release_ids["nginx_api-delta"]}"
+  remus_api_release_id   = "${local.pinned_remus_api != "" ? local.pinned_remus_api : var.release_ids["api"]}"
+  remus_nginx_release_id = "${local.pinned_remus_nginx != "" ? local.pinned_remus_nginx : var.release_ids["nginx_api-delta"]}"
 
   romulus_app_uri   = "${module.ecr_repository_api.repository_url}:${local.romulus_api_release_id}"
   romulus_nginx_uri = "${module.ecr_repository_nginx_api-delta.repository_url}:${local.romulus_nginx_release_id}"


### PR DESCRIPTION
This fixes a silly bug in our API Terraform, where we'd pin the *staging* API (by setting an empty container ID), and let the *prod* API advance every time we pushed a new container image.

Oops.

🙈 