### PR TITLE
Break up functions.Makefile into individual Makefiles that can be imported separately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ WELLCOME_MONITORING_BUCKET = wellcomecollection-platform-monitoring
 
 include functions.Makefile
 
+# This can't be included in functions.Makefile because it actually defines some
+# targets, which makes Make unhappy when the targets get overridden a dozen times!
+include makefiles/formatting.Makefile
+
 include archive/Makefile
 include assets/Makefile
 include builds/Makefile

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ WELLCOME_MONITORING_BUCKET = wellcomecollection-platform-monitoring
 
 include functions.Makefile
 
-include formatting.Makefile
-
 include archive/Makefile
 include assets/Makefile
 include builds/Makefile

--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,6 @@ INFRA_BUCKET = wellcomecollection-platform-infra
 WELLCOME_INFRA_BUCKET      = wellcomecollection-platform-infra
 WELLCOME_MONITORING_BUCKET = wellcomecollection-platform-monitoring
 
-LAMBDA_PUSHES_TOPIC_ARN = arn:aws:sns:eu-west-1:760097843905:lambda_pushes
-ECR_PUSHES_TOPIC_ARN    = "arn:aws:sns:eu-west-1:760097843905:ecr_pushes"
-
-DOCKER_IMG_BUILD_TEST_PYTHON = wellcome/build_test_python
-DOCKER_IMG_PUBLISH_LAMBDA    = wellcome/publish_lambda:12
-DOCKER_IMG_TERRAFORM         = hashicorp/terraform:0.11.10
-DOCKER_IMG_TERRAFORM_WRAPPER = wellcome/terraform_wrapper:13
-DOCKER_IMG_IMAGE_BUILDER     = wellcome/image_builder:latest
-DOCKER_IMG_PUBLISH_SERVICE   = wellcome/publish_service:latest
-DOCKER_IMG_SBT_WRAPPER       = wellcome/sbt_wrapper
-
-
 include functions.Makefile
 
 include formatting.Makefile

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 ROOT = $(shell git rev-parse --show-toplevel)
-INFRA_BUCKET = wellcomecollection-platform-infra
 
 WELLCOME_INFRA_BUCKET      = wellcomecollection-platform-infra
 WELLCOME_MONITORING_BUCKET = wellcomecollection-platform-monitoring

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,43 @@
+ROOT = $(shell git rev-parse --show-toplevel)
+INFRA_BUCKET = wellcomecollection-platform-infra
+
+WELLCOME_INFRA_BUCKET      = wellcomecollection-platform-infra
+WELLCOME_MONITORING_BUCKET = wellcomecollection-platform-monitoring
+
+LAMBDA_PUSHES_TOPIC_ARN = arn:aws:sns:eu-west-1:760097843905:lambda_pushes
+ECR_PUSHES_TOPIC_ARN    = "arn:aws:sns:eu-west-1:760097843905:ecr_pushes"
+
+DOCKER_IMG_BUILD_TEST_PYTHON = wellcome/build_test_python
+DOCKER_IMG_PUBLISH_LAMBDA    = wellcome/publish_lambda:12
+DOCKER_IMG_TERRAFORM         = hashicorp/terraform:0.11.10
+DOCKER_IMG_TERRAFORM_WRAPPER = wellcome/terraform_wrapper:13
+DOCKER_IMG_IMAGE_BUILDER     = wellcome/image_builder:latest
+DOCKER_IMG_PUBLISH_SERVICE   = wellcome/publish_service:latest
+DOCKER_IMG_SBT_WRAPPER       = wellcome/sbt_wrapper
+
+
 include functions.Makefile
 
 include formatting.Makefile
 
+include archive/Makefile
 include assets/Makefile
 include builds/Makefile
-include loris/Makefile
-include shared_infra/Makefile
-include data_api/Makefile
-include data_science/Makefile
 include catalogue_api/Makefile
 include catalogue_pipeline/Makefile
-include infra_critical/Makefile
+include data_api/Makefile
+include data_science/Makefile
 include goobi_adapter/Makefile
+include infra_critical/Makefile
+include loris/Makefile
 include monitoring/Makefile
+include nginx/Makefile
 include ontologies/Makefile
 include reindexer/Makefile
-include sbt_common/Makefile
-include sierra_adapter/Makefile
-include nginx/Makefile
-include archive/Makefile
 include reporting/Makefile
