### PR TITLE
Implement multiple workType filters, e.g. ?workType=a,b

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -109,16 +109,15 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
     * be applied to the corresponding Elasticsearch request.
     */
   private def buildFilters(request: M): List[WorkFilter] = {
-    val workTypes =
+    val workTypeIds =
       request.workType
         .map { arg => arg.split(",").map { _.trim } }
         .flatten
-        .map { id: String => WorkType(id = id, label = "") }
         .toList
 
-    val maybeWorkTypeFilter: Option[WorkTypeFilter] = workTypes match {
+    val maybeWorkTypeFilter: Option[WorkTypeFilter] = workTypeIds match {
       case Nil => None
-      case workTypes: List[WorkType] => Some(WorkTypeFilter(workTypes))
+      case workTypes: List[WorkType] => Some(WorkTypeFilter(workTypeIds))
     }
 
     List(maybeWorkTypeFilter).flatten

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -111,8 +111,12 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
   private def buildFilters(request: M): List[WorkFilter] = {
     val maybeWorkTypeFilter: Option[WorkTypeFilter] =
       request.workType
-        .map { arg => arg.split(",").map { _.trim } }
-        .map { workTypeIds: Array[String] => WorkTypeFilter(workTypeIds) }
+        .map { arg =>
+          arg.split(",").map { _.trim }
+        }
+        .map { workTypeIds: Array[String] =>
+          WorkTypeFilter(workTypeIds)
+        }
 
     List(maybeWorkTypeFilter).flatten
   }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -16,7 +16,6 @@ import uk.ac.wellcome.platform.api.responses.{
 }
 import uk.ac.wellcome.platform.api.services.{
   ElasticsearchDocumentOptions,
-  WorkTypeFilter,
   WorksSearchOptions,
   WorksService
 }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -52,7 +52,7 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
     toDisplayWork: (IdentifiedWork, W) => T)(
     implicit evidence: TypeTag[DisplayResultList[T]],
     manifest: Manifest[M]): Unit = {
-    getWithDoc(s"$endpointSuffix") { doc =>
+    getWithDoc(endpointSuffix) { doc =>
       setupResultListSwaggerDocs[T](s"$endpointSuffix", swagger, doc)
     } { request: M =>
       val pageSize = request.pageSize.getOrElse(apiConfig.defaultPageSize)
@@ -80,7 +80,7 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
     endpointSuffix: String,
     toDisplayWork: (IdentifiedWork, W) => T)(implicit evidence: TypeTag[T],
                                              manifest: Manifest[S]): Unit = {
-    getWithDoc(s"$endpointSuffix") { doc =>
+    getWithDoc(endpointSuffix) { doc =>
       setUpSingleWorkSwaggerDocs[T](swagger, doc)
     } { request: S =>
       val includes = request.include.getOrElse(emptyWorksIncludes)

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -109,16 +109,10 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
     * be applied to the corresponding Elasticsearch request.
     */
   private def buildFilters(request: M): List[WorkFilter] = {
-    val workTypeIds =
+    val maybeWorkTypeFilter: Option[WorkTypeFilter] =
       request.workType
         .map { arg => arg.split(",").map { _.trim } }
-        .flatten
-        .toList
-
-    val maybeWorkTypeFilter: Option[WorkTypeFilter] = workTypeIds match {
-      case Nil => None
-      case workTypes: List[WorkType] => Some(WorkTypeFilter(workTypeIds))
-    }
+        .map { workTypeIds: Array[String] => WorkTypeFilter(workTypeIds) }
 
     List(maybeWorkTypeFilter).flatten
   }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -16,6 +16,7 @@ import uk.ac.wellcome.platform.api.responses.{
 }
 import uk.ac.wellcome.platform.api.services.{
   ElasticsearchDocumentOptions,
+  WorkTypeFilter,
   WorksSearchOptions,
   WorksService
 }
@@ -111,8 +112,12 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
       documentType = documentType
     )
 
+    val filters = List(
+      request.workType.map { arg => WorkTypeFilter(arg) }
+    ).flatten
+
     val worksSearchOptions = WorksSearchOptions(
-      workTypeFilter = request.workType,
+      filters = filters,
       pageSize = pageSize,
       pageNumber = request.page
     )

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
@@ -1,0 +1,14 @@
+package uk.ac.wellcome.platform.api.models
+
+import uk.ac.wellcome.models.work.internal.WorkType
+
+sealed trait WorkFilter
+
+case class WorkTypeFilter(workTypes: Seq[WorkType]) extends WorkFilter
+
+case object WorkTypeFilter {
+  def apply(arg: String): WorkTypeFilter =
+    WorkTypeFilter(
+      workTypes = arg.split(",").map { id => WorkType(id, label = "") }
+    )
+}

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
@@ -5,6 +5,6 @@ sealed trait WorkFilter
 case class WorkTypeFilter(workTypeIds: Seq[String]) extends WorkFilter
 
 case object WorkTypeFilter {
-  def apply(arg: String): WorkTypeFilter =
-    WorkTypeFilter(workTypeIds = arg.split(","))
+  def apply(workTypeId: String): WorkTypeFilter =
+    WorkTypeFilter(workTypeIds = List(workTypeId))
 }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
@@ -1,14 +1,10 @@
 package uk.ac.wellcome.platform.api.models
 
-import uk.ac.wellcome.models.work.internal.WorkType
-
 sealed trait WorkFilter
 
-case class WorkTypeFilter(workTypes: Seq[WorkType]) extends WorkFilter
+case class WorkTypeFilter(workTypeIds: Seq[String]) extends WorkFilter
 
 case object WorkTypeFilter {
   def apply(arg: String): WorkTypeFilter =
-    WorkTypeFilter(
-      workTypes = arg.split(",").map { id => WorkType(id, label = "") }
-    )
+    WorkTypeFilter(workTypeIds = arg.split(","))
 }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -6,7 +6,10 @@ import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.http.get.GetResponse
 import com.sksamuel.elastic4s.http.search.SearchResponse
 import com.sksamuel.elastic4s.searches.SearchDefinition
-import com.sksamuel.elastic4s.searches.queries.{BoolQueryDefinition, QueryDefinition}
+import com.sksamuel.elastic4s.searches.queries.{
+  BoolQueryDefinition,
+  QueryDefinition
+}
 import com.sksamuel.elastic4s.searches.queries.term.TermsQueryDefinition
 import com.sksamuel.elastic4s.searches.sort.FieldSortDefinition
 import uk.ac.wellcome.platform.api.models.{WorkFilter, WorkTypeFilter}
@@ -81,9 +84,11 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient) {
       .execute { searchDefinition }
   }
 
-  private def toTermQuery(workFilter: WorkFilter): TermsQueryDefinition[String] =
+  private def toTermQuery(
+    workFilter: WorkFilter): TermsQueryDefinition[String] =
     workFilter match {
-      case WorkTypeFilter(workTypeIds) => termsQuery(field = "workType.id", values = workTypeIds)
+      case WorkTypeFilter(workTypeIds) =>
+        termsQuery(field = "workType.id", values = workTypeIds)
     }
 
   private def buildQuery(maybeQueryString: Option[String],
@@ -92,7 +97,10 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient) {
       maybeQueryString.map { simpleStringQuery }
     ).flatten
 
-    val filterDefinitions: List[QueryDefinition] = filters.map { toTermQuery } :+ termQuery("type", "IdentifiedWork")
+    val filterDefinitions
+      : List[QueryDefinition] = filters.map { toTermQuery } :+ termQuery(
+      "type",
+      "IdentifiedWork")
 
     must(queries).filter(filterDefinitions)
   }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -6,11 +6,16 @@ import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.http.get.GetResponse
 import com.sksamuel.elastic4s.http.search.SearchResponse
 import com.sksamuel.elastic4s.searches.SearchDefinition
-import com.sksamuel.elastic4s.searches.queries.BoolQueryDefinition
-import com.sksamuel.elastic4s.searches.queries.term.TermQueryDefinition
+import com.sksamuel.elastic4s.searches.queries.{BoolQueryDefinition, QueryDefinition}
+import com.sksamuel.elastic4s.searches.queries.term.{TermQueryDefinition, TermsQueryDefinition}
 import com.sksamuel.elastic4s.searches.sort.FieldSortDefinition
+import uk.ac.wellcome.models.work.internal.WorkType
 
 import scala.concurrent.Future
+
+sealed trait WorkFilter
+
+case class WorkTypeFilter(workTypes: List[WorkType]) extends WorkFilter
 
 case class ElasticsearchDocumentOptions(
   indexName: String,
@@ -18,7 +23,7 @@ case class ElasticsearchDocumentOptions(
 )
 
 case class ElasticsearchQueryOptions(
-  workTypeFilter: Option[String],
+  filters: List[WorkTypeFilter],
   limit: Int,
   from: Int
 )
@@ -60,7 +65,7 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient) {
     queryOptions: ElasticsearchQueryOptions): Future[SearchResponse] = {
     val queryDefinition = buildQuery(
       maybeQueryString = maybeQueryString,
-      workTypeFilter = queryOptions.workTypeFilter
+      filters = queryOptions.filters
     )
 
     val sortDefinitions: List[FieldSortDefinition] =
@@ -80,17 +85,19 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient) {
       .execute { searchDefinition }
   }
 
-  private def buildQuery(
-    maybeQueryString: Option[String],
-    workTypeFilter: Option[String]): BoolQueryDefinition = {
+  private def toTermQuery(workFilter: WorkFilter): TermsQueryDefinition[String] =
+    workFilter match {
+      case WorkTypeFilter(workTypes) => termsQuery(field = "workType.id", values = workTypes.map { _.id })
+    }
+
+  private def buildQuery(maybeQueryString: Option[String],
+                         filters: List[WorkFilter]): BoolQueryDefinition = {
     val queries = List(
       maybeQueryString.map { simpleStringQuery }
     ).flatten
 
-    val filters: List[TermQueryDefinition] = List(
-      workTypeFilter.map { termQuery("workType.id", _) }
-    ).flatten :+ termQuery("type", "IdentifiedWork")
+    val filterDefinitions: List[QueryDefinition] = filters.map { toTermQuery } :+ termQuery("type", "IdentifiedWork")
 
-    must(queries).filter(filters)
+    must(queries).filter(filterDefinitions)
   }
 }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -9,20 +9,9 @@ import com.sksamuel.elastic4s.searches.SearchDefinition
 import com.sksamuel.elastic4s.searches.queries.{BoolQueryDefinition, QueryDefinition}
 import com.sksamuel.elastic4s.searches.queries.term.TermsQueryDefinition
 import com.sksamuel.elastic4s.searches.sort.FieldSortDefinition
-import uk.ac.wellcome.models.work.internal.WorkType
+import uk.ac.wellcome.platform.api.models.{WorkFilter, WorkTypeFilter}
 
 import scala.concurrent.Future
-
-sealed trait WorkFilter
-
-case class WorkTypeFilter(workTypes: Seq[WorkType]) extends WorkFilter
-
-case object WorkTypeFilter {
-  def apply(arg: String): WorkTypeFilter =
-    WorkTypeFilter(
-      workTypes = arg.split(",").map { id => WorkType(id, label = "") }
-    )
-}
 
 case class ElasticsearchDocumentOptions(
   indexName: String,

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -7,7 +7,7 @@ import com.sksamuel.elastic4s.http.get.GetResponse
 import com.sksamuel.elastic4s.http.search.SearchResponse
 import com.sksamuel.elastic4s.searches.SearchDefinition
 import com.sksamuel.elastic4s.searches.queries.{BoolQueryDefinition, QueryDefinition}
-import com.sksamuel.elastic4s.searches.queries.term.{TermQueryDefinition, TermsQueryDefinition}
+import com.sksamuel.elastic4s.searches.queries.term.TermsQueryDefinition
 import com.sksamuel.elastic4s.searches.sort.FieldSortDefinition
 import uk.ac.wellcome.models.work.internal.WorkType
 
@@ -15,7 +15,14 @@ import scala.concurrent.Future
 
 sealed trait WorkFilter
 
-case class WorkTypeFilter(workTypes: List[WorkType]) extends WorkFilter
+case class WorkTypeFilter(workTypes: Seq[WorkType]) extends WorkFilter
+
+case object WorkTypeFilter {
+  def apply(arg: String): WorkTypeFilter =
+    WorkTypeFilter(
+      workTypes = arg.split(",").map { id => WorkType(id, label = "") }
+    )
+}
 
 case class ElasticsearchDocumentOptions(
   indexName: String,
@@ -23,7 +30,7 @@ case class ElasticsearchDocumentOptions(
 )
 
 case class ElasticsearchQueryOptions(
-  filters: List[WorkTypeFilter],
+  filters: List[WorkFilter],
   limit: Int,
   from: Int
 )

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -83,7 +83,7 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient) {
 
   private def toTermQuery(workFilter: WorkFilter): TermsQueryDefinition[String] =
     workFilter match {
-      case WorkTypeFilter(workTypes) => termsQuery(field = "workType.id", values = workTypes.map { _.id })
+      case WorkTypeFilter(workTypeIds) => termsQuery(field = "workType.id", values = workTypeIds)
     }
 
   private def buildQuery(maybeQueryString: Option[String],

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 case class WorksSearchOptions(
-  workTypeFilter: Option[String],
+  filters: List[WorkFilter],
   pageSize: Int,
   pageNumber: Int
 )
@@ -51,7 +51,7 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
   private def toElasticsearchQueryOptions(
     worksSearchOptions: WorksSearchOptions): ElasticsearchQueryOptions =
     ElasticsearchQueryOptions(
-      workTypeFilter = worksSearchOptions.workTypeFilter,
+      filters = worksSearchOptions.filters,
       limit = worksSearchOptions.pageSize,
       from = (worksSearchOptions.pageNumber - 1) * worksSearchOptions.pageSize
     )

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -5,7 +5,7 @@ import com.sksamuel.elastic4s.http.search.{SearchHit, SearchResponse}
 import io.circe.Decoder
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, IdentifiedWork}
-import uk.ac.wellcome.platform.api.models.ResultList
+import uk.ac.wellcome.platform.api.models.{ResultList, WorkFilter}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -31,20 +31,24 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
         else None
       }
 
-  def listWorks: (ElasticsearchDocumentOptions, WorksSearchOptions) => Future[ResultList] =
+  def listWorks
+    : (ElasticsearchDocumentOptions, WorksSearchOptions) => Future[ResultList] =
     executeSearch(
       searchService.listResults(sortByField = "canonicalId")
     )
 
-  def searchWorks(query: String): (ElasticsearchDocumentOptions, WorksSearchOptions) => Future[ResultList] =
+  def searchWorks(query: String)
+    : (ElasticsearchDocumentOptions, WorksSearchOptions) => Future[ResultList] =
     executeSearch(
       searchService.simpleStringQueryResults(query)
     )
 
   private def executeSearch(
-    searchRequest: (ElasticsearchDocumentOptions, ElasticsearchQueryOptions) => Future[SearchResponse]
+    searchRequest: (ElasticsearchDocumentOptions,
+                    ElasticsearchQueryOptions) => Future[SearchResponse]
   ): (ElasticsearchDocumentOptions, WorksSearchOptions) => Future[ResultList] =
-    (documentOptions: ElasticsearchDocumentOptions, worksSearchOptions: WorksSearchOptions) => {
+    (documentOptions: ElasticsearchDocumentOptions,
+     worksSearchOptions: WorksSearchOptions) => {
       val queryOptions = toElasticsearchQueryOptions(worksSearchOptions)
       searchRequest(documentOptions, queryOptions)
         .map { createResultList }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -31,21 +31,22 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
         else None
       }
 
-  def listWorks(
-    documentOptions: ElasticsearchDocumentOptions,
-    worksSearchOptions: WorksSearchOptions): Future[ResultList] =
-    searchService.listResults(sortByField = "canonicalId")(
-      documentOptions,
-      toElasticsearchQueryOptions(worksSearchOptions))
+  def listWorks(documentOptions: ElasticsearchDocumentOptions,
+                worksSearchOptions: WorksSearchOptions): Future[ResultList] =
+    searchService
+      .listResults(sortByField = "canonicalId")(
+        documentOptions,
+        toElasticsearchQueryOptions(worksSearchOptions))
       .map { createResultList }
 
   def searchWorks(query: String)(
     documentOptions: ElasticsearchDocumentOptions,
     worksSearchOptions: WorksSearchOptions): Future[ResultList] =
-    searchService.simpleStringQueryResults(query)(
-      documentOptions,
-      toElasticsearchQueryOptions(worksSearchOptions))
-        .map { createResultList }
+    searchService
+      .simpleStringQueryResults(query)(
+        documentOptions,
+        toElasticsearchQueryOptions(worksSearchOptions))
+      .map { createResultList }
 
   private def toElasticsearchQueryOptions(
     worksSearchOptions: WorksSearchOptions): ElasticsearchQueryOptions =

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -31,28 +31,21 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
         else None
       }
 
-  def listWorks
-    : (ElasticsearchDocumentOptions, WorksSearchOptions) => Future[ResultList] =
-    executeSearch(
-      searchService.listResults(sortByField = "canonicalId")
-    )
+  def listWorks(
+    documentOptions: ElasticsearchDocumentOptions,
+    worksSearchOptions: WorksSearchOptions): Future[ResultList] =
+    searchService.listResults(sortByField = "canonicalId")(
+      documentOptions,
+      toElasticsearchQueryOptions(worksSearchOptions))
+      .map { createResultList }
 
-  def searchWorks(query: String)
-    : (ElasticsearchDocumentOptions, WorksSearchOptions) => Future[ResultList] =
-    executeSearch(
-      searchService.simpleStringQueryResults(query)
-    )
-
-  private def executeSearch(
-    searchRequest: (ElasticsearchDocumentOptions,
-                    ElasticsearchQueryOptions) => Future[SearchResponse]
-  ): (ElasticsearchDocumentOptions, WorksSearchOptions) => Future[ResultList] =
-    (documentOptions: ElasticsearchDocumentOptions,
-     worksSearchOptions: WorksSearchOptions) => {
-      val queryOptions = toElasticsearchQueryOptions(worksSearchOptions)
-      searchRequest(documentOptions, queryOptions)
+  def searchWorks(query: String)(
+    documentOptions: ElasticsearchDocumentOptions,
+    worksSearchOptions: WorksSearchOptions): Future[ResultList] =
+    searchService.simpleStringQueryResults(query)(
+      documentOptions,
+      toElasticsearchQueryOptions(worksSearchOptions))
         .map { createResultList }
-    }
 
   private def toElasticsearchQueryOptions(
     worksSearchOptions: WorksSearchOptions): ElasticsearchQueryOptions =

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
@@ -1,12 +1,17 @@
 package uk.ac.wellcome.platform.api.generators
 
 import uk.ac.wellcome.platform.api.models.WorkFilter
-import uk.ac.wellcome.platform.api.services.{ElasticsearchDocumentOptions, ElasticsearchQueryOptions, WorksSearchOptions}
+import uk.ac.wellcome.platform.api.services.{
+  ElasticsearchDocumentOptions,
+  ElasticsearchQueryOptions,
+  WorksSearchOptions
+}
 
 trait SearchOptionsGenerators {
   val itemType: String
 
-  def createElasticsearchDocumentOptionsWith(indexName: String): ElasticsearchDocumentOptions =
+  def createElasticsearchDocumentOptionsWith(
+    indexName: String): ElasticsearchDocumentOptions =
     ElasticsearchDocumentOptions(
       indexName = indexName,
       documentType = itemType
@@ -23,7 +28,8 @@ trait SearchOptionsGenerators {
       from = from
     )
 
-  def createElasticsearchQueryOptions: ElasticsearchQueryOptions = createElasticsearchQueryOptionsWith()
+  def createElasticsearchQueryOptions: ElasticsearchQueryOptions =
+    createElasticsearchQueryOptionsWith()
 
   def createWorksSearchOptionsWith(
     filters: List[WorkFilter] = List(),
@@ -36,5 +42,6 @@ trait SearchOptionsGenerators {
       pageNumber = pageNumber
     )
 
-  def createWorksSearchOptions: WorksSearchOptions = createWorksSearchOptionsWith()
+  def createWorksSearchOptions: WorksSearchOptions =
+    createWorksSearchOptionsWith()
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
@@ -1,0 +1,27 @@
+package uk.ac.wellcome.platform.api.generators
+
+import uk.ac.wellcome.platform.api.models.WorkFilter
+import uk.ac.wellcome.platform.api.services.{ElasticsearchDocumentOptions, ElasticsearchQueryOptions}
+
+trait SearchOptionsGenerators {
+  val itemType: String
+
+  def createElasticsearchDocumentOptionsWith(indexName: String): ElasticsearchDocumentOptions =
+    ElasticsearchDocumentOptions(
+      indexName = indexName,
+      documentType = itemType
+    )
+
+  def createElasticsearchQueryOptionsWith(
+    filters: List[WorkFilter] = List(),
+    limit: Int = 10,
+    from: Int = 0
+  ): ElasticsearchQueryOptions =
+    ElasticsearchQueryOptions(
+      filters = filters,
+      limit = limit,
+      from = from
+    )
+
+  def createElasticsearchQueryOptions: ElasticsearchQueryOptions = createElasticsearchQueryOptionsWith()
+}

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.api.generators
 
-import uk.ac.wellcome.platform.api.models.WorkFilter
-import uk.ac.wellcome.platform.api.services.{ElasticsearchDocumentOptions, ElasticsearchQueryOptions}
+import uk.ac.wellcome.platform.api.models.{WorkFilter, WorkTypeFilter}
+import uk.ac.wellcome.platform.api.services.{ElasticsearchDocumentOptions, ElasticsearchQueryOptions, WorksSearchOptions}
 
 trait SearchOptionsGenerators {
   val itemType: String
@@ -24,4 +24,17 @@ trait SearchOptionsGenerators {
     )
 
   def createElasticsearchQueryOptions: ElasticsearchQueryOptions = createElasticsearchQueryOptionsWith()
+
+  def createWorksSearchOptionsWith(
+    filters: List[WorkFilter] = List(),
+    pageSize: Int = 10,
+    pageNumber: Int = 1
+  ): WorksSearchOptions =
+    WorksSearchOptions(
+      filters = filters,
+      pageSize = pageSize,
+      pageNumber = pageNumber
+    )
+
+  def createWorksSearchOptions: WorksSearchOptions = createWorksSearchOptionsWith()
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.api.generators
 
-import uk.ac.wellcome.platform.api.models.{WorkFilter, WorkTypeFilter}
+import uk.ac.wellcome.platform.api.models.WorkFilter
 import uk.ac.wellcome.platform.api.services.{ElasticsearchDocumentOptions, ElasticsearchQueryOptions, WorksSearchOptions}
 
 trait SearchOptionsGenerators {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -102,7 +102,7 @@ class ElasticsearchServiceTest
           indexName = indexName,
           queryString = "artichokes",
           queryOptions = createElasticsearchQueryOptionsWith(
-            workTypeFilter = Some("b")
+            workTypeFilter = Some("b,m")
           ),
           expectedWorks = List(work1, work2)
         )
@@ -304,7 +304,7 @@ class ElasticsearchServiceTest
           workWithWrongWorkType)
 
         val queryOptions = createElasticsearchQueryOptionsWith(
-          workTypeFilter = Some("b")
+          workTypeFilter = Some("b, m")
         )
 
         assertListResultsAreCorrect(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -5,7 +5,11 @@ import com.sksamuel.elastic4s.http.search.{SearchHit, SearchResponse}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, IdentifiedWork, WorkType}
+import uk.ac.wellcome.models.work.internal.{
+  IdentifiedBaseWork,
+  IdentifiedWork,
+  WorkType
+}
 import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.api.fixtures.ElasticsearchServiceFixture
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
@@ -95,7 +99,10 @@ class ElasticsearchServiceTest
         insertIntoElasticsearch(
           indexName,
           itemType,
-          work1, workWithWrongTitle, work2, workWithWrongType)
+          work1,
+          workWithWrongTitle,
+          work2,
+          workWithWrongType)
 
         assertSearchResultsAreCorrect(
           indexName = indexName,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -8,7 +8,8 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, IdentifiedWork, WorkType}
 import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.api.fixtures.ElasticsearchServiceFixture
-import uk.ac.wellcome.platform.api.models.{WorkFilter, WorkTypeFilter}
+import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
+import uk.ac.wellcome.platform.api.models.WorkTypeFilter
 
 import scala.concurrent.Future
 
@@ -17,6 +18,7 @@ class ElasticsearchServiceTest
     with ElasticsearchServiceFixture
     with Matchers
     with ScalaFutures
+    with SearchOptionsGenerators
     with WorksGenerators {
 
   val itemType = "work"
@@ -353,26 +355,6 @@ class ElasticsearchServiceTest
         searchResponseToWorks(response) should contain theSameElementsAs expectedWorks
       }
     }
-
-  private def createElasticsearchDocumentOptionsWith(
-    indexName: String): ElasticsearchDocumentOptions =
-    ElasticsearchDocumentOptions(
-      indexName = indexName,
-      documentType = itemType
-    )
-
-  private def createElasticsearchQueryOptionsWith(
-    filters: List[WorkFilter] = List(),
-    limit: Int = 10,
-    from: Int = 0
-  ): ElasticsearchQueryOptions =
-    ElasticsearchQueryOptions(
-      filters = filters,
-      limit = limit,
-      from = from
-    )
-
-  private def createElasticsearchQueryOptions: ElasticsearchQueryOptions = createElasticsearchQueryOptionsWith()
 
   private def searchResponseToWorks(
     response: SearchResponse): List[IdentifiedBaseWork] =

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -370,12 +370,17 @@ class ElasticsearchServiceTest
     workTypeFilter: Option[String] = None,
     limit: Int = 10,
     from: Int = 0
-  ): ElasticsearchQueryOptions =
+  ): ElasticsearchQueryOptions = {
+    val filters = List(
+      workTypeFilter.map { arg => WorkTypeFilter(arg) }
+    ).flatten
+
     ElasticsearchQueryOptions(
-      workTypeFilter = workTypeFilter,
+      filters = filters,
       limit = limit,
       from = from
     )
+  }
 
   private def searchResponseToWorks(
     response: SearchResponse): List[IdentifiedBaseWork] =

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -73,6 +73,41 @@ class ElasticsearchServiceTest
         )
       }
     }
