### PR TITLE
Move display models into their own module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ cache:
     - sierra_adapter/sierra_item_merger/target
 
     - archive/commmon/target
+    - archive/display/target
     - archive/archivist/target
     - archive/notifier/target
     - archive/progress_common/target
@@ -166,6 +167,7 @@ jobs:
 
     # Archive
     - env: TASK=archive_api-test
+    - env: TASK=archive_display-test
     - env: TASK=archive_common-test
     - env: TASK=archivist-test
     - env: TASK=progress_common-test

--- a/archive/Makefile
+++ b/archive/Makefile
@@ -5,7 +5,7 @@ STACK_ROOT 	= archive
 
 SBT_APPS    = archivist progress_async progress_http notifier registrar_async registrar_http
 SBT_DOCKER_LIBRARIES = archive_common progress_common
-SBT_NO_DOCKER_LIBRARIES = registrar_common
+SBT_NO_DOCKER_LIBRARIES = registrar_common archive_display
 
 ECS_TASKS   = bagger archive_api callback_stub_server
 LAMBDAS     = migrator

--- a/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/progress/models/Progress.scala
+++ b/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/progress/models/Progress.scala
@@ -1,14 +1,10 @@
 package uk.ac.wellcome.platform.archive.common.progress.models
 
-import java.net.URI
 import java.time.Instant
 import java.util.UUID
 
 import uk.ac.wellcome.platform.archive.common.json.URIConverters
-import uk.ac.wellcome.platform.archive.common.models.{
-  BagId,
-  RequestDisplayIngest
-}
+import uk.ac.wellcome.platform.archive.common.models.BagId
 
 case class Progress(id: UUID,
                     sourceLocation: StorageLocation,
@@ -44,16 +40,4 @@ case object Progress extends URIConverters {
     override def toString: String = failureString
   }
 
-  def apply(createRequest: RequestDisplayIngest): Progress = {
-    Progress(
-      id = generateId,
-      sourceLocation = StorageLocation(createRequest.sourceLocation),
-      callback = Callback(createRequest.callback.map(displayCallback =>
-        URI.create(displayCallback.url))),
-      space = Namespace(createRequest.space.id),
-      status = Progress.Initialised
-    )
-  }
-
-  private def generateId: UUID = UUID.randomUUID
 }

--- a/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/progress/models/StorageLocation.scala
+++ b/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/progress/models/StorageLocation.scala
@@ -1,20 +1,6 @@
 package uk.ac.wellcome.platform.archive.common.progress.models
-import uk.ac.wellcome.platform.archive.common.models.{
-  DisplayLocation,
-  DisplayProvider
-}
 import uk.ac.wellcome.storage.ObjectLocation
 
 case class StorageLocation(provider: StorageProvider, location: ObjectLocation)
-object StorageLocation {
-  def apply(displayLocation: DisplayLocation): StorageLocation =
-    StorageLocation(
-      StorageProvider(displayLocation.provider),
-      ObjectLocation(displayLocation.bucket, displayLocation.path))
-}
 
 case class StorageProvider(id: String)
-object StorageProvider {
-  def apply(displayProvider: DisplayProvider): StorageProvider =
-    StorageProvider(displayProvider.id)
-}

--- a/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/progress/models/ProgressTest.scala
+++ b/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/progress/models/ProgressTest.scala
@@ -1,16 +1,8 @@
 package uk.ac.wellcome.platform.archive.common.progress.models
 
-import java.net.URI
-import java.util.UUID
-
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
-import uk.ac.wellcome.platform.archive.common.models._
-import uk.ac.wellcome.platform.archive.common.progress.fixtures.{
-  ProgressGenerators,
-  TimeTestFixture
-}
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.platform.archive.common.progress.fixtures.{ProgressGenerators, TimeTestFixture}
 
 class ProgressTest
     extends FunSpec
@@ -24,32 +16,6 @@ class ProgressTest
     progress.status shouldBe Progress.Initialised
     assertRecent(progress.createdDate)
     progress.lastModifiedDate shouldBe progress.createdDate