+include sbt_common/Makefile
+include shared_infra/Makefile
+include sierra_adapter/Makefile
 
 
 travis-lambda-test:

--- a/functions.Makefile
+++ b/functions.Makefile
@@ -13,144 +13,12 @@ DOCKER_IMG_TERRAFORM         = hashicorp/terraform:0.11.10
 DOCKER_IMG_TERRAFORM_WRAPPER = wellcome/terraform_wrapper:13
 DOCKER_IMG_IMAGE_BUILDER     = wellcome/image_builder:latest
 DOCKER_IMG_PUBLISH_SERVICE   = wellcome/publish_service:latest
+DOCKER_IMG_SBT_WRAPPER       = wellcome/sbt_wrapper
 
 include makefiles/docker.Makefile
 include makefiles/python.Makefile
+include makefiles/sbt.Makefile
 include makefiles/terraform.Makefile
-
-
-# Test an sbt project.
-#
-# Args:
-#   $1 - Name of the project.
-#
-define sbt_test
-	$(ROOT)/docker_run.py --dind --sbt --root -- \
-		--net host \
-		wellcome/sbt_wrapper \
-		"project $(1)" ";dockerComposeUp;test;dockerComposeStop"
-endef
-
-
-
-# Test an sbt project without docker-compose.
-#
-# Args:
-#   $1 - Name of the project.
-#
-define sbt_test_no_docker
-	$(ROOT)/docker_run.py --dind --sbt --root -- \
-		--net host \
-		wellcome/sbt_wrapper \
-		"project $(1)" "test"
-endef
-
-
-# Build an sbt project.
-#
-# Args:
-#   $1 - Name of the project.
-#
-define sbt_build
-	$(ROOT)/docker_run.py --dind --sbt --root -- \
-		--net host \
-		wellcome/sbt_wrapper \
-		"project $(1)" ";stage"
-endef
-
-
-# Run docker-compose up.
-#
-# Args:
-#   $1 - Path to the docker-compose file.
-#
-define docker_compose_up
-	$(ROOT)/docker_run.py --dind --sbt --root -- \
-		--net host \
-		wellcome/sbt_wrapper \
-		"project $(1)" "dockerComposeUp"
-endef
-
-
-# Run docker-compose down.
-#
-# Args:
-#   $1 - Path to the docker-compose file.
-#
-define docker_compose_down
-	$(ROOT)/docker_run.py --dind --sbt --root -- \
-		--net host \
-		wellcome/sbt_wrapper \
-		"project $(1)" "dockerComposeDown"
-endef
-
-
-# Define a series of Make tasks (build, test, publish) for a Scala services.
-#
-# Args:
-#	$1 - Name of the project in sbt.
-#	$2 - Root of the project's source code.
-#
-define __sbt_target_template
-$(eval $(call __sbt_base_docker_template,$(1),$(2)))
-
-$(1)-build:
-	$(call sbt_build,$(1))
-	$(call build_image,$(1),$(2)/Dockerfile)
-
-$(1)-publish: $(1)-build
-	$(call publish_service,$(1))
-endef
-
-
-# Define a series of Make tasks for a Scala libraries that use docker-compose for tests.
-#
-# Args:
-#	$1 - Name of the project in sbt.
-#	$2 - Root of the project's source code.
-#
-define __sbt_library_docker_template
-$(eval $(call __sbt_base_docker_template,$(1),$(2)))
-
-$(1)-publish:
-	echo "Nothing to do!"
-
-endef
-
-
-# Define a series of Make tasks for a Scala modules that use docker-compose for tests.
-#
-# Args:
-#	$1 - Name of the project in sbt.
-#	$2 - Root of the project's source code.
-#
-define __sbt_base_docker_template
-$(1)-docker_compose_up:
-	$(call docker_compose_up,$(1))
-
-$(1)-docker_compose_down:
-	$(call docker_compose_down,$(1))
-
-$(1)-test:
-	$(call sbt_test,$(1))
-
-endef
-
-
-# Define a series of Make tasks for a Scala libraries.
-#
-# Args:
-#	$1 - Name of the project in sbt.
-#	$2 - Root of the project's source code.
-#
-define __sbt_library_template
-$(1)-test:
-	$(call sbt_test_no_docker,$(1))
-
-$(1)-publish:
-	echo "Nothing to do!"
-
-endef
 
 
 # Define a series of Make tasks (build, test, publish) for an ECS service.
