### PR TITLE
Halve the memory/CPU usage of the Sierra and pipeline apps

### DIFF
--- a/catalogue_pipeline/terraform/pipelines/service/main.tf
+++ b/catalogue_pipeline/terraform/pipelines/service/main.tf
@@ -18,8 +18,8 @@ module "service" {
   ecs_cluster_id   = "${data.aws_ecs_cluster.cluster.id}"
   ecs_cluster_name = "${var.cluster_name}"
 
-  cpu    = 512
-  memory = 2048
+  cpu    = 256
+  memory = 1024
 
   env_vars        = "${var.env_vars}"
   env_vars_length = "${var.env_vars_length}"

--- a/sierra_adapter/terraform/bib_merger/main.tf
+++ b/sierra_adapter/terraform/bib_merger/main.tf
@@ -21,8 +21,8 @@ module "sierra_merger_service" {
   ecs_cluster_id   = "${data.aws_ecs_cluster.cluster.id}"
   ecs_cluster_name = "${var.cluster_name}"
 
-  cpu    = 512
-  memory = 2048
+  cpu    = 256
+  memory = 1024
 
   env_vars = {
     windows_queue_url = "${module.updates_queue.id}"

--- a/sierra_adapter/terraform/item_merger/main.tf
+++ b/sierra_adapter/terraform/item_merger/main.tf
@@ -21,8 +21,8 @@ module "sierra_merger_service" {
   ecs_cluster_id   = "${data.aws_ecs_cluster.cluster.id}"
   ecs_cluster_name = "${var.cluster_name}"
 
-  cpu    = 512
-  memory = 2048
+  cpu    = 256
+  memory = 1024
 
   env_vars = {
     windows_queue_url   = "${module.updates_queue.id}"

--- a/sierra_adapter/terraform/sierra_reader/main.tf
+++ b/sierra_adapter/terraform/sierra_reader/main.tf
@@ -15,8 +15,8 @@ module "sierra_reader_service" {
     "${var.service_egress_security_group_id}",
   ]
 
-  cpu    = 512
-  memory = 2048
+  cpu    = 256
+  memory = 1024
 
   source_queue_name = "${module.windows_queue.name}"
   source_queue_arn  = "${module.windows_queue.arn}"


### PR DESCRIPTION
Scala apps use the JVM, and the JVM is super memory and CPU-hungry… right?

Or maybe it isn’t. We’ve been running with this config in sierra_items_to_dynamo for a while, and it’s never had any problems. Let’s try turning down some other apps that aren’t public-facing, and see how (if at all) it affects anything except costs. The Sierra adapter ran all yesterday with this applied, and nobody noticed.

Rationale: our biggest daily cost right now is Fargate, and reducing the CPU/memory provision of the pipeline apps that we spin up in large numbers should hopefully make a dent in that cost.