### PR TITLE
Remove two unused fields from SQSConfig

### DIFF
--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/config/ArgsConfigurator.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/config/ArgsConfigurator.scala
@@ -60,8 +60,6 @@ class ArgsConfigurator(val arguments: Seq[String])
 
   private val sqsQueueUrl: ScallopOption[String] =
     opt[String]("sqs-queue-url", required = false)
-  private val sqsMaxMessages =
-    opt[Int]("sqs-max-messages", required = false, default = Some(10))
   private val sqsParallelism =
     opt[Int]("sqs-parallelism", required = false, default = Some(10))
 
@@ -113,7 +111,6 @@ class ArgsConfigurator(val arguments: Seq[String])
 
   val sqsConfig = SQSConfig(
     queueUrl = sqsQueueUrl(),
-    maxMessages = sqsMaxMessages(),
     parallelism = sqsParallelism()
   )
 

--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/config/ArgsConfigurator.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/config/ArgsConfigurator.scala
@@ -60,8 +60,6 @@ class ArgsConfigurator(val arguments: Seq[String])
 
   private val sqsQueueUrl: ScallopOption[String] =
     opt[String]("sqs-queue-url", required = false)
-  private val sqsWaitTimeSeconds =
-    opt[Int]("sqs-wait-time-seconds", required = false, default = Some(20))
   private val sqsMaxMessages =
     opt[Int]("sqs-max-messages", required = false, default = Some(10))
   private val sqsParallelism =
@@ -115,7 +113,6 @@ class ArgsConfigurator(val arguments: Seq[String])
 
   val sqsConfig = SQSConfig(
     queueUrl = sqsQueueUrl(),
-    waitTime = sqsWaitTimeSeconds() seconds,
     maxMessages = sqsMaxMessages(),
     parallelism = sqsParallelism()
   )

--- a/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/SqsConfigConfigurator.scala
+++ b/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/SqsConfigConfigurator.scala
@@ -7,14 +7,12 @@ trait SqsConfigConfigurator extends ScallopConf {
   val arguments: Seq[String]
 
   private val sqsQueueUrl: ScallopOption[String] = opt[String](required = true)
-  private val sqsMaxMessages = opt[Int](required = true, default = Some(10))
   private val sqsParallelism = opt[Int](required = true, default = Some(10))
 
   verify()
 
   val sqsConfig = SQSConfig(
     queueUrl = sqsQueueUrl(),
-    maxMessages = sqsMaxMessages(),
     parallelism = sqsParallelism()
   )
 }

--- a/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/SqsConfigConfigurator.scala
+++ b/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/SqsConfigConfigurator.scala
@@ -3,13 +3,10 @@ package uk.ac.wellcome.platform.archive.common.config
 import org.rogach.scallop.{ScallopConf, ScallopOption}
 import uk.ac.wellcome.messaging.sqs.SQSConfig
 
