### PR TITLE
Clean up SnsPublishFlow to make the subject mandatory

### DIFF
--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlow.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlow.scala
@@ -59,7 +59,7 @@ object ArchiveZipFileFlow extends Logging {
                     SnsPublishFlow[ProgressUpdate](
                       snsClient,
                       snsConfig,
-                      Some("archivist_progress")))
+                      subject = "archivist_progress"))
                   .map(_ => result)
             )
       }

--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/NotificationMessageFlow.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/NotificationMessageFlow.scala
@@ -49,7 +49,7 @@ object NotificationMessageFlow extends Logging {
               SnsPublishFlow[ProgressUpdate](
                 snsClient,
                 progressSnsConfig,
-                Some("archivist_progress")))
+                subject = "archivist_progress"))
             .map(_ => bagRequest)
         }
       )

--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/RegistrarNotifierFlow.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/RegistrarNotifierFlow.scala
@@ -19,7 +19,7 @@ object RegistrarNotifierFlow {
         SnsPublishFlow[ArchiveComplete](
           snsClient,
           snsRegistrarConfig,
-          Some("archive_completed")))
+          subject = "archive_completed"))
       .log("published notification")
   }
 }

--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ZipFileDownloadFlow.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ZipFileDownloadFlow.scala
@@ -83,7 +83,7 @@ object ZipFileDownloadFlow extends Logging {
               SnsPublishFlow[ProgressUpdate](
                 snsClient,
                 snsConfig,
-                Some("archivist_progress")))
+                subject = "archivist_progress"))
             .map(_ => result)
       )
       .log("downloaded zipfile")

--- a/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/messaging/SnsPublishFlow.scala
+++ b/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/messaging/SnsPublishFlow.scala
@@ -28,7 +28,7 @@ object SnsPublishFlow extends Logging {
     def publish(t: T) =
       toJson[T](t)
         .map { messageString =>
-          debug(s"snsPublishMessage: ${messageString}")
+          debug(s"snsPublishMessage: $messageString")
           maybeSubject match {
             case Some(subject) =>
               new PublishRequest(snsConfig.topicArn, messageString, subject)

--- a/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/messaging/SnsPublishFlow.scala
+++ b/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/messaging/SnsPublishFlow.scala
@@ -42,4 +42,15 @@ object SnsPublishFlow extends Logging {
         ActorAttributes.dispatcher(
           "akka.stream.materializer.blocking-io-dispatcher"))
   }
+
+  def apply[T](
+    snsClient: AmazonSNS,
+    snsConfig: SNSConfig,
+    subject: String
+  )(implicit encode: Encoder[T]): Flow[T, PublishResult, NotUsed] =
+    apply(
+      snsClient = snsClient,
+      snsConfig = snsConfig,
+      maybeSubject = Some(subject)
+    )
 }

--- a/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/flows/SNSPublishFlowTest.scala
+++ b/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/flows/SNSPublishFlowTest.scala
@@ -29,7 +29,10 @@ class SNSPublishFlowTest
 
           val snsConfig = SNSConfig(topic.arn)
           val publishFlow =
-            SnsPublishFlow[Person](snsClient, snsConfig, subject = "SNSPublishFlowTest")
+            SnsPublishFlow[Person](
+              snsClient,
+              snsConfig,
+              subject = "SNSPublishFlowTest")
 
           val publication = Source
             .single(bob)
@@ -60,7 +63,10 @@ class SNSPublishFlowTest
 
         val snsConfig = SNSConfig("bad_topic")
         val publishFlow =
-          SnsPublishFlow[Person](snsClient, snsConfig, subject = "SNSPublishFlowTest")
+          SnsPublishFlow[Person](
+            snsClient,
+            snsConfig,
+            subject = "SNSPublishFlowTest")
 
         val publication = Source
           .fromIterator(bobs)
@@ -88,7 +94,10 @@ class SNSPublishFlowTest
 
           val snsConfig = SNSConfig(topic.arn)
           val publishFlow =
-            SnsPublishFlow[Person](snsClient, snsConfig, subject = "SNSPublishFlowTest")
+            SnsPublishFlow[Person](
+              snsClient,
+              snsConfig,
+              subject = "SNSPublishFlowTest")
 
           val publication = Source
             .fromIterator(bobs)

--- a/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/flows/SNSPublishFlowTest.scala
+++ b/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/flows/SNSPublishFlowTest.scala
@@ -29,7 +29,7 @@ class SNSPublishFlowTest
 
           val snsConfig = SNSConfig(topic.arn)
           val publishFlow =
-            SnsPublishFlow[Person](snsClient, snsConfig)
+            SnsPublishFlow[Person](snsClient, snsConfig, subject = "SNSPublishFlowTest")
 
           val publication = Source
             .single(bob)
@@ -60,7 +60,7 @@ class SNSPublishFlowTest
 
         val snsConfig = SNSConfig("bad_topic")
         val publishFlow =
-          SnsPublishFlow[Person](snsClient, snsConfig)
+          SnsPublishFlow[Person](snsClient, snsConfig, subject = "SNSPublishFlowTest")
 
         val publication = Source
           .fromIterator(bobs)
@@ -88,7 +88,7 @@ class SNSPublishFlowTest
 
           val snsConfig = SNSConfig(topic.arn)
           val publishFlow =
-            SnsPublishFlow[Person](snsClient, snsConfig)
+            SnsPublishFlow[Person](snsClient, snsConfig, subject = "SNSPublishFlowTest")
 
           val publication = Source
             .fromIterator(bobs)

--- a/archive/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/flows/NotificationFlow.scala
+++ b/archive/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/flows/NotificationFlow.scala
@@ -30,7 +30,7 @@ object NotificationFlow {
     val snsPublishFlow = SnsPublishFlow[ProgressUpdate](
       snsClient,
       snsConfig,
-      subject=s"Sent by ${this.getClass.getName}"
+      subject = s"Sent by ${this.getClass.getName}"
     )
 
     callbackUrlFlow

--- a/archive/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/flows/NotificationFlow.scala
+++ b/archive/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/flows/NotificationFlow.scala
@@ -27,7 +27,11 @@ object NotificationFlow {
 
     val callbackUrlFlow = CallbackUrlFlow()
     val prepareNotificationFlow = PrepareNotificationFlow()
-    val snsPublishFlow = SnsPublishFlow[ProgressUpdate](snsClient, snsConfig)
+    val snsPublishFlow = SnsPublishFlow[ProgressUpdate](
+      snsClient,
+      snsConfig,
+      subject=s"Sent by ${this.getClass.getName}"
+    )
 
     callbackUrlFlow
       .via(prepareNotificationFlow)

--- a/archive/progress_async/src/main/scala/uk/ac/wellcome/platform/archive/progress_async/flows/CallbackNotificationFlow.scala
+++ b/archive/progress_async/src/main/scala/uk/ac/wellcome/platform/archive/progress_async/flows/CallbackNotificationFlow.scala
@@ -27,7 +27,7 @@ object CallbackNotificationFlow extends Logging {
     val publishFlow = SnsPublishFlow[CallbackNotification](
       snsClient,
       snsConfig,
-      Some("callback_notification")
+      subject = "callback_notification"
     )
 
     def notifyFlow(progress: Progress, id: UUID, callbackUri: URI) = {

--- a/archive/registrar_async/src/main/scala/uk/ac/wellcome/platform/archive/registrar/async/flows/NotifyFailureFlow.scala
+++ b/archive/registrar_async/src/main/scala/uk/ac/wellcome/platform/archive/registrar/async/flows/NotifyFailureFlow.scala
@@ -27,5 +27,5 @@ object NotifyFailureFlow {
             List(ProgressEvent(error.toString))
         )
       )
-      .via(SnsPublishFlow[ProgressUpdate](snsClient, snsConfig, Some(subject)))
+      .via(SnsPublishFlow[ProgressUpdate](snsClient, snsConfig, subject))
 }

--- a/archive/registrar_async/src/main/scala/uk/ac/wellcome/platform/archive/registrar/async/flows/UpdateStoredManifestFlow.scala
+++ b/archive/registrar_async/src/main/scala/uk/ac/wellcome/platform/archive/registrar/async/flows/UpdateStoredManifestFlow.scala
@@ -36,7 +36,7 @@ object UpdateStoredManifestFlow {
         SnsPublishFlow[ProgressUpdate](
           snsClient,
           progressSnsConfig,
-          Some("registration_complete")))
+          subject = "registration_complete"))
       .map(_ => ())
 
   private def updateStoredManifest(


### PR DESCRIPTION
It’s a useful debugging tool, we’re almost always setting it, and it lets us clarify some of the downstream code. Wins all round!