-    progress.events shouldBe List.empty
-  }
-
-  it("can be created from a request display ingest") {
-    val displayProvider = DisplayProvider("s3", "Amazon s3")
-    val bucket = "ingest-bucket"
-    val path = "bag.zip"
-    val progressCreateRequest = RequestDisplayIngest(
-      DisplayLocation(displayProvider, bucket, path),
-      Some(
-        DisplayCallback("http://www.wellcomecollection.org/callback/ok", None)),
-      DisplayIngestType("create"),
-      DisplayStorageSpace("space-id")
-    )
-
-    val progress = Progress(progressCreateRequest)
-
-    progress.id shouldBe a[UUID]
-    progress.sourceLocation shouldBe StorageLocation(
-      StorageProvider(displayProvider.id),
-      ObjectLocation(bucket, path))
-    progress.callback shouldBe Some(
-      Callback(URI.create(progressCreateRequest.callback.get.url)))
-    progress.status shouldBe Progress.Initialised
-    assertRecent(progress.createdDate)
-    assertRecent(progress.lastModifiedDate)
     progress.events shouldBe List.empty
   }
 

--- a/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/progress/models/ProgressTest.scala
+++ b/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/progress/models/ProgressTest.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.archive.common.progress.models
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
-import uk.ac.wellcome.platform.archive.common.progress.fixtures.{ProgressGenerators, TimeTestFixture}
+import uk.ac.wellcome.platform.archive.common.progress.fixtures.{
+  ProgressGenerators,
+  TimeTestFixture
+}
 
 class ProgressTest
     extends FunSpec