+
+    it("filters search results with multiple workTypes") {
+      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+        val work1 = createIdentifiedWorkWith(
+          title = "Animated artichokes",
+          workType = Some(WorkType(id = "b", label = "Books"))
+        )
+        val workWithWrongTitle = createIdentifiedWorkWith(
+          title = "Bouncing bananas",
+          workType = Some(WorkType(id = "b", label = "Books"))
+        )
+        val work2 = createIdentifiedWorkWith(
+          title = "Animated artichokes",
+          workType = Some(WorkType(id = "m", label = "Manuscripts"))
+        )
+        val workWithWrongType = createIdentifiedWorkWith(
+          title = "Animated artichokes",
+          workType = Some(WorkType(id = "a", label = "Archives"))
+        )
+
+        insertIntoElasticsearch(
+          indexName,
+          itemType,
+          work1, workWithWrongTitle, work2, workWithWrongType)
+
+        assertSearchResultsAreCorrect(
+          indexName = indexName,
+          queryString = "artichokes",
+          queryOptions = createElasticsearchQueryOptionsWith(
+            workTypeFilter = Some("b")
+          ),
+          expectedWorks = List(work1, work2)
+        )
+      }
+    }
   }
 
   describe("findResultById") {
@@ -217,15 +252,12 @@ class ElasticsearchServiceTest
     it("filters list results by workType") {
       withLocalElasticsearchIndex(itemType = itemType) { indexName =>
         val work1 = createIdentifiedWorkWith(
-          title = "Animated artichokes",
           workType = Some(WorkType(id = "b", label = "Books"))
         )
         val work2 = createIdentifiedWorkWith(
-          title = "Bouncing bananas",
           workType = Some(WorkType(id = "b", label = "Books"))
         )
         val workWithWrongWorkType = createIdentifiedWorkWith(
-          title = "Animated artichokes",
           workType = Some(WorkType(id = "m", label = "Manuscripts"))
         )
 
@@ -244,6 +276,41 @@ class ElasticsearchServiceTest
           indexName = indexName,
           queryOptions = queryOptions,
           expectedWorks = List(work1, work2)
+        )
+      }
+    }
+
+    it("filters list results with multiple workTypes") {
+      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+        val work1 = createIdentifiedWorkWith(
+          workType = Some(WorkType(id = "b", label = "Books"))
+        )
+        val work2 = createIdentifiedWorkWith(
+          workType = Some(WorkType(id = "b", label = "Books"))
+        )
+        val work3 = createIdentifiedWorkWith(
+          workType = Some(WorkType(id = "a", label = "Archives"))
+        )
+        val workWithWrongWorkType = createIdentifiedWorkWith(
+          workType = Some(WorkType(id = "m", label = "Manuscripts"))
+        )
+
+        insertIntoElasticsearch(
+          indexName,
+          itemType,
+          work1,
+          work2,
+          work3,
+          workWithWrongWorkType)
+
+        val queryOptions = createElasticsearchQueryOptionsWith(
+          workTypeFilter = Some("b")
+        )
+
+        assertListResultsAreCorrect(
+          indexName = indexName,
+          queryOptions = queryOptions,
+          expectedWorks = List(work1, work2, work3)
         )
       }
     }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -324,8 +324,7 @@ class ElasticsearchServiceTest
   private def assertSearchResultsAreCorrect(
     indexName: String,
     queryString: String,
-    queryOptions: ElasticsearchQueryOptions =
-      createElasticsearchQueryOptionsWith(),
+    queryOptions: ElasticsearchQueryOptions = createElasticsearchQueryOptions,
     expectedWorks: List[IdentifiedWork]
   ): Assertion =
     withElasticsearchService { searchService =>
@@ -341,8 +340,7 @@ class ElasticsearchServiceTest
 
   private def assertListResultsAreCorrect(
     indexName: String,
-    queryOptions: ElasticsearchQueryOptions =
-      createElasticsearchQueryOptionsWith(),
+    queryOptions: ElasticsearchQueryOptions = createElasticsearchQueryOptions,
     expectedWorks: Seq[IdentifiedWork]
   ): Assertion =
     withElasticsearchService { searchService =>
@@ -378,6 +376,8 @@ class ElasticsearchServiceTest
       from = from
     )
   }
