### PR TITLE
Add a script for listing all of our Elasticsearch indexes

### DIFF
--- a/misc/list_all_es_indexes.py
+++ b/misc/list_all_es_indexes.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8
+
+import boto3
+import hcl
+import requests
+
+
+def get_terraform_vars():
+    s3_client = boto3.client("s3")
+    tfvars_body = s3_client.get_object(
+        Bucket="wellcomecollection-platform-infra",
+        Key="terraform.tfvars"
+    )["Body"]
+    return hcl.load(tfvars_body)
+
+
+def build_url(es_credentials):
+    protocol = es_credentials["protocol"]
+    name = es_credentials["name"]
+    region = es_credentials["region"]
+    port = es_credentials["port"]
+    return f"{protocol}://{name}.{region}.aws.found.io:{port}"
+
+
+def get_all_indexes(es_url, username, password):
+    resp = requests.get(
+        f"{es_url}/_cat/indices",
+        auth=(username, password),
+        params={"format": "json"}
+    )
+    resp.raise_for_status()
+
+    return resp.json()
+
+
+if __name__ == "__main__":
+    terraform_vars = get_terraform_vars()
+    es_cluster_credentials = terraform_vars["es_cluster_credentials"]
+
+    es_url = build_url(es_cluster_credentials)
+
+    username = es_cluster_credentials["username"]
+    password = es_cluster_credentials["password"]
+
+    indexes = get_all_indexes(es_url, username=username, password=password)
+
+    print(
+        '\n'.join(sorted(
+            idx["index"]
+            for idx in indexes
+            if not idx["index"].startswith(".")
+        ))
+    )

--- a/misc/list_all_es_indexes.py
+++ b/misc/list_all_es_indexes.py
@@ -9,8 +9,7 @@ import requests
 def get_terraform_vars():
     s3_client = boto3.client("s3")
     tfvars_body = s3_client.get_object(
-        Bucket="wellcomecollection-platform-infra",
-        Key="terraform.tfvars"
+        Bucket="wellcomecollection-platform-infra", Key="terraform.tfvars"
     )["Body"]
     return hcl.load(tfvars_body)
 
@@ -25,9 +24,7 @@ def build_url(es_credentials):
 
 def get_all_indexes(es_url, username, password):
     resp = requests.get(
-        f"{es_url}/_cat/indices",
-        auth=(username, password),
-        params={"format": "json"}
+        f"{es_url}/_cat/indices", auth=(username, password), params={"format": "json"}
     )
     resp.raise_for_status()
 
@@ -46,9 +43,7 @@ if __name__ == "__main__":
     indexes = get_all_indexes(es_url, username=username, password=password)
 
     print(
-        '\n'.join(sorted(
-            idx["index"]
-            for idx in indexes
-            if not idx["index"].startswith(".")
-        ))
+        "\n".join(
+            sorted(idx["index"] for idx in indexes if not idx["index"].startswith("."))
+        )
     )


### PR DESCRIPTION
This adds a small script for listing our Elasticsearch indexes, because we have quite a lot! 85 at the current count.

And we're starting to fill up the storage on our cluster – 75% when I checked yesterday.

It is **not** a tool for deleting indexes. I considered that, but getting the heuristics right felt trickier than I fancied at 8am on a Thursday morning. It just gives you information, you decide what to do with it.

One thing it tells me, for example, is that we have a bunch of indexes that aren't prefixed with a date or version:

```
2018-06-21-alex-testing
better-sierra-ids
credit-awards-legacy-ids-061117
deleteme
items-with-innopac-ids
miro-preproc-2-november-rerun
miro-preproc-monday-rerun
miro-preproc-tuesday-rerun
miro-preproc-wednesday-rerun
miro-reindex
sierra-bibs-title
sierra-creators-with-identifiers
using-credit-not-copyright
works-from-miro-preprocessor
works-from-miro-preprocessor-with-exceptions
```

which has been our practice for nearly six months. I thus propose that these be the first against the wall when the ~revolution~ ~purge~ cleanup comes!