### PR TITLE
Remove unused lambda_type in migrator module

### DIFF
--- a/archive/terraform/main.tf
+++ b/archive/terraform/main.tf
@@ -241,8 +241,6 @@ module "migrator" {
   name        = "migrator"
   description = "Passes on the location of a successfully bagged set of METS and objects to the Archive Ingest API"
 
-  lambda_type = "vpc"
-
   timeout = 25
 
   environment_variables = {


### PR DESCRIPTION
Fixes archive stack.