+
+  private def createElasticsearchQueryOptions: ElasticsearchQueryOptions = createElasticsearchQueryOptionsWith()
 
   private def searchResponseToWorks(
     response: SearchResponse): List[IdentifiedBaseWork] =

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -5,13 +5,10 @@ import com.sksamuel.elastic4s.http.search.{SearchHit, SearchResponse}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.models.work.internal.{
-  IdentifiedBaseWork,
-  IdentifiedWork,
-  WorkType
-}
+import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, IdentifiedWork, WorkType}
 import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.api.fixtures.ElasticsearchServiceFixture
+import uk.ac.wellcome.platform.api.models.WorkTypeFilter
 
 import scala.concurrent.Future
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, IdentifiedWork, WorkType}
 import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.api.fixtures.ElasticsearchServiceFixture
-import uk.ac.wellcome.platform.api.models.WorkTypeFilter
+import uk.ac.wellcome.platform.api.models.{WorkFilter, WorkTypeFilter}
 
 import scala.concurrent.Future
 
@@ -64,7 +64,7 @@ class ElasticsearchServiceTest
           indexName = indexName,
           queryString = "artichokes",
           queryOptions = createElasticsearchQueryOptionsWith(
-            workTypeFilter = Some("b")
+            filters = List(WorkTypeFilter("b"))
           ),
           expectedWorks = List(workWithCorrectWorkType)
         )