--- a/archive/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
+++ b/archive/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
@@ -20,8 +20,8 @@ case class RequestDisplayIngest(sourceLocation: DisplayLocation,
     Progress(
       id = UUID.randomUUID,
       sourceLocation = sourceLocation.toStorageLocation,
-      callback = Callback(callback.map(displayCallback =>
-        URI.create(displayCallback.url))),
+      callback = Callback(
+        callback.map(displayCallback => URI.create(displayCallback.url))),
       space = Namespace(space.id),
       status = Progress.Initialised
     )

--- a/archive/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
+++ b/archive/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
@@ -1,14 +1,11 @@
-package uk.ac.wellcome.platform.archive.common.models
+package uk.ac.wellcome.platform.archive.display
 
-import java.net.URL
+import java.net.{URI, URL}
 import java.util.UUID
 
 import io.circe.generic.extras.JsonKey
-import uk.ac.wellcome.platform.archive.common.progress.models.{
-  Callback,
-  Progress,
-  ProgressEvent
-}
+import uk.ac.wellcome.platform.archive.common.models.BagId
+import uk.ac.wellcome.platform.archive.common.progress.models._
 
 sealed trait DisplayIngest
 
@@ -18,7 +15,18 @@ case class RequestDisplayIngest(sourceLocation: DisplayLocation,
                                 space: DisplayStorageSpace,
                                 @JsonKey("type")
                                 ontologyType: String = "Ingest")
-    extends DisplayIngest
+    extends DisplayIngest {
+  def toProgress: Progress = {
+    Progress(
+      id = UUID.randomUUID,
+      sourceLocation = sourceLocation.toStorageLocation,
+      callback = Callback(callback.map(displayCallback =>
+        URI.create(displayCallback.url))),
+      space = Namespace(space.id),
+      status = Progress.Initialised
+    )
+  }
+}
 
 case class ResponseDisplayIngest(@JsonKey("@context")
                                  context: String,

--- a/archive/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
+++ b/archive/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
@@ -1,12 +1,18 @@
-package uk.ac.wellcome.platform.archive.common.models
+package uk.ac.wellcome.platform.archive.display
 
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.progress.models.StorageLocation
+import uk.ac.wellcome.storage.ObjectLocation
 
 case class DisplayLocation(provider: DisplayProvider,
                            bucket: String,
                            path: String,
-                           @JsonKey("type") ontologyType: String = "Location")
+                           @JsonKey("type") ontologyType: String = "Location") {
+  def toStorageLocation : StorageLocation =
+  StorageLocation(
+    provider.toStorageProvider,
+    ObjectLocation(bucket, path))
+}
 object DisplayLocation {
   def apply(location: StorageLocation): DisplayLocation =
     DisplayLocation(

--- a/archive/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
+++ b/archive/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
@@ -8,10 +8,8 @@ case class DisplayLocation(provider: DisplayProvider,
                            bucket: String,
                            path: String,
                            @JsonKey("type") ontologyType: String = "Location") {
-  def toStorageLocation : StorageLocation =
-  StorageLocation(
-    provider.toStorageProvider,
-    ObjectLocation(bucket, path))
+  def toStorageLocation: StorageLocation =
+    StorageLocation(provider.toStorageProvider, ObjectLocation(bucket, path))
 }
 object DisplayLocation {
   def apply(location: StorageLocation): DisplayLocation =

--- a/archive/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayProvider.scala
+++ b/archive/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayProvider.scala
@@ -1,10 +1,12 @@
-package uk.ac.wellcome.platform.archive.common.models
+package uk.ac.wellcome.platform.archive.display
 
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.progress.models.StorageProvider
 
 case class DisplayProvider(id: String,
-                           @JsonKey("type") ontologyType: String = "Provider")
+                           @JsonKey("type") ontologyType: String = "Provider") {
+  def toStorageProvider: StorageProvider = StorageProvider(id)
+}
 object DisplayProvider {
   def apply(provider: StorageProvider): DisplayProvider =
     DisplayProvider(id = provider.id)

--- a/archive/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
+++ b/archive/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.models
+package uk.ac.wellcome.platform.archive.display
 
 import java.net.{URI, URL}
 import java.time.Instant
@@ -7,10 +7,11 @@ import java.util.UUID
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
+import uk.ac.wellcome.platform.archive.common.progress.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.progress.models._
 import uk.ac.wellcome.storage.ObjectLocation
 
-class DisplayIngestTest extends FunSpec with Matchers with RandomThings {
+class DisplayIngestTest extends FunSpec with Matchers with RandomThings with TimeTestFixture{
 
   private val id = UUID.randomUUID()
   private val callbackUrl = "http://www.example.com/callback"
@@ -56,5 +57,31 @@ class DisplayIngestTest extends FunSpec with Matchers with RandomThings {
     ingest.lastModifiedDate shouldBe modifiedDate
     ingest.events shouldBe List(
       DisplayProgressEvent(eventDescription, eventDate))
+  }
+
+  it("transforms itself into a progress") {
+    val displayProvider = DisplayProvider("s3", "Amazon s3")
+    val bucket = "ingest-bucket"
+    val path = "bag.zip"
+    val progressCreateRequest = RequestDisplayIngest(
+      DisplayLocation(displayProvider, bucket, path),
+      Some(
+        DisplayCallback("http://www.wellcomecollection.org/callback/ok", None)),
+      DisplayIngestType("create"),
+      DisplayStorageSpace("space-id")
+    )
+
+    val progress = progressCreateRequest.toProgress
+
+    progress.id shouldBe a[UUID]
+    progress.sourceLocation shouldBe StorageLocation(
+      StorageProvider(displayProvider.id),
+      ObjectLocation(bucket, path))
+    progress.callback shouldBe Some(
+      Callback(URI.create(progressCreateRequest.callback.get.url)))
+    progress.status shouldBe Progress.Initialised
+    assertRecent(progress.createdDate)
+    assertRecent(progress.lastModifiedDate)
+    progress.events shouldBe List.empty
   }
 }

--- a/archive/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
+++ b/archive/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
@@ -11,7 +11,11 @@ import uk.ac.wellcome.platform.archive.common.progress.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.progress.models._
 import uk.ac.wellcome.storage.ObjectLocation
 
-class DisplayIngestTest extends FunSpec with Matchers with RandomThings with TimeTestFixture{
+class DisplayIngestTest
+    extends FunSpec
+    with Matchers
+    with RandomThings
+    with TimeTestFixture {
 
   private val id = UUID.randomUUID()
   private val callbackUrl = "http://www.example.com/callback"

--- a/archive/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/flows/CallbackUrlFlow.scala
+++ b/archive/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/flows/CallbackUrlFlow.scala
@@ -8,11 +8,9 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.stream.scaladsl.Flow
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.common.models.{
-  CallbackNotification,
-  ResponseDisplayIngest
-}
+import uk.ac.wellcome.platform.archive.common.models.CallbackNotification
 import uk.ac.wellcome.platform.archive.common.progress.models.Progress
+import uk.ac.wellcome.platform.archive.display.ResponseDisplayIngest
 import uk.ac.wellcome.platform.archive.notifier.models.CallbackFlowResult
 
 object CallbackUrlFlow {

--- a/archive/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/archive/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -4,17 +4,32 @@ import java.net.URI
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import com.github.tomakehurst.wiremock.client.WireMock.{equalToJson, postRequestedFor, urlPathEqualTo, _}
+import com.github.tomakehurst.wiremock.client.WireMock.{
+  equalToJson,
+  postRequestedFor,
+  urlPathEqualTo,
+  _
+}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Inside, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
 import uk.ac.wellcome.platform.archive.common.models._
-import uk.ac.wellcome.platform.archive.common.progress.fixtures.{ProgressGenerators, TimeTestFixture}
-import uk.ac.wellcome.platform.archive.common.progress.models.{Callback, ProgressCallbackStatusUpdate, ProgressUpdate}
+import uk.ac.wellcome.platform.archive.common.progress.fixtures.{
+  ProgressGenerators,
+  TimeTestFixture
+}
+import uk.ac.wellcome.platform.archive.common.progress.models.{
+  Callback,
+  ProgressCallbackStatusUpdate,
+  ProgressUpdate
+}
 import uk.ac.wellcome.platform.archive.display._
-import uk.ac.wellcome.platform.archive.notifier.fixtures.{LocalWireMockFixture, NotifierFixture}
+import uk.ac.wellcome.platform.archive.notifier.fixtures.{
+  LocalWireMockFixture,
+  NotifierFixture
+}
 
 class NotifierFeatureTest
     extends FunSpec

--- a/archive/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/archive/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -4,31 +4,17 @@ import java.net.URI
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import com.github.tomakehurst.wiremock.client.WireMock.{
-  equalToJson,
-  postRequestedFor,
-  urlPathEqualTo,
-  _
-}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalToJson, postRequestedFor, urlPathEqualTo, _}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Inside, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
 import uk.ac.wellcome.platform.archive.common.models._
-import uk.ac.wellcome.platform.archive.common.progress.fixtures.{
-  ProgressGenerators,
-  TimeTestFixture
-}
-import uk.ac.wellcome.platform.archive.common.progress.models.{
-  Callback,
-  ProgressCallbackStatusUpdate,
-  ProgressUpdate
-}
-import uk.ac.wellcome.platform.archive.notifier.fixtures.{
-  LocalWireMockFixture,
-  NotifierFixture
-}
+import uk.ac.wellcome.platform.archive.common.progress.fixtures.{ProgressGenerators, TimeTestFixture}
+import uk.ac.wellcome.platform.archive.common.progress.models.{Callback, ProgressCallbackStatusUpdate, ProgressUpdate}
+import uk.ac.wellcome.platform.archive.display._
+import uk.ac.wellcome.platform.archive.notifier.fixtures.{LocalWireMockFixture, NotifierFixture}
 
 class NotifierFeatureTest
     extends FunSpec

--- a/archive/progress_http/src/main/scala/uk/ac/wellcome/platform/archive/progress_http/Router.scala
+++ b/archive/progress_http/src/main/scala/uk/ac/wellcome/platform/archive/progress_http/Router.scala
@@ -10,7 +10,10 @@ import io.circe.Printer
 import uk.ac.wellcome.platform.archive.common.config.models.HTTPServerConfig
 import uk.ac.wellcome.platform.archive.common.progress.models.Progress
 import uk.ac.wellcome.platform.archive.common.progress.monitor.ProgressTracker
-import uk.ac.wellcome.platform.archive.display.{RequestDisplayIngest, ResponseDisplayIngest}
+import uk.ac.wellcome.platform.archive.display.{
+  RequestDisplayIngest,
+  ResponseDisplayIngest
+}
 
 class Router(
   monitor: ProgressTracker,
@@ -31,7 +34,8 @@ class Router(
     pathPrefix("progress") {
       post {
         entity(as[RequestDisplayIngest]) { progressCreateRequest =>
-          onSuccess(progressStarter.initialise(progressCreateRequest.toProgress)) {
+          onSuccess(
+            progressStarter.initialise(progressCreateRequest.toProgress)) {
             progress =>
               respondWithHeaders(List(createLocationHeader(progress))) {
                 complete(Created -> ResponseDisplayIngest(progress, contextURL))

--- a/archive/progress_http/src/main/scala/uk/ac/wellcome/platform/archive/progress_http/Router.scala
+++ b/archive/progress_http/src/main/scala/uk/ac/wellcome/platform/archive/progress_http/Router.scala
@@ -8,12 +8,9 @@ import akka.http.scaladsl.model.headers.Location
 import akka.http.scaladsl.server.Route
 import io.circe.Printer
 import uk.ac.wellcome.platform.archive.common.config.models.HTTPServerConfig
-import uk.ac.wellcome.platform.archive.common.models.{
-  RequestDisplayIngest,
-  ResponseDisplayIngest
-}
 import uk.ac.wellcome.platform.archive.common.progress.models.Progress
 import uk.ac.wellcome.platform.archive.common.progress.monitor.ProgressTracker
+import uk.ac.wellcome.platform.archive.display.{RequestDisplayIngest, ResponseDisplayIngest}
 
 class Router(
   monitor: ProgressTracker,
@@ -34,7 +31,7 @@ class Router(
     pathPrefix("progress") {
       post {
         entity(as[RequestDisplayIngest]) { progressCreateRequest =>
-          onSuccess(progressStarter.initialise(Progress(progressCreateRequest))) {
+          onSuccess(progressStarter.initialise(progressCreateRequest.toProgress)) {
             progress =>
               respondWithHeaders(List(createLocationHeader(progress))) {
                 complete(Created -> ResponseDisplayIngest(progress, contextURL))

--- a/archive/progress_http/src/test/scala/uk/ac/wellcome/platform/archive/progress_http/ProgressHttpFeatureTest.scala
+++ b/archive/progress_http/src/test/scala/uk/ac/wellcome/platform/archive/progress_http/ProgressHttpFeatureTest.scala
@@ -15,6 +15,7 @@ import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
 import uk.ac.wellcome.platform.archive.common.models._
 import uk.ac.wellcome.platform.archive.common.progress.fixtures.ProgressTrackerFixture
 import uk.ac.wellcome.platform.archive.common.progress.models._
+import uk.ac.wellcome.platform.archive.display._
 import uk.ac.wellcome.platform.archive.progress_http.fixtures.ProgressHttpFixture
 import uk.ac.wellcome.storage.ObjectLocation
 

--- a/archive/registrar_http/src/main/scala/uk/ac/wellcome/platform/archive/registrar/http/models/DisplayBag.scala
+++ b/archive/registrar_http/src/main/scala/uk/ac/wellcome/platform/archive/registrar/http/models/DisplayBag.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.archive.registrar.http.models
 import java.net.URL
 
 import io.circe.generic.extras.JsonKey
-import uk.ac.wellcome.platform.archive.display.{DisplayLocation, DisplayStorageSpace}
+import uk.ac.wellcome.platform.archive.display.{
+  DisplayLocation,
+  DisplayStorageSpace
+}
 import uk.ac.wellcome.platform.archive.registrar.common.models._
 
 case class DisplayBag(

--- a/archive/registrar_http/src/main/scala/uk/ac/wellcome/platform/archive/registrar/http/models/DisplayBag.scala
+++ b/archive/registrar_http/src/main/scala/uk/ac/wellcome/platform/archive/registrar/http/models/DisplayBag.scala
@@ -2,10 +2,7 @@ package uk.ac.wellcome.platform.archive.registrar.http.models
 import java.net.URL
 
 import io.circe.generic.extras.JsonKey
-import uk.ac.wellcome.platform.archive.common.models.{
-  DisplayLocation,
-  DisplayStorageSpace
-}
+import uk.ac.wellcome.platform.archive.display.{DisplayLocation, DisplayStorageSpace}
 import uk.ac.wellcome.platform.archive.registrar.common.models._
 
 case class DisplayBag(

--- a/archive/registrar_http/src/test/scala/uk/ac/wellcome/platform/archive/registrar/http/RegistrarHttpFeatureTest.scala
+++ b/archive/registrar_http/src/test/scala/uk/ac/wellcome/platform/archive/registrar/http/RegistrarHttpFeatureTest.scala
@@ -12,8 +12,15 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Inside, Matchers}
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
-import uk.ac.wellcome.platform.archive.common.progress.models.{StorageLocation, StorageProvider}
-import uk.ac.wellcome.platform.archive.display.{DisplayLocation, DisplayProvider, DisplayStorageSpace}
+import uk.ac.wellcome.platform.archive.common.progress.models.{
+  StorageLocation,
+  StorageProvider
+}
+import uk.ac.wellcome.platform.archive.display.{
+  DisplayLocation,
+  DisplayProvider,
+  DisplayStorageSpace
+}
 import uk.ac.wellcome.platform.archive.registrar.common.models._
 import uk.ac.wellcome.platform.archive.registrar.http.fixtures.RegistrarHttpFixture
 import uk.ac.wellcome.platform.archive.registrar.http.models._

--- a/archive/registrar_http/src/test/scala/uk/ac/wellcome/platform/archive/registrar/http/RegistrarHttpFeatureTest.scala
+++ b/archive/registrar_http/src/test/scala/uk/ac/wellcome/platform/archive/registrar/http/RegistrarHttpFeatureTest.scala
@@ -12,15 +12,8 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Inside, Matchers}
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
-import uk.ac.wellcome.platform.archive.common.models.{
-  DisplayLocation,
-  DisplayProvider,
-  DisplayStorageSpace
-}
-import uk.ac.wellcome.platform.archive.common.progress.models.{
-  StorageLocation,
-  StorageProvider
-}
+import uk.ac.wellcome.platform.archive.common.progress.models.{StorageLocation, StorageProvider}
+import uk.ac.wellcome.platform.archive.display.{DisplayLocation, DisplayProvider, DisplayStorageSpace}
 import uk.ac.wellcome.platform.archive.registrar.common.models._
 import uk.ac.wellcome.platform.archive.registrar.http.fixtures.RegistrarHttpFixture
 import uk.ac.wellcome.platform.archive.registrar.http.models._

--- a/build.sbt
+++ b/build.sbt
@@ -185,11 +185,15 @@ lazy val archive_common = doServiceSetup(project, "archive/common")
   .dependsOn(config_storage % "compile->compile;test->test")
   .settings(libraryDependencies ++= Dependencies.archiveCommonDependencies)
 
+lazy val archive_display = doServiceSetup(project, "archive/display")
+  .dependsOn(archive_common % "compile->compile;test->test")
+
 lazy val archivist = doServiceSetup(project, "archive/archivist")
   .dependsOn(archive_common % "compile->compile;test->test")
 
 lazy val notifier = doServiceSetup(project, "archive/notifier")
   .dependsOn(archive_common % "compile->compile;test->test")
+  .dependsOn(archive_display % "compile->compile;test->test")
   .settings(libraryDependencies ++= Dependencies.wiremockDependencies)
 
 lazy val registrar_common = doServiceSetup(project, "archive/registrar_common")
@@ -200,6 +204,7 @@ lazy val registrar_async = doServiceSetup(project, "archive/registrar_async")
 
 lazy val registrar_http = doServiceSetup(project, "archive/registrar_http")
   .dependsOn(registrar_common % "compile->compile;test->test")
+  .dependsOn(archive_display % "compile->compile;test->test")
 
 lazy val progress_common = doServiceSetup(project, "archive/progress_common")
   .dependsOn(archive_common % "compile->compile;test->test")
@@ -210,7 +215,7 @@ lazy val progress_async = doServiceSetup(project, "archive/progress_async")
 
 lazy val progress_http = doServiceSetup(project, "archive/progress_http")
   .dependsOn(progress_common % "compile->compile;test->test")
-  .settings(libraryDependencies ++= Dependencies.wiremockDependencies)
+  .dependsOn(archive_display % "compile->compile;test->test")
 
 lazy val root = (project in file("."))
   .aggregate(
@@ -254,6 +259,7 @@ lazy val root = (project in file("."))
     snapshot_generator,
 
     archive_common,
+    archive_display,
     archivist,
     notifier,
     registrar_async,


### PR DESCRIPTION
As part of #3018, I need to add the dependency to akka-http-swagger to whatever includes the display models. At the moment that's archive_common, which means that every service would have a dependency on swagger even though only the HTTP services actually need it. 

So let's take the display models out to avoid polluting the classpath of everything else