### PR TITLE
Use the new test helpers to reduce test boilerplate

### DIFF
--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlowTest.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlowTest.scala
@@ -56,7 +56,6 @@ class ArchiveZipFileFlowTest
       withActorSystem { actorSystem =>
         withMaterializer(actorSystem) { implicit materializer =>
           withLocalSnsTopic { reportingTopic =>
-            val bagUploaderConfig = createBagUploaderConfig(storageBucket)
             withBagItZip() {
               case (bagName, zipFile) =>
                 withArchiveZipFileFlow(storageBucket, reportingTopic) {
@@ -103,7 +102,6 @@ class ArchiveZipFileFlowTest
       withActorSystem { actorSystem =>
         withMaterializer(actorSystem) { implicit materializer =>
           withLocalSnsTopic { reportingTopic =>
-            val bagUploaderConfig = createBagUploaderConfig(storageBucket)
             withBagItZip(createDigest = _ => "bad_digest") {
               case (_, zipFile) =>
                 withArchiveZipFileFlow(storageBucket, reportingTopic) {

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlowTest.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlowTest.scala
@@ -4,7 +4,6 @@ import akka.NotUsed
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Inside, Matchers}
-import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.test.fixtures.SNS
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.platform.archive.archivist.fixtures.{
@@ -263,7 +262,7 @@ class ArchiveZipFileFlowTest
     val bagUploaderConfig = createBagUploaderConfig(bucket)
     val flow = ArchiveZipFileFlow(
       config = bagUploaderConfig,
-      snsConfig = SNSConfig(topicArn = topic.arn)
+      snsConfig = createSNSConfigWith(topic)
     )
 
     testWith(flow)

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ZipFileDownloadFlowTest.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ZipFileDownloadFlowTest.scala
@@ -7,7 +7,6 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Inside, Matchers}
-import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.test.fixtures.SNS
 import uk.ac.wellcome.platform.archive.archivist.fixtures.{
   Archivist => ArchivistFixture
@@ -43,8 +42,10 @@ class ZipFileDownloadFlowTest
       withLocalSnsTopic { progressTopic =>
         withBagItZip() {
           case (bagName, zipFile) =>
-            val downloadZipFlow =
-              ZipFileDownloadFlow(10, SNSConfig(progressTopic.arn))
+            val downloadZipFlow = ZipFileDownloadFlow(
+              parallelism = 10,
+              snsConfig = createSNSConfigWith(progressTopic)
+            )
 
             val uploadKey = bagName.toString
 
@@ -82,8 +83,10 @@ class ZipFileDownloadFlowTest
       withLocalSnsTopic { progressTopic =>
         val bagIdentifier = randomAlphanumeric()
 
-        val downloadZipFlow =
-          ZipFileDownloadFlow(10, SNSConfig(progressTopic.arn))
+        val downloadZipFlow = ZipFileDownloadFlow(
+          parallelism = 10,
+          snsConfig = createSNSConfigWith(progressTopic)
+        )
 
         val objectLocation =
           ObjectLocation(storageBucket.name, bagIdentifier.toString)

--- a/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/flows/SNSPublishFlowTest.scala
+++ b/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/flows/SNSPublishFlowTest.scala
@@ -7,6 +7,7 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.test.fixtures.SNS
+import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.platform.archive.common.messaging.SnsPublishFlow
 import uk.ac.wellcome.test.fixtures.Akka
 

--- a/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/flows/SNSPublishFlowTest.scala
+++ b/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/flows/SNSPublishFlowTest.scala
@@ -6,7 +6,6 @@ import org.scalatest.FunSpec
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.test.fixtures.SNS
 import uk.ac.wellcome.platform.archive.common.messaging.SnsPublishFlow
 import uk.ac.wellcome.test.fixtures.Akka
@@ -27,7 +26,7 @@ class SNSPublishFlowTest
         withMaterializer(actorSystem) { materializer =>
           val bob = Person("Bobbert", 42)
 
-          val snsConfig = SNSConfig(topic.arn)
+          val snsConfig = createSNSConfigWith(topic)
           val publishFlow =
             SnsPublishFlow[Person](
               snsClient,
@@ -61,7 +60,7 @@ class SNSPublishFlowTest
             Person("Borbbit", 40)
         )
 
-        val snsConfig = SNSConfig("bad_topic")
+        val snsConfig = createSNSConfigWith(Topic("bad_topic"))
         val publishFlow =
           SnsPublishFlow[Person](
             snsClient,
@@ -92,7 +91,7 @@ class SNSPublishFlowTest
               Person("Borbbit", 40)
           )
 
-          val snsConfig = SNSConfig(topic.arn)
+          val snsConfig = createSNSConfigWith(topic)
           val publishFlow =
             SnsPublishFlow[Person](
               snsClient,

--- a/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/messaging/MessageStreamTest.scala
+++ b/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/messaging/MessageStreamTest.scala
@@ -10,7 +10,6 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sqs.SQSConfig
 import uk.ac.wellcome.messaging.test.fixtures.Messaging
 import uk.ac.wellcome.messaging.test.fixtures.SQS.{Queue, QueuePair}
 import uk.ac.wellcome.monitoring.MetricsSender
@@ -150,7 +149,7 @@ class MessageStreamTest
       withLocalSqsQueueAndDlq {
         case queuePair @ QueuePair(queue, _) =>
           withMockMetricSender { metricsSender =>
-            val sqsConfig = SQSConfig(queueUrl = queue.url)
+            val sqsConfig = createSQSConfigWith(queue)
 
             val stream = new MessageStream[ExampleObject, Unit](
               actorSystem = actorSystem,

--- a/archive/progress_async/src/test/scala/uk/ac/wellcome/platform/archive/progress_async/flows/CallbackNotificationFlowTest.scala
+++ b/archive/progress_async/src/test/scala/uk/ac/wellcome/platform/archive/progress_async/flows/CallbackNotificationFlowTest.scala
@@ -4,7 +4,6 @@ import akka.stream.scaladsl.{Sink, Source}
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.test.fixtures.SNS
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
 import uk.ac.wellcome.platform.archive.common.json.{
@@ -43,8 +42,10 @@ class CallbackNotificationFlowTest
       withActorSystem { actorSystem =>
         withMaterializer(actorSystem) { materializer =>
           withLocalSnsTopic { topic =>
-            val callbackNotificationFlow =
-              CallbackNotificationFlow(snsClient, SNSConfig(topic.arn))
+            val callbackNotificationFlow = CallbackNotificationFlow(
+              snsClient,
+              snsConfig = createSNSConfigWith(topic)
+            )
 
             val progress = createProgressWith(
               status = progressStatus,
@@ -87,8 +88,10 @@ class CallbackNotificationFlowTest
         withLocalSnsTopic { topic =>
           forAll(doesNotSendCallbackStatus) {
             (progressStatus, callbackStatus) =>
-              val callbackNotificationFlow =
-                CallbackNotificationFlow(snsClient, SNSConfig(topic.arn))
+              val callbackNotificationFlow = CallbackNotificationFlow(
+                snsClient,
+                snsConfig = createSNSConfigWith(topic)
+              )
 
               val progress = createProgressWith(
                 status = progressStatus,

--- a/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
@@ -9,7 +9,6 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.message.{MessageWriter, MessageWriterConfig}
-import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
@@ -196,7 +195,10 @@ class HybridRecordReceiverTest
     implicit objectStore: ObjectStore[TestTransformable]) = {
     val s3Config = S3Config(bucket.name)
 
-    val messageConfig = MessageWriterConfig(SNSConfig(topic.arn), s3Config)
+    val messageConfig = MessageWriterConfig(
+      snsConfig = createSNSConfigWith(topic),
+      s3Config = s3Config
+    )
 
     val messageWriter =
       new MessageWriter[TransformedBaseWork](

--- a/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
@@ -191,14 +191,16 @@ class HybridRecordReceiverTest
     snsClient: AmazonSNS = snsClient
   )(testWith: TestWith[HybridRecordReceiver[TestTransformable], R])(
     implicit objectStore: ObjectStore[TestTransformable]): R =
-    withMessageWriter[TransformedBaseWork, R](bucket, topic, writerSnsClient = snsClient) {
-      messageWriter =>
-        val recordReceiver = new HybridRecordReceiver[TestTransformable](
-          messageWriter = messageWriter,
-          objectsStore = objectStore
-        )
+    withMessageWriter[TransformedBaseWork, R](
+      bucket,
+      topic,
+      writerSnsClient = snsClient) { messageWriter =>
+      val recordReceiver = new HybridRecordReceiver[TestTransformable](
+        messageWriter = messageWriter,
+        objectsStore = objectStore
+      )
 
-        testWith(recordReceiver)
+      testWith(recordReceiver)
     }
 
   private def mockSnsClientFailPublishMessage = {

--- a/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
@@ -8,7 +8,6 @@ import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.message.{MessageWriter, MessageWriterConfig}
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
@@ -20,7 +19,6 @@ import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectStore}
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
-import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.vhs.HybridRecord
 import uk.ac.wellcome.test.fixtures.TestWith
 
@@ -175,7 +173,7 @@ class HybridRecordReceiverTest
           withHybridRecordReceiver(
             topic,
             bucket,
-            Some(mockSnsClientFailPublishMessage)) { recordReceiver =>
+            mockSnsClientFailPublishMessage) { recordReceiver =>
             val future = recordReceiver.receiveMessage(message, transformToWork)
 
             whenReady(future.failed) { x =>
@@ -190,30 +188,18 @@ class HybridRecordReceiverTest
   def withHybridRecordReceiver[R](
     topic: Topic,
     bucket: Bucket,
-    maybeSnsClient: Option[AmazonSNS] = None
+    snsClient: AmazonSNS = snsClient
   )(testWith: TestWith[HybridRecordReceiver[TestTransformable], R])(
-    implicit objectStore: ObjectStore[TestTransformable]) = {
-    val s3Config = S3Config(bucket.name)
+    implicit objectStore: ObjectStore[TestTransformable]): R =
+    withMessageWriter[TransformedBaseWork, R](bucket, topic, writerSnsClient = snsClient) {
+      messageWriter =>
+        val recordReceiver = new HybridRecordReceiver[TestTransformable](
+          messageWriter = messageWriter,
+          objectsStore = objectStore
+        )
 
-    val messageConfig = MessageWriterConfig(
-      snsConfig = createSNSConfigWith(topic),
-      s3Config = s3Config
-    )
-
-    val messageWriter =
-      new MessageWriter[TransformedBaseWork](
-        messageConfig = messageConfig,
-        snsClient = maybeSnsClient.getOrElse(snsClient),
-        s3Client = s3Client
-      )
-
-    val recordReceiver = new HybridRecordReceiver[TestTransformable](
-      messageWriter = messageWriter,
-      objectsStore = objectStore
-    )
-
-    testWith(recordReceiver)
-  }
+        testWith(recordReceiver)
+    }
 
   private def mockSnsClientFailPublishMessage = {
     val mockSNSClient = mock[AmazonSNS]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object WellcomeDependencies {
   private lazy val versions = new {
     val json = "1.0.0"
     val monitoring = "1.1.0"
-    val storage = "2.4.1"
+    val storage = "2.5.0"
   }
 
   val jsonLibrary: Seq[ModuleID] = Seq(

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -12,7 +12,6 @@ import io.circe.{Decoder, Encoder}
 import org.scalatest.Matchers
 import uk.ac.wellcome.messaging.message._
 import uk.ac.wellcome.messaging.sns.SNSConfig
-import uk.ac.wellcome.messaging.sqs.SQSConfig
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.{Queue, QueuePair}
 import uk.ac.wellcome.monitoring.MetricsSender
@@ -106,7 +105,7 @@ trait Messaging
     metricsSender: MetricsSender)(testWith: TestWith[MessageStream[T], R])(
     implicit objectStore: ObjectStore[T]) = {
     val s3Config = S3Config(bucketName = bucket.name)
-    val sqsConfig = SQSConfig(queueUrl = queue.url)
+    val sqsConfig = createSQSConfigWith(queue)
 
     val messageConfig = MessageReaderConfig(
       sqsConfig = sqsConfig,

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -83,7 +83,7 @@ trait Messaging
     testWith: TestWith[MessageWriter[T], R])(
     implicit store: ObjectStore[T]): R = {
     val s3Config = S3Config(bucketName = bucket.name)
-    val snsConfig = SNSConfig(topicArn = topic.arn)
+    val snsConfig = createSNSConfigWith(topic)
     val messageConfig = MessageWriterConfig(
       s3Config = s3Config,
       snsConfig = snsConfig

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -11,13 +11,11 @@ import com.amazonaws.services.sqs.model.SendMessageResult
 import io.circe.{Decoder, Encoder}
 import org.scalatest.Matchers
 import uk.ac.wellcome.messaging.message._
-import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS.{Queue, QueuePair}
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectStore}
-import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures._
@@ -82,11 +80,9 @@ trait Messaging
                               writerSnsClient: AmazonSNS = snsClient)(
     testWith: TestWith[MessageWriter[T], R])(
     implicit store: ObjectStore[T]): R = {
-    val s3Config = S3Config(bucketName = bucket.name)
-    val snsConfig = createSNSConfigWith(topic)
     val messageConfig = MessageWriterConfig(
-      s3Config = s3Config,
-      snsConfig = snsConfig
+      s3Config = createS3ConfigWith(bucket),
+      snsConfig = createSNSConfigWith(topic)
     )
 
     val messageWriter = new MessageWriter[T](
@@ -104,12 +100,9 @@ trait Messaging
     queue: SQS.Queue,
     metricsSender: MetricsSender)(testWith: TestWith[MessageStream[T], R])(
     implicit objectStore: ObjectStore[T]) = {
-    val s3Config = S3Config(bucketName = bucket.name)
-    val sqsConfig = createSQSConfigWith(queue)
-
     val messageConfig = MessageReaderConfig(
-      sqsConfig = sqsConfig,
-      s3Config = s3Config
+      sqsConfig = createSQSConfigWith(queue),
+      s3Config = createS3ConfigWith(bucket)
     )
 
     val stream = new MessageStream[T](

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
@@ -205,6 +205,9 @@ trait SNS extends Matchers with Logging {
     val maybeT = listNotifications[T](topic).head
     maybeT.get
   }
+
+  def createSNSConfigWith(topic: Topic): SNSConfig =
+    SNSConfig(topicArn = topic.arn)
 }
 
 case class SNSNotificationMessage(

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SQS.scala
@@ -295,4 +295,7 @@ trait SQS extends Matchers with Logging {
       .asScala
     messages
   }
+
+  def createSQSConfigWith(queue: Queue): SQSConfig =
+    SQSConfig(queueUrl = queue.url)
 }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/modules/WindowManagerTest.scala
@@ -10,7 +10,6 @@ import uk.ac.wellcome.platform.sierra_reader.models.{
   SierraResourceTypes,
   WindowStatus
 }
-import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures.TestWith
@@ -39,7 +38,7 @@ class WindowManagerTest
 
     val windowManager = new WindowManager(
       s3client = s3Client,
-      s3Config = S3Config(bucket.name),
+      s3Config = createS3ConfigWith(bucket),
       sierraConfig = sierraConfig
     )
 

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -7,7 +7,6 @@ import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.sierra_reader.modules.WindowManager
-import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import org.scalatest.compatible.Assertion
@@ -68,10 +67,10 @@ class SierraReaderWorkerServiceTest
                 system = actorSystem,
                 sqsStream = sqsStream,
                 s3client = s3Client,
-                s3Config = S3Config(bucket.name),
+                s3Config = createS3ConfigWith(bucket),
                 windowManager = new WindowManager(
                   s3Client,
-                  S3Config(bucket.name),
+                  createS3ConfigWith(bucket),
                   sierraConfig = sierraConfig
                 ),
                 readerConfig = ReaderConfig(batchSize = batchSize),


### PR DESCRIPTION
Plus add a few new ones. Follows https://github.com/wellcometrust/scala-storage/pull/32