@@ -99,7 +99,7 @@ class ElasticsearchServiceTest
           indexName = indexName,
           queryString = "artichokes",
           queryOptions = createElasticsearchQueryOptionsWith(
-            workTypeFilter = Some("b,m")
+            filters = List(WorkTypeFilter("b,m"))
           ),
           expectedWorks = List(work1, work2)
         )
@@ -266,7 +266,7 @@ class ElasticsearchServiceTest
           workWithWrongWorkType)
 
         val queryOptions = createElasticsearchQueryOptionsWith(
-          workTypeFilter = Some("b")
+          filters = List(WorkTypeFilter("b"))
         )
 
         assertListResultsAreCorrect(
@@ -301,7 +301,7 @@ class ElasticsearchServiceTest
           workWithWrongWorkType)
 
         val queryOptions = createElasticsearchQueryOptionsWith(
-          workTypeFilter = Some("b, m")
+          filters = List(WorkTypeFilter(List("b", "a")))
         )
 
         assertListResultsAreCorrect(
@@ -362,20 +362,15 @@ class ElasticsearchServiceTest
     )
 
   private def createElasticsearchQueryOptionsWith(
-    workTypeFilter: Option[String] = None,
+    filters: List[WorkFilter] = List(),
     limit: Int = 10,
     from: Int = 0
-  ): ElasticsearchQueryOptions = {
-    val filters = List(
-      workTypeFilter.map { arg => WorkTypeFilter(arg) }
-    ).flatten
-
+  ): ElasticsearchQueryOptions =
     ElasticsearchQueryOptions(
       filters = filters,
       limit = limit,
       from = from
     )
