### PR TITLE
Make heavier use of the SourceIdentifier generators

### DIFF
--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -5,8 +5,8 @@ import com.sksamuel.elastic4s.http.search.{SearchHit, SearchResponse}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.api.fixtures.ElasticsearchServiceFixture
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
 import uk.ac.wellcome.platform.api.models.{

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -2,8 +2,8 @@ package uk.ac.wellcome.platform.api.services
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, WorkType}
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.api.fixtures.{
   ElasticsearchServiceFixture,
   WorksServiceFixture

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -6,8 +6,8 @@ import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.api.Server
 import uk.ac.wellcome.test.fixtures.TestWith
 

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -5,9 +5,9 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 
 import scala.collection.JavaConverters._
 

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.idminter.database
 
 import org.scalatest.{FunSpec, Matchers}
 import scalikejdbc._
-import uk.ac.wellcome.models.work.test.util.IdentifiersGenerators
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.platform.idminter.database.exceptions.IdMinterException
 import uk.ac.wellcome.platform.idminter.fixtures
 import uk.ac.wellcome.platform.idminter.models.{Identifier, IdentifiersTable}

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdEmbedderTests.scala
@@ -6,10 +6,10 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.utils.JsonAssertions
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Try

--- a/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/catalogue_pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -5,7 +5,7 @@ import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import scalikejdbc._
-import uk.ac.wellcome.models.work.test.util.IdentifiersGenerators
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.platform.idminter.database.{
   IdentifiersDao,
   TableProvisioner

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -5,9 +5,9 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
 import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.utils.JsonAssertions
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 
 import scala.collection.JavaConverters._
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -46,9 +46,7 @@ class IngestorFeatureTest
   it(
     "reads a sierra identified work from the queue and ingests it in the v2 index only") {
     val work = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(
-        identifierType = createSierraSystemSourceIdentifierType
-      )
+      sourceIdentifier = createSierraSystemSourceIdentifier
     )
 
     withLocalSqsQueue { queue =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.messaging.message.MessageStream
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
-import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, Subject}
+import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, IdentifierType, Subject}
 import uk.ac.wellcome.platform.ingestor.{IngestElasticConfig, IngestorConfig}
 import uk.ac.wellcome.platform.ingestor.fixtures.WorkIndexerFixtures
 import uk.ac.wellcome.storage.fixtures.S3
@@ -161,7 +161,7 @@ class IngestorWorkerServiceTest
   it("Inserts a non sierra or miro identified work") {
     val work = createIdentifiedWorkWith(
       sourceIdentifier = createSourceIdentifierWith(
-        identifierType = createCalmSourceIdentifierType
+        identifierType = IdentifierType("calm-altref-no")
       )
     )
 
@@ -196,7 +196,8 @@ class IngestorWorkerServiceTest
     )
     val otherWork = createIdentifiedWorkWith(
       sourceIdentifier = createSourceIdentifierWith(
-        identifierType = createCalmSourceIdentifierType)
+        identifierType = IdentifierType("calm-altref-no")
+      )
     )
 
     val works = List(miroWork, sierraWork, otherWork)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -130,12 +130,10 @@ class IngestorWorkerServiceTest
 
   it("inserts a mixture of miro and sierra works into the correct index") {
     val miroWork1 = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(
-        identifierType = createMiroSourceIdentifierType)
+      sourceIdentifier = createMiroSourceIdentifier
     )
     val miroWork2 = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(
-        identifierType = createMiroSourceIdentifierType)
+      sourceIdentifier = createMiroSourceIdentifier
     )
     val sierraWork1 = createIdentifiedWorkWith(
       sourceIdentifier = createSourceIdentifierWith(
@@ -199,8 +197,7 @@ class IngestorWorkerServiceTest
   it(
     "inserts a mixture of miro and sierra works into the index and sends invalid messages to the dlq") {
     val miroWork = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(
-        identifierType = createMiroSourceIdentifierType)
+      sourceIdentifier = createMiroSourceIdentifier
     )
     val sierraWork = createIdentifiedWorkWith(
       sourceIdentifier = createSourceIdentifierWith(

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -12,8 +12,8 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.message.MessageStream
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, Subject}
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.ingestor.{IngestElasticConfig, IngestorConfig}
 import uk.ac.wellcome.platform.ingestor.fixtures.WorkIndexerFixtures
 import uk.ac.wellcome.storage.fixtures.S3

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -61,9 +61,7 @@ class IngestorWorkerServiceTest
 
   it("inserts an Sierra identified Work into the index") {
     val work = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(
-        identifierType = createSierraSystemSourceIdentifierType
-      )
+      sourceIdentifier = createSierraSystemSourceIdentifier
     )
 
     withLocalElasticsearchIndex(itemType = itemType) { esIndex =>
@@ -84,9 +82,7 @@ class IngestorWorkerServiceTest
 
   it("inserts an Sierra identified invisible Work into the index") {
     val work = createIdentifiedInvisibleWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(
-        identifierType = createSierraSystemSourceIdentifierType
-      )
+      sourceIdentifier = createSierraSystemSourceIdentifier
     )
 
     withLocalElasticsearchIndex(itemType = itemType) { esIndex =>
@@ -107,9 +103,7 @@ class IngestorWorkerServiceTest
 
   it("inserts an Sierra identified redirected Work into the index") {
     val work = createIdentifiedRedirectedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(
-        identifierType = createSierraSystemSourceIdentifierType
-      )
+      sourceIdentifier = createSierraSystemSourceIdentifier
     )
 
     withLocalElasticsearchIndex(itemType = itemType) { esIndex =>
@@ -136,12 +130,10 @@ class IngestorWorkerServiceTest
       sourceIdentifier = createMiroSourceIdentifier
     )
     val sierraWork1 = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(
-        identifierType = createSierraSystemSourceIdentifierType)
+      sourceIdentifier = createSierraSystemSourceIdentifier
     )
     val sierraWork2 = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(
-        identifierType = createSierraSystemSourceIdentifierType)
+      sourceIdentifier = createSierraSystemSourceIdentifier
     )
 
     val works = List(miroWork1, miroWork2, sierraWork1, sierraWork2)
@@ -200,8 +192,7 @@ class IngestorWorkerServiceTest
       sourceIdentifier = createMiroSourceIdentifier
     )
     val sierraWork = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(
-        identifierType = createSierraSystemSourceIdentifierType)
+      sourceIdentifier = createSierraSystemSourceIdentifier
     )
     val otherWork = createIdentifiedWorkWith(
       sourceIdentifier = createSourceIdentifierWith(
@@ -238,12 +229,10 @@ class IngestorWorkerServiceTest
   it(
     "deletes successfully ingested works from the queue, including older versions of already ingested works") {
     val sierraWork = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(
-        identifierType = createSierraSystemSourceIdentifierType)
+      sourceIdentifier = createSierraSystemSourceIdentifier
     )
     val newSierraWork = createIdentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(
-        identifierType = createSierraSystemSourceIdentifierType),
+      sourceIdentifier = createSierraSystemSourceIdentifier
       version = 2
     )
     val oldSierraWork = newSierraWork.copy(version = 1)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -233,7 +233,7 @@ class IngestorWorkerServiceTest
       sourceIdentifier = createSierraSystemSourceIdentifier
     )
     val newSierraWork = createIdentifiedWorkWith(
-      sourceIdentifier = createSierraSystemSourceIdentifier
+      sourceIdentifier = createSierraSystemSourceIdentifier,
       version = 2
     )
     val oldSierraWork = newSierraWork.copy(version = 1)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -13,7 +13,11 @@ import uk.ac.wellcome.messaging.message.MessageStream
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
-import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, IdentifierType, Subject}
+import uk.ac.wellcome.models.work.internal.{
+  IdentifiedBaseWork,
+  IdentifierType,
+  Subject
+}
 import uk.ac.wellcome.platform.ingestor.{IngestElasticConfig, IngestorConfig}
 import uk.ac.wellcome.platform.ingestor.fixtures.WorkIndexerFixtures
 import uk.ac.wellcome.storage.fixtures.S3

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -3,8 +3,8 @@ package uk.ac.wellcome.platform.ingestor.services
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.Subject
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.ingestor.fixtures.WorkIndexerFixtures
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -10,8 +10,8 @@ import uk.ac.wellcome.models.matcher.{
   WorkNode
 }
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 
 class MatcherFeatureTest

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -9,12 +9,10 @@ import org.apache.commons.codec.digest.DigestUtils
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
-import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.{
   IdentifierType,
   SourceIdentifier,
-  TransformedBaseWork,
-  UnidentifiedWork
+  TransformedBaseWork
 }
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
@@ -43,8 +41,7 @@ trait MatcherFixtures
     with SNS
     with LocalWorkGraphDynamoDb
     with MetricsSenderFixture