@@ -200,9 +68,9 @@ define stack_setup
 # It can't actually be written that way because Make is very sensitive to
 # whitespace, but that's the general idea.
 
-$(foreach proj,$(SBT_APPS),$(eval $(call __sbt_target_template,$(proj),$(STACK_ROOT)/$(proj))))
-$(foreach library,$(SBT_DOCKER_LIBRARIES),$(eval $(call __sbt_library_docker_template,$(library),$(STACK_ROOT)/$(library))))
-$(foreach library,$(SBT_NO_DOCKER_LIBRARIES),$(eval $(call __sbt_library_template,$(library))))
+$(foreach proj,$(SBT_APPS),$(eval $(call sbt_target_template,$(proj),$(STACK_ROOT)/$(proj))))
+$(foreach library,$(SBT_DOCKER_LIBRARIES),$(eval $(call sbt_library_docker_template,$(library),$(STACK_ROOT)/$(library))))
+$(foreach library,$(SBT_NO_DOCKER_LIBRARIES),$(eval $(call sbt_library_template,$(library))))
 $(foreach task,$(ECS_TASKS),$(eval $(call __ecs_target_template,$(task),$(STACK_ROOT)/$(task)/Dockerfile)))
 $(foreach lamb,$(LAMBDAS),$(eval $(call lambda_target_template,$(lamb),$(STACK_ROOT)/$(lamb))))
 $(foreach name,$(TF_NAME),$(eval $(call terraform_target_template,$(TF_NAME),$(TF_PATH),$(TF_IS_PUBLIC_FACING))))

--- a/functions.Makefile
+++ b/functions.Makefile
@@ -1,20 +1,3 @@
-ROOT = $(shell git rev-parse --show-toplevel)
-INFRA_BUCKET = wellcomecollection-platform-infra
-
-WELLCOME_INFRA_BUCKET      = wellcomecollection-platform-infra
-WELLCOME_MONITORING_BUCKET = wellcomecollection-platform-monitoring
-
-LAMBDA_PUSHES_TOPIC_ARN = arn:aws:sns:eu-west-1:760097843905:lambda_pushes
-ECR_PUSHES_TOPIC_ARN    = "arn:aws:sns:eu-west-1:760097843905:ecr_pushes"
-
-DOCKER_IMG_BUILD_TEST_PYTHON = wellcome/build_test_python
-DOCKER_IMG_PUBLISH_LAMBDA    = wellcome/publish_lambda:12
-DOCKER_IMG_TERRAFORM         = hashicorp/terraform:0.11.10
-DOCKER_IMG_TERRAFORM_WRAPPER = wellcome/terraform_wrapper:13
-DOCKER_IMG_IMAGE_BUILDER     = wellcome/image_builder:latest
-DOCKER_IMG_PUBLISH_SERVICE   = wellcome/publish_service:latest
-DOCKER_IMG_SBT_WRAPPER       = wellcome/sbt_wrapper
-
 include makefiles/docker.Makefile
 include makefiles/python.Makefile
 include makefiles/sbt.Makefile

--- a/functions.Makefile
+++ b/functions.Makefile
@@ -1,5 +1,4 @@
 include makefiles/docker.Makefile
-include makefiles/formatting.Makefile
 include makefiles/python.Makefile
 include makefiles/sbt.Makefile
 include makefiles/terraform.Makefile

--- a/functions.Makefile
+++ b/functions.Makefile
@@ -5,45 +5,18 @@ WELLCOME_INFRA_BUCKET      = wellcomecollection-platform-infra
 WELLCOME_MONITORING_BUCKET = wellcomecollection-platform-monitoring
 
 LAMBDA_PUSHES_TOPIC_ARN = arn:aws:sns:eu-west-1:760097843905:lambda_pushes
+ECR_PUSHES_TOPIC_ARN    = "arn:aws:sns:eu-west-1:760097843905:ecr_pushes"
 
 DOCKER_IMG_BUILD_TEST_PYTHON = wellcome/build_test_python
 DOCKER_IMG_PUBLISH_LAMBDA    = wellcome/publish_lambda:12
 DOCKER_IMG_TERRAFORM         = hashicorp/terraform:0.11.10
 DOCKER_IMG_TERRAFORM_WRAPPER = wellcome/terraform_wrapper:13
+DOCKER_IMG_IMAGE_BUILDER     = wellcome/image_builder:latest
+DOCKER_IMG_PUBLISH_SERVICE   = wellcome/publish_service:latest
 
+include makefiles/docker.Makefile
 include makefiles/python.Makefile
 include makefiles/terraform.Makefile
-
-
-# Build and tag a Docker image.
-#
-# Args:
-#   $1 - Name of the image.
-#   $2 - Path to the Dockerfile, relative to the root of the repo.
-#
-define build_image
-	$(ROOT)/docker_run.py \
-	    --dind -- \
-	    wellcome/image_builder:latest \
-            --project=$(1) \
-            --file=$(2)
-endef
-
-
-# Publish a Docker image to ECR, and put its associated release ID in S3.
-#
-# Args:
-#   $1 - Name of the Docker image.
-#
-define publish_service
-	$(ROOT)/docker_run.py \
-	    --aws --dind -- \
-	    wellcome/publish_service:latest \
-	        --project="$(1)" \
-	        --namespace=uk.ac.wellcome \
-	        --infra-bucket="$(INFRA_BUCKET)" \
-			--sns-topic="arn:aws:sns:eu-west-1:760097843905:ecr_pushes"
-endef
 
 
 # Test an sbt project.

--- a/functions.Makefile
+++ b/functions.Makefile
@@ -21,24 +21,6 @@ include makefiles/sbt.Makefile
 include makefiles/terraform.Makefile
 
 
-# Define a series of Make tasks (build, test, publish) for an ECS service.
-#
-# Args:
-#	$1 - Name of the ECS service.
-#	$2 - Path to the associated Dockerfile.
-#
-define __ecs_target_template
-$(1)-build:
-	$(call build_image,$(1),$(2))
-
-$(1)-test:
-	$(call test_python,$(STACK_ROOT)/$(1))
-
-$(1)-publish: $(1)-build
-	$(call publish_service,$(1))
-endef
-
-
 # Define all the Make tasks for a stack.
 #
 # Args:
@@ -71,7 +53,7 @@ define stack_setup
 $(foreach proj,$(SBT_APPS),$(eval $(call sbt_target_template,$(proj),$(STACK_ROOT)/$(proj))))
 $(foreach library,$(SBT_DOCKER_LIBRARIES),$(eval $(call sbt_library_docker_template,$(library),$(STACK_ROOT)/$(library))))
 $(foreach library,$(SBT_NO_DOCKER_LIBRARIES),$(eval $(call sbt_library_template,$(library))))
-$(foreach task,$(ECS_TASKS),$(eval $(call __ecs_target_template,$(task),$(STACK_ROOT)/$(task)/Dockerfile)))
+$(foreach task,$(ECS_TASKS),$(eval $(call python_ecs_target_template,$(task),$(STACK_ROOT)/$(task)/Dockerfile)))
 $(foreach lamb,$(LAMBDAS),$(eval $(call lambda_target_template,$(lamb),$(STACK_ROOT)/$(lamb))))
 $(foreach name,$(TF_NAME),$(eval $(call terraform_target_template,$(TF_NAME),$(TF_PATH),$(TF_IS_PUBLIC_FACING))))
 endef

--- a/functions.Makefile
+++ b/functions.Makefile
@@ -1,4 +1,5 @@
 include makefiles/docker.Makefile
+include makefiles/formatting.Makefile
 include makefiles/python.Makefile
 include makefiles/sbt.Makefile
 include makefiles/terraform.Makefile

--- a/makefiles/docker.Makefile
+++ b/makefiles/docker.Makefile
@@ -1,0 +1,27 @@
+# Build and tag a Docker image.
+#
+# Args:
+#   $1 - Name of the image.
+#   $2 - Path to the Dockerfile, relative to the root of the repo.
+#
+define build_image
+	$(ROOT)/docker_run.py \
+	    --dind -- \
+	    $(DOCKER_IMG_IMAGE_BUILDER) --project=$(1) --file=$(2)
+endef
+
+
+# Publish a Docker image to ECR, and put its associated release ID in S3.
+#
+# Args:
+#   $1 - Name of the Docker image.
+#
+define publish_service
+	$(ROOT)/docker_run.py \
+	    --aws --dind -- \
+	    $(DOCKER_IMG_PUBLISH_SERVICE) \
+	        --project="$(1)" \
+	        --namespace=uk.ac.wellcome \
+	        --infra-bucket="$(WELLCOME_INFRA_BUCKET)" \
+			--sns-topic="$(ECR_PUSHES_TOPIC_ARN)"
+endef

--- a/makefiles/docker.Makefile
+++ b/makefiles/docker.Makefile
@@ -1,3 +1,9 @@
+ECR_PUSHES_TOPIC_ARN = "arn:aws:sns:eu-west-1:760097843905:ecr_pushes"
+
+DOCKER_IMG_IMAGE_BUILDER   = wellcome/image_builder:latest
+DOCKER_IMG_PUBLISH_SERVICE = wellcome/publish_service:latest
+
+
 # Build and tag a Docker image.
 #
 # Args:

--- a/makefiles/formatting.Makefile
+++ b/makefiles/formatting.Makefile
@@ -1,43 +1,48 @@
+DOCKER_IMG_BUILD_TOOLING = wellcome/build_tooling
+DOCKER_IMG_FLAKE8        = wellcome/flake8:latest
+DOCKER_IMG_FORMAT_JSON   = wellcome/format_json:latest
+DOCKER_IMG_FORMAT_PYTHON = wellcome/format_python
+DOCKER_IMG_JSLINT        = wellcome/jslint:latest
+DOCKER_IMG_SCALAFMT      = wellcome/scalafmt
+DOCKER_IMG_TERRAFORM     = hashicorp/terraform:light
+
+
 lint-python:
 	$(ROOT)/docker_run.py -- \
 		--volume $(ROOT):/data \
 		--workdir /data \
-		wellcome/flake8:latest \
+		$(DOCKER_IMG_FLAKE8) \
 		    --exclude .git,__pycache__,target,.terraform \
 		    --ignore=E501,E122,E126,E203,W503
 
 lint-js:
 	$(ROOT)/docker_run.py -- \
 		--volume $(ROOT):/data \
-		wellcome/jslint:latest
+		$(DOCKER_IMG_JSLINT)
 
 format-rfcs:
 	$(ROOT)/docker_run.py -- \
 		--volume $(ROOT):/data \
-		wellcome/build_tooling \
+		$(DOCKER_IMG_BUILD_TOOLING) \
 		python3 /data/fix_rfc_headers.py
 
 format-terraform:
 	$(ROOT)/docker_run.py --aws -- \
 		--volume $(ROOT):/repo \
 		--workdir /repo \
-		hashicorp/terraform:light fmt
+		$(DOCKER_IMG_TERRAFORM) fmt
 
 format-python:
-	$(ROOT)/docker_run.py -- \
-		--volume $(ROOT):/repo \
-		wellcome/format_python
+	$(ROOT)/docker_run.py -- --volume $(ROOT):/repo $(DOCKER_IMG_FORMAT_PYTHON)
 
 format-scala:
-	$(ROOT)/docker_run.py --sbt -- \
-		--volume $(ROOT):/repo \
-		wellcome/scalafmt
+	$(ROOT)/docker_run.py --sbt -- --volume $(ROOT):/repo $(DOCKER_IMG_SCALAFMT)
 
 format-json:
 	$(ROOT)/docker_run.py -- \
 		--volume $(ROOT):/src \
 		--workdir /src \
-		wellcome/format_json:latest
+		$(DOCKER_IMG_FORMAT_JSON)
 
 format: format-terraform format-scala format-python format-json
 
@@ -45,4 +50,4 @@ check-format: format lint-python lint-ontologies
 	git diff --exit-code
 
 travis-format:
-	python3 run_autoformat.py
+	python3 $(ROOT)/run_autoformat.py

--- a/makefiles/formatting.Makefile
+++ b/makefiles/formatting.Makefile
@@ -1,5 +1,3 @@
-ROOT = $(shell git rev-parse --show-toplevel)
-
 lint-python:
 	$(ROOT)/docker_run.py -- \
 		--volume $(ROOT):/data \

--- a/makefiles/git.Makefile
+++ b/makefiles/git.Makefile
@@ -1,0 +1,33 @@
+ifndef UPTODATE_GIT_DEFINED
+
+# This target checks if you're up-to-date with the current master.
+# This avoids problems where Terraform goes backwards or breaks
+# already-applied changes.
+#
+# Consider the following scenario:
+#
+#     * --- * --- X --- Z                 master
+#                  \
+#                   Y --- Y --- Y         feature branch
+#
+# We cut a feature branch at X, then applied commits Y.  Meanwhile master
+# added commit Z, and ran `terraform apply`.  If we run `terraform apply` on
+# the feature branch, this would revert the changes in Z!  We'd rather the
+# branches looked like this:
+#
+#     * --- * --- X --- Z                 master
+#                        \
+#                         Y --- Y --- Y   feature branch
+#
+# So that the commits in the feature branch don't unintentionally revert Z.
+#
+uptodate-git:
+	@git fetch origin
+	@if ! git merge-base --is-ancestor origin/master HEAD; then \
+		echo "You need to be up-to-date with master before you can continue!"; \
+		exit 1; \
+	fi
+
+UPTODATE_GIT_DEFINED = true
+
+endif

--- a/makefiles/python.Makefile
+++ b/makefiles/python.Makefile
@@ -1,0 +1,62 @@
+ROOT = $(shell git rev-parse --show-toplevel)
+
+WELLCOME_INFRA_BUCKET = wellcomecollection-platform-infra
+
+LAMBDA_PUSHES_TOPIC_ARN = arn:aws:sns:eu-west-1:760097843905:lambda_pushes
+
+DOCKER_IMG_PUBLISH_LAMBDA    = wellcome/publish_lambda:12
+DOCKER_IMG_BUILD_TEST_PYTHON = wellcome/build_test_python
+
+
+# Publish a ZIP file containing a Lambda definition to S3.
+#
+# Args:
+#   $1 - Path to the Lambda src directory, relative to the root of the repo.
+#
+define publish_lambda
+	$(ROOT)/docker_run.py --aws --root -- \
+		$(DOCKER_IMG_PUBLISH_LAMBDA) \
+		"$(1)" --key="lambdas/$(1).zip" --bucket="$(WELLCOME_INFRA_BUCKET)" --sns-topic="$(LAMBDA_PUSHES_TOPIC_ARN)"
+endef
+
+
+# Test a Python project.
+#
+# Args:
+#   $1 - Path to the Python project's directory, relative to the root
+#        of the repo.
+#
+define test_python
+	$(ROOT)/docker_run.py --aws --dind -- \
+		$(DOCKER_IMG_BUILD_TEST_PYTHON) $(1)
+
+	$(ROOT)/docker_run.py --aws --dind -- \
+		--net=host \
+		--volume $(ROOT)/shared_conftest.py:/conftest.py \
+		--workdir $(ROOT)/$(1) --tty \
+		wellcome/test_python_$(shell basename $(1)):latest
+endef
+
+
+# Define a series of Make tasks (test, publish) for a Python Lambda.
+#
+# Args:
+#	$1 - Name of the target.
+#	$2 - Path to the Lambda source directory.
+#
+define lambda_target_template
+$(1)-test:
+	$(call test_python,$(2))
+
+$(1)-publish:
+	$(call publish_lambda,$(2))
+
+$(ROOT)/$(2)/requirements.txt: $(ROOT)/$(2)/requirements.in
+	$(ROOT)/docker_run.py -- \
+		--volume $(ROOT)/$(2)/src:/src micktwomey/pip-tools
+
+$(ROOT)/$(2)/test_requirements.txt: $(ROOT)/$(2)/test_requirements.in
+	$(ROOT)/docker_run.py -- \
+		--volume $(ROOT)/$(2)/src:/src micktwomey/pip-tools \
+		pip-compile test_requirements.in
+endef

--- a/makefiles/python.Makefile
+++ b/makefiles/python.Makefile
@@ -1,13 +1,3 @@
-ROOT = $(shell git rev-parse --show-toplevel)
-
-WELLCOME_INFRA_BUCKET = wellcomecollection-platform-infra
-
-LAMBDA_PUSHES_TOPIC_ARN = arn:aws:sns:eu-west-1:760097843905:lambda_pushes
-
-DOCKER_IMG_PUBLISH_LAMBDA    = wellcome/publish_lambda:12
-DOCKER_IMG_BUILD_TEST_PYTHON = wellcome/build_test_python
-
-
 # Publish a ZIP file containing a Lambda definition to S3.
 #
 # Args:

--- a/makefiles/python.Makefile
+++ b/makefiles/python.Makefile
@@ -50,3 +50,22 @@ $(ROOT)/$(2)/test_requirements.txt: $(ROOT)/$(2)/test_requirements.in
 		--volume $(ROOT)/$(2)/src:/src micktwomey/pip-tools \
 		pip-compile test_requirements.in
 endef
+
+
+# Define a series of Make tasks (build, test, publish) for an ECS service
+# written in Python.
+#
+# Args:
+#	$1 - Name of the ECS service.
+#	$2 - Path to the associated Dockerfile.
+#
+define python_ecs_target_template
+$(1)-build:
+	$(call build_image,$(1),$(2))
+
+$(1)-test:
+	$(call test_python,$(STACK_ROOT)/$(1))
+
+$(1)-publish: $(1)-build
+	$(call publish_service,$(1))
+endef

--- a/makefiles/python.Makefile
+++ b/makefiles/python.Makefile
@@ -1,3 +1,9 @@
+LAMBDA_PUSHES_TOPIC_ARN = arn:aws:sns:eu-west-1:760097843905:lambda_pushes
+
+DOCKER_IMG_BUILD_TEST_PYTHON = wellcome/build_test_python
+DOCKER_IMG_PUBLISH_LAMBDA    = wellcome/publish_lambda:12
+
+
 # Publish a ZIP file containing a Lambda definition to S3.
 #
 # Args:

--- a/makefiles/sbt.Makefile
+++ b/makefiles/sbt.Makefile
@@ -1,3 +1,6 @@
+DOCKER_IMG_SBT_WRAPPER = wellcome/sbt_wrapper
+
+
 # Test an sbt project.
 #
 # Args:

--- a/makefiles/sbt.Makefile
+++ b/makefiles/sbt.Makefile
@@ -1,0 +1,132 @@
+# Test an sbt project.
+#
+# Args:
+#   $1 - Name of the project.
+#
+define sbt_test
+	$(ROOT)/docker_run.py --dind --sbt --root -- \
+		--net host \
+		$(DOCKER_IMG_SBT_WRAPPER) \
+		"project $(1)" ";dockerComposeUp;test;dockerComposeStop"
+endef
+
+
+
+# Test an sbt project without docker-compose.
+#
+# Args:
+#   $1 - Name of the project.
+#
+define sbt_test_no_docker
+	$(ROOT)/docker_run.py --dind --sbt --root -- \
+		--net host \
+		$(DOCKER_IMG_SBT_WRAPPER) \
+		"project $(1)" "test"
+endef
+
+
+# Build an sbt project.
+#
+# Args:
+#   $1 - Name of the project.
+#
+define sbt_build
+	$(ROOT)/docker_run.py --dind --sbt --root -- \
+		--net host \
+		$(DOCKER_IMG_SBT_WRAPPER) \
+		"project $(1)" ";stage"
+endef
+
+
+# Run docker-compose up.
+#
+# Args:
+#   $1 - Path to the docker-compose file.
+#
+define docker_compose_up
+	$(ROOT)/docker_run.py --dind --sbt --root -- \
+		--net host \
+		$(DOCKER_IMG_SBT_WRAPPER) \
+		"project $(1)" "dockerComposeUp"
+endef
+
+
+# Run docker-compose down.
+#
+# Args:
+#   $1 - Path to the docker-compose file.
+#
+define docker_compose_down
+	$(ROOT)/docker_run.py --dind --sbt --root -- \
+		--net host \
+		$(DOCKER_IMG_SBT_WRAPPER) \
+		"project $(1)" "dockerComposeDown"
+endef
+
+
+# Define a series of Make tasks for a Scala modules that use docker-compose for tests.
+#
+# Args:
+#	$1 - Name of the project in sbt.
+#	$2 - Root of the project's source code.
+#
+define __sbt_base_docker_template
+$(1)-docker_compose_up:
+	$(call docker_compose_up,$(1))
+
+$(1)-docker_compose_down:
+	$(call docker_compose_down,$(1))
+
+$(1)-test:
+	$(call sbt_test,$(1))
+
+endef
+
+
+# Define a series of Make tasks (build, test, publish) for a Scala services.
+#
+# Args:
+#	$1 - Name of the project in sbt.
+#	$2 - Root of the project's source code.
+#
+define sbt_target_template
+$(eval $(call __sbt_base_docker_template,$(1),$(2)))
+
+$(1)-build:
+	$(call sbt_build,$(1))
+	$(call build_image,$(1),$(2)/Dockerfile)
+
+$(1)-publish: $(1)-build
+	$(call publish_service,$(1))
+endef
+
+
+# Define a series of Make tasks for a Scala libraries that use docker-compose for tests.
+#
+# Args:
+#	$1 - Name of the project in sbt.
+#	$2 - Root of the project's source code.
+#
+define sbt_library_docker_template
+$(eval $(call __sbt_base_docker_template,$(1),$(2)))
+
+$(1)-publish:
+	echo "Nothing to do!"
+
+endef
+
+
+# Define a series of Make tasks for a Scala library that doesn't use Docker.
+#
+# Args:
+#	$1 - Name of the project in sbt.
+#	$2 - Root of the project's source code.
+#
+define sbt_library_template
+$(1)-test:
+	$(call sbt_test_no_docker,$(1))
+
+$(1)-publish:
+	echo "Nothing to do!"
+
+endef

--- a/makefiles/terraform.Makefile
+++ b/makefiles/terraform.Makefile
@@ -1,6 +1,9 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 MAKEFILES = $(ROOT)/makefiles
 
+DOCKER_IMG_TERRAFORM         = hashicorp/terraform:0.11.10
+DOCKER_IMG_TERRAFORM_WRAPPER = wellcome/terraform_wrapper:13
+
 include $(MAKEFILES)/git.Makefile
 
 

--- a/makefiles/terraform.Makefile
+++ b/makefiles/terraform.Makefile
@@ -1,0 +1,63 @@
+ROOT = $(shell git rev-parse --show-toplevel)
+MAKEFILES = $(ROOT)/makefiles
+
+include $(MAKEFILES)/git.Makefile
+
+
+# Define a series of Make tasks (plan, apply) for a Terraform stack.
+#
+# Args:
+#	$1 - Name of the stack.
+#	$2 - Root to the Terraform directory.
+#	$3 - Is this a public-facing stack?  (true/false)
+#
+define terraform_target_template
+$(1)-terraform-plan: uptodate-git
+	$(ROOT)/docker_run.py --aws -- \
+		--volume $(ROOT):$(ROOT) \
+		--workdir $(ROOT)/$(2) \
+		--env OP=plan \
+		--env GET_TFVARS=true \
+		--env BUCKET_NAME=$(WELLCOME_INFRA_BUCKET) \
+		--env OBJECT_KEY=terraform.tfvars \
+		--env IS_PUBLIC_FACING=$(3) \
+		$(DOCKER_IMG_TERRAFORM_WRAPPER)
+
+
+	$(call terraform_plan,$(2),$(3))
+
+$(1)-terraform-apply: uptodate-git
+	$(ROOT)/docker_run.py --aws -- \
+		--volume $(ROOT):$(ROOT) \
+		--workdir $(ROOT)/$(2) \
+		--env BUCKET_NAME=$(WELLCOME_MONITORING_BUCKET) \
+		--env OP=apply \
+		$(DOCKER_IMG_TERRAFORM_WRAPPER)
+
+# These are a pair of dodgy hacks to allow us to run something like:
+#
+#	$ make stack-terraform-import aws_s3_bucket.bucket my-bucket-name
+#
+#	$ make stack-terraform-state-rm aws_s3_bucket.bucket
+#
+# In practice it slightly breaks the conventions of Make (you're not meant to
+# read command-line arguments), but since this is only for one-offs I think
+# it's okay.
+#
+# This is slightly easier than using terraform on the command line, as paths
+# are different in/outside Docker, so you have to reload all your modules,
+# which is slow and boring.
+#
+$(1)-terraform-import:
+	$(ROOT)/docker_run.py --aws -- \
+		--volume $(ROOT):$(ROOT) \
+		--workdir $(ROOT)/$(2) \
+		$(DOCKER_IMG_TERRAFORM) import $(filter-out $(1)-terraform-import,$(MAKECMDGOALS))
+
+$(1)-terraform-state-rm:
+	$(ROOT)/docker_run.py --aws -- \
+		--volume $(ROOT):$(ROOT) \
+		--workdir $(ROOT)/$(2) \
+		$(DOCKER_IMG_TERRAFORM) state rm $(filter-out $(1)-terraform-state-rm,$(MAKECMDGOALS))
+
+endef


### PR DESCRIPTION
A first step to making our build more reproducible – first I’m pushing all the Makefiles into a separate directory, and doing a bit of refactoring to make it easier to bump image definitions.

Pulling them out into a separate repo (and wrangling Git submodules) is a separate task.