-  }
 
   private def createElasticsearchQueryOptions: ElasticsearchQueryOptions = createElasticsearchQueryOptionsWith()
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -101,7 +101,7 @@ class ElasticsearchServiceTest
           indexName = indexName,
           queryString = "artichokes",
           queryOptions = createElasticsearchQueryOptionsWith(
-            filters = List(WorkTypeFilter("b,m"))
+            filters = List(WorkTypeFilter(List("b", "m")))
           ),
           expectedWorks = List(work1, work2)
         )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -4,10 +4,8 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal.WorkType
 import uk.ac.wellcome.models.work.test.util.WorksGenerators
-import uk.ac.wellcome.platform.api.fixtures.{
-  ElasticsearchServiceFixture,
-  WorksServiceFixture
-}
+import uk.ac.wellcome.platform.api.fixtures.{ElasticsearchServiceFixture, WorksServiceFixture}
+import uk.ac.wellcome.platform.api.models.WorkTypeFilter
 
 class WorksServiceTest
     extends FunSpec

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -285,7 +285,9 @@ class WorksServiceTest
     pageNumber: Int = 1
   ): WorksSearchOptions =
     WorksSearchOptions(
-      workTypeFilter = workTypeFilter,
+      filters = List(
+        workTypeFilter.map { arg => WorkTypeFilter(arg) }
+      ).flatten,
       pageSize = pageSize,
       pageNumber = pageNumber
     )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal.WorkType
 import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.api.fixtures.{ElasticsearchServiceFixture, WorksServiceFixture}