-    with S3
-    with WorksGenerators {
+    with S3 {
 
   implicit val instantLongFormat: AnyRef with DynamoFormat[Instant] =
     DynamoFormat.coercedXmap[Instant, Long, IllegalArgumentException](
@@ -187,11 +184,6 @@ trait MatcherFixtures
       identifierType = IdentifierType("sierra-system-number"),
       "Work",
       id)
-
-  def anUnidentifiedSierraWork: UnidentifiedWork =
-    createUnidentifiedWorkWith(
-      sourceIdentifier = aSierraSourceIdentifier("id")
-    )
 
   def ciHash(str: String): String = {
     DigestUtils.sha256Hex(str)

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -9,11 +9,7 @@ import org.apache.commons.codec.digest.DigestUtils
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
-import uk.ac.wellcome.models.work.internal.{
-  IdentifierType,
-  SourceIdentifier,
-  TransformedBaseWork
-}
+import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.matcher.Server
@@ -178,12 +174,6 @@ trait MatcherFixtures
     )
     testWith(workNodeDao)
   }
-
-  def aSierraSourceIdentifier(id: String) =
-    SourceIdentifier(
-      identifierType = IdentifierType("sierra-system-number"),
-      "Work",
-      id)
 
   def ciHash(str: String): String = {
     DigestUtils.sha256Hex(str)

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -9,13 +9,13 @@ import org.apache.commons.codec.digest.DigestUtils
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.{
   IdentifierType,
   SourceIdentifier,
   TransformedBaseWork,
   UnidentifiedWork
 }
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.matcher.Server

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
@@ -31,8 +31,10 @@ class WorkMatcherConcurrencyTest
                   withWorkMatcherAndLockingService(
                     workGraphStore,
                     dynamoLockingService) { workMatcher =>
-                    val identifierA = createSierraSystemSourceIdentifierWith(value = "A")
-                    val identifierB = createSierraSystemSourceIdentifierWith(value = "B")
+                    val identifierA =
+                      createSierraSystemSourceIdentifierWith(value = "A")
+                    val identifierB =
+                      createSierraSystemSourceIdentifierWith(value = "B")
 
                     val workA = createUnidentifiedWorkWith(
                       sourceIdentifier = identifierA,

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
@@ -29,8 +29,8 @@ class WorkMatcherConcurrencyTest
                   withWorkMatcherAndLockingService(
                     workGraphStore,
                     dynamoLockingService) { workMatcher =>
-                    val identifierA = aSierraSourceIdentifier("A")
-                    val identifierB = aSierraSourceIdentifier("B")
+                    val identifierA = createSierraSystemSourceIdentifierWith(value = "A")
+                    val identifierB = createSierraSystemSourceIdentifierWith(value = "B")
 
                     val workA = createUnidentifiedWorkWith(
                       sourceIdentifier = identifierA,

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.exceptions.GracefulFailureException
 import uk.ac.wellcome.models.matcher.MatcherResult
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.MergeCandidate
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 
@@ -16,7 +17,8 @@ class WorkMatcherConcurrencyTest
     with Matchers
     with MatcherFixtures
     with ScalaFutures
-    with MockitoSugar {
+    with MockitoSugar
+    with WorksGenerators {
 
   it("processes one of two conflicting concurrent updates and locks the other") {
     withMockMetricSender { metricsSender =>

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -13,6 +13,7 @@ import uk.ac.wellcome.models.matcher.{
   WorkIdentifier,
   WorkNode
 }
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.MergeCandidate
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
@@ -32,7 +33,8 @@ class WorkMatcherTest
     with Matchers
     with MatcherFixtures
     with ScalaFutures
-    with MockitoSugar {
+    with MockitoSugar
+    with WorksGenerators {
 
   private val identifierA = createSierraSystemSourceIdentifierWith(value = "A")
   private val identifierB = createSierraSystemSourceIdentifierWith(value = "B")

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -51,19 +51,18 @@ class WorkMatcherTest
                 val work = createUnidentifiedSierraWork
                 val workId = work.sourceIdentifier.toString
 
-                whenReady(workMatcher.matchWork(work)) {
-                  matcherResult =>
-                    matcherResult shouldBe
-                      MatcherResult(
-                        Set(MatchedIdentifiers(Set(WorkIdentifier(workId, 1)))))
+                whenReady(workMatcher.matchWork(work)) { matcherResult =>
+                  matcherResult shouldBe
+                    MatcherResult(
+                      Set(MatchedIdentifiers(Set(WorkIdentifier(workId, 1)))))
 
-                    val savedLinkedWork = Scanamo
-                      .get[WorkNode](dynamoDbClient)(graphTable.name)(
-                        'id -> workId)
-                      .map(_.right.get)
+                  val savedLinkedWork = Scanamo
+                    .get[WorkNode](dynamoDbClient)(graphTable.name)(
+                      'id -> workId)
+                    .map(_.right.get)
 
-                    savedLinkedWork shouldBe Some(
-                      WorkNode(workId, 1, Nil, ciHash(workId)))
+                  savedLinkedWork shouldBe Some(
+                    WorkNode(workId, 1, Nil, ciHash(workId)))
                 }
             }
           }
@@ -229,9 +228,7 @@ class WorkMatcherTest
                     workGraphStore,
                     dynamoLockingService) { workMatcher =>
                     val failedLock = for {
-                      _ <- rowLockDao.lockRow(
-                        Identifier(workId),
-                        "processId")
+                      _ <- rowLockDao.lockRow(Identifier(workId), "processId")
                       result <- workMatcher.matchWork(work)
                     } yield result
 
@@ -259,7 +256,6 @@ class WorkMatcherTest
                   withWorkMatcherAndLockingService(
                     workGraphStore,
                     dynamoLockingService) { workMatcher =>
-
                     // A->B->C
                     workGraphStore.put(WorkGraph(Set(
                       WorkNode(
@@ -318,9 +314,10 @@ class WorkMatcherTest
                       FailedUnlockException("test", new RuntimeException)))
 
                   whenReady(
-                    workMatcher.matchWork(createUnidentifiedSierraWork).failed) {
-                    failedMatch =>
-                      failedMatch shouldBe a[MatcherException]
+                    workMatcher
+                      .matchWork(createUnidentifiedSierraWork)
+                      .failed) { failedMatch =>
+                    failedMatch shouldBe a[MatcherException]
                   }
                 }
             }
@@ -342,7 +339,8 @@ class WorkMatcherTest
             when(mockWorkGraphStore.put(any[WorkGraph]))
               .thenThrow(expectedException)
 
-            whenReady(workMatcher.matchWork(createUnidentifiedSierraWork).failed) {
+            whenReady(
+              workMatcher.matchWork(createUnidentifiedSierraWork).failed) {
               actualException =>
                 actualException shouldBe expectedException
             }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -34,6 +34,10 @@ class WorkMatcherTest
     with ScalaFutures
     with MockitoSugar {
 
+  private val identifierA = createSierraSystemSourceIdentifierWith(value = "A")
+  private val identifierB = createSierraSystemSourceIdentifierWith(value = "B")
+  private val identifierC = createSierraSystemSourceIdentifierWith(value = "C")
+
   it(
     "matches a work with no linked identifiers to itself only A and saves the updated graph A") {
     withMockMetricSender { mockMetricsSender =>
@@ -100,8 +104,6 @@ class WorkMatcherTest
           withWorkGraphStore(graphTable) { workGraphStore =>
             withWorkMatcher(workGraphStore, lockTable, mockMetricsSender) {
               workMatcher =>
-                val identifierA = aSierraSourceIdentifier("A")
-                val identifierB = aSierraSourceIdentifier("B")
                 val work = createUnidentifiedWorkWith(
                   sourceIdentifier = identifierA,
                   mergeCandidates = List(MergeCandidate(identifierB))
@@ -164,12 +166,10 @@ class WorkMatcherTest
                 Scanamo.put(dynamoDbClient)(graphTable.name)(existingWorkB)
                 Scanamo.put(dynamoDbClient)(graphTable.name)(existingWorkC)
 
-                val bIdentifier = aSierraSourceIdentifier("B")
-                val cIdentifier = aSierraSourceIdentifier("C")
                 val work = createUnidentifiedWorkWith(
-                  sourceIdentifier = bIdentifier,
+                  sourceIdentifier = identifierB,
                   version = 2,
-                  mergeCandidates = List(MergeCandidate(cIdentifier)))
+                  mergeCandidates = List(MergeCandidate(identifierC)))
 
                 whenReady(workMatcher.matchWork(work)) { identifiersList =>
                   identifiersList shouldBe
@@ -257,8 +257,6 @@ class WorkMatcherTest
                   withWorkMatcherAndLockingService(
                     workGraphStore,
                     dynamoLockingService) { workMatcher =>
-                    val identifierA = aSierraSourceIdentifier("A")
-                    val identifierB = aSierraSourceIdentifier("B")
 
                     // A->B->C
                     workGraphStore.put(WorkGraph(Set(

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
@@ -39,8 +39,7 @@ class MatcherMessageReceiverTest
             val updatedWork = createUnidentifiedSierraWork
             val expectedMatchedWorks =
               MatcherResult(
-                Set(MatchedIdentifiers(
-                  Set(WorkIdentifier(updatedWork)))))
+                Set(MatchedIdentifiers(Set(WorkIdentifier(updatedWork)))))
 
             processAndAssertMatchedWorkIs(
               updatedWork,

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
@@ -11,6 +11,7 @@ import uk.ac.wellcome.models.matcher.{
   MatcherResult,
   WorkIdentifier
 }
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
@@ -22,7 +23,8 @@ class MatcherMessageReceiverTest
     with Matchers
     with Eventually
     with IntegrationPatience
-    with MatcherFixtures {
+    with MatcherFixtures
+    with WorksGenerators {
 
   private val identifierA = createSierraSystemSourceIdentifierWith(value = "A")
   private val identifierB = createSierraSystemSourceIdentifierWith(value = "B")

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
@@ -24,9 +24,9 @@ class MatcherMessageReceiverTest
     with IntegrationPatience
     with MatcherFixtures {
 
-  private val aIdentifier = aSierraSourceIdentifier("A")
-  private val bIdentifier = aSierraSourceIdentifier("B")
-  private val cIdentifier = aSierraSourceIdentifier("C")
+  private val identifierA = createSierraSystemSourceIdentifierWith(value = "A")
+  private val identifierB = createSierraSystemSourceIdentifierWith(value = "B")
+  private val identifierC = createSierraSystemSourceIdentifierWith(value = "C")
 
   it("creates a work without identifiers") {
     withLocalSnsTopic { topic =>
@@ -89,8 +89,8 @@ class MatcherMessageReceiverTest
             // Work Av1
             val workAv1 =
               createUnidentifiedWorkWith(
-                sourceIdentifier = aIdentifier,
-                mergeCandidates = List(MergeCandidate(bIdentifier)))
+                sourceIdentifier = identifierA,
+                mergeCandidates = List(MergeCandidate(identifierB)))
             // Work Av1 matched to B (before B exists hence version 0)
             // need to match to works that do not exist to support
             // bi-directionally matched works without deadlocking (A->B, B->A)
@@ -120,7 +120,7 @@ class MatcherMessageReceiverTest
           withMatcherMessageReceiver(queue, storageBucket, topic) { _ =>
             // Work Av1
             val workAv1 =
-              createUnidentifiedWorkWith(sourceIdentifier = aIdentifier)
+              createUnidentifiedWorkWith(sourceIdentifier = identifierA)
 
             val expectedMatchedWorks = MatcherResult(
               Set(
@@ -137,7 +137,7 @@ class MatcherMessageReceiverTest
 
             // Work Bv1
             val workBv1 =
-              createUnidentifiedWorkWith(sourceIdentifier = bIdentifier)
+              createUnidentifiedWorkWith(sourceIdentifier = identifierB)
 
             processAndAssertMatchedWorkIs(
               workBv1,
@@ -149,9 +149,9 @@ class MatcherMessageReceiverTest
 
             // Work Av1 matched to B
             val workAv2 = createUnidentifiedWorkWith(
-              sourceIdentifier = aIdentifier,
+              sourceIdentifier = identifierA,
               version = 2,
-              mergeCandidates = List(MergeCandidate(bIdentifier)))
+              mergeCandidates = List(MergeCandidate(identifierB)))
 
             processAndAssertMatchedWorkIs(
               workAv2,
@@ -167,7 +167,7 @@ class MatcherMessageReceiverTest
 
             // Work Cv1
             val workCv1 =
-              createUnidentifiedWorkWith(sourceIdentifier = cIdentifier)
+              createUnidentifiedWorkWith(sourceIdentifier = identifierC)
 
             processAndAssertMatchedWorkIs(
               workCv1,
@@ -179,9 +179,9 @@ class MatcherMessageReceiverTest
 
             // Work Bv2 matched to C
             val workBv2 = createUnidentifiedWorkWith(
-              sourceIdentifier = bIdentifier,
+              sourceIdentifier = identifierB,
               version = 2,
-              mergeCandidates = List(MergeCandidate(cIdentifier)))
+              mergeCandidates = List(MergeCandidate(identifierC)))
 
             processAndAssertMatchedWorkIs(
               workBv2,
@@ -209,7 +209,7 @@ class MatcherMessageReceiverTest
           withMatcherMessageReceiver(queue, storageBucket, topic) { _ =>
             // Work Av1
             val workAv1 = createUnidentifiedWorkWith(
-              sourceIdentifier = aIdentifier,
+              sourceIdentifier = identifierA,
               version = 1)
 
             processAndAssertMatchedWorkIs(
@@ -222,7 +222,7 @@ class MatcherMessageReceiverTest
 
             // Work Bv1
             val workBv1 = createUnidentifiedWorkWith(
-              sourceIdentifier = bIdentifier,
+              sourceIdentifier = identifierB,
               version = 1)
 
             processAndAssertMatchedWorkIs(
@@ -235,9 +235,9 @@ class MatcherMessageReceiverTest
 
             // Match Work A to Work B
             val workAv2MatchedToB = createUnidentifiedWorkWith(
-              sourceIdentifier = aIdentifier,
+              sourceIdentifier = identifierA,
               version = 2,
-              mergeCandidates = List(MergeCandidate(bIdentifier)))
+              mergeCandidates = List(MergeCandidate(identifierB)))
 
             processAndAssertMatchedWorkIs(
               workAv2MatchedToB,
@@ -253,7 +253,7 @@ class MatcherMessageReceiverTest
 
             // A no longer matches B
             val workAv3WithNoMatchingWorks = createUnidentifiedWorkWith(
-              sourceIdentifier = aIdentifier,
+              sourceIdentifier = identifierA,
               version = 3)
 
             processAndAssertMatchedWorkIs(
@@ -282,7 +282,7 @@ class MatcherMessageReceiverTest
             _ =>
               // process Work V2
               val workAv2 = createUnidentifiedWorkWith(
-                sourceIdentifier = aIdentifier,
+                sourceIdentifier = identifierA,
                 version = 2
               )
 
@@ -299,7 +299,7 @@ class MatcherMessageReceiverTest
 
               // Work V1 is sent but not matched
               val workAv1 = createUnidentifiedWorkWith(
-                sourceIdentifier = aIdentifier,
+                sourceIdentifier = identifierA,
                 version = 1)
 
               sendMessage[TransformedBaseWork](
@@ -327,7 +327,7 @@ class MatcherMessageReceiverTest
           withLocalS3Bucket { storageBucket =>
             withMatcherMessageReceiver(queue, storageBucket, topic) { _ =>
               val workAv2 = createUnidentifiedWorkWith(
-                sourceIdentifier = aIdentifier,
+                sourceIdentifier = identifierA,
                 version = 2
               )
 
@@ -344,8 +344,8 @@ class MatcherMessageReceiverTest
 
               // Work V1 is sent but not matched
               val differentWorkAv2 = createUnidentifiedWorkWith(
-                sourceIdentifier = aIdentifier,
-                mergeCandidates = List(MergeCandidate(bIdentifier)),
+                sourceIdentifier = identifierA,
+                mergeCandidates = List(MergeCandidate(identifierB)),
                 version = 2)
 
               sendMessage[TransformedBaseWork](

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/messages/MatcherMessageReceiverTest.scala
@@ -34,11 +34,11 @@ class MatcherMessageReceiverTest
         withLocalS3Bucket { storageBucket =>
           withMatcherMessageReceiver(queue, storageBucket, topic) { _ =>
             // Work Av1 created without any matched works
-            val updatedWork = anUnidentifiedSierraWork
+            val updatedWork = createUnidentifiedSierraWork
             val expectedMatchedWorks =
               MatcherResult(
                 Set(MatchedIdentifiers(
-                  Set(WorkIdentifier("sierra-system-number/id", 1)))))
+                  Set(WorkIdentifier(updatedWork)))))
 
             processAndAssertMatchedWorkIs(
               updatedWork,

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -5,8 +5,8 @@ import org.scalatest.{Assertion, FunSpec}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.test.fixtures.Messaging
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.merger.fixtures.{
   LocalWorksVhs,
   MatcherResultFixture

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/physicaldigital/SierraPhysicalDigitalMergeRuleTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/physicaldigital/SierraPhysicalDigitalMergeRuleTest.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.merger.rules.physicaldigital
 
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.merger.rules.physicaldigital.SierraPhysicalDigitalMergeRule.mergeAndRedirectWorks
 
 class SierraPhysicalDigitalMergeRuleTest

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/physicaldigital/SierraPhysicalDigitalPartitionerTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/physicaldigital/SierraPhysicalDigitalPartitionerTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.merger.rules.physicaldigital
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 
 class SierraPhysicalDigitalPartitionerTest
     extends FunSpec

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRuleTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRuleTest.scala
@@ -75,8 +75,9 @@ class SierraMiroMergeRuleTest
       val sierraWork =
         createUnidentifiedSierraWorkWith(items = List(sierraItem))
 
-      val miroLibraryReferenceSourceIdentifier =
-        createMiroLibraryReferenceSourceIdentifier
+      val miroLibraryReferenceSourceIdentifier = createSourceIdentifierWith(
+        identifierType = IdentifierType("miro-library-reference")
+      )
       val miroWork = createMiroWorkWith(
         otherIdentifiers = List(
           miroLibraryReferenceSourceIdentifier,

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRuleTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRuleTest.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.merger.rules.singlepagemiro
 
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.merger.rules.singlepagemiro.SierraMiroMergeRule.mergeAndRedirectWorks
 
 class SierraMiroMergeRuleTest

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroPartitionerTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroPartitionerTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.merger.rules.singlepagemiro
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 
 class SierraMiroPartitionerTest
     extends FunSpec

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
@@ -1,13 +1,13 @@
 package uk.ac.wellcome.platform.merger.services
 
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.{
   BaseWork,
   IdentifiableRedirect,
   UnidentifiedRedirectedWork,
   UnidentifiedWork
 }
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 
 class MergerManagerTest extends FunSpec with Matchers with WorksGenerators {
 

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.merger.services
 
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 
 class MergerTest extends FunSpec with WorksGenerators with Matchers {
   private val sierraPhysicalWork = createSierraPhysicalWork

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -14,8 +14,8 @@ import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult}
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.merger.fixtures.{

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
@@ -4,8 +4,8 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.matcher.WorkIdentifier
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.merger.fixtures.LocalWorksVhs
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}

--- a/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
+++ b/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
@@ -4,8 +4,8 @@ import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.test.fixtures.Messaging
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.storage.fixtures.LocalVersionedHybridStore
 import uk.ac.wellcome.storage.vhs.EmptyMetadata
 

--- a/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -9,8 +9,8 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.{Queue, QueuePair}
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.fixtures.LocalVersionedHybridStore

--- a/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
@@ -12,11 +12,11 @@ import uk.ac.wellcome.messaging.message.{MessageWriter, MessageWriterConfig}
 import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.{
   TransformedBaseWork,
   UnidentifiedWork
 }
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectStore}
 import uk.ac.wellcome.storage.fixtures.S3

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableTransformerTest.scala
@@ -2,24 +2,24 @@ package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.models.work.internal._
 
 class MiroTransformableTransformerTest
     extends FunSpec
     with Matchers
+    with IdentifiersGenerators
     with MiroTransformableWrapper {
 
   it("passes through the Miro identifier") {
-    val MiroID = "M0000005_test"
+    val miroId = "M0000005_test"
     val work = transformWork(
       data = """"image_title": "A picture of a passing porpoise"""",
-      miroId = MiroID
+      miroId = miroId
     )
     work.identifiers shouldBe List(
-      SourceIdentifier(
-        identifierType = IdentifierType("miro-image-number"),
-        "Work",
-        MiroID))
+      createMiroSourceIdentifierWith(value = miroId)
+    )
   }
 
   it("passes through the INNOPAC ID as the Sierra system number") {
@@ -286,10 +286,12 @@ class MiroTransformableTransformerTest
     work.itemsV1 shouldBe List(
       Identifiable(
         Item(List(expectedLocation)),
-        SourceIdentifier(
-          IdentifierType("miro-image-number"),
-          "Item",
-          "B0011308")))
+        createMiroSourceIdentifierWith(
+          value = "B0011308",
+          ontologyType = "Item"
+        )
+      )
+    )
     work.items shouldBe List(Unidentifiable(Item(List(expectedLocation))))
   }
 
@@ -310,10 +312,8 @@ class MiroTransformableTransformerTest
     triedMaybeWork.isSuccess shouldBe true
 
     triedMaybeWork.get shouldBe UnidentifiedInvisibleWork(
-      sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("miro-image-number"),
-        ontologyType = "Work",
-        value = miroTransformable.sourceId
+      sourceIdentifier = createMiroSourceIdentifierWith(
+        value = miroId
       ),
       version = 1
     )
@@ -332,14 +332,8 @@ class MiroTransformableTransformerTest
       miroId = miroID
     )
     work.identifiers shouldBe List(
-      SourceIdentifier(
-        identifierType = IdentifierType("miro-image-number"),
-        "Work",
-        miroID),
-      SourceIdentifier(
-        identifierType = IdentifierType("sierra-system-number"),
-        "Work",
-        expectedSierraNumber)
+      createMiroSourceIdentifierWith(value = miroID),
+      createSierraSystemSourceIdentifierWith(value = expectedSierraNumber)
     )
   }
 
@@ -347,24 +341,22 @@ class MiroTransformableTransformerTest
     data: String,
     expectedValues: List[String]
   ) = {
+    val miroId = "V0175278"
     val work = transformWork(
       data = s"""
         "image_title": "A fanciful frolicking of fish",
         $data
       """,
-      miroId = "V0175278"
+      miroId = miroId
     )
     val miroIDList = List(
-      SourceIdentifier(
-        identifierType = IdentifierType("miro-image-number"),
-        "Work",
-        "V0175278")
+      createMiroSourceIdentifierWith(value = miroId)
     )
-    val libraryRefList = expectedValues.map {
-      SourceIdentifier(
+    val libraryRefList = expectedValues.map { value =>
+      createSourceIdentifierWith(
         identifierType = IdentifierType("miro-library-reference"),
-        "Work",
-        _)
+        value = value
+      )
     }
     work.identifiers shouldBe (miroIDList ++ libraryRefList)
   }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/miro/MiroIdentifiersTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/miro/MiroIdentifiersTest.scala
@@ -5,7 +5,10 @@ import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.platform.transformer.miro.source.MiroTransformableData
 import uk.ac.wellcome.platform.transformer.miro.transformers.MiroIdentifiers
 
-class MiroIdentifiersTest extends FunSpec with Matchers with IdentifiersGenerators {
+class MiroIdentifiersTest
+    extends FunSpec
+    with Matchers
+    with IdentifiersGenerators {
 
   it("fixes the malformed INNOPAC ID on L0035411") {
     val miroData = MiroTransformableData(

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/miro/MiroIdentifiersTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/miro/MiroIdentifiersTest.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers.miro
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier}
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.platform.transformer.miro.source.MiroTransformableData
 import uk.ac.wellcome.platform.transformer.miro.transformers.MiroIdentifiers
 
-class MiroIdentifiersTest extends FunSpec with Matchers {
+class MiroIdentifiersTest extends FunSpec with Matchers with IdentifiersGenerators {
 
   it("fixes the malformed INNOPAC ID on L0035411") {
     val miroData = MiroTransformableData(
@@ -16,10 +16,8 @@ class MiroIdentifiersTest extends FunSpec with Matchers {
       transformer.getOtherIdentifiers(miroData = miroData, miroId = "L0035411")
 
     otherIdentifiers shouldBe List(
-      SourceIdentifier(
-        identifierType = IdentifierType("sierra-system-number"),
-        value = "b15551040",
-        ontologyType = "Work"
+      createSierraSystemSourceIdentifierWith(
+        value = "b15551040"
       )
     )
   }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/miro/MiroItemsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/miro/MiroItemsTest.scala
@@ -1,11 +1,12 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers.miro
 
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.miro.source.MiroTransformableData
 import uk.ac.wellcome.platform.transformer.miro.transformers.MiroItems
 
-class MiroItemsTest extends FunSpec with Matchers {
+class MiroItemsTest extends FunSpec with Matchers with IdentifiersGenerators {
   val transformer = new MiroItems {}
 
   describe("getItemsV1") {
@@ -23,10 +24,10 @@ class MiroItemsTest extends FunSpec with Matchers {
             LocationType("iiif-image"),
             Some(License_CC0),
             credit = Some("Ezra Feilden")))),
-          sourceIdentifier = SourceIdentifier(
-            IdentifierType("miro-image-number"),
-            "Item",
-            "B0011308")
+          sourceIdentifier = createMiroSourceIdentifierWith(
+            value = "B0011308",
+            ontologyType = "Item"
+          )
         ))
     }
   }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerFeatureTest.scala
@@ -73,9 +73,10 @@ class SierraTransformerFeatureTest
                   value = id.withCheckDigit
                 )
 
-                val sierraIdentifier = createSierraIdentifierSourceIdentifierWith(
-                  value = id.withoutCheckDigit
-                )
+                val sierraIdentifier =
+                  createSierraIdentifierSourceIdentifierWith(
+                    value = id.withoutCheckDigit
+                  )
 
                 val works = getMessages[UnidentifiedWork](topic)
                 works.length shouldBe >=(1)

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerFeatureTest.scala
@@ -7,11 +7,7 @@ import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.SierraTransformable._
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraGenerators
-import uk.ac.wellcome.models.work.internal.{
-  IdentifierType,
-  SourceIdentifier,
-  UnidentifiedWork
-}
+import uk.ac.wellcome.models.work.internal.UnidentifiedWork
 import uk.ac.wellcome.storage.fixtures.S3
 
 class SierraTransformerFeatureTest
@@ -73,15 +69,11 @@ class SierraTransformerFeatureTest
                 val snsMessages = listMessagesReceivedFromSNS(topic)
                 snsMessages.size should be >= 1
 
-                val sourceIdentifier = SourceIdentifier(
-                  identifierType = IdentifierType("sierra-system-number"),
-                  ontologyType = "Work",
+                val sourceIdentifier = createSierraSystemSourceIdentifierWith(
                   value = id.withCheckDigit
                 )
 
-                val sierraIdentifier = SourceIdentifier(
-                  identifierType = IdentifierType("sierra-identifier"),
-                  ontologyType = "Work",
+                val sierraIdentifier = createSierraIdentifierSourceIdentifierWith(
                   value = id.withoutCheckDigit
                 )
 

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/SierraDataGenerators.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/SierraDataGenerators.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.transformer.sierra.generators
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraGenerators
-import uk.ac.wellcome.models.work.test.util.IdentifiersGenerators
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.platform.transformer.sierra.source._
 import uk.ac.wellcome.platform.transformer.sierra.source.sierra.{
   SierraSourceLanguage,

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -4,11 +4,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraGenerators
-import uk.ac.wellcome.models.transformable.sierra.{
-  SierraBibNumber,
-  SierraBibRecord,
-  SierraItemRecord
-}
+import uk.ac.wellcome.models.transformable.sierra.{SierraBibNumber, SierraBibRecord, SierraItemRecord}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
@@ -37,10 +33,9 @@ class SierraTransformableTransformerTest
     )
 
     val expectedIdentifiers = itemRecords.map { record =>
-      SourceIdentifier(
-        identifierType = IdentifierType("sierra-system-number"),
-        ontologyType = "Item",
-        value = record.id.withCheckDigit
+      createSierraSystemSourceIdentifierWith(
+        value = record.id.withCheckDigit,
+        ontologyType = "Item"
       )
     }
 
@@ -120,17 +115,15 @@ class SierraTransformableTransformerTest
     val unidentifiedWork = work.asInstanceOf[UnidentifiedWork]
     unidentifiedWork.items should have size 1
 
-    val expectedSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("sierra-system-number"),
-      ontologyType = "Item",
-      value = itemId.withCheckDigit
+    val expectedSourceIdentifier = createSierraSystemSourceIdentifierWith(
+      value = itemId.withCheckDigit,
+      ontologyType = "Item"
     )
 
     val expectedOtherIdentifiers = List(
-      SourceIdentifier(
-        identifierType = IdentifierType("sierra-identifier"),
-        ontologyType = "Item",
-        value = itemId.withoutCheckDigit
+      createSierraIdentifierSourceIdentifierWith(
+        value = itemId.withoutCheckDigit,
+        ontologyType = "Item"
       )
     )
 
@@ -242,14 +235,10 @@ class SierraTransformableTransformerTest
          |}
         """.stripMargin
 
-    val sourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("sierra-system-number"),
-      ontologyType = "Work",
+    val sourceIdentifier = createSierraSystemSourceIdentifierWith(
       value = id.withCheckDigit
     )
-    val sierraIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("sierra-identifier"),
-      ontologyType = "Work",
+    val sierraIdentifier = createSierraIdentifierSourceIdentifierWith(
       value = id.withoutCheckDigit
     )
 
@@ -418,9 +407,7 @@ class SierraTransformableTransformerTest
     val id = createSierraBibNumber
     val data = s"""{"id": "$id", "title": "A title"}"""
 
-    val expectedSourceIdentifier = SourceIdentifier(
-      identifierType = IdentifierType("sierra-system-number"),
-      ontologyType = "Work",
+    val expectedSourceIdentifier = createSierraSystemSourceIdentifierWith(
       value = id.withCheckDigit
     )
 
@@ -674,9 +661,7 @@ class SierraTransformableTransformerTest
     val work = transformDataToUnidentifiedWork(id = id, data = data)
     work.mergeCandidates shouldBe List(
       MergeCandidate(
-        identifier = SourceIdentifier(
-          identifierType = IdentifierType("sierra-system-number"),
-          ontologyType = "Work",
+        identifier = createSierraIdentifierSourceIdentifierWith(
           value = mergeCandidateBibNumber
         ),
         reason = Some("Physical/digitised Sierra work")
@@ -713,11 +698,7 @@ class SierraTransformableTransformerTest
     val work = transformDataToUnidentifiedWork(id = id, data = data)
     work.mergeCandidates shouldBe List(
       MergeCandidate(
-        identifier = SourceIdentifier(
-          identifierType = IdentifierType("miro-image-number"),
-          ontologyType = "Work",
-          value = miroId
-        ),
+        identifier = createMiroSourceIdentifierWith(value = miroId),
         reason = Some("Single page Miro/Sierra work")
       )
     )
@@ -753,11 +734,7 @@ class SierraTransformableTransformerTest
     val work = transformDataToUnidentifiedWork(id = id, data = data)
     work.mergeCandidates shouldBe List(
       MergeCandidate(
-        identifier = SourceIdentifier(
-          identifierType = IdentifierType("miro-image-number"),
-          ontologyType = "Work",
-          value = miroId
-        ),
+        identifier = createMiroSourceIdentifierWith(value = miroId),
         reason = Some("Single page Miro/Sierra work")
       )
     )
@@ -896,9 +873,7 @@ class SierraTransformableTransformerTest
     triedMaybeWork.isSuccess shouldBe true
 
     triedMaybeWork.get shouldBe UnidentifiedInvisibleWork(
-      sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType("sierra-system-number"),
-        ontologyType = "Work",
+      sourceIdentifier = createSierraSystemSourceIdentifierWith(
         value = id.withCheckDigit
       ),
       version = 1

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -661,7 +661,7 @@ class SierraTransformableTransformerTest
     val work = transformDataToUnidentifiedWork(id = id, data = data)
     work.mergeCandidates shouldBe List(
       MergeCandidate(
-        identifier = createSierraIdentifierSourceIdentifierWith(
+        identifier = createSierraSystemSourceIdentifierWith(
           value = mergeCandidateBibNumber
         ),
         reason = Some("Physical/digitised Sierra work")

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -4,7 +4,11 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraGenerators
-import uk.ac.wellcome.models.transformable.sierra.{SierraBibNumber, SierraBibRecord, SierraItemRecord}
+import uk.ac.wellcome.models.transformable.sierra.{
+  SierraBibNumber,
+  SierraBibRecord,
+  SierraItemRecord
+}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -9,8 +9,8 @@ import uk.ac.wellcome.models.transformable.sierra.{
   SierraBibRecord,
   SierraItemRecord
 }
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.sierra.SierraTransformableTransformer
 import uk.ac.wellcome.platform.transformer.sierra.generators.MarcGenerators

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -11,7 +11,6 @@ import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import uk.ac.wellcome.monitoring.fixtures.CloudWatch
 import uk.ac.wellcome.platform.snapshot_generator.fixtures.AkkaS3
 import uk.ac.wellcome.platform.snapshot_generator.models.{
@@ -24,6 +23,7 @@ import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.utils.JsonAssertions
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 
 class SnapshotGeneratorFeatureTest
     extends FunSpec

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models.{V1WorksIncludes, V2WorksIncludes}
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.test.fixtures.Akka
 
 class IdentifiedWorkToVisibleDisplayWorkFlowTest

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -21,7 +21,7 @@ import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
 import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.platform.snapshot_generator.finatra.modules.AkkaS3ClientModule
 import uk.ac.wellcome.platform.snapshot_generator.fixtures.AkkaS3
 import uk.ac.wellcome.platform.snapshot_generator.models.{

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElastisearchSourceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElastisearchSourceTest.scala
@@ -4,7 +4,7 @@ import akka.stream.scaladsl.Sink
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.test.fixtures.Akka
 
 class ElastisearchSourceTest

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayAgentV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayAgentV1Test.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.models.work.internal.{Agent, Identified}
-import uk.ac.wellcome.models.work.test.util.IdentifiersGenerators
 
 class DisplayAgentV1Test
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
@@ -2,8 +2,8 @@ package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 
 class DisplayCreatorsV1SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1Test.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.test.util.ItemsGenerators
+import uk.ac.wellcome.models.work.generators.ItemsGenerators
 
 class DisplayItemV1Test extends FunSpec with Matchers with ItemsGenerators {
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
@@ -3,8 +3,8 @@ package uk.ac.wellcome.display.models.v1
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.V1WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 
 class DisplayLocationsV1SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -3,8 +3,8 @@ package uk.ac.wellcome.display.models.v1
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.V1WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 
 class DisplayWorkV1SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -2,8 +2,8 @@ package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models._
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 
 class DisplayWorkV1Test extends FunSpec with Matchers with WorksGenerators {
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractAgentV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractAgentV2Test.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.IdentifiersGenerators
 
 class DisplayAbstractAgentV2Test
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
@@ -2,8 +2,8 @@ package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.IdentifiersGenerators
 
 class DisplayAbstractConceptSerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayConceptTest.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.IdentifiersGenerators
 
 class DisplayConceptTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
@@ -2,8 +2,8 @@ package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.IdentifiersGenerators
 
 class DisplayGenreV2SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2Test.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.test.util.ItemsGenerators
+import uk.ac.wellcome.models.work.generators.ItemsGenerators
 
 class DisplayItemV2Test extends FunSpec with Matchers with ItemsGenerators {
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationsV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationsV2SerialisationTest.scala
@@ -3,8 +3,8 @@ package uk.ac.wellcome.display.models.v2
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.V2WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 
 class DisplayLocationsV2SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
@@ -2,8 +2,8 @@ package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.IdentifiersGenerators
 
 class DisplaySubjectV2SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -3,8 +3,8 @@ package uk.ac.wellcome.display.models.v2
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.V2WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 
 class DisplayWorkV2SerialisationTest
     extends FunSpec

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2Test.scala
@@ -4,8 +4,8 @@ import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
 import org.scalacheck.ScalacheckShapeless._
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 
 class DisplayWorkV2Test
     extends FunSpec

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexTest.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, Person, Subject, Unidentifiable}
 import org.scalacheck.ScalacheckShapeless._
 import uk.ac.wellcome.json.utils.JsonAssertions
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 
 import scala.concurrent.ExecutionContext.Implicits.global
 

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/test/utils/SierraGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/transformable/sierra/test/utils/SierraGenerators.scala
@@ -9,8 +9,8 @@ import uk.ac.wellcome.models.transformable.sierra.{
   SierraItemNumber,
   SierraItemRecord
 }
-import uk.ac.wellcome.models.work.test.util.IdentifiersGenerators
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 
 import scala.util.Random
 

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
@@ -59,10 +59,6 @@ trait IdentifiersGenerators {
   def createMiroSourceIdentifier: SourceIdentifier =
     createMiroSourceIdentifierWith()
 
-  def createMiroLibraryReferenceSourceIdentifier: SourceIdentifier =
-    createSourceIdentifierWith(
-      identifierType = createMiroLibrarySourceIdentifierType)
-
   def createSierraIdentifierSourceIdentifier: SourceIdentifier =
     createSourceIdentifierWith(
       identifierType = createSierraIdentifierSourceIdentifierType)
@@ -77,10 +73,6 @@ trait IdentifiersGenerators {
 
   def createIsbnSourceIdentifierType: IdentifierType = {
     IdentifierType("isbn")
-  }
-
-  def createMiroLibrarySourceIdentifierType: IdentifierType = {
-    IdentifierType("miro-library-reference")
   }
 
   def createCalmSourceIdentifierType: IdentifierType = {

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.models.work.test.util
+package uk.ac.wellcome.models.work.generators
 
 import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier}
 

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
@@ -27,9 +27,10 @@ trait IdentifiersGenerators {
 
   def createSierraSystemSourceIdentifierWith(
     value: String = randomAlphanumeric(length = 10),
-    ontologyType: String = "Work"): SourceIdentifier =
+    ontologyType: String = "Work"
+  ): SourceIdentifier =
     SourceIdentifier(
-      identifierType = createSierraSystemSourceIdentifierType,
+      identifierType = IdentifierType("sierra-system-number"),
       value = value,
       ontologyType = ontologyType
     )
@@ -62,10 +63,6 @@ trait IdentifiersGenerators {
   def createSierraIdentifierSourceIdentifier: SourceIdentifier =
     createSourceIdentifierWith(
       identifierType = createSierraIdentifierSourceIdentifierType)
-
-  def createSierraSystemSourceIdentifierType: IdentifierType = {
-    IdentifierType("sierra-system-number")
-  }
 
   def createSierraIdentifierSourceIdentifierType: IdentifierType = {
     IdentifierType("sierra-identifier")

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
@@ -49,16 +49,8 @@ trait IdentifiersGenerators {
     createSierraIdentifierSourceIdentifierWith()
 
   def createIsbnSourceIdentifier: SourceIdentifier =
-    createIsbnSourceIdentifierWith()
-
-  def createIsbnSourceIdentifierWith(
-    value: String = randomAlphanumeric(length = 10),
-    ontologyType: String = "Work"
-  ): SourceIdentifier =
-    SourceIdentifier(
-      identifierType = IdentifierType("isbn"),
-      value = value,
-      ontologyType = ontologyType
+    createSourceIdentifierWith(
+      identifierType = IdentifierType("isbn")
     )
 
   def createMiroSourceIdentifierWith(

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
@@ -53,9 +53,10 @@ trait IdentifiersGenerators {
 
   def createIsbnSourceIdentifierWith(
     value: String = randomAlphanumeric(length = 10),
-    ontologyType: String = "Work"): SourceIdentifier =
+    ontologyType: String = "Work"
+  ): SourceIdentifier =
     SourceIdentifier(
-      identifierType = createIsbnSourceIdentifierType,
+      identifierType = IdentifierType("isbn"),
       value = value,
       ontologyType = ontologyType
     )
@@ -72,12 +73,4 @@ trait IdentifiersGenerators {
 
   def createMiroSourceIdentifier: SourceIdentifier =
     createMiroSourceIdentifierWith()
-
-  def createIsbnSourceIdentifierType: IdentifierType = {
-    IdentifierType("isbn")
-  }
-
-  def createCalmSourceIdentifierType: IdentifierType = {
-    IdentifierType("calm-altref-no")
-  }
 }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
@@ -13,7 +13,7 @@ trait IdentifiersGenerators {
   def createSourceIdentifier: SourceIdentifier = createSourceIdentifierWith()
 
   def createSourceIdentifierWith(
-    identifierType: IdentifierType = createMiroSourceIdentifierType,
+    identifierType: IdentifierType = IdentifierType("miro-image-number"),
     value: String = randomAlphanumeric(length = 10),
     ontologyType: String = "Work"): SourceIdentifier =
     SourceIdentifier(
@@ -46,8 +46,18 @@ trait IdentifiersGenerators {
       ontologyType = ontologyType
     )
 
+  def createMiroSourceIdentifierWith(
+    value: String = randomAlphanumeric(length = 10),
+    ontologyType: String = "Work"
+  ): SourceIdentifier =
+    SourceIdentifier(
+      identifierType = IdentifierType("miro-image-number"),
+      ontologyType = ontologyType,
+      value = value
+    )
+
   def createMiroSourceIdentifier: SourceIdentifier =
-    createSourceIdentifierWith(identifierType = createMiroSourceIdentifierType)
+    createMiroSourceIdentifierWith()
 
   def createMiroLibraryReferenceSourceIdentifier: SourceIdentifier =
     createSourceIdentifierWith(
@@ -63,10 +73,6 @@ trait IdentifiersGenerators {
 
   def createSierraIdentifierSourceIdentifierType: IdentifierType = {
     IdentifierType("sierra-identifier")
-  }
-
-  def createMiroSourceIdentifierType: IdentifierType = {
-    IdentifierType("miro-image-number")
   }
 
   def createIsbnSourceIdentifierType: IdentifierType = {

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
@@ -22,9 +22,6 @@ trait IdentifiersGenerators {
       ontologyType = ontologyType
     )
 
-  def createSierraSystemSourceIdentifier: SourceIdentifier =
-    createSierraSystemSourceIdentifierWith()
-
   def createSierraSystemSourceIdentifierWith(
     value: String = randomAlphanumeric(length = 10),
     ontologyType: String = "Work"
@@ -34,6 +31,22 @@ trait IdentifiersGenerators {
       value = value,
       ontologyType = ontologyType
     )
+
+  def createSierraSystemSourceIdentifier: SourceIdentifier =
+    createSierraSystemSourceIdentifierWith()
+
+  def createSierraIdentifierSourceIdentifierWith(
+    value: String = randomAlphanumeric(length = 10),
+    ontologyType: String = "Work"
+  ): SourceIdentifier =
+    SourceIdentifier(
+      identifierType = IdentifierType("sierra-identifier"),
+      value = value,
+      ontologyType = ontologyType
+    )
+
+  def createSierraIdentifierSourceIdentifier: SourceIdentifier =
+    createSierraIdentifierSourceIdentifierWith()
 
   def createIsbnSourceIdentifier: SourceIdentifier =
     createIsbnSourceIdentifierWith()
@@ -59,14 +72,6 @@ trait IdentifiersGenerators {
 
   def createMiroSourceIdentifier: SourceIdentifier =
     createMiroSourceIdentifierWith()
-
-  def createSierraIdentifierSourceIdentifier: SourceIdentifier =
-    createSourceIdentifierWith(
-      identifierType = createSierraIdentifierSourceIdentifierType)
-
-  def createSierraIdentifierSourceIdentifierType: IdentifierType = {
-    IdentifierType("sierra-identifier")
-  }
 
   def createIsbnSourceIdentifierType: IdentifierType = {
     IdentifierType("isbn")

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.models.work.test.util
+package uk.ac.wellcome.models.work.generators
 
 import uk.ac.wellcome.models.work.internal.{DigitalLocation, _}
 

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.models.work.test.util
+package uk.ac.wellcome.models.work.generators
 
 import uk.ac.wellcome.models.work.internal._
 

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -167,9 +167,7 @@ trait WorksGenerators extends ItemsGenerators {
     createUnidentifiedWorkWith(
       sourceIdentifier = createSierraSystemSourceIdentifier,
       workType = workType,
-      otherIdentifiers = List(
-        createSourceIdentifierWith(
-          identifierType = createSierraIdentifierSourceIdentifierType)),
+      otherIdentifiers = List(createSierraSystemSourceIdentifier),
       items = items
     )
 

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -165,8 +165,7 @@ trait WorksGenerators extends ItemsGenerators {
                                        items: List[MaybeDisplayable[Item]] =
                                          List()): UnidentifiedWork =
     createUnidentifiedWorkWith(
-      sourceIdentifier = createSourceIdentifierWith(
-        identifierType = createSierraSystemSourceIdentifierType),
+      sourceIdentifier = createSierraSystemSourceIdentifier,
       workType = workType,
       otherIdentifiers = List(
         createSourceIdentifierWith(

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedRedirectedWorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/UnidentifiedRedirectedWorkTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.models.work.internal
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.test.util.WorksGenerators
+import uk.ac.wellcome.models.work.generators.WorksGenerators
 
 class UnidentifiedRedirectedWorkTest
     extends FunSpec

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/WorkTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/WorkTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.models.work.internal
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.exceptions.JsonDecodingError
-import uk.ac.wellcome.models.work.test.util.IdentifiersGenerators
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 
 class WorkTest extends FunSpec with Matchers with IdentifiersGenerators {
 


### PR DESCRIPTION
We already have them, they're just used inconsistently (and in some places, duplicated).

Essentially a bunch of cleanup in the tests.