### PR TITLE
Expire old records in the Sierra adapter bucket

### DIFF
--- a/sierra_adapter/terraform/s3_sierra_adapter.tf
+++ b/sierra_adapter/terraform/s3_sierra_adapter.tf
@@ -4,4 +4,24 @@ resource "aws_s3_bucket" "sierra_adapter" {
   lifecycle {
     prevent_destroy = true
   }
+
+  lifecycle_rule {
+    id      = "expire_old_items"
+    prefix  = "records_items/"
+    enabled = true
+
+    expiration {
+      days = 7
+    }
+  }
+
+  lifecycle_rule {
+    id      = "expire_old_bibs"
+    prefix  = "records_bibs/"
+    enabled = true
+
+    expiration {
+      days = 7
+    }
+  }
 }


### PR DESCRIPTION
We have no mechanism for reloading these records, we've never done it, and we have a lot of them. Keeping them all in S3 Standard storage is just wasting money.

💸 💸 💸 