### PR TITLE
Have another go at fixing the flaky archivist test

### DIFF
--- a/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/progress/ProgressUpdateAssertions.scala
+++ b/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/progress/ProgressUpdateAssertions.scala
@@ -43,7 +43,7 @@ trait ProgressUpdateAssertions extends SNS with Inside with Logging {
     val messages = listMessagesReceivedFromSNS(progressTopic)
     val progressUpdates = messages.map { messageinfo =>
       fromJson[ProgressUpdate](messageinfo.message).get
-    }.distinct
+    }
     progressUpdates.size should be > 0
 
     val (success, failure) = progressUpdates
@@ -57,6 +57,7 @@ trait ProgressUpdateAssertions extends SNS with Inside with Logging {
         })
       }
       .partition(_.isSuccess)
-    success should have size 1
+
+    success.distinct should have size 1
   }
 }


### PR DESCRIPTION
The error is pretty consistently:

    List(Success(Succeeded), Success(Succeeded)) had size 2, not 1

I think it's if we get multiple ProgressUpdate instances delivered by SNS, but I was filtering at the wrong point.