### PR TITLE
Fix test flakiness in WorksServiceTest

### DIFF
--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -272,7 +272,9 @@ class WorksServiceTest
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
       withElasticsearchService { searchService =>
         withWorksService(searchService) { worksService =>
-          insertIntoElasticsearch(indexName, itemType, allWorks: _*)
+          if (!allWorks.isEmpty) {
+            insertIntoElasticsearch(indexName, itemType, allWorks: _*)
+          }
 
           val documentOptions = createElasticsearchDocumentOptionsWith(
             indexName = indexName

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -10,6 +10,7 @@ import uk.ac.wellcome.platform.api.fixtures.{
 }
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
 import uk.ac.wellcome.platform.api.models.WorkTypeFilter
+import uk.ac.wellcome.test.fixtures.TestWith
 
 class WorksServiceTest
     extends FunSpec
@@ -233,23 +234,21 @@ class WorksServiceTest
     worksSearchOptions: WorksSearchOptions = createWorksSearchOptions
   ) =
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withElasticsearchService { searchService =>
-        withWorksService(searchService) { worksService =>
-          insertIntoElasticsearch(indexName, itemType, allWorks: _*)
+      withWorksService { worksService =>
+        insertIntoElasticsearch(indexName, itemType, allWorks: _*)
 
-          val documentOptions = createElasticsearchDocumentOptionsWith(
-            indexName = indexName
-          )
+        val documentOptions = createElasticsearchDocumentOptionsWith(
+          indexName = indexName
+        )
 
-          val future = worksService.listWorks(
-            documentOptions = documentOptions,
-            worksSearchOptions = worksSearchOptions
-          )
+        val future = worksService.listWorks(
+          documentOptions = documentOptions,
+          worksSearchOptions = worksSearchOptions
+        )
 
-          whenReady(future) { works =>
-            works.results should contain theSameElementsAs expectedWorks
-            works.totalResults shouldBe expectedTotalResults
-          }
+        whenReady(future) { works =>
+          works.results should contain theSameElementsAs expectedWorks
+          works.totalResults shouldBe expectedTotalResults
         }
       }
     }
@@ -261,23 +260,28 @@ class WorksServiceTest
     worksSearchOptions: WorksSearchOptions = createWorksSearchOptions
   ) =
     withLocalElasticsearchIndex(itemType = itemType) { indexName =>
-      withElasticsearchService { searchService =>
-        withWorksService(searchService) { worksService =>
-          insertIntoElasticsearch(indexName, itemType, allWorks: _*)
+      withWorksService { worksService =>
+        insertIntoElasticsearch(indexName, itemType, allWorks: _*)
 
-          val documentOptions = createElasticsearchDocumentOptionsWith(
-            indexName = indexName
-          )
+        val documentOptions = createElasticsearchDocumentOptionsWith(
+          indexName = indexName
+        )
 
-          val future = worksService.searchWorks(query = query)(
-            documentOptions = documentOptions,
-            worksSearchOptions = worksSearchOptions
-          )
+        val future = worksService.searchWorks(query = query)(
+          documentOptions = documentOptions,
+          worksSearchOptions = worksSearchOptions
+        )
 
-          whenReady(future) { works =>
-            works.results should contain theSameElementsAs expectedWorks
-          }
+        whenReady(future) { works =>
+          works.results should contain theSameElementsAs expectedWorks
         }
+      }
+    }
+
+  def withWorksService[R](testWith: TestWith[WorksService, R]): R =
+    withElasticsearchService { searchService =>
+      withWorksService(searchService) { worksService =>
+        testWith(worksService)
       }
     }
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -279,6 +279,7 @@ class WorksServiceTest
 
           whenReady(future) { works =>
             works.results should contain theSameElementsAs expectedWorks
+            works.totalResults shouldBe expectedTotalResults
           }
         }
       }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -173,7 +173,8 @@ class WorksServiceTest
       )
 
       assertSearchResultIsCorrect(
-        query = "emu \"unmatched quotes are a lexical error in the Elasticsearch parser"
+        query =
+          "emu \"unmatched quotes are a lexical error in the Elasticsearch parser"
       )(
         allWorks = List(workEmu),
         expectedWorks = List(workEmu),
@@ -259,7 +260,9 @@ class WorksServiceTest
     )(allWorks, expectedWorks, expectedTotalResults, worksSearchOptions)
 
   private def assertResultIsCorrect(
-    partialSearchFunction: (WorksService) => ((ElasticsearchDocumentOptions, WorksSearchOptions) => Future[ResultList])
+    partialSearchFunction: (WorksService) => (
+      (ElasticsearchDocumentOptions,
+       WorksSearchOptions) => Future[ResultList])
   )(
     allWorks: Seq[IdentifiedBaseWork],
     expectedWorks: Seq[IdentifiedBaseWork],
@@ -275,7 +278,9 @@ class WorksServiceTest
             indexName = indexName
           )
 
-          val future = partialSearchFunction(worksService)(documentOptions, worksSearchOptions)
+          val future = partialSearchFunction(worksService)(
+            documentOptions,
+            worksSearchOptions)
 
           whenReady(future) { works =>
             works.results should contain theSameElementsAs expectedWorks


### PR DESCRIPTION
Travis is failing on master because I’m querying Elasticsearch and then asserting `Seq(...) shouldBe result` – which fails if the order of randomly generated IDs happens to be wrong.

This patch changes that entire test to use `theSameElementsAs` consistently.