### PR TITLE
Add a lifecycle rule for sending content in the Goobi adapters bucket to IA

### DIFF
--- a/goobi_adapter/terraform/s3.tf
+++ b/goobi_adapter/terraform/s3.tf
@@ -4,4 +4,16 @@ resource "aws_s3_bucket" "goobi_adapter" {
   lifecycle {
     prevent_destroy = true
   }
+
+  # We'll probably want to remove this rule when we actually start working with
+  # the Goobi adapter and this content, but while we're not using it this should
+  # save a bit of money.
+  lifecycle_rule {
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    enabled = true
+  }
 }


### PR DESCRIPTION
Not a huge cost saving, but we’re spending ~$150 a month on Standard storage, and this bucket is a large chunk of that. We’re not using it, so let’s put it in Standard-IA until then.