### PR TITLE
Ignore changes to the archive-common lib in non-archive apps

### DIFF
--- a/travistooling/decisionmaker.py
+++ b/travistooling/decisionmaker.py
@@ -148,6 +148,14 @@ def does_file_affect_build_task(path, task):
                 if project.exclusive_path.startswith(("catalogue_api/",)):
                     raise ChangeToUnusedLibrary("messaging")
 
+    # We have a library for common archive code.
+    #
+    # Only apps in the archive stack use this code.
+    if path.startswith("archive/common"):
+        if task.startswith(project.name) and (project.type == "sbt_app"):
+            if not project.exclusive_path.startswith("archive/"):
+                raise ChangeToUnusedLibrary("archive_common")
+
     # We have a couple of sbt common libs and files scattered around the
     # repository; changes to any of these don't affect non-sbt applications.
     if path.startswith(

--- a/travistooling/tests/test_decisionmaker.py
+++ b/travistooling/tests/test_decisionmaker.py
@@ -232,18 +232,8 @@ from travistooling.decisions import (
             False,
         ),
         # Changes to the Archive common don't affect all the stacks
-        (
-            "archive/common/foo.scala",
-            "api-test",
-            ChangeToUnusedLibrary,
-            False
-        ),
-        (
-            "archive/common/foo.scala",
-            "notifier-test",
-            UnrecognisedFile,
-            True
-        ),
+        ("archive/common/foo.scala", "api-test", ChangeToUnusedLibrary, False),
+        ("archive/common/foo.scala", "notifier-test", UnrecognisedFile, True),
         # Changes to Scala test files trigger a -test Scala task, but not
         # a -publish task.
         (

--- a/travistooling/tests/test_decisionmaker.py
+++ b/travistooling/tests/test_decisionmaker.py
@@ -38,7 +38,7 @@ from travistooling.decisions import (
         ("foo.txt", "snapshot_generator-publish", UnrecognisedFile, True),
         # Certain file formats are always excluded.
         ("foo.md", "ingestor-build", IgnoredFileFormat, False),
-        ("image.png", "reindex_request_creator-test", IgnoredFileFormat, False),
+        ("image.png", "reindex_worker-test", IgnoredFileFormat, False),
         ("ontology.graffle", "nginx-test", IgnoredFileFormat, False),
         ("Makefile", "travistooling-test", IgnoredFileFormat, False),
         ("monitoring/Makefile", "travistooling-test", IgnoredFileFormat, False),
@@ -133,7 +133,7 @@ from travistooling.decisions import (
         ),
         (
             "sbt_common/display/model.scala",
-            "reindex_request_creator-test",
+            "reindex_worker-test",
             ChangeToUnusedLibrary,
             False,
         ),
@@ -159,7 +159,7 @@ from travistooling.decisions import (
         ),
         (
             "sbt_common/elasticsearch/model.scala",
-            "reindex_request_creator-test",
+            "reindex_worker-test",
             ChangeToUnusedLibrary,
             False,
         ),
@@ -189,7 +189,7 @@ from travistooling.decisions import (
         ),
         (
             "sbt_common/finatra_elasticsearch/model.scala",
-            "reindex_request_creator-test",
+            "reindex_worker-test",
             ChangeToUnusedLibrary,
             False,
         ),
@@ -231,6 +231,19 @@ from travistooling.decisions import (
             ChangeToUnusedLibrary,
             False,
         ),
+        # Changes to the Archive common don't affect all the stacks
+        (
+            "archive/common/foo.scala",
+            "api-test",
+            ChangeToUnusedLibrary,
+            False
+        ),
+        (
+            "archive/common/foo.scala",
+            "notifier-test",
+            UnrecognisedFile,
+            True
+        ),
         # Changes to Scala test files trigger a -test Scala task, but not
         # a -publish task.
         (
@@ -266,20 +279,20 @@ from travistooling.decisions import (
             False,
         ),
         (
-            "reindex_request_creator/.coveragerc",
+            "reindex_worker/.coveragerc",
             "reindex_shard_generator-publish",
             ChangesToTestsDontGetPublished,
             False,
         ),
         # Changes to Lambdas trigger the travis-lambda-test task.
         (
-            "reindexer/reindex_request_creator/src/reindex_request_creator.py",
+            "reindexer/reindex_worker/src/reindex_worker.py",
             "travis-lambda-test",
             CheckedByTravisLambda,
             True,
         ),
         (
-            "reindexer/reindex_request_creator/src/reindex_request_creator.py",
+            "reindexer/reindex_worker/src/reindex_worker.py",
             "travis-lambda-publish",
             CheckedByTravisLambda,
             True,


### PR DESCRIPTION
This is having a substantial drag on build times – any changes to `archive/common` trigger a complete run of tests, which now takes 2+ hours. This should bring build times down again.