### PR TITLE
Clean up the fields on NotificationMessage

### DIFF
--- a/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/messaging/NotificationParsingFlow.scala
+++ b/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/messaging/NotificationParsingFlow.scala
@@ -11,8 +11,8 @@ import uk.ac.wellcome.platform.archive.common.models.NotificationMessage
   */
 object NotificationParsingFlow {
   def apply[T]()(implicit dec: Decoder[T]) = {
-    def parse(msg: NotificationMessage) =
-      fromJson[T](msg.Message)
+    def parse(notificationMessage: NotificationMessage) =
+      fromJson[T](notificationMessage.body)
 
     ProcessLogDiscardFlow[NotificationMessage, T]("parse_notification")(parse)
   }

--- a/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/models/NotificationMessage.scala
+++ b/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/models/NotificationMessage.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.platform.archive.common.models
 
+import io.circe.generic.extras.JsonKey
+
 case class NotificationMessage(
-  MessageId: String,
-  TopicArn: String,
-  Subject: Option[String],
-  Message: String
+  @JsonKey("Message") body: String
 )

--- a/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/flows/NotificationParsingFlowTest.scala
+++ b/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/flows/NotificationParsingFlowTest.scala
@@ -33,11 +33,7 @@ class NotificationParsingFlowTest
           .patch(2, badStrings, 0)
           .map(
             body =>
-              NotificationMessage(
-                MessageId = "MessageId",
-                TopicArn = "TopicArn",
-                Subject = None,
-                Message = body.toString
+              NotificationMessage(body = body.toString
             ))
 
         val source = Source(messages)

--- a/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/flows/NotificationParsingFlowTest.scala
+++ b/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/flows/NotificationParsingFlowTest.scala
@@ -31,10 +31,7 @@ class NotificationParsingFlowTest
 
         val messages = jsonStrings
           .patch(2, badStrings, 0)
-          .map(
-            body =>
-              NotificationMessage(body = body.toString
-            ))
+          .map(body => NotificationMessage(body = body.toString))
 
         val source = Source(messages)
         val parsingFlow = NotificationParsingFlow[Character]

--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
@@ -25,7 +25,7 @@ class MergerWorkerService @Inject()(
 
   private def processMessage(message: NotificationMessage): Future[Unit] =
     for {
-      matcherResult <- Future.fromTry(fromJson[MatcherResult](message.Message))
+      matcherResult <- Future.fromTry(fromJson[MatcherResult](message.body))
       _ <- Future.sequence(matcherResult.works.map { applyMerge })
     } yield ()
 

--- a/catalogue_pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiver.scala
+++ b/catalogue_pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiver.scala
@@ -25,7 +25,7 @@ class HybridRecordReceiver[T] @Inject()(
     debug(s"Starting to process message $message")
 
     val futurePublishAttempt = for {
-      hybridRecord <- Future.fromTry(fromJson[HybridRecord](message.Message))
+      hybridRecord <- Future.fromTry(fromJson[HybridRecord](message.body))
       transformableRecord <- getTransformable(hybridRecord)
       work <- Future.fromTry(
         transformToWork(transformableRecord, hybridRecord.version))

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotGeneratorWorkerService.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotGeneratorWorkerService.scala
@@ -20,7 +20,7 @@ class SnapshotGeneratorWorkerService @Inject()(
 
   private def processMessage(message: NotificationMessage): Future[Unit] =
     for {
-      snapshotJob <- Future.fromTry(fromJson[SnapshotJob](message.Message))
+      snapshotJob <- Future.fromTry(fromJson[SnapshotJob](message.body))
       completedSnapshotJob <- snapshotService.generateSnapshot(
         snapshotJob = snapshotJob)
       _ <- snsWriter.writeMessage(

--- a/goobi_adapter/goobi_reader/src/main/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerService.scala
+++ b/goobi_adapter/goobi_reader/src/main/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerService.scala
@@ -43,13 +43,13 @@ class GoobiReaderWorkerService @Inject()(
       // AWS events are URL encoded, which means that the object key is URL encoded
       // The s3Client.putObject method doesn't want URL encoded keys, so decode it
       urlDecodedMessage <- Future.fromTry(
-        Try(java.net.URLDecoder.decode(snsNotification.Message, "utf-8")))
+        Try(java.net.URLDecoder.decode(snsNotification.body, "utf-8")))
       eventNotification <- Future.fromTry(fromJson[S3Event](urlDecodedMessage))
       _ <- Future.sequence(eventNotification.Records.map(updateRecord))
     } yield ()
     eventuallyProcessedMessages.failed.foreach { e: Throwable =>
       error(
-        s"Error processing message with SNS-MessageId=${snsNotification.MessageId}. Exception ${e.getClass.getCanonicalName} $e.getMessage")
+        s"Error processing message. Exception ${e.getClass.getCanonicalName} ${e.getMessage}")
     }
     eventuallyProcessedMessages
   }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorker.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorker.scala
@@ -21,7 +21,7 @@ class ReindexWorker @Inject()(
   private def processMessage(message: NotificationMessage): Future[Unit] =
     for {
       reindexJob: ReindexJob <- Future.fromTry(
-        fromJson[ReindexJob](message.Message))
+        fromJson[ReindexJob](message.body))
       outdatedRecords: List[HybridRecord] <- recordReader
         .findRecordsForReindexing(reindexJob)
       _ <- hybridRecordSender.sendToSNS(records = outdatedRecords)

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageStream.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageStream.scala
@@ -45,7 +45,7 @@ class MessageStream[T] @Inject()(actorSystem: ActorSystem,
       streamName = streamName,
       process = (notification: NotificationMessage) =>
         for {
-          body <- getBody(notification.Message)
+          body <- getBody(notification.body)
           result <- process(body)
         } yield result
     )
@@ -56,7 +56,7 @@ class MessageStream[T] @Inject()(actorSystem: ActorSystem,
     source.mapAsyncUnordered(messageReaderConfig.sqsConfig.parallelism) {
       case (message, notification) =>
         for {
-          deserialisedObject <- getBody(notification.Message)
+          deserialisedObject <- getBody(notification.body)
         } yield (message, deserialisedObject)
     }
   }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/NotificationMessage.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/NotificationMessage.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.messaging.sns
 
+import io.circe.generic.extras.JsonKey
+
 case class NotificationMessage(
-  Message: String
+  @JsonKey("Message") body: String
 )

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/NotificationMessage.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/NotificationMessage.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.messaging.sns
 
 case class NotificationMessage(
-  TopicArn: String,
   Subject: String,
   Message: String
 )

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/NotificationMessage.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/NotificationMessage.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.messaging.sns
 
 case class NotificationMessage(
-  MessageId: String,
   TopicArn: String,
   Subject: String,
   Message: String

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/NotificationMessage.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/NotificationMessage.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.messaging.sns
 
 case class NotificationMessage(
-  Subject: String,
   Message: String
 )

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -164,7 +164,6 @@ trait SQS extends Matchers with Logging {
 
   def createNotificationMessageWith(body: String): NotificationMessage =
     NotificationMessage(
-      MessageId = Random.alphanumeric take 10 mkString,
       TopicArn = Random.alphanumeric take 10 mkString,
       Subject = Random.alphanumeric take 10 mkString,
       Message = body

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -163,9 +163,7 @@ trait SQS extends Matchers with Logging {
   }
 
   def createNotificationMessageWith(body: String): NotificationMessage =
-    NotificationMessage(
-      body = body
-    )
+    NotificationMessage(body = body)
 
   def createNotificationMessageWith[T](message: T)(
     implicit encoder: Encoder[T]): NotificationMessage =

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -164,7 +164,6 @@ trait SQS extends Matchers with Logging {
 
   def createNotificationMessageWith(body: String): NotificationMessage =
     NotificationMessage(
-      Subject = Random.alphanumeric take 10 mkString,
       Message = body
     )
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -164,7 +164,6 @@ trait SQS extends Matchers with Logging {
 
   def createNotificationMessageWith(body: String): NotificationMessage =
     NotificationMessage(
-      TopicArn = Random.alphanumeric take 10 mkString,
       Subject = Random.alphanumeric take 10 mkString,
       Message = body
     )

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -164,7 +164,7 @@ trait SQS extends Matchers with Logging {
 
   def createNotificationMessageWith(body: String): NotificationMessage =
     NotificationMessage(
-      Message = body
+      body = body
     )
 
   def createNotificationMessageWith[T](message: T)(

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerService.scala
@@ -20,7 +20,7 @@ class SierraBibMergerWorkerService @Inject()(
 
   private def process(message: NotificationMessage): Future[Unit] =
     for {
-      bibRecord <- Future.fromTry(fromJson[SierraBibRecord](message.Message))
+      bibRecord <- Future.fromTry(fromJson[SierraBibRecord](message.body))
       hybridRecord <- sierraBibMergerUpdaterService.update(bibRecord)
       _ <- snsWriter.writeMessage(
         hybridRecord,

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerWorkerService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerWorkerService.scala
@@ -23,7 +23,7 @@ class SierraItemMergerWorkerService @Inject()(
 
   private def process(message: NotificationMessage): Future[Unit] =
     for {
-      hybridRecord <- Future.fromTry(fromJson[HybridRecord](message.Message))
+      hybridRecord <- Future.fromTry(fromJson[HybridRecord](message.body))
       itemRecord <- objectStore.get(hybridRecord.location)
       hybridRecords: Seq[HybridRecord] <- sierraItemMergerUpdaterService.update(
         itemRecord)

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerService.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerService.scala
@@ -20,7 +20,7 @@ class SierraItemsToDynamoWorkerService @Inject()(
 
   private def process(message: NotificationMessage): Future[Unit] =
     for {
-      itemRecord <- Future.fromTry(fromJson[SierraItemRecord](message.Message))
+      itemRecord <- Future.fromTry(fromJson[SierraItemRecord](message.body))
       hybridRecord <- dynamoInserter.insertIntoDynamo(itemRecord)
       _ <- snsWriter.writeMessage(
         message = hybridRecord,

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -55,7 +55,7 @@ class SierraReaderWorkerService @Inject()(
   def processMessage(notificationMessage: NotificationMessage): Future[Unit] =
     for {
       window <- Future.fromTry(
-        WindowExtractor.extractWindow(notificationMessage.Message)
+        WindowExtractor.extractWindow(notificationMessage.body)
       )
       windowStatus <- windowManager.getCurrentStatus(window = window)
       _ <- runSierraStream(window = window, windowStatus = windowStatus)


### PR DESCRIPTION
This removes all the fields we weren't using, and renames the final field from `Message` to `body`, as that's a more accurate representation of what it means!