-import scala.concurrent.duration._
-
 trait SqsConfigConfigurator extends ScallopConf {
   val arguments: Seq[String]
 
   private val sqsQueueUrl: ScallopOption[String] = opt[String](required = true)
-  private val sqsWaitTimeSeconds = opt[Int](required = true, default = Some(20))
   private val sqsMaxMessages = opt[Int](required = true, default = Some(10))
   private val sqsParallelism = opt[Int](required = true, default = Some(10))
 
@@ -17,7 +14,6 @@ trait SqsConfigConfigurator extends ScallopConf {
 
   val sqsConfig = SQSConfig(
     queueUrl = sqsQueueUrl(),
-    waitTime = sqsWaitTimeSeconds() seconds,
     maxMessages = sqsMaxMessages(),
     parallelism = sqsParallelism()
   )

--- a/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/messaging/MessageStreamTest.scala
+++ b/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/messaging/MessageStreamTest.scala
@@ -16,8 +16,6 @@ import uk.ac.wellcome.messaging.test.fixtures.SQS.{Queue, QueuePair}
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.test.fixtures.TestWith
 
-import scala.concurrent.duration._
-
 class MessageStreamTest
     extends FunSpec
     with Matchers
@@ -154,7 +152,6 @@ class MessageStreamTest
           withMockMetricSender { metricsSender =>
             val sqsConfig = SQSConfig(
               queueUrl = queue.url,
-              waitTime = 1 millisecond,
               maxMessages = 1
             )
 

--- a/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/messaging/MessageStreamTest.scala
+++ b/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/messaging/MessageStreamTest.scala
@@ -150,10 +150,7 @@ class MessageStreamTest
       withLocalSqsQueueAndDlq {
         case queuePair @ QueuePair(queue, _) =>
           withMockMetricSender { metricsSender =>
-            val sqsConfig = SQSConfig(
-              queueUrl = queue.url,
-              maxMessages = 1
-            )
+            val sqsConfig = SQSConfig(queueUrl = queue.url)
 
             val stream = new MessageStream[ExampleObject, Unit](
               actorSystem = actorSystem,

--- a/archive/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/config/ArgsConfigurator.scala
+++ b/archive/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/config/ArgsConfigurator.scala
@@ -45,8 +45,6 @@ class ArgsConfigurator(val arguments: Seq[String])
 
   private val sqsQueueUrl: ScallopOption[String] =
     opt[String]("sqs-queue-url", required = true)
-  private val sqsMaxMessages =
-    opt[Int]("sqs-max-messages", required = true, default = Some(10))
   private val sqsParallelism =
     opt[Int]("sqs-parallelism", required = true, default = Some(10))
 
@@ -82,7 +80,6 @@ class ArgsConfigurator(val arguments: Seq[String])
 
   val sqsConfig = SQSConfig(
     queueUrl = sqsQueueUrl(),
-    maxMessages = sqsMaxMessages(),
     parallelism = sqsParallelism()
   )
 

--- a/archive/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/config/ArgsConfigurator.scala
+++ b/archive/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/config/ArgsConfigurator.scala
@@ -45,8 +45,6 @@ class ArgsConfigurator(val arguments: Seq[String])
 
   private val sqsQueueUrl: ScallopOption[String] =
     opt[String]("sqs-queue-url", required = true)
-  private val sqsWaitTimeSeconds =
-    opt[Int]("sqs-wait-time-seconds", required = true, default = Some(20))
   private val sqsMaxMessages =
     opt[Int]("sqs-max-messages", required = true, default = Some(10))
   private val sqsParallelism =
@@ -84,7 +82,6 @@ class ArgsConfigurator(val arguments: Seq[String])
 
   val sqsConfig = SQSConfig(
     queueUrl = sqsQueueUrl(),
-    waitTime = sqsWaitTimeSeconds() seconds,
     maxMessages = sqsMaxMessages(),
     parallelism = sqsParallelism()
   )

--- a/archive/progress_async/src/main/scala/uk/ac/wellcome/platform/archive/progress_async/config/ArgsConfigurator.scala
+++ b/archive/progress_async/src/main/scala/uk/ac/wellcome/platform/archive/progress_async/config/ArgsConfigurator.scala
@@ -57,8 +57,6 @@ class ArgsConfigurator(val arguments: Seq[String])
 
   private val sqsQueueUrl: ScallopOption[String] =
     opt[String]("sqs-queue-url", required = true)
-  private val sqsWaitTimeSeconds =
-    opt[Int]("sqs-wait-time-seconds", required = true, default = Some(20))
   private val sqsMaxMessages =
     opt[Int]("sqs-max-messages", required = true, default = Some(10))
   private val sqsParallelism =
@@ -96,7 +94,6 @@ class ArgsConfigurator(val arguments: Seq[String])
 
   val sqsConfig = SQSConfig(
     queueUrl = sqsQueueUrl(),
-    waitTime = sqsWaitTimeSeconds() seconds,
     maxMessages = sqsMaxMessages(),
     parallelism = sqsParallelism()
   )

--- a/archive/progress_async/src/main/scala/uk/ac/wellcome/platform/archive/progress_async/config/ArgsConfigurator.scala
+++ b/archive/progress_async/src/main/scala/uk/ac/wellcome/platform/archive/progress_async/config/ArgsConfigurator.scala
@@ -57,8 +57,6 @@ class ArgsConfigurator(val arguments: Seq[String])
 
   private val sqsQueueUrl: ScallopOption[String] =
     opt[String]("sqs-queue-url", required = true)
-  private val sqsMaxMessages =
-    opt[Int]("sqs-max-messages", required = true, default = Some(10))
   private val sqsParallelism =
     opt[Int]("sqs-parallelism", required = true, default = Some(10))
 
@@ -94,7 +92,6 @@ class ArgsConfigurator(val arguments: Seq[String])
 
   val sqsConfig = SQSConfig(
     queueUrl = sqsQueueUrl(),
-    maxMessages = sqsMaxMessages(),
     parallelism = sqsParallelism()
   )
 

--- a/archive/registrar_async/src/main/scala/uk/ac/wellcome/platform/archive/registrar/async/config/RegistrarAsyncArgsConfigurator.scala
+++ b/archive/registrar_async/src/main/scala/uk/ac/wellcome/platform/archive/registrar/async/config/RegistrarAsyncArgsConfigurator.scala
@@ -40,8 +40,6 @@ class RegistrarAsyncArgsConfigurator(val arguments: Seq[String])
 
   private val sqsQueueUrl: ScallopOption[String] =
     opt[String]("sqs-queue-url", required = true)
-  private val sqsWaitTimeSeconds =
-    opt[Int]("sqs-wait-time-seconds", required = true, default = Some(20))
   private val sqsMaxMessages =
     opt[Int]("sqs-max-messages", required = true, default = Some(10))
   private val sqsParallelism =
@@ -106,7 +104,6 @@ class RegistrarAsyncArgsConfigurator(val arguments: Seq[String])
 
   val sqsConfig = SQSConfig(
     queueUrl = sqsQueueUrl(),
-    waitTime = sqsWaitTimeSeconds() seconds,
     maxMessages = sqsMaxMessages(),
     parallelism = sqsParallelism()
   )

--- a/archive/registrar_async/src/main/scala/uk/ac/wellcome/platform/archive/registrar/async/config/RegistrarAsyncArgsConfigurator.scala
+++ b/archive/registrar_async/src/main/scala/uk/ac/wellcome/platform/archive/registrar/async/config/RegistrarAsyncArgsConfigurator.scala
@@ -40,8 +40,6 @@ class RegistrarAsyncArgsConfigurator(val arguments: Seq[String])
 
   private val sqsQueueUrl: ScallopOption[String] =
     opt[String]("sqs-queue-url", required = true)
-  private val sqsMaxMessages =
-    opt[Int]("sqs-max-messages", required = true, default = Some(10))
   private val sqsParallelism =
     opt[Int]("sqs-parallelism", required = true, default = Some(10))
 
@@ -104,7 +102,6 @@ class RegistrarAsyncArgsConfigurator(val arguments: Seq[String])
 
   val sqsConfig = SQSConfig(
     queueUrl = sqsQueueUrl(),
-    maxMessages = sqsMaxMessages(),
     parallelism = sqsParallelism()
   )
 

--- a/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
+++ b/catalogue_pipeline/id_minter/src/universal/conf/application.ini.template
@@ -10,4 +10,3 @@
 -aws.message.writer.sns.topic.arn=${topic_arn}
 -aws.message.writer.s3.bucketName=${message_bucket_name}
 -aws.message.reader.sqs.queue.url=${queue_url}
--aws.message.reader.sqs.maxMessages=${sqs_max_messages}

--- a/catalogue_pipeline/terraform/pipelines/v1_pipeline/services.tf
+++ b/catalogue_pipeline/terraform/pipelines/v1_pipeline/services.tf
@@ -18,11 +18,10 @@ module "id_minter" {
     db_password         = "${var.identifiers_rds_cluster_password}"
     queue_url           = "${module.id_minter_queue.id}"
     topic_arn           = "${module.es_ingest_topic.arn}"
-    sqs_max_messages    = 10
     max_connections     = 8
   }
 
-  env_vars_length   = 10
+  env_vars_length   = 9
   container_image   = "${var.id_minter_container_image}"
   source_queue_name = "${module.id_minter_queue.name}"
   source_queue_arn  = "${module.id_minter_queue.arn}"

--- a/catalogue_pipeline/terraform/pipelines/v2_pipeline/services.tf
+++ b/catalogue_pipeline/terraform/pipelines/v2_pipeline/services.tf
@@ -102,11 +102,10 @@ module "id_minter" {
     db_password         = "${var.identifiers_rds_cluster_password}"
     queue_url           = "${module.id_minter_queue.id}"
     topic_arn           = "${module.es_ingest_topic.arn}"
-    sqs_max_messages    = 10
     max_connections     = 8
   }
 
-  env_vars_length   = 10
+  env_vars_length   = 9
   container_image   = "${var.id_minter_container_image}"
   source_queue_name = "${module.id_minter_queue.name}"
   source_queue_arn  = "${module.id_minter_queue.arn}"

--- a/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageReaderConfigModule.scala
+++ b/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageReaderConfigModule.scala
@@ -6,8 +6,6 @@ import uk.ac.wellcome.messaging.message.MessageReaderConfig
 import uk.ac.wellcome.messaging.sqs.SQSConfig
 import uk.ac.wellcome.storage.s3.S3Config
 
-import scala.concurrent.duration._
-
 object MessageReaderConfigModule extends TwitterModule {
   private val readerBucketName =
     flag[String](
@@ -17,10 +15,6 @@ object MessageReaderConfigModule extends TwitterModule {
     flag[String](
       "aws.message.reader.sqs.queue.url",
       "URL of the SQS Queue to read messages from")
-  private val readerWaitTime = flag(
-    "aws.message.reader.sqs.waitTime",
-    20,
-    "Time to wait (in seconds) for a message to arrive on the queue before returning")
   private val readerMaxMessages =
     flag(
       "aws.message.reader.sqs.maxMessages",
@@ -37,7 +31,6 @@ object MessageReaderConfigModule extends TwitterModule {
   def providesMessageReaderConfig(): MessageReaderConfig = {
     val sqsConfig = SQSConfig(
       queueUrl = readerQueueUrl(),
-      waitTime = readerWaitTime() seconds,
       maxMessages = readerMaxMessages(),
       parallelism = readerParallelism()
     )

--- a/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageReaderConfigModule.scala
+++ b/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/MessageReaderConfigModule.scala
@@ -15,11 +15,6 @@ object MessageReaderConfigModule extends TwitterModule {
     flag[String](
       "aws.message.reader.sqs.queue.url",
       "URL of the SQS Queue to read messages from")
-  private val readerMaxMessages =
-    flag(
-      "aws.message.reader.sqs.maxMessages",
-      10,
-      "Maximum number of SQS messages to return")
   private val readerParallelism =
     flag(
       name = "aws.message.reader.sqs.parallelism",
@@ -31,7 +26,6 @@ object MessageReaderConfigModule extends TwitterModule {
   def providesMessageReaderConfig(): MessageReaderConfig = {
     val sqsConfig = SQSConfig(
       queueUrl = readerQueueUrl(),
-      maxMessages = readerMaxMessages(),
       parallelism = readerParallelism()
     )
     val s3Config = S3Config(bucketName = readerBucketName())

--- a/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/SQSConfigModule.scala
+++ b/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/SQSConfigModule.scala
@@ -4,17 +4,11 @@ import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.messaging.sqs.SQSConfig
 
-import scala.concurrent.duration._
-
 object SQSConfigModule extends TwitterModule {
   private val queueUrl = flag[String](
     name = "aws.sqs.queue.url",
     help = "URL of the SQS Queue"
   )
-  val waitTime = flag(
-    "aws.sqs.waitTime",
-    20,
-    "Time to wait (in seconds) for a message to arrive on the queue before returning")
   val maxMessages =
     flag("aws.sqs.maxMessages", 10, "Maximum number of SQS messages to return")
 
@@ -24,5 +18,5 @@ object SQSConfigModule extends TwitterModule {
   @Singleton
   @Provides
   def providesSQSConfig(): SQSConfig =
-    SQSConfig(queueUrl(), waitTime() seconds, maxMessages(), parallelism())
+    SQSConfig(queueUrl(), maxMessages(), parallelism())
 }

--- a/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/SQSConfigModule.scala
+++ b/sbt_common/finatra_messaging/src/main/scala/uk/ac/wellcome/finatra/messaging/SQSConfigModule.scala
@@ -9,8 +9,6 @@ object SQSConfigModule extends TwitterModule {
     name = "aws.sqs.queue.url",
     help = "URL of the SQS Queue"
   )
-  val maxMessages =
-    flag("aws.sqs.maxMessages", 10, "Maximum number of SQS messages to return")
 
   val parallelism =
     flag("aws.sqs.parallelism", 10, "Number of messages to process in parallel")
@@ -18,5 +16,5 @@ object SQSConfigModule extends TwitterModule {
   @Singleton
   @Provides
   def providesSQSConfig(): SQSConfig =
-    SQSConfig(queueUrl(), maxMessages(), parallelism())
+    SQSConfig(queueUrl(), parallelism())
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSConfig.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSConfig.scala
@@ -1,5 +1,3 @@
 package uk.ac.wellcome.messaging.sqs
 
-case class SQSConfig(queueUrl: String,
-                     maxMessages: Integer = 10,
-                     parallelism: Integer = 10)
+case class SQSConfig(queueUrl: String, parallelism: Integer = 10)

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSConfig.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSConfig.scala
@@ -1,8 +1,5 @@
 package uk.ac.wellcome.messaging.sqs
 
-import scala.concurrent.duration._
-
 case class SQSConfig(queueUrl: String,
-                     waitTime: Duration = 10 seconds,
                      maxMessages: Integer = 10,
                      parallelism: Integer = 10)

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -23,7 +23,6 @@ import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures._
 
-import scala.concurrent.duration._
 import scala.util.{Random, Success}
 import uk.ac.wellcome.json.JsonUtil._
 
@@ -63,7 +62,6 @@ trait Messaging
     Map(
       "aws.message.reader.s3.bucketName" -> bucket.name,
       "aws.message.reader.sqs.queue.url" -> queue.url,
-      "aws.message.reader.sqs.waitTime" -> "1",
     ) ++ s3ClientLocalFlags ++ sqsLocalClientFlags
 
   def messageWriterLocalFlags(bucket: Bucket, topic: Topic) =
@@ -109,7 +107,7 @@ trait Messaging
     implicit objectStore: ObjectStore[T]) = {
     val s3Config = S3Config(bucketName = bucket.name)
     val sqsConfig =
-      SQSConfig(queueUrl = queue.url, waitTime = 1 millisecond, maxMessages = 1)
+      SQSConfig(queueUrl = queue.url, maxMessages = 1)
 
     val messageConfig = MessageReaderConfig(
       sqsConfig = sqsConfig,

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -106,8 +106,7 @@ trait Messaging
     metricsSender: MetricsSender)(testWith: TestWith[MessageStream[T], R])(
     implicit objectStore: ObjectStore[T]) = {
     val s3Config = S3Config(bucketName = bucket.name)
-    val sqsConfig =
-      SQSConfig(queueUrl = queue.url, maxMessages = 1)
+    val sqsConfig = SQSConfig(queueUrl = queue.url)
 
     val messageConfig = MessageReaderConfig(
       sqsConfig = sqsConfig,

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -145,10 +145,7 @@ trait SQS extends Matchers with Logging {
     actorSystem: ActorSystem,
     queue: Queue,
     metricsSender: MetricsSender)(testwith: TestWith[SQSStream[T], R]) = {
-    val sqsConfig = SQSConfig(
-      queueUrl = queue.url,
-      maxMessages = 1
-    )
+    val sqsConfig = SQSConfig(queueUrl = queue.url)
 
     val stream = new SQSStream[T](
       actorSystem = actorSystem,

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -12,7 +12,6 @@ import uk.ac.wellcome.messaging.sqs._
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.test.fixtures._
 
-import scala.concurrent.duration._
 import scala.collection.JavaConverters._
 import scala.util.Random
 import uk.ac.wellcome.json.JsonUtil._
@@ -50,7 +49,6 @@ trait SQS extends Matchers with Logging {
 
   def sqsLocalFlags(queue: Queue) = sqsLocalClientFlags ++ Map(
     "aws.sqs.queue.url" -> queue.url,
-    "aws.sqs.waitTime" -> "1"
   )
 
   def sqsLocalClientFlags = Map(
@@ -149,7 +147,6 @@ trait SQS extends Matchers with Logging {
     metricsSender: MetricsSender)(testwith: TestWith[SQSStream[T], R]) = {
     val sqsConfig = SQSConfig(
       queueUrl = queue.url,
-      waitTime = 1 millisecond,
       maxMessages = 1
     )
 


### PR DESCRIPTION
According to both IntelliJ and grep, nothing ever reads the value of these parameters, so we can safely delete them.

Nominally part of #2785.