+import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
 import uk.ac.wellcome.platform.api.models.WorkTypeFilter
 
 class WorksServiceTest
@@ -13,6 +14,7 @@ class WorksServiceTest
     with WorksServiceFixture
     with Matchers
     with ScalaFutures
+    with SearchOptionsGenerators
     with WorksGenerators {
 
   val itemType = "work"
@@ -105,10 +107,10 @@ class WorksServiceTest
               workWithWrongWorkType)
 
             val future = worksService.listWorks(
-              documentOptions =
-                createElasticsearchDocumentOptionsWith(indexName = indexName),
-              worksSearchOptions =
-                createWorksSearchOptionsWith(workTypeFilter = Some("b"))
+              documentOptions = createElasticsearchDocumentOptionsWith(indexName = indexName),
+              worksSearchOptions = createWorksSearchOptionsWith(
+                filters = List(WorkTypeFilter("b"))
+              )
             )
 
             whenReady(future) { resultList =>
@@ -254,11 +256,12 @@ class WorksServiceTest
               workWithWrongTitle,
               workWithWrongWorkType)
 
-            val searchForEmu = worksService.searchWorks(query = "artichokes")(
-              documentOptions =
-                createElasticsearchDocumentOptionsWith(indexName = indexName),
-              worksSearchOptions =
-                createWorksSearchOptionsWith(workTypeFilter = Some("b"))
+            val searchForEmu = worksService.searchWorks(
+              query = "artichokes")(
+              documentOptions = createElasticsearchDocumentOptionsWith(indexName = indexName),
+              worksSearchOptions = createWorksSearchOptionsWith(
+                filters = List(WorkTypeFilter("b"))
+              )
             )
 
             whenReady(searchForEmu) { works =>
@@ -269,27 +272,4 @@ class WorksServiceTest
       }
     }
   }
-
-  private def createElasticsearchDocumentOptionsWith(
-    indexName: String): ElasticsearchDocumentOptions =
-    ElasticsearchDocumentOptions(
-      indexName = indexName,
-      documentType = itemType
-    )
-
-  private def createWorksSearchOptionsWith(
-    workTypeFilter: Option[String] = None,
-    pageSize: Int = 10,
-    pageNumber: Int = 1
-  ): WorksSearchOptions =
-    WorksSearchOptions(
-      filters = List(
-        workTypeFilter.map { arg => WorkTypeFilter(arg) }
-      ).flatten,
-      pageSize = pageSize,
-      pageNumber = pageNumber
-    )
-
-  private def createWorksSearchOptions: WorksSearchOptions =
-    createWorksSearchOptionsWith()
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -4,7 +4,10 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal.WorkType
 import uk.ac.wellcome.models.work.test.util.WorksGenerators
-import uk.ac.wellcome.platform.api.fixtures.{ElasticsearchServiceFixture, WorksServiceFixture}
+import uk.ac.wellcome.platform.api.fixtures.{
+  ElasticsearchServiceFixture,
+  WorksServiceFixture
+}
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
 import uk.ac.wellcome.platform.api.models.WorkTypeFilter
 
@@ -104,7 +107,8 @@ class WorksServiceTest
               workWithWrongWorkType)
 
             val future = worksService.listWorks(
-              documentOptions = createElasticsearchDocumentOptionsWith(indexName = indexName),
+              documentOptions =
+                createElasticsearchDocumentOptionsWith(indexName = indexName),
               worksSearchOptions = createWorksSearchOptionsWith(
                 filters = List(WorkTypeFilter("b"))
               )
@@ -146,7 +150,8 @@ class WorksServiceTest
               workWithWrongWorkType)
 
             val future = worksService.listWorks(
-              documentOptions = createElasticsearchDocumentOptionsWith(indexName = indexName),
+              documentOptions =
+                createElasticsearchDocumentOptionsWith(indexName = indexName),
               worksSearchOptions = createWorksSearchOptionsWith(
                 filters = List(WorkTypeFilter(List("b", "a")))
               )
@@ -296,9 +301,9 @@ class WorksServiceTest
               workWithWrongTitle,
               workWithWrongWorkType)
 
-            val searchForEmu = worksService.searchWorks(
-              query = "artichokes")(
-              documentOptions = createElasticsearchDocumentOptionsWith(indexName = indexName),
+            val searchForEmu = worksService.searchWorks(query = "artichokes")(
+              documentOptions =
+                createElasticsearchDocumentOptionsWith(indexName = indexName),
               worksSearchOptions = createWorksSearchOptionsWith(
                 filters = List(WorkTypeFilter("b"))
               )
@@ -341,9 +346,9 @@ class WorksServiceTest
               work2,
               workWithWrongWorkType)
 
-            val searchForEmu = worksService.searchWorks(
-              query = "artichokes")(
-              documentOptions = createElasticsearchDocumentOptionsWith(indexName = indexName),
+            val searchForEmu = worksService.searchWorks(query = "artichokes")(
+              documentOptions =
+                createElasticsearchDocumentOptionsWith(indexName = indexName),
               worksSearchOptions = createWorksSearchOptionsWith(
                 filters = List(WorkTypeFilter(List("b", "m")))
               )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -59,11 +59,7 @@ trait ApiWorksTestBase
 
   def emptyJsonResult(apiPrefix: String): String = s"""
     |{
-    |  "@context": "https://localhost:8888/$apiPrefix/context.json",
-    |  "type": "ResultList",
-    |  "pageSize": 10,
-    |  "totalPages": 0,
-    |  "totalResults": 0,
+    |  ${resultList(apiPrefix, totalPages = 0, totalResults = 0)}
     |  "results": []
     |}""".stripMargin
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -59,7 +59,7 @@ trait ApiWorksTestBase
 
   def emptyJsonResult(apiPrefix: String): String = s"""
     |{
-    |  ${resultList(apiPrefix, totalPages = 0, totalResults = 0)}
+    |  ${resultList(apiPrefix, totalPages = 0, totalResults = 0)},
     |  "results": []
     |}""".stripMargin
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1FiltersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1FiltersTest.scala
@@ -99,11 +99,11 @@ class ApiV1FiltersTest extends ApiV1WorksTestBase {
     it("can filter by multiple workTypes") {
       withV1Api {
         case (
-          apiPrefix,
-          indexNameV1,
-          _,
-          itemType,
-          server: EmbeddedHttpServer) =>
+            apiPrefix,
+            indexNameV1,
+            _,
+            itemType,
+            server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               workType = Some(WorkType(id = "m", label = "Manuscripts")))
@@ -130,7 +130,8 @@ class ApiV1FiltersTest extends ApiV1WorksTestBase {
                                 |      "type": "Work",
                                 |      "id": "${matchingWork1.canonicalId}",
                                 |      "title": "${matchingWork1.title}",
-                                |      "workType": ${workType(matchingWork1.workType.get)},
+                                |      "workType": ${workType(
+                                  matchingWork1.workType.get)},
                                 |      "creators": [ ],
                                 |      "subjects": [ ],
                                 |      "genres": [ ],
@@ -141,7 +142,8 @@ class ApiV1FiltersTest extends ApiV1WorksTestBase {
                                 |      "type": "Work",
                                 |      "id": "${matchingWork2.canonicalId}",
                                 |      "title": "${matchingWork2.title}",
-                                |      "workType": ${workType(matchingWork2.workType.get)},
+                                |      "workType": ${workType(
+                                  matchingWork2.workType.get)},
                                 |      "creators": [ ],
                                 |      "subjects": [ ],
                                 |      "genres": [ ],
@@ -254,7 +256,12 @@ class ApiV1FiltersTest extends ApiV1WorksTestBase {
 
     it("can filter by multiple workTypes") {
       withV1Api {
-        case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+        case (
+            apiPrefix,
+            indexNameV1,
+            _,
+            itemType,
+            server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               title = "Bouncing bananas",
@@ -284,7 +291,8 @@ class ApiV1FiltersTest extends ApiV1WorksTestBase {
                                 |      "type": "Work",
                                 |      "id": "${matchingWork1.canonicalId}",
                                 |      "title": "${matchingWork1.title}",
-                                |      "workType": ${workType(matchingWork1.workType.get)},
+                                |      "workType": ${workType(
+                                  matchingWork1.workType.get)},
                                 |      "creators": [ ],
                                 |      "subjects": [ ],
                                 |      "genres": [ ],
@@ -295,7 +303,8 @@ class ApiV1FiltersTest extends ApiV1WorksTestBase {
                                 |      "type": "Work",
                                 |      "id": "${matchingWork2.canonicalId}",
                                 |      "title": "${matchingWork2.title}",
-                                |      "workType": ${workType(matchingWork2.workType.get)},
+                                |      "workType": ${workType(
+                                  matchingWork2.workType.get)},
                                 |      "creators": [ ],
                                 |      "subjects": [ ],
                                 |      "genres": [ ],

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1FiltersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1FiltersTest.scala
@@ -95,6 +95,66 @@ class ApiV1FiltersTest extends ApiV1WorksTestBase {
           }
       }
     }
+
+    it("can filter by multiple workTypes") {
+      withV1Api {
+        case (
+          apiPrefix,
+          indexNameV1,
+          _,
+          itemType,
+          server: EmbeddedHttpServer) =>
+          val wrongWorkTypeWorks = (1 to 3).map { _ =>
+            createIdentifiedWorkWith(
+              workType = Some(WorkType(id = "m", label = "Manuscripts")))
+          }
+          val matchingWork1 = createIdentifiedWorkWith(
+            canonicalId = "001",
+            workType = Some(WorkType(id = "b", label = "Books")))
+          val matchingWork2 = createIdentifiedWorkWith(
+            canonicalId = "002",
+            workType = Some(WorkType(id = "a", label = "Archives")))
+
+          val works = wrongWorkTypeWorks :+ matchingWork1 :+ matchingWork2
+          insertIntoElasticsearch(indexNameV1, itemType, works: _*)
+
+          eventually {
+            server.httpGet(
+              path = s"/$apiPrefix/works?workType=a,b",
+              andExpect = Status.Ok,
+              withJsonBody = s"""
+                                |{
+                                |  ${resultList(apiPrefix, totalResults = 2)},
+                                |  "results": [
+                                |    {
+                                |      "type": "Work",
+                                |      "id": "${matchingWork1.canonicalId}",
+                                |      "title": "${matchingWork1.title}",
+                                |      "workType": ${workType(matchingWork1.workType.get)},
+                                |      "creators": [ ],
+                                |      "subjects": [ ],
+                                |      "genres": [ ],
+                                |      "publishers": [ ],
+                                |      "placesOfPublication": [ ]
+                                |    },
+                                |    {
+                                |      "type": "Work",
+                                |      "id": "${matchingWork2.canonicalId}",
+                                |      "title": "${matchingWork2.title}",
+                                |      "workType": ${workType(matchingWork2.workType.get)},
+                                |      "creators": [ ],
+                                |      "subjects": [ ],
+                                |      "genres": [ ],
+                                |      "publishers": [ ],
+                                |      "placesOfPublication": [ ]
+                                |    }
+                                |  ]
+                                |}
+          """.stripMargin
+            )
+          }
+      }
+    }
   }
 
   describe("searching works") {
@@ -186,6 +246,64 @@ class ApiV1FiltersTest extends ApiV1WorksTestBase {
                    |    }
                    |  ]
                    |}
+          """.stripMargin
+            )
+          }
+      }
+    }
+
+    it("can filter by multiple workTypes") {
+      withV1Api {
+        case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+          val wrongWorkTypeWorks = (1 to 3).map { _ =>
+            createIdentifiedWorkWith(
+              title = "Bouncing bananas",
+              workType = Some(WorkType(id = "m", label = "Manuscripts")))
+          }
+          val matchingWork1 = createIdentifiedWorkWith(
+            canonicalId = "001",
+            title = "Bouncing bananas",
+            workType = Some(WorkType(id = "b", label = "Books")))
+          val matchingWork2 = createIdentifiedWorkWith(
+            canonicalId = "002",
+            title = "Bouncing bananas",
+            workType = Some(WorkType(id = "a", label = "Archives")))
+
+          val works = wrongWorkTypeWorks :+ matchingWork1 :+ matchingWork2
+          insertIntoElasticsearch(indexNameV1, itemType, works: _*)
+
+          eventually {
+            server.httpGet(
+              path = s"/$apiPrefix/works?query=bananas&workType=a,b",
+              andExpect = Status.Ok,
+              withJsonBody = s"""
+                                |{
+                                |  ${resultList(apiPrefix, totalResults = 2)},
+                                |  "results": [
+                                |    {
+                                |      "type": "Work",
+                                |      "id": "${matchingWork1.canonicalId}",
+                                |      "title": "${matchingWork1.title}",
+                                |      "workType": ${workType(matchingWork1.workType.get)},
+                                |      "creators": [ ],
+                                |      "subjects": [ ],
+                                |      "genres": [ ],
+                                |      "publishers": [ ],
+                                |      "placesOfPublication": [ ]
+                                |    },
+                                |    {
+                                |      "type": "Work",
+                                |      "id": "${matchingWork2.canonicalId}",
+                                |      "title": "${matchingWork2.title}",
+                                |      "workType": ${workType(matchingWork2.workType.get)},
+                                |      "creators": [ ],
+                                |      "subjects": [ ],
+                                |      "genres": [ ],
+                                |      "publishers": [ ],
+                                |      "placesOfPublication": [ ]
+                                |    }
+                                |  ]
+                                |}
           """.stripMargin
             )
           }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
@@ -89,11 +89,11 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
     it("can filter by multiple workTypes") {
       withV2Api {
         case (
-          apiPrefix,
-          _,
-          indexNameV2,
-          itemType,
-          server: EmbeddedHttpServer) =>
+            apiPrefix,
+            _,
+            indexNameV2,
+            itemType,
+            server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               workType = Some(WorkType(id = "m", label = "Manuscripts")))
@@ -120,13 +120,15 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
                                 |      "type": "Work",
                                 |      "id": "${matchingWork1.canonicalId}",
                                 |      "title": "${matchingWork1.title}",
-                                |      "workType": ${workType(matchingWork1.workType.get)}
+                                |      "workType": ${workType(
+                                  matchingWork1.workType.get)}
                                 |    },
                                 |    {
                                 |      "type": "Work",
                                 |      "id": "${matchingWork2.canonicalId}",
                                 |      "title": "${matchingWork2.title}",
-                                |      "workType": ${workType(matchingWork2.workType.get)}
+                                |      "workType": ${workType(
+                                  matchingWork2.workType.get)}
                                 |    }
                                 |  ]
                                 |}
@@ -225,11 +227,11 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
     it("can filter by multiple workTypes") {
       withV2Api {
         case (
-          apiPrefix,
-          _,
-          indexNameV2,
-          itemType,
-          server: EmbeddedHttpServer) =>
+            apiPrefix,
+            _,
+            indexNameV2,
+            itemType,
+            server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               title = "Bouncing bananas",
@@ -259,13 +261,15 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
                                 |      "type": "Work",
                                 |      "id": "${matchingWork1.canonicalId}",
                                 |      "title": "${matchingWork1.title}",
-                                |      "workType": ${workType(matchingWork1.workType.get)}
+                                |      "workType": ${workType(
+                                  matchingWork1.workType.get)}
                                 |    },
                                 |    {
                                 |      "type": "Work",
                                 |      "id": "${matchingWork2.canonicalId}",
                                 |      "title": "${matchingWork2.title}",
-                                |      "workType": ${workType(matchingWork2.workType.get)}
+                                |      "workType": ${workType(
+                                  matchingWork2.workType.get)}
                                 |    }
                                 |  ]
                                 |}


### PR DESCRIPTION
Follows #2901, another part of #2798.

This patch:

* Adds a generic `WorkFilter` trait, with one instance `WorkTypeFilter`
* Modifies `WorkTypeFilter` to support matching on multiple values
* Modifies ElasticsearchQueryOptions and WorksSearchOptions to have a more general `List[WorkFilter]` parameter
* Adds a bunch of tests for filtering against multiple values