### PR TITLE
Bagger permissions fix

### DIFF
--- a/archive/bagger/Dockerfile
+++ b/archive/bagger/Dockerfile
@@ -8,7 +8,6 @@ RUN apk add --update --no-cache --virtual=run-deps \
 ENV EXAMPLE_VARIABLE example_value
 
 WORKDIR /opt/app
-CMD ["/opt/app/run.sh"]
 
 COPY run.sh /opt/app/
 RUN chmod +x /opt/app/run.sh
@@ -17,3 +16,5 @@ COPY src/requirements.txt /opt/app/
 RUN pip3 install --no-cache-dir -r /opt/app/requirements.txt
 
 COPY src /opt/app/
+
+CMD ["/opt/app/run.sh"]

--- a/archive/terraform/iam_policy_document.tf
+++ b/archive/terraform/iam_policy_document.tf
@@ -128,6 +128,7 @@ data "aws_iam_policy_document" "read_from_bagger_queue" {
       "sqs:DeleteMessage",
       "sqs:ReceiveMessage",
       "sqs:ChangeMessageVisibility",
+      "sqs:GetQueueUrl",
     ]
 
     resources = [


### PR DESCRIPTION
Allow the `bagger` service to go from a queue name to a URL.
