### PR TITLE
Use blocking dispatcher in UploadInputStreamFlow

### DIFF
--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/DownloadItemFlow.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/DownloadItemFlow.scala
@@ -59,8 +59,7 @@ object DownloadItemFlow extends Logging {
         }
       )
       .withAttributes(ActorAttributes.dispatcher(
-        "akka.stream.materializer.blocking-io-dispatcher")
-      )
+        "akka.stream.materializer.blocking-io-dispatcher"))
   }
 
 }

--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/DownloadItemFlow.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/DownloadItemFlow.scala
@@ -27,7 +27,8 @@ object DownloadItemFlow extends Logging {
           val triedInputStream = Try(
             s3Client
               .getObject(job.uploadLocation.namespace, job.uploadLocation.key)
-              .getObjectContent)
+              .getObjectContent
+          )
 
           triedInputStream match {
             case Failure(exception) =>
@@ -58,7 +59,8 @@ object DownloadItemFlow extends Logging {
         }
       )
       .withAttributes(ActorAttributes.dispatcher(
-        "akka.stream.materializer.blocking-io-dispatcher"))
+        "akka.stream.materializer.blocking-io-dispatcher")
+      )
   }
 
 }

--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/UploadAndGetChecksumFlow.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/UploadAndGetChecksumFlow.scala
@@ -19,10 +19,7 @@ object UploadAndGetChecksumFlow {
 
         val verify = b.add(ArchiveChecksumFlow("SHA-256"))
         val flow = b.add(Flow[ByteString])
-        val upload = b.add(
-          S3UploadFlow(uploadLocation)
-            .withAttributes(ActorAttributes.dispatcher(
-              "akka.stream.materializer.blocking-io-dispatcher")))
+        val upload = b.add(S3UploadFlow(uploadLocation))
         val zip = b.add(Zip[Try[CompleteMultipartUploadResult], String])
 
         flow.out.log("calculating checksum") ~> verify.inlets.head

--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/UploadAndGetChecksumFlow.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/UploadAndGetChecksumFlow.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.archive.archivist.flow
 
 import akka.NotUsed
-import akka.stream.{ActorAttributes, FlowShape}
+import akka.stream.FlowShape
 import akka.stream.scaladsl.{Flow, GraphDSL, Zip}
 import akka.util.ByteString
 import com.amazonaws.services.s3.AmazonS3

--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/UploadInputStreamFlow.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/UploadInputStreamFlow.scala
@@ -2,14 +2,12 @@ package uk.ac.wellcome.platform.archive.archivist.flow
 import java.io.InputStream
 
 import akka.NotUsed
+import akka.stream.ActorAttributes
 import akka.stream.scaladsl.{Flow, StreamConverters}
 import com.amazonaws.services.s3.AmazonS3
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.archivist.models.ArchiveItemJob
-import uk.ac.wellcome.platform.archive.archivist.models.errors.{
-  ChecksumNotMatchedOnUploadError,
-  UploadError
-}
+import uk.ac.wellcome.platform.archive.archivist.models.errors.{ChecksumNotMatchedOnUploadError, UploadError}
 import uk.ac.wellcome.platform.archive.common.models.error.ArchiveError
 
 import scala.util.{Failure, Success}
@@ -58,6 +56,11 @@ object UploadInputStreamFlow extends Logging {
                   Left(UploadError(exception, job))
               }
         }
+      )
+      .withAttributes(
+        ActorAttributes.dispatcher(
+          "akka.stream.materializer.blocking-io-dispatcher"
+        )
       )
 
 }

--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/UploadInputStreamFlow.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/UploadInputStreamFlow.scala
@@ -7,7 +7,10 @@ import akka.stream.scaladsl.{Flow, StreamConverters}
 import com.amazonaws.services.s3.AmazonS3
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.archivist.models.ArchiveItemJob
-import uk.ac.wellcome.platform.archive.archivist.models.errors.{ChecksumNotMatchedOnUploadError, UploadError}
+import uk.ac.wellcome.platform.archive.archivist.models.errors.{
+  ChecksumNotMatchedOnUploadError,
+  UploadError
+}
 import uk.ac.wellcome.platform.archive.common.models.error.ArchiveError
 
 import scala.util.{Failure, Success}

--- a/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bag/BagInfoParser.scala
+++ b/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bag/BagInfoParser.scala
@@ -46,6 +46,8 @@ object BagInfoParser {
       extractInternalSenderDescription(bagInfoLines)
     ).mapN(BagInfo.apply)
 
+    inputStream.close()
+
     validated.toEither.leftMap(list => InvalidBagInfo(t, list.toList))
   }
 


### PR DESCRIPTION
### What is this PR trying to achieve?

We are seeing the following errors in the archivist service when under load:

"Unable to execute HTTP request: Timeout waiting for connection from pool"

This is symptomatic of all connections made available from the client (in this case via the AWS Client) being used up which is itself likely caused by the number of threads being made available to perform this operation being higher than those available in the AWS Client.

In this case the AWS client builder provides a default connection pool of 50. Unless otherwise specified the default Akka streams dispatcher providing threads does not by default have a cap on the number of threads it will hand out to run streams.

So 50 < infinity, we run out of connections.

This can be mitigated by using a `blocking-dispatcher` which by default allows a maximum number of threads for all streams making use of it.

We did use this dispatcher in all places the archivist uses streams from S3, however in `UploadAndGetChecksumFlow.scala` the dispatcher is attached to `S3UploadFlow` which is reused for all uploads. This is likely resulting in the thread restriction being inappropriately applied at too high a level.

This change moves the blocking dispatcher to `UploadInputStreamFlow.scala` which is created for each upload.

### Who is this change for?

🔬 ⚓️  