### PR TITLE
Don’t have stubbed out logic for filtering in the V1 API

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
@@ -4,7 +4,7 @@ import com.google.inject.{Inject, Singleton}
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.display.models.{ApiVersions, V1WorksIncludes}
 import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
-import uk.ac.wellcome.platform.api.models.ApiConfig
+import uk.ac.wellcome.platform.api.models.{ApiConfig, WorkFilter}
 import uk.ac.wellcome.platform.api.requests.{
   V1MultipleResultsRequest,
   V1SingleWorkRequest
@@ -37,4 +37,8 @@ class V1WorksController @Inject()(
     setupSingleWorkEndpoint(ApiVersions.v1, "/works/:id", DisplayWorkV1.apply)
   }
   lazy override protected val includeParameterName: String = "includes"
+
+  /* There's no requirement for any filtering in the V1 API. */
+  override def buildFilters(
+    request: V1MultipleResultsRequest): List[WorkFilter] = List()
 }

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
@@ -5,7 +5,7 @@ import io.swagger.models.{Operation, Swagger}
 import uk.ac.wellcome.display.models.{ApiVersions, DisplayWork, V2WorksIncludes}
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
 import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
-import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayResultList}
+import uk.ac.wellcome.platform.api.models._
 import uk.ac.wellcome.platform.api.requests.{
   V2MultipleResultsRequest,
   V2SingleWorkRequest
@@ -39,6 +39,29 @@ class V2WorksController @Inject()(
   prefix(s"${apiConfig.pathPrefix}/${ApiVersions.v2.toString}") {
     setupResultListEndpoint(ApiVersions.v2, "/works", DisplayWorkV2.apply)
     setupSingleWorkEndpoint(ApiVersions.v2, "/works/:id", DisplayWorkV2.apply)
+  }
+
+  override def buildFilters(
+    request: V2MultipleResultsRequest): List[WorkFilter] = {
+    val maybeItemLocationTypeFilter: Option[ItemLocationTypeFilter] =
+      request.itemLocationType
+        .map { arg =>
+          arg.split(",").map { _.trim }
+        }
+        .map { locationTypeIds: Array[String] =>
+          ItemLocationTypeFilter(locationTypeIds)
+        }
+
+    val maybeWorkTypeFilter: Option[WorkTypeFilter] =
+      request.workType
+        .map { arg =>
+          arg.split(",").map { _.trim }
+        }
+        .map { workTypeIds: Array[String] =>
+          WorkTypeFilter(workTypeIds)
+        }
+
+    List(maybeItemLocationTypeFilter, maybeWorkTypeFilter).flatten
   }
 
   override def setupResultListSwaggerDocs[T <: DisplayWork](

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -108,27 +108,7 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
   /** Given a request object, return a list of WorkFilter instances that should
     * be applied to the corresponding Elasticsearch request.
     */
-  private def buildFilters(request: M): List[WorkFilter] = {
-    val maybeItemLocationTypeFilter: Option[ItemLocationTypeFilter] =
-      request.itemLocationType
-        .map { arg =>
-          arg.split(",").map { _.trim }
-        }
-        .map { locationTypeIds: Array[String] =>
-          ItemLocationTypeFilter(locationTypeIds)
-        }
-
-    val maybeWorkTypeFilter: Option[WorkTypeFilter] =
-      request.workType
-        .map { arg =>
-          arg.split(",").map { _.trim }
-        }
-        .map { workTypeIds: Array[String] =>
-          WorkTypeFilter(workTypeIds)
-        }
-
-    List(maybeItemLocationTypeFilter, maybeWorkTypeFilter).flatten
-  }
+  def buildFilters(request: M): List[WorkFilter]
 
   private def getWorkList(request: M, pageSize: Int): Future[ResultList] = {
     val documentOptions = ElasticsearchDocumentOptions(

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
@@ -18,8 +18,6 @@ trait MultipleResultsRequest[W <: WorksIncludes] extends ApiRequest {
   val pageSize: Option[Int]
   val include: Option[W]
   val query: Option[String]
-  val workType: Option[String]
-  val itemLocationType: Option[String]
   val _index: Option[String]
   val request: Request
 }
@@ -33,14 +31,6 @@ case class V1MultipleResultsRequest(
   request: Request
 ) extends MultipleResultsRequest[V1WorksIncludes] {
   val include: Option[V1WorksIncludes] = includes
-
-  // Every item in the V1 API has the same workType, so this filter
-  // has no purpose.
-  override val workType = None
-
-  // Every item in the V1 API has a single item with the same LocationType,
-  // so this filter isn't very useful!
-  override val itemLocationType: Option[String] = None
 }
 
 case class V2MultipleResultsRequest(


### PR DESCRIPTION
Picking up a comment from #2921 – now we know we’ll never need filters in V1, let’s push all this logic into V2 specific classes.