### PR TITLE
Add bucket policy for DLCS.IO API/Echo-FS users to access archive-storage images

### DIFF
--- a/archive/terraform/iam_policy_document.tf
+++ b/archive/terraform/iam_policy_document.tf
@@ -54,6 +54,31 @@ data "aws_iam_policy_document" "ingest_workflow_get" {
   }
 }
 
+data "aws_iam_policy_document" "archive_dlcs_get" {
+  statement {
+    effect = "ALLOW"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::653428163053:user/echo-fs",
+        "arn:aws:iam::653428163053:user/api",
+      ]
+    }
+
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${local.archive_bucket_name}",
+      "arn:aws:s3:::${local.archive_bucket_name}/*",
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "read_from_archivist_queue" {
   statement {
     actions = [

--- a/archive/terraform/s3.tf
+++ b/archive/terraform/s3.tf
@@ -5,6 +5,8 @@ data "aws_s3_bucket" "storage_manifests" {
 resource "aws_s3_bucket" "archive_storage" {
   bucket = "${local.archive_bucket_name}"
   acl    = "private"
+
+  policy = "${data.aws_iam_policy_document.archive_dlcs_get.json}"
 }
 
 resource "aws_s3_bucket" "ingest_storage" {


### PR DESCRIPTION
This adds a bucket policy to the archive-storage bucket that allows the `api` and `echo-fs` users on the DLCS.IO AWS account to have read-only access to images stored in the bucket. `s3:ListBucket` permission has been added so that the DLCS can provide a correct error status for failed ingests (i.e. so it reports a literal 404 instead of a 403 when a bucket object doesn't exist).

This change is for the DLCS.IO image ingest process.
