### PR TITLE
Bump the timeout when talking to our internal Scala services

### DIFF
--- a/archive/archive_api/src/bags_manager.py
+++ b/archive/archive_api/src/bags_manager.py
@@ -19,7 +19,7 @@ class BagsManager:
         self.sess = sess or requests.Session()
 
     def lookup_bag(self, space, id):
-        resp = self.sess.get(f"{self.endpoint}/registrar/{space}/{id}", timeout=1)
+        resp = self.sess.get(f"{self.endpoint}/registrar/{space}/{id}", timeout=5)
 
         if resp.status_code not in (200, 404):
             raise BagServiceError(

--- a/archive/archive_api/src/progress_manager.py
+++ b/archive/archive_api/src/progress_manager.py
@@ -32,7 +32,7 @@ class ProgressManager:
         self.sess = sess or requests.Session()
 
     def create_request(self, request_json):
-        resp = self.sess.post(f"{self.endpoint}/progress", json=request_json, timeout=1)
+        resp = self.sess.post(f"{self.endpoint}/progress", json=request_json, timeout=5)
 
         # The service should return an HTTP 202 if successful.  Anything
         # else should be treated as an error.
@@ -47,7 +47,7 @@ class ProgressManager:
         Passes the response through directly (if any).
 
         """
-        resp = self.sess.get(f"{self.endpoint}/progress/{id}", timeout=1)
+        resp = self.sess.get(f"{self.endpoint}/progress/{id}", timeout=5)
 
         # The service should return an HTTP 200 (if present) or 404 (if not).
         # Anything else should be treated as an error.


### PR DESCRIPTION
When the JVM is cold, it can fail to return a response within 1s, even though a correct response eventually arrives -- the effect is a 500 in the user-facing API.  Bumping the timeouts should make this less likely.