### PR TITLE
Simplify our Elasticsearch fixtures and terminology

### DIFF
--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
@@ -8,13 +8,13 @@ import uk.ac.wellcome.platform.api.services.{
 }
 
 trait SearchOptionsGenerators {
-  val itemType: String
+  val documentType: String
 
   def createElasticsearchDocumentOptionsWith(
     indexName: String): ElasticsearchDocumentOptions =
     ElasticsearchDocumentOptions(
       indexName = indexName,
-      documentType = itemType
+      documentType = documentType
     )
 
   def createElasticsearchQueryOptionsWith(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -166,11 +166,7 @@ class ElasticsearchServiceTest
           )
         )
 
-        insertIntoElasticsearch(
-          indexName,
-          work,
-          notMatchingWork,
-          work2)
+        insertIntoElasticsearch(indexName, work, notMatchingWork, work2)
 
         assertSearchResultsAreCorrect(
           indexName = indexName,
@@ -337,11 +333,7 @@ class ElasticsearchServiceTest
           workType = Some(WorkType(id = "m", label = "Manuscripts"))
         )
 
-        insertIntoElasticsearch(
-          indexName,
-          work1,
-          work2,
-          workWithWrongWorkType)
+        insertIntoElasticsearch(indexName, work1, work2, workWithWrongWorkType)
 
         val queryOptions = createElasticsearchQueryOptionsWith(
           filters = List(WorkTypeFilter(workTypeId = "b"))

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -25,11 +25,11 @@ class ElasticsearchServiceTest
     with SearchOptionsGenerators
     with WorksGenerators {
 
-  val itemType = "work"
+  val itemType = documentType
 
   describe("simpleStringQueryResults") {
     it("finds results for a simpleStringQuery search") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         val work1 = createIdentifiedWorkWith(title = "Amid an Aegean")
         val work2 = createIdentifiedWorkWith(title = "Before a Bengal")
         val work3 = createIdentifiedWorkWith(title = "Circling a Cheetah")
@@ -45,7 +45,7 @@ class ElasticsearchServiceTest
     }
 
     it("filters search results by workType") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         val workWithCorrectWorkType = createIdentifiedWorkWith(
           title = "Animated artichokes",
           workType = Some(WorkType(id = "b", label = "Books"))
@@ -78,7 +78,7 @@ class ElasticsearchServiceTest
     }
 
     it("filters search results with multiple workTypes") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         val work1 = createIdentifiedWorkWith(
           title = "Animated artichokes",
           workType = Some(WorkType(id = "b", label = "Books"))
@@ -116,7 +116,7 @@ class ElasticsearchServiceTest
     }
 
     it("filters results by item locationType") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         val work = createIdentifiedWorkWith(
           title = "Tumbling tangerines",
           items = List(
@@ -147,7 +147,7 @@ class ElasticsearchServiceTest
     }
 
     it("filters results by multiple item locationTypes") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         val work = createIdentifiedWorkWith(
           title = "Tumbling tangerines",
           items = List(
@@ -193,7 +193,7 @@ class ElasticsearchServiceTest
 
   describe("findResultById") {
     it("finds a result by ID") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         val work = createIdentifiedWork
 
         insertIntoElasticsearch(indexName, itemType, work)
@@ -217,7 +217,7 @@ class ElasticsearchServiceTest
 
   describe("listResults") {
     it("sorts results from Elasticsearch in the correct order") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         val work1 = createIdentifiedWorkWith(canonicalId = "000Z")
         val work2 = createIdentifiedWorkWith(canonicalId = "000Y")
         val work3 = createIdentifiedWorkWith(canonicalId = "000X")
@@ -236,7 +236,7 @@ class ElasticsearchServiceTest
     }
 
     it("returns everything if we ask for a limit > result size") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         val works = populateElasticsearch(indexName)
 
         val queryOptions = createElasticsearchQueryOptionsWith(
@@ -252,7 +252,7 @@ class ElasticsearchServiceTest
     }
 
     it("returns a page from the beginning of the result set") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         val works = populateElasticsearch(indexName)
 
         val queryOptions = createElasticsearchQueryOptionsWith(limit = 4)
@@ -266,7 +266,7 @@ class ElasticsearchServiceTest
     }
 
     it("returns a page from halfway through the result set") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         val works = populateElasticsearch(indexName)
 
         val queryOptions = createElasticsearchQueryOptionsWith(
@@ -283,7 +283,7 @@ class ElasticsearchServiceTest
     }
 
     it("returns a page from the end of the result set") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         val works = populateElasticsearch(indexName)
 
         val queryOptions = createElasticsearchQueryOptionsWith(
@@ -300,7 +300,7 @@ class ElasticsearchServiceTest
     }
 
     it("returns an empty page if asked for a limit > result size") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         val works = populateElasticsearch(indexName)
 
         val queryOptions = createElasticsearchQueryOptionsWith(
@@ -316,7 +316,7 @@ class ElasticsearchServiceTest
     }
 
     it("does not list works that have visible=false") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         val visibleWorks = createIdentifiedWorks(count = 8)
         val invisibleWorks = createIdentifiedInvisibleWorks(count = 2)
 
@@ -331,7 +331,7 @@ class ElasticsearchServiceTest
     }
 
     it("filters list results by workType") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         val work1 = createIdentifiedWorkWith(
           workType = Some(WorkType(id = "b", label = "Books"))
         )
@@ -362,7 +362,7 @@ class ElasticsearchServiceTest
     }
 
     it("filters list results with multiple workTypes") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         val work1 = createIdentifiedWorkWith(
           workType = Some(WorkType(id = "b", label = "Books"))
         )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -25,8 +25,6 @@ class ElasticsearchServiceTest
     with SearchOptionsGenerators
     with WorksGenerators {
 
-  val itemType = documentType
-
   describe("simpleStringQueryResults") {
     it("finds results for a simpleStringQuery search") {
       withLocalElasticsearchIndex { indexName =>
@@ -34,7 +32,7 @@ class ElasticsearchServiceTest
         val work2 = createIdentifiedWorkWith(title = "Before a Bengal")
         val work3 = createIdentifiedWorkWith(title = "Circling a Cheetah")
 
-        insertIntoElasticsearch(indexName, itemType, work1, work2, work3)
+        insertIntoElasticsearch(indexName, work1, work2, work3)
 
         assertSearchResultsAreCorrect(
           indexName = indexName,
@@ -61,7 +59,6 @@ class ElasticsearchServiceTest
 
         insertIntoElasticsearch(
           indexName,
-          itemType,
           workWithCorrectWorkType,
           workWithWrongTitle,
           workWithWrongWorkType)
@@ -98,7 +95,6 @@ class ElasticsearchServiceTest
 
         insertIntoElasticsearch(
           indexName,
-          itemType,
           work1,
           workWithWrongTitle,
           work2,
@@ -132,7 +128,7 @@ class ElasticsearchServiceTest
           )
         )
 
-        insertIntoElasticsearch(indexName, itemType, work, notMatchingWork)
+        insertIntoElasticsearch(indexName, work, notMatchingWork)
 
         assertSearchResultsAreCorrect(
           indexName = indexName,
@@ -172,7 +168,6 @@ class ElasticsearchServiceTest
 
         insertIntoElasticsearch(
           indexName,
-          itemType,
           work,
           notMatchingWork,
           work2)
@@ -196,7 +191,7 @@ class ElasticsearchServiceTest
       withLocalElasticsearchIndex { indexName =>
         val work = createIdentifiedWork
 
-        insertIntoElasticsearch(indexName, itemType, work)
+        insertIntoElasticsearch(indexName, work)
 
         withElasticsearchService { searchService =>
           val documentOptions =
@@ -222,7 +217,7 @@ class ElasticsearchServiceTest
         val work2 = createIdentifiedWorkWith(canonicalId = "000Y")
         val work3 = createIdentifiedWorkWith(canonicalId = "000X")
 
-        insertIntoElasticsearch(indexName, itemType, work1, work2, work3)
+        insertIntoElasticsearch(indexName, work1, work2, work3)
 
         assertListResultsAreCorrect(
           indexName = indexName,
@@ -321,7 +316,7 @@ class ElasticsearchServiceTest
         val invisibleWorks = createIdentifiedInvisibleWorks(count = 2)
 
         val works = visibleWorks ++ invisibleWorks
-        insertIntoElasticsearch(indexName, itemType, works: _*)
+        insertIntoElasticsearch(indexName, works: _*)
 
         assertListResultsAreCorrect(
           indexName = indexName,
@@ -344,7 +339,6 @@ class ElasticsearchServiceTest
 
         insertIntoElasticsearch(
           indexName,
-          itemType,
           work1,
           work2,
           workWithWrongWorkType)
@@ -378,7 +372,6 @@ class ElasticsearchServiceTest
 
         insertIntoElasticsearch(
           indexName,
-          itemType,
           work1,
           work2,
           work3,
@@ -416,7 +409,7 @@ class ElasticsearchServiceTest
   private def populateElasticsearch(indexName: String): List[IdentifiedWork] = {
     val works = createIdentifiedWorks(count = 10)
 
-    insertIntoElasticsearch(indexName, itemType, works: _*)
+    insertIntoElasticsearch(indexName, works: _*)
 
     works.sortBy(_.canonicalId).toList
   }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -4,7 +4,10 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, WorkType}
-import uk.ac.wellcome.platform.api.fixtures.{ElasticsearchServiceFixture, WorksServiceFixture}
+import uk.ac.wellcome.platform.api.fixtures.{
+  ElasticsearchServiceFixture,
+  WorksServiceFixture
+}
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
 import uk.ac.wellcome.platform.api.models.{ResultList, WorkTypeFilter}
 
@@ -255,8 +258,9 @@ class WorksServiceTest
     )(allWorks, expectedWorks, expectedTotalResults, worksSearchOptions)
 
   private def assertResultIsCorrect(
-    partialSearchFunction: WorksService => (ElasticsearchDocumentOptions,
-     WorksSearchOptions) => Future[ResultList]
+    partialSearchFunction: WorksService => (
+      ElasticsearchDocumentOptions,
+      WorksSearchOptions) => Future[ResultList]
   )(
     allWorks: Seq[IdentifiedBaseWork],
     expectedWorks: Seq[IdentifiedBaseWork],

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -22,7 +22,7 @@ class WorksServiceTest
     with SearchOptionsGenerators
     with WorksGenerators {
 
-  val itemType = "work"
+  val itemType = documentType
 
   describe("listWorks") {
     it("gets records in Elasticsearch") {
@@ -100,7 +100,7 @@ class WorksServiceTest
 
   describe("findWorkById") {
     it("gets a DisplayWork by id") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         withElasticsearchService { searchService =>
           withWorksService(searchService) { worksService =>
             val work = createIdentifiedWork
@@ -123,7 +123,7 @@ class WorksServiceTest
     }
 
     it("returns a future of None if it cannot get a record by id") {
-      withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         withElasticsearchService { searchService =>
           withWorksService(searchService) { worksService =>
             val documentOptions =
@@ -269,7 +269,7 @@ class WorksServiceTest
     expectedTotalResults: Int,
     worksSearchOptions: WorksSearchOptions
   ) =
-    withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+    withLocalElasticsearchIndex { indexName =>
       withElasticsearchService { searchService =>
         withWorksService(searchService) { worksService =>
           if (!allWorks.isEmpty) {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -1,13 +1,10 @@
 package uk.ac.wellcome.platform.api.services
 
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, WorkType}
-import uk.ac.wellcome.platform.api.fixtures.{
-  ElasticsearchServiceFixture,
-  WorksServiceFixture
-}
+import uk.ac.wellcome.platform.api.fixtures.{ElasticsearchServiceFixture, WorksServiceFixture}
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
 import uk.ac.wellcome.platform.api.models.{ResultList, WorkTypeFilter}
 
@@ -21,8 +18,6 @@ class WorksServiceTest
     with ScalaFutures
     with SearchOptionsGenerators
     with WorksGenerators {
-
-  val itemType = documentType
 
   describe("listWorks") {
     it("gets records in Elasticsearch") {
@@ -105,7 +100,7 @@ class WorksServiceTest
           withWorksService(searchService) { worksService =>
             val work = createIdentifiedWork
 
-            insertIntoElasticsearch(indexName, itemType, work)
+            insertIntoElasticsearch(indexName, work)
 
             val documentOptions =
               createElasticsearchDocumentOptionsWith(indexName = indexName)
@@ -260,20 +255,19 @@ class WorksServiceTest
     )(allWorks, expectedWorks, expectedTotalResults, worksSearchOptions)
 
   private def assertResultIsCorrect(
-    partialSearchFunction: (WorksService) => (
-      (ElasticsearchDocumentOptions,
-       WorksSearchOptions) => Future[ResultList])
+    partialSearchFunction: WorksService => (ElasticsearchDocumentOptions,
+     WorksSearchOptions) => Future[ResultList]
   )(
     allWorks: Seq[IdentifiedBaseWork],
     expectedWorks: Seq[IdentifiedBaseWork],
     expectedTotalResults: Int,
     worksSearchOptions: WorksSearchOptions
-  ) =
+  ): Assertion =
     withLocalElasticsearchIndex { indexName =>
       withElasticsearchService { searchService =>
         withWorksService(searchService) { worksService =>
           if (!allWorks.isEmpty) {
-            insertIntoElasticsearch(indexName, itemType, allWorks: _*)
+            insertIntoElasticsearch(indexName, allWorks: _*)
           }
 
           val documentOptions = createElasticsearchDocumentOptionsWith(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
@@ -9,7 +9,7 @@ class ApiContextTest extends ApiWorksTestBase {
   it("returns a context for all versions") {
     ApiVersions.values.toList.foreach { version: ApiVersions.Value =>
       withApiFixtures(apiVersion = version) {
-        case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
           server.httpGet(
             path = s"/$apiPrefix/context.json",
             andExpect = Status.Ok,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -23,14 +23,13 @@ trait ApiWorksTestBase
 
   def withServer[R](
     indexNameV1: String,
-    indexNameV2: String)(testWith: TestWith[EmbeddedHttpServer, R]) = {
+    indexNameV2: String)(testWith: TestWith[EmbeddedHttpServer, R]): R = {
 
     val server: EmbeddedHttpServer = new EmbeddedHttpServer(
       new Server,
       flags = displayEsLocalFlags(
         indexNameV1 = indexNameV1,
-        indexNameV2 = indexNameV2,
-        itemType = documentType
+        indexNameV2 = indexNameV2
       )
     )
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -45,17 +45,14 @@ trait ApiWorksTestBase
 
   def withApiFixtures[R](apiVersion: ApiVersions.Value,
                          apiName: String = "catalogue/")(
-    testWith: TestWith[(String, String, String, String, EmbeddedHttpServer),
-                       R]): R = {
-    val itemType = documentType
+    testWith: TestWith[(String, String, String, EmbeddedHttpServer), R]): R =
     withLocalElasticsearchIndex { indexV1 =>
       withLocalElasticsearchIndex { indexV2 =>
         withServer(indexV1, indexV2) { server =>
-          testWith((apiName + apiVersion, indexV1, indexV2, itemType, server))
+          testWith((apiName + apiVersion, indexV1, indexV2, server))
         }
       }
     }
-  }
 
   def emptyJsonResult(apiPrefix: String): String = s"""
     |{

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -45,10 +45,10 @@ trait ApiWorksTestBase
   }
 
   def withApiFixtures[R](apiVersion: ApiVersions.Value,
-                         apiName: String = "catalogue/",
-                         itemType: String = "work")(
+                         apiName: String = "catalogue/")(
     testWith: TestWith[(String, String, String, String, EmbeddedHttpServer),
-                       R]) =
+                       R]): R = {
+    val itemType = documentType
     withLocalElasticsearchIndex(itemType = itemType) { indexV1 =>
       withLocalElasticsearchIndex(itemType = itemType) { indexV2 =>
         withServer(indexV1, indexV2, itemType) { server =>
@@ -56,6 +56,7 @@ trait ApiWorksTestBase
         }
       }
     }
+  }
 
   def emptyJsonResult(apiPrefix: String): String = s"""
     |{

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -23,15 +23,14 @@ trait ApiWorksTestBase
 
   def withServer[R](
     indexNameV1: String,
-    indexNameV2: String,
-    itemType: String = "work")(testWith: TestWith[EmbeddedHttpServer, R]) = {
+    indexNameV2: String)(testWith: TestWith[EmbeddedHttpServer, R]) = {
 
     val server: EmbeddedHttpServer = new EmbeddedHttpServer(
       new Server,
       flags = displayEsLocalFlags(
         indexNameV1 = indexNameV1,
         indexNameV2 = indexNameV2,
-        itemType = itemType
+        itemType = documentType
       )
     )
 
@@ -51,7 +50,7 @@ trait ApiWorksTestBase
     val itemType = documentType
     withLocalElasticsearchIndex(itemType = itemType) { indexV1 =>
       withLocalElasticsearchIndex(itemType = itemType) { indexV2 =>
-        withServer(indexV1, indexV2, itemType) { server =>
+        withServer(indexV1, indexV2) { server =>
           testWith((apiName + apiVersion, indexV1, indexV2, itemType, server))
         }
       }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -21,9 +21,8 @@ trait ApiWorksTestBase
       toJson(t).get
   }
 
-  def withServer[R](
-    indexNameV1: String,
-    indexNameV2: String)(testWith: TestWith[EmbeddedHttpServer, R]): R = {
+  def withServer[R](indexNameV1: String, indexNameV2: String)(
+    testWith: TestWith[EmbeddedHttpServer, R]): R = {
 
     val server: EmbeddedHttpServer = new EmbeddedHttpServer(
       new Server,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -48,8 +48,8 @@ trait ApiWorksTestBase
     testWith: TestWith[(String, String, String, String, EmbeddedHttpServer),
                        R]): R = {
     val itemType = documentType
-    withLocalElasticsearchIndex(itemType = itemType) { indexV1 =>
-      withLocalElasticsearchIndex(itemType = itemType) { indexV2 =>
+    withLocalElasticsearchIndex { indexV1 =>
+      withLocalElasticsearchIndex { indexV2 =>
         withServer(indexV1, indexV2) { server =>
           testWith((apiName + apiVersion, indexV1, indexV2, itemType, server))
         }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
@@ -7,7 +7,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
 
   it("returns a BadRequest error when malformed query parameters are presented") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?pageSize=penguin",
           andExpect = Status.BadRequest,
@@ -20,7 +20,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
 
   it("returns a NotFound error when requesting a work with a non-existent id") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         val badId = "non-existing-id"
         server.httpGet(
           path = s"/$apiPrefix/works/$badId",
@@ -34,7 +34,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
   it(
     "returns a BadRequest error if the user asks for a page size just over the maximum") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         val pageSize = 101
         server.httpGet(
           path = s"/$apiPrefix/works?pageSize=$pageSize",
@@ -50,7 +50,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
   it(
     "returns a BadRequest error if the user asks for an overly large page size") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         val pageSize = 100000
         server.httpGet(
           path = s"/$apiPrefix/works?pageSize=$pageSize",
@@ -65,7 +65,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
 
   it("returns a BadRequest error if the user asks for zero-length pages") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         val pageSize = 0
         server.httpGet(
           path = s"/$apiPrefix/works?pageSize=$pageSize",
@@ -80,7 +80,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
 
   it("returns a BadRequest error if the user asks for a negative page size") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         val pageSize = -50
         server.httpGet(
           path = s"/$apiPrefix/works?pageSize=$pageSize",
@@ -94,7 +94,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
 
   it("returns a BadRequest error if the user asks for page 0") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?page=0",
           andExpect = Status.BadRequest,
@@ -107,7 +107,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
 
   it("returns a BadRequest error if the user asks for a page before 0") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?page=-50",
           andExpect = Status.BadRequest,
@@ -121,7 +121,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
 
   it("returns multiple errors if there's more than one invalid parameter") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?pageSize=-60&page=-50",
           andExpect = Status.BadRequest,
@@ -134,7 +134,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
 
   it("returns a Bad Request error if asked for an invalid include") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?includes=foo",
           andExpect = Status.BadRequest,
@@ -147,7 +147,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
 
   it("returns a Bad Request error if asked for more than one invalid include") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?includes=foo,bar",
           andExpect = Status.BadRequest,
@@ -162,7 +162,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
   it(
     "returns a Bad Request error if asked for a mixture of valid and invalid includes") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?includes=foo,identifiers,bar",
           andExpect = Status.BadRequest,
@@ -177,7 +177,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
   it(
     "returns a Bad Request error if asked for an invalid include on an individual work") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works/nfdn7wac?includes=foo",
           andExpect = Status.BadRequest,
@@ -190,7 +190,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
 
   it("returns Not Found if you look up a non-existent index") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?_index=foobarbaz",
           andExpect = Status.NotFound,
@@ -202,7 +202,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
 
   it("returns Not Found if you ask for a non-existent work") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works/xhu96f9j",
           andExpect = Status.NotFound,
@@ -214,7 +214,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
 
   it("returns Bad Request if you ask for a malformed identifier") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works/zd224ncv]",
           andExpect = Status.NotFound,
@@ -232,7 +232,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
     // a canonicalId field to sort on.  Trying to query one of these will
     // trigger one such exception!
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?_index=.watches",
           andExpect = Status.InternalServerError,
@@ -249,7 +249,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
 
   it("returns a Bad Request error if you try to access the 10000th page") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?page=10000",
           andExpect = Status.BadRequest,
@@ -264,7 +264,7 @@ class ApiV1ErrorsTest extends ApiV1WorksTestBase {
   it(
     "returns a Bad Request error if you try to get the 101th page with 100 results per page") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?pageSize=100&page=101",
           andExpect = Status.BadRequest,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
@@ -8,8 +8,8 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
     val redirectedWork = createIdentifiedRedirectedWork
 
     withV1Api {
-      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-        insertIntoElasticsearch(indexNameV1, itemType, redirectedWork)
+      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
+        insertIntoElasticsearch(indexNameV1, redirectedWork)
         server.httpGet(
           path = s"/$apiPrefix/works/${redirectedWork.canonicalId}",
           andExpect = Status.Found,
@@ -24,8 +24,8 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
     val redirectedWork = createIdentifiedRedirectedWork
 
     withV1Api {
-      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-        insertIntoElasticsearch(indexNameV1, itemType, redirectedWork)
+      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
+        insertIntoElasticsearch(indexNameV1, redirectedWork)
         server.httpGet(
           path =
             s"/$apiPrefix/works/${redirectedWork.canonicalId}?includes=identifiers",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -219,7 +219,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("ignores parameters that are unused when making an API request") {
     withV1Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?foo=bar",
           andExpect = Status.Ok,
@@ -368,10 +368,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
           insertIntoElasticsearch(indexNameV1, work)
 
           val work_alt = createIdentifiedWork
-          insertIntoElasticsearch(
-            indexName = otherIndex,
-            itemType = itemType,
-            work_alt)
+          insertIntoElasticsearch(indexName = otherIndex, work_alt)
 
           eventually {
             server.httpGet(
@@ -429,10 +426,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
           val work_alt = createIdentifiedWorkWith(
             title = work.title
           )
-          insertIntoElasticsearch(
-            indexName = otherIndex,
-            itemType = itemType,
-            work_alt)
+          insertIntoElasticsearch(indexName = otherIndex, work_alt)
 
           eventually {
             server.httpGet(
@@ -533,7 +527,6 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
           apiPrefix,
           indexNameV1,
           indexNameV2,
-          itemType,
           server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "One orange ocelot"

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -8,10 +8,10 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("returns a list of works") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
-        insertIntoElasticsearch(indexNameV1, itemType, works: _*)
+        insertIntoElasticsearch(indexNameV1, works: _*)
 
         eventually {
           server.httpGet(
@@ -61,10 +61,10 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("returns a single work when requested with id") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWork
 
-        insertIntoElasticsearch(indexNameV1, itemType, work)
+        insertIntoElasticsearch(indexNameV1, work)
 
         eventually {
           server.httpGet(
@@ -90,12 +90,12 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("renders the items if the items include is present") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           itemsV1 = createIdentifiedItems(count = 1)
         )
 
-        insertIntoElasticsearch(indexNameV1, itemType, work)
+        insertIntoElasticsearch(indexNameV1, work)
 
         eventually {
           server.httpGet(
@@ -123,10 +123,10 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it(
     "returns the requested page of results when requested with page & pageSize") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
-        insertIntoElasticsearch(indexNameV1, itemType, works: _*)
+        insertIntoElasticsearch(indexNameV1, works: _*)
 
         eventually {
           server.httpGet(
@@ -230,14 +230,14 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("returns matching results if doing a full-text search") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "A drawing of a dodo"
         )
         val work2 = createIdentifiedWorkWith(
           title = "A mezzotint of a mouse"
         )
-        insertIntoElasticsearch(indexNameV1, itemType, work1, work2)
+        insertIntoElasticsearch(indexNameV1, work1, work2)
 
         eventually {
           server.httpGet(
@@ -275,7 +275,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it(
     "includes a list of identifiers on a list endpoint if we pass ?includes=identifiers") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val identifier0 = createSourceIdentifier
@@ -284,7 +284,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
         val work0 = works(0).copy(otherIdentifiers = List(identifier0))
         val work1 = works(1).copy(otherIdentifiers = List(identifier1))
 
-        insertIntoElasticsearch(indexNameV1, itemType, work0, work1)
+        insertIntoElasticsearch(indexNameV1, work0, work1)
 
         eventually {
           server.httpGet(
@@ -329,12 +329,12 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it(
     "includes a list of identifiers on a single work endpoint if we pass ?includes=identifiers") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
         val otherIdentifier = createSourceIdentifier
         val work = createIdentifiedWorkWith(
           otherIdentifiers = List(otherIdentifier)
         )
-        insertIntoElasticsearch(indexNameV1, itemType, work)
+        insertIntoElasticsearch(indexNameV1, work)
 
         eventually {
           server.httpGet(
@@ -362,10 +362,10 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("searches different indices with the ?_index query parameter") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
         withLocalElasticsearchIndex { otherIndex =>
           val work = createIdentifiedWork
-          insertIntoElasticsearch(indexNameV1, itemType, work)
+          insertIntoElasticsearch(indexNameV1, work)
 
           val work_alt = createIdentifiedWork
           insertIntoElasticsearch(
@@ -419,12 +419,12 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("looks up works in different indices with the ?_index query parameter") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
         withLocalElasticsearchIndex { otherIndex =>
           val work = createIdentifiedWorkWith(
             title = "Wombles of Wimbledon"
           )
-          insertIntoElasticsearch(indexNameV1, itemType, work)
+          insertIntoElasticsearch(indexNameV1, work)
 
           val work_alt = createIdentifiedWorkWith(
             title = work.title
@@ -488,7 +488,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it(
     "includes the thumbnail field if available and we use the thumbnail include") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           thumbnail = Some(
             DigitalLocation(
@@ -497,7 +497,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
               license = Some(License_CCBY)
             ))
         )
-        insertIntoElasticsearch(indexNameV1, itemType, work)
+        insertIntoElasticsearch(indexNameV1, work)
 
         eventually {
           server.httpGet(
@@ -538,10 +538,10 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
         val work1 = createIdentifiedWorkWith(
           title = "One orange ocelot"
         )
-        insertIntoElasticsearch(indexNameV1, itemType, work1)
+        insertIntoElasticsearch(indexNameV1, work1)
 
         val work2 = createIdentifiedWorkWith(title = work1.title)
-        insertIntoElasticsearch(indexNameV2, itemType, work2)
+        insertIntoElasticsearch(indexNameV2, work2)
 
         eventually {
           server.httpGet(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -523,11 +523,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("only returns works from the v1 index") {
     withV1Api {
-      case (
-          apiPrefix,
-          indexNameV1,
-          indexNameV2,
-          server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexNameV1, indexNameV2, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "One orange ocelot"
         )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -363,7 +363,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it("searches different indices with the ?_index query parameter") {
     withV1Api {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-        withLocalElasticsearchIndex(itemType = itemType) { otherIndex =>
+        withLocalElasticsearchIndex { otherIndex =>
           val work = createIdentifiedWork
           insertIntoElasticsearch(indexNameV1, itemType, work)
 
@@ -420,7 +420,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it("looks up works in different indices with the ?_index query parameter") {
     withV1Api {
       case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
-        withLocalElasticsearchIndex(itemType = itemType) { otherIndex =>
+        withLocalElasticsearchIndex { otherIndex =>
           val work = createIdentifiedWorkWith(
             title = "Wombles of Wimbledon"
           )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
@@ -2,17 +2,16 @@ package uk.ac.wellcome.platform.api.works.v1
 
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
-import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 
 class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
 
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
-    withApiFixtures(apiVersion = ApiVersions.v1) {
-      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+    withV1Api {
+      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
         val work = createIdentifiedInvisibleWork
 
-        insertIntoElasticsearch(indexNameV1, itemType, work)
+        insertIntoElasticsearch(indexNameV1, work)
 
         eventually {
           server.httpGet(
@@ -25,13 +24,13 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
   }
 
   it("excludes works with visible=false from list results") {
-    withApiFixtures(apiVersion = ApiVersions.v1) {
-      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+    withV1Api {
+      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
         val deletedWork = createIdentifiedInvisibleWork
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val worksToIndex = Seq[IdentifiedBaseWork](deletedWork) ++ works
-        insertIntoElasticsearch(indexNameV1, itemType, worksToIndex: _*)
+        insertIntoElasticsearch(indexNameV1, worksToIndex: _*)
 
         eventually {
           server.httpGet(
@@ -70,13 +69,13 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
   }
 
   it("excludes works with visible=false from search results") {
-    withApiFixtures(apiVersion = ApiVersions.v1) {
-      case (apiPrefix, indexNameV1, _, itemType, server: EmbeddedHttpServer) =>
+    withV1Api {
+      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           title = "An upside-down umbrella"
         )
         val deletedWork = createIdentifiedInvisibleWork
-        insertIntoElasticsearch(indexNameV1, itemType, work, deletedWork)
+        insertIntoElasticsearch(indexNameV1, work, deletedWork)
 
         eventually {
           server.httpGet(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
@@ -8,7 +8,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
 
   it("returns a BadRequest error when malformed query parameters are presented") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?pageSize=penguin",
           andExpect = Status.BadRequest,
@@ -20,7 +20,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
 
   it("returns a NotFound error when requesting a work with a non-existent id") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         val badId = "non-existing-id"
         server.httpGet(
           path = s"/$apiPrefix/works/$badId",
@@ -34,7 +34,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
   it(
     "returns a BadRequest error if the user asks for a page size just over the maximum") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         val pageSize = 101
         server.httpGet(
           path = s"/$apiPrefix/works?pageSize=$pageSize",
@@ -50,7 +50,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
   it(
     "returns a BadRequest error if the user asks for an overly large page size") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         val pageSize = 100000
         server.httpGet(
           path = s"/$apiPrefix/works?pageSize=$pageSize",
@@ -65,7 +65,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
 
   it("returns a BadRequest error if the user asks for zero-length pages") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         val pageSize = 0
         server.httpGet(
           path = s"/$apiPrefix/works?pageSize=$pageSize",
@@ -80,7 +80,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
 
   it("returns a BadRequest error if the user asks for a negative page size") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         val pageSize = -50
         server.httpGet(
           path = s"/$apiPrefix/works?pageSize=$pageSize",
@@ -95,7 +95,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
 
   it("returns a BadRequest error if the user asks for page 0") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?page=0",
           andExpect = Status.BadRequest,
@@ -108,7 +108,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
 
   it("returns a BadRequest error if the user asks for a page before 0") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?page=-50",
           andExpect = Status.BadRequest,
@@ -122,7 +122,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
 
   it("returns multiple errors if there's more than one invalid parameter") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?pageSize=-60&page=-50",
           andExpect = Status.BadRequest,
@@ -135,7 +135,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
 
   it("returns a Bad Request error if asked for an invalid include") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?include=foo",
           andExpect = Status.BadRequest,
@@ -147,7 +147,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
 
   it("returns a Bad Request error if asked for more than one invalid include") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?include=foo,bar",
           andExpect = Status.BadRequest,
@@ -162,7 +162,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
   it(
     "returns a Bad Request error if asked for a mixture of valid and invalid includes") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?include=foo,identifiers,bar",
           andExpect = Status.BadRequest,
@@ -176,7 +176,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
   it(
     "returns a Bad Request error if asked for an invalid include on an individual work") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works/nfdn7wac?include=foo",
           andExpect = Status.BadRequest,
@@ -188,7 +188,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
 
   it("returns Not Found if you look up a non-existent index") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?_index=foobarbaz",
           andExpect = Status.NotFound,
@@ -199,7 +199,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
 
   it("returns Not Found if you ask for a non-existent work") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works/xhu96f9j",
           andExpect = Status.NotFound,
@@ -212,7 +212,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
 
   it("returns Bad Request if you ask for a malformed identifier") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works/zd224ncv]",
           andExpect = Status.NotFound,
@@ -231,7 +231,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
     // a canonicalId field to sort on.  Trying to query one of these will
     // trigger one such exception!
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?_index=.watches",
           andExpect = Status.InternalServerError,
@@ -248,7 +248,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
 
   it("returns a Bad Request error if you try to access the 10000th page") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?page=10000",
           andExpect = Status.BadRequest,
@@ -263,7 +263,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
   it(
     "returns a Bad Request error if you try to get the 101th page with 100 results per page") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?pageSize=100&page=101",
           andExpect = Status.BadRequest,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
@@ -11,12 +11,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
   describe("listing works") {
     it("ignores works with no workType") {
       withV2Api {
-        case (
-            apiPrefix,
-            _,
-            indexNameV2,
-            itemType,
-            server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
           val noWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(workType = None)
           }
@@ -24,7 +19,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             workType = Some(WorkType(id = "b", label = "Books")))
 
           val works = noWorkTypeWorks :+ matchingWork
-          insertIntoElasticsearch(indexNameV2, itemType, works: _*)
+          insertIntoElasticsearch(indexNameV2, works: _*)
 
           eventually {
             server.httpGet(
@@ -50,12 +45,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("filters out works with a different workType") {
       withV2Api {
-        case (
-            apiPrefix,
-            _,
-            indexNameV2,
-            itemType,
-            server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               workType = Some(WorkType(id = "m", label = "Manuscripts")))
@@ -64,7 +54,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             workType = Some(WorkType(id = "b", label = "Books")))
 
           val works = wrongWorkTypeWorks :+ matchingWork
-          insertIntoElasticsearch(indexNameV2, itemType, works: _*)
+          insertIntoElasticsearch(indexNameV2, works: _*)
 
           eventually {
             server.httpGet(
@@ -90,12 +80,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("can filter by multiple workTypes") {
       withV2Api {
-        case (
-            apiPrefix,
-            _,
-            indexNameV2,
-            itemType,
-            server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               workType = Some(WorkType(id = "m", label = "Manuscripts")))
@@ -108,7 +93,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             workType = Some(WorkType(id = "a", label = "Archives")))
 
           val works = wrongWorkTypeWorks :+ matchingWork1 :+ matchingWork2
-          insertIntoElasticsearch(indexNameV2, itemType, works: _*)
+          insertIntoElasticsearch(indexNameV2, works: _*)
 
           eventually {
             server.httpGet(
@@ -142,12 +127,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("filters by item LocationType") {
       withV2Api {
-        case (
-            apiPrefix,
-            _,
-            indexNameV2,
-            itemType,
-            server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
           val noItemWorks = createIdentifiedWorks(count = 3)
           val matchingWork1 = createIdentifiedWorkWith(
             canonicalId = "001",
@@ -169,7 +149,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           )
 
           val works = noItemWorks :+ matchingWork1 :+ matchingWork2 :+ wrongLocationTypeWork
-          insertIntoElasticsearch(indexNameV2, itemType, works: _*)
+          insertIntoElasticsearch(indexNameV2, works: _*)
 
           eventually {
             server.httpGet(
@@ -204,12 +184,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
   describe("searching works") {
     it("ignores works with no workType") {
       withV2Api {
-        case (
-            apiPrefix,
-            _,
-            indexNameV2,
-            itemType,
-            server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
           val noWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               title = "Amazing aubergines",
@@ -220,7 +195,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             workType = Some(WorkType(id = "b", label = "Books")))
 
           val works = noWorkTypeWorks :+ matchingWork
-          insertIntoElasticsearch(indexNameV2, itemType, works: _*)
+          insertIntoElasticsearch(indexNameV2, works: _*)
 
           eventually {
             server.httpGet(
@@ -246,12 +221,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("filters out works with a different workType") {
       withV2Api {
-        case (
-            apiPrefix,
-            _,
-            indexNameV2,
-            itemType,
-            server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               title = "Bouncing bananas",
@@ -262,7 +232,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             workType = Some(WorkType(id = "b", label = "Books")))
 
           val works = wrongWorkTypeWorks :+ matchingWork
-          insertIntoElasticsearch(indexNameV2, itemType, works: _*)
+          insertIntoElasticsearch(indexNameV2, works: _*)
 
           eventually {
             server.httpGet(
@@ -288,12 +258,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("can filter by multiple workTypes") {
       withV2Api {
-        case (
-            apiPrefix,
-            _,
-            indexNameV2,
-            itemType,
-            server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               title = "Bouncing bananas",
@@ -309,7 +274,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             workType = Some(WorkType(id = "a", label = "Archives")))
 
           val works = wrongWorkTypeWorks :+ matchingWork1 :+ matchingWork2
-          insertIntoElasticsearch(indexNameV2, itemType, works: _*)
+          insertIntoElasticsearch(indexNameV2, works: _*)
 
           eventually {
             server.httpGet(
@@ -343,12 +308,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("filters by item LocationType") {
       withV2Api {
-        case (
-            apiPrefix,
-            _,
-            indexNameV2,
-            itemType,
-            server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
           val noItemWorks = createIdentifiedWorks(count = 3)
           val matchingWork1 = createIdentifiedWorkWith(
             canonicalId = "001",
@@ -372,7 +332,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           )
 
           val works = noItemWorks :+ matchingWork1 :+ matchingWork2 :+ wrongLocationTypeWork
-          insertIntoElasticsearch(indexNameV2, itemType, works: _*)
+          insertIntoElasticsearch(indexNameV2, works: _*)
 
           eventually {
             server.httpGet(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
@@ -8,8 +8,8 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
     val redirectedWork = createIdentifiedRedirectedWork
 
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-        insertIntoElasticsearch(indexNameV2, itemType, redirectedWork)
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+        insertIntoElasticsearch(indexNameV2, redirectedWork)
         server.httpGet(
           path = s"/$apiPrefix/works/${redirectedWork.canonicalId}",
           andExpect = Status.Found,
@@ -24,8 +24,8 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
     val redirectedWork = createIdentifiedRedirectedWork
 
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-        insertIntoElasticsearch(indexNameV2, itemType, redirectedWork)
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+        insertIntoElasticsearch(indexNameV2, redirectedWork)
         server.httpGet(
           path =
             s"/$apiPrefix/works/${redirectedWork.canonicalId}?include=identifiers",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
@@ -8,7 +8,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of identifiers on a list endpoint if we pass ?include=identifiers") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val identifier0 = createSourceIdentifier
@@ -17,7 +17,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
         val work0 = works(0).copy(otherIdentifiers = List(identifier0))
         val work1 = works(1).copy(otherIdentifiers = List(identifier1))
 
-        insertIntoElasticsearch(indexNameV2, itemType, work0, work1)
+        insertIntoElasticsearch(indexNameV2, work0, work1)
 
         eventually {
           server.httpGet(
@@ -53,12 +53,12 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of identifiers on a single work endpoint if we pass ?include=identifiers") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val otherIdentifier = createSourceIdentifier
         val work = createIdentifiedWorkWith(
           otherIdentifiers = List(otherIdentifier)
         )
-        insertIntoElasticsearch(indexNameV2, itemType, work)
+        insertIntoElasticsearch(indexNameV2, work)
 
         eventually {
           server.httpGet(
@@ -82,12 +82,12 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
 
   it("renders the items if the items include is present") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           items = createIdentifiedItems(count = 1) :+ createUnidentifiableItemWith()
         )
 
-        insertIntoElasticsearch(indexNameV2, itemType, work)
+        insertIntoElasticsearch(indexNameV2, work)
 
         eventually {
           server.httpGet(
@@ -110,7 +110,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of subjects on a list endpoint if we pass ?include=subjects") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val subjects1 = List(
@@ -120,7 +120,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
         val work0 = works(0).copy(subjects = subjects1)
         val work1 = works(1).copy(subjects = subjects2)
 
-        insertIntoElasticsearch(indexNameV2, itemType, work0, work1)
+        insertIntoElasticsearch(indexNameV2, work0, work1)
 
         eventually {
           server.httpGet(
@@ -153,12 +153,12 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of subjects on a single work endpoint if we pass ?include=subjects") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val subject = List(
           Subject("ornithology", List(Unidentifiable(Concept("ornithology")))))
         val work = createIdentifiedWork.copy(subjects = subject)
 
-        insertIntoElasticsearch(indexNameV2, itemType, work)
+        insertIntoElasticsearch(indexNameV2, work)
 
         eventually {
           server.httpGet(
@@ -180,7 +180,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
 
   it("includes a list of genres on a list endpoint if we pass ?include=genres") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val genres1 = List(
@@ -190,7 +190,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
         val work0 = works(0).copy(genres = genres1)
         val work1 = works(1).copy(genres = genres2)
 
-        insertIntoElasticsearch(indexNameV2, itemType, work0, work1)
+        insertIntoElasticsearch(indexNameV2, work0, work1)
 
         eventually {
           server.httpGet(
@@ -223,12 +223,12 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of genres on a single work endpoint if we pass ?include=genres") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val genre = List(
           Genre("ornithology", List(Unidentifiable(Concept("ornithology")))))
         val work = createIdentifiedWork.copy(genres = genre)
 
-        insertIntoElasticsearch(indexNameV2, itemType, work)
+        insertIntoElasticsearch(indexNameV2, work)
 
         eventually {
           server.httpGet(
@@ -251,7 +251,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of contributors on a list endpoint if we pass ?include=contributors") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val contributors1 =
@@ -261,7 +261,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
         val work0 = works(0).copy(contributors = contributors1)
         val work1 = works(1).copy(contributors = contributors2)
 
-        insertIntoElasticsearch(indexNameV2, itemType, work0, work1)
+        insertIntoElasticsearch(indexNameV2, work0, work1)
 
         eventually {
           server.httpGet(
@@ -294,12 +294,12 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of contributors on a single work endpoint if we pass ?include=contributors") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val contributor =
           List(Contributor(Unidentifiable(Person("Ginger Rogers"))))
         val work = createIdentifiedWork.copy(contributors = contributor)
 
-        insertIntoElasticsearch(indexNameV2, itemType, work)
+        insertIntoElasticsearch(indexNameV2, work)
 
         eventually {
           server.httpGet(
@@ -322,7 +322,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of production events on a list endpoint if we pass ?include=production") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val productionEvents1 = List(
@@ -340,7 +340,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
         val work0 = works(0).copy(production = productionEvents1)
         val work1 = works(1).copy(production = productionEvents2)
 
-        insertIntoElasticsearch(indexNameV2, itemType, work0, work1)
+        insertIntoElasticsearch(indexNameV2, work0, work1)
 
         eventually {
           server.httpGet(
@@ -373,7 +373,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of production on a single work endpoint if we pass ?include=production") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val productionEvent = List(
           ProductionEvent(
             List(Place("London")),
@@ -382,7 +382,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
             None))
         val work = createIdentifiedWork.copy(production = productionEvent)
 
-        insertIntoElasticsearch(indexNameV2, itemType, work)
+        insertIntoElasticsearch(indexNameV2, work)
 
         eventually {
           server.httpGet(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -202,7 +202,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   it("searches different indices with the ?_index query parameter") {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-        withLocalElasticsearchIndex(itemType = itemType) { otherIndex =>
+        withLocalElasticsearchIndex { otherIndex =>
           val work = createIdentifiedWork
           insertIntoElasticsearch(indexNameV2, itemType, work)
 
@@ -249,7 +249,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   it("looks up works in different indices with the ?_index query parameter") {
     withV2Api {
       case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
-        withLocalElasticsearchIndex(itemType = itemType) { otherIndex =>
+        withLocalElasticsearchIndex { otherIndex =>
           val work = createIdentifiedWorkWith(
             title = "Playing with pangolins"
           )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -151,7 +151,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("ignores parameters that are unused when making an API request") {
     withV2Api {
-      case (apiPrefix, _, _, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?foo=bar",
           andExpect = Status.Ok,
@@ -207,10 +207,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
           insertIntoElasticsearch(indexNameV2, work)
 
           val work_alt = createIdentifiedWork
-          insertIntoElasticsearch(
-            indexName = otherIndex,
-            itemType = itemType,
-            work_alt)
+          insertIntoElasticsearch(indexName = otherIndex, work_alt)
 
           eventually {
             server.httpGet(
@@ -258,10 +255,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
           val work_alt = createIdentifiedWorkWith(
             title = "Playing with pangolins"
           )
-          insertIntoElasticsearch(
-            indexName = otherIndex,
-            itemType = itemType,
-            work_alt)
+          insertIntoElasticsearch(indexName = otherIndex, work_alt)
 
           eventually {
             server.httpGet(
@@ -342,12 +336,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("only returns works from the v2 index") {
     withV2Api {
-      case (
-          apiPrefix,
-          indexNameV1,
-          indexNameV2,
-          itemType,
-          server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexNameV1, indexNameV2, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "Working with wombats"
         )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -7,10 +7,10 @@ import uk.ac.wellcome.models.work.internal._
 class ApiV2WorksTest extends ApiV2WorksTestBase {
   it("returns a list of works") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
-        insertIntoElasticsearch(indexNameV2, itemType, works: _*)
+        insertIntoElasticsearch(indexNameV2, works: _*)
 
         eventually {
           server.httpGet(
@@ -45,10 +45,10 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("returns a single work when requested with id") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWork
 
-        insertIntoElasticsearch(indexNameV2, itemType, work)
+        insertIntoElasticsearch(indexNameV2, work)
 
         eventually {
           server.httpGet(
@@ -70,10 +70,10 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   it(
     "returns the requested page of results when requested with page & pageSize") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
-        insertIntoElasticsearch(indexNameV2, itemType, works: _*)
+        insertIntoElasticsearch(indexNameV2, works: _*)
 
         eventually {
           server.httpGet(
@@ -162,14 +162,14 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("returns matching results if doing a full-text search") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "A drawing of a dodo"
         )
         val work2 = createIdentifiedWorkWith(
           title = "A mezzotint of a mouse"
         )
-        insertIntoElasticsearch(indexNameV2, itemType, work1, work2)
+        insertIntoElasticsearch(indexNameV2, work1, work2)
 
         eventually {
           server.httpGet(
@@ -201,10 +201,10 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("searches different indices with the ?_index query parameter") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         withLocalElasticsearchIndex { otherIndex =>
           val work = createIdentifiedWork
-          insertIntoElasticsearch(indexNameV2, itemType, work)
+          insertIntoElasticsearch(indexNameV2, work)
 
           val work_alt = createIdentifiedWork
           insertIntoElasticsearch(
@@ -248,12 +248,12 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("looks up works in different indices with the ?_index query parameter") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         withLocalElasticsearchIndex { otherIndex =>
           val work = createIdentifiedWorkWith(
             title = "Playing with pangolins"
           )
-          insertIntoElasticsearch(indexNameV2, itemType, work)
+          insertIntoElasticsearch(indexNameV2, work)
 
           val work_alt = createIdentifiedWorkWith(
             title = "Playing with pangolins"
@@ -306,7 +306,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("shows the thumbnail field if available") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           thumbnail = Some(
             DigitalLocation(
@@ -315,7 +315,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
               license = Some(License_CCBY)
             ))
         )
-        insertIntoElasticsearch(indexNameV2, itemType, work)
+        insertIntoElasticsearch(indexNameV2, work)
 
         eventually {
           server.httpGet(
@@ -351,12 +351,12 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
         val work1 = createIdentifiedWorkWith(
           title = "Working with wombats"
         )
-        insertIntoElasticsearch(indexNameV1, itemType, work1)
+        insertIntoElasticsearch(indexNameV1, work1)
 
         val work2 = createIdentifiedWorkWith(
           title = work1.title
         )
-        insertIntoElasticsearch(indexNameV2, itemType, work2)
+        insertIntoElasticsearch(indexNameV2, work2)
 
         eventually {
           server.httpGet(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
@@ -7,10 +7,10 @@ import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedInvisibleWork
 
-        insertIntoElasticsearch(indexNameV2, itemType, work)
+        insertIntoElasticsearch(indexNameV2, work)
 
         eventually {
           server.httpGet(
@@ -24,12 +24,12 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
 
   it("excludes works with visible=false from list results") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val deletedWork = createIdentifiedInvisibleWork
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val worksToIndex = Seq[IdentifiedBaseWork](deletedWork) ++ works
-        insertIntoElasticsearch(indexNameV2, itemType, worksToIndex: _*)
+        insertIntoElasticsearch(indexNameV2, worksToIndex: _*)
 
         eventually {
           server.httpGet(
@@ -59,12 +59,12 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
 
   it("excludes works with visible=false from search results") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, itemType, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           title = "This shouldn't be deleted!"
         )
         val deletedWork = createIdentifiedInvisibleWork
-        insertIntoElasticsearch(indexNameV2, itemType, work, deletedWork)
+        insertIntoElasticsearch(indexNameV2, work, deletedWork)
 
         eventually {
           server.httpGet(

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -43,8 +43,8 @@ class IngestorWorkerService @Inject()(
       works <- Future.successful(messageBundles.map(m => m.work))
       either <- identifiedWorkIndexer.indexWorks(
         works = works,
-        esIndex = index,
-        esType = ingestorConfig.elasticConfig.documentType
+        indexName = index,
+        documentType = ingestorConfig.elasticConfig.documentType
       )
 
     } yield {

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -27,14 +27,14 @@ class WorkIndexer @Inject()(
   }
 
   def indexWorks(works: Seq[IdentifiedBaseWork],
-                 esIndex: String,
-                 esType: String)
+                 indexName: String,
+                 documentType: String)
     : Future[Either[Seq[IdentifiedBaseWork], Seq[IdentifiedBaseWork]]] = {
 
     debug(s"Indexing work ${works.map(_.canonicalId).mkString(", ")}")
 
     val inserts = works.map { work =>
-      indexInto(esIndex / esType)
+      indexInto(indexName / documentType)
         .version(work.version)
         .versionType(VersionType.EXTERNAL_GTE)
         .id(work.canonicalId)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -35,7 +35,7 @@ class IngestorFeatureTest
           queue = queue,
           obj = work)
         withLocalElasticsearchIndex { indexName =>
-          withServer(queue, bucket, indexName, itemType) { _ =>
+          withServer(queue, bucket, indexName) { _ =>
             assertElasticsearchEventuallyHasWork(indexName, itemType, work)
           }
         }
@@ -56,7 +56,7 @@ class IngestorFeatureTest
           queue = queue,
           obj = work)
         withLocalElasticsearchIndex { indexName =>
-          withServer(queue, bucket, indexName, itemType) { _ =>
+          withServer(queue, bucket, indexName) { _ =>
             assertElasticsearchNeverHasWork(indexName, itemType, work)
           }
         }
@@ -68,7 +68,7 @@ class IngestorFeatureTest
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalElasticsearchIndex { indexName =>
-          withServer(queue, bucket, indexName, itemType) { _ =>
+          withServer(queue, bucket, indexName) { _ =>
             sendNotificationToSQS(
               queue = queue,
               body = "not a json string -- this will fail parsing"

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -22,7 +22,7 @@ class IngestorFeatureTest
     with SQS
     with WorksGenerators {
 
-  val itemType = "work"
+  val itemType = documentType
 
   it(
     "reads a miro identified work from the queue and ingests it in the v1 and v2 index") {
@@ -34,7 +34,7 @@ class IngestorFeatureTest
           bucket = bucket,
           queue = queue,
           obj = work)
-        withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+        withLocalElasticsearchIndex { indexName =>
           withServer(queue, bucket, indexName, itemType) { _ =>
             assertElasticsearchEventuallyHasWork(indexName, itemType, work)
           }
@@ -55,7 +55,7 @@ class IngestorFeatureTest
           bucket = bucket,
           queue = queue,
           obj = work)
-        withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+        withLocalElasticsearchIndex { indexName =>
           withServer(queue, bucket, indexName, itemType) { _ =>
             assertElasticsearchNeverHasWork(indexName, itemType, work)
           }
@@ -67,7 +67,7 @@ class IngestorFeatureTest
   it("does not delete a message from the queue if it fails processing") {
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+        withLocalElasticsearchIndex { indexName =>
           withServer(queue, bucket, indexName, itemType) { _ =>
             sendNotificationToSQS(
               queue = queue,

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -22,8 +22,6 @@ class IngestorFeatureTest
     with SQS
     with WorksGenerators {
 
-  val itemType = documentType
-
   it(
     "reads a miro identified work from the queue and ingests it in the v1 and v2 index") {
     val work = createIdentifiedWork
@@ -36,7 +34,7 @@ class IngestorFeatureTest
           obj = work)
         withLocalElasticsearchIndex { indexName =>
           withServer(queue, bucket, indexName) { _ =>
-            assertElasticsearchEventuallyHasWork(indexName, itemType, work)
+            assertElasticsearchEventuallyHasWork(indexName, work)
           }
         }
       }
@@ -57,7 +55,7 @@ class IngestorFeatureTest
           obj = work)
         withLocalElasticsearchIndex { indexName =>
           withServer(queue, bucket, indexName) { _ =>
-            assertElasticsearchNeverHasWork(indexName, itemType, work)
+            assertElasticsearchNeverHasWork(indexName, work)
           }
         }
       }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.ingestor
 import com.sksamuel.elastic4s.ElasticDsl.{deleteIndex, index}
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
 import uk.ac.wellcome.storage.fixtures.S3
@@ -18,31 +18,29 @@ class IngestorIndexTest
     with Messaging
     with ElasticsearchFixtures {
 
-  val indexName = "works"
-  val itemType = "work"
-
   it("creates the index at startup if it doesn't already exist") {
+    val indexName = "works"
+
     deleteIndexIfExists(indexName)
 
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        withServer(queue, bucket, indexName, itemType) { _ =>
+        withServer(queue, bucket, indexName) { _ =>
           eventuallyIndexExists(indexName)
         }
       }
     }
   }
 
-  private def eventuallyIndexExists(indexName: String): Any = {
+  private def eventuallyIndexExists(indexName: String): Assertion =
     eventually {
       val future = elasticClient.execute(index exists indexName)
       whenReady(future) { result =>
         result.isExists should be(true)
       }
     }
-  }
 
-  private def deleteIndexIfExists(indexName: String) = {
+  private def deleteIndexIfExists(indexName: String): Assertion = {
     elasticClient.execute(deleteIndex(indexName))
 
     eventually {

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/Server.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/Server.scala
@@ -21,8 +21,7 @@ trait Server extends CloudWatch with Messaging with ElasticsearchFixtures {
     val server: EmbeddedHttpServer = new EmbeddedHttpServer(
       new AppServer(),
       flags = messageReaderLocalFlags(bucket, queue) ++ ingestEsLocalFlags(
-        indexName,
-        itemType) ++ cloudWatchLocalFlags ++ Map(
+        indexName) ++ cloudWatchLocalFlags ++ Map(
         "es.ingest.flushInterval" -> "5 seconds")
     )
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/Server.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/Server.scala
@@ -12,10 +12,8 @@ import uk.ac.wellcome.test.fixtures.TestWith
 
 trait Server extends CloudWatch with Messaging with ElasticsearchFixtures {
   this: Suite =>
-  def withServer[R](
-    queue: Queue,
-    bucket: Bucket,
-    indexName: String)(testWith: TestWith[EmbeddedHttpServer, R]): R = {
+  def withServer[R](queue: Queue, bucket: Bucket, indexName: String)(
+    testWith: TestWith[EmbeddedHttpServer, R]): R = {
 
     val server: EmbeddedHttpServer = new EmbeddedHttpServer(
       new AppServer(),

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/Server.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/Server.scala
@@ -15,8 +15,7 @@ trait Server extends CloudWatch with Messaging with ElasticsearchFixtures {
   def withServer[R](
     queue: Queue,
     bucket: Bucket,
-    indexName: String,
-    itemType: String)(testWith: TestWith[EmbeddedHttpServer, R]): R = {
+    indexName: String)(testWith: TestWith[EmbeddedHttpServer, R]): R = {
 
     val server: EmbeddedHttpServer = new EmbeddedHttpServer(
       new AppServer(),

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
@@ -12,10 +12,4 @@ trait WorkIndexerFixtures extends ElasticsearchFixtures { this: Suite =>
     val workIndexer = new WorkIndexer(elasticClient = elasticClient)
     testWith(workIndexer)
   }
-
-  def withWorkIndexerFixtures[R](esType: String)(
-    testWith: TestWith[WorkIndexer, R]): R =
-    withWorkIndexer { workIndexer =>
-      testWith(workIndexer)
-    }
 }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
@@ -3,22 +3,19 @@ package uk.ac.wellcome.platform.ingestor.fixtures
 import org.scalatest.Suite
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.platform.ingestor.services.WorkIndexer
-import uk.ac.wellcome.test.fixtures._
+import uk.ac.wellcome.test.fixtures.TestWith
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait WorkIndexerFixtures extends Akka with ElasticsearchFixtures { this: Suite =>
+trait WorkIndexerFixtures extends ElasticsearchFixtures { this: Suite =>
   def withWorkIndexer[R](testWith: TestWith[WorkIndexer, R]): R = {
     val workIndexer = new WorkIndexer(elasticClient = elasticClient)
     testWith(workIndexer)
   }
 
   def withWorkIndexerFixtures[R](esType: String)(
-    testWith: TestWith[WorkIndexer, R]): R = {
-    withActorSystem { actorSystem =>
-      withWorkIndexer { workIndexer =>
-        testWith(workIndexer)
-      }
+    testWith: TestWith[WorkIndexer, R]): R =
+    withWorkIndexer { workIndexer =>
+      testWith(workIndexer)
     }
-  }
 }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
@@ -2,19 +2,20 @@ package uk.ac.wellcome.platform.ingestor.fixtures
 
 import com.sksamuel.elastic4s.http.HttpClient
 import org.scalatest.Suite
+import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.platform.ingestor.services.WorkIndexer
 import uk.ac.wellcome.test.fixtures._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait WorkIndexerFixtures extends Akka { this: Suite =>
+trait WorkIndexerFixtures extends Akka with ElasticsearchFixtures { this: Suite =>
   def withWorkIndexer[R](elasticClient: HttpClient)(
     testWith: TestWith[WorkIndexer, R]): R = {
     val workIndexer = new WorkIndexer(elasticClient = elasticClient)
     testWith(workIndexer)
   }
 
-  def withWorkIndexerFixtures[R](esType: String, elasticClient: HttpClient)(
+  def withWorkIndexerFixtures[R](esType: String)(
     testWith: TestWith[WorkIndexer, R]): R = {
     withActorSystem { actorSystem =>
       withWorkIndexer(elasticClient = elasticClient) { workIndexer =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkIndexerFixtures.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.ingestor.fixtures
 
-import com.sksamuel.elastic4s.http.HttpClient
 import org.scalatest.Suite
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.platform.ingestor.services.WorkIndexer
@@ -9,8 +8,7 @@ import uk.ac.wellcome.test.fixtures._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait WorkIndexerFixtures extends Akka with ElasticsearchFixtures { this: Suite =>
-  def withWorkIndexer[R](elasticClient: HttpClient)(
-    testWith: TestWith[WorkIndexer, R]): R = {
+  def withWorkIndexer[R](testWith: TestWith[WorkIndexer, R]): R = {
     val workIndexer = new WorkIndexer(elasticClient = elasticClient)
     testWith(workIndexer)
   }
@@ -18,7 +16,7 @@ trait WorkIndexerFixtures extends Akka with ElasticsearchFixtures { this: Suite 
   def withWorkIndexerFixtures[R](esType: String)(
     testWith: TestWith[WorkIndexer, R]): R = {
     withActorSystem { actorSystem =>
-      withWorkIndexer(elasticClient = elasticClient) { workIndexer =>
+      withWorkIndexer { workIndexer =>
         testWith(workIndexer)
       }
     }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/CustomElasticsearchMapping.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/CustomElasticsearchMapping.scala
@@ -18,8 +18,9 @@ import scala.concurrent.ExecutionContext
 
 trait CustomElasticsearchMapping {
 
-  class SubsetOfFieldsWorksIndex(elasticClient: HttpClient, documentType: String)(
-    implicit val ec: ExecutionContext)
+  class SubsetOfFieldsWorksIndex(
+    elasticClient: HttpClient,
+    documentType: String)(implicit val ec: ExecutionContext)
       extends ElasticsearchIndex {
     val httpClient: HttpClient = elasticClient
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/CustomElasticsearchMapping.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/CustomElasticsearchMapping.scala
@@ -18,7 +18,7 @@ import scala.concurrent.ExecutionContext
 
 trait CustomElasticsearchMapping {
 
-  class SubsetOfFieldsWorksIndex(elasticClient: HttpClient, esType: String)(
+  class SubsetOfFieldsWorksIndex(elasticClient: HttpClient, documentType: String)(
     implicit val ec: ExecutionContext)
       extends ElasticsearchIndex {
     val httpClient: HttpClient = elasticClient
@@ -63,7 +63,7 @@ trait CustomElasticsearchMapping {
         keywordField("type")
       )
 
-    override val mappingDefinition: MappingDefinition = mapping(esType)
+    override val mappingDefinition: MappingDefinition = mapping(documentType)
       .dynamic(DynamicMapping.Strict)
       .as(rootIndexFields)
   }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -397,7 +397,7 @@ class IngestorWorkerServiceTest
         withLocalSqsQueueAndDlqAndTimeout(10) {
           case queuePair @ QueuePair(queue, dlq) =>
             withLocalS3Bucket { bucket =>
-              withWorkIndexer[R](elasticClient = elasticClient) { workIndexer =>
+              withWorkIndexer { workIndexer =>
                 withMessageStream[IdentifiedBaseWork, R](
                   actorSystem,
                   bucket,

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -47,7 +47,7 @@ class IngestorWorkerServiceTest
 
     val work = createIdentifiedWorkWith(sourceIdentifier = miroSourceIdentifier)
 
-    withLocalElasticsearchIndex(itemType = itemType) { esIndex =>
+    withLocalElasticsearchIndex { esIndex =>
       withIngestorWorkerService(esIndex) {
         case (QueuePair(queue, _), bucket) =>
           sendMessage[IdentifiedBaseWork](
@@ -68,7 +68,7 @@ class IngestorWorkerServiceTest
       sourceIdentifier = createSierraSystemSourceIdentifier
     )
 
-    withLocalElasticsearchIndex(itemType = itemType) { esIndex =>
+    withLocalElasticsearchIndex { esIndex =>
       withIngestorWorkerService(esIndex) {
         case (QueuePair(queue, _), bucket) =>
           sendMessage[IdentifiedBaseWork](
@@ -89,7 +89,7 @@ class IngestorWorkerServiceTest
       sourceIdentifier = createSierraSystemSourceIdentifier
     )
 
-    withLocalElasticsearchIndex(itemType = itemType) { esIndex =>
+    withLocalElasticsearchIndex { esIndex =>
       withIngestorWorkerService(esIndex) {
         case (QueuePair(queue, _), bucket) =>
           sendMessage[IdentifiedBaseWork](
@@ -110,7 +110,7 @@ class IngestorWorkerServiceTest
       sourceIdentifier = createSierraSystemSourceIdentifier
     )
 
-    withLocalElasticsearchIndex(itemType = itemType) { esIndex =>
+    withLocalElasticsearchIndex { esIndex =>
       withIngestorWorkerService(esIndex) {
         case (QueuePair(queue, _), bucket) =>
           sendMessage[IdentifiedBaseWork](
@@ -142,7 +142,7 @@ class IngestorWorkerServiceTest
 
     val works = List(miroWork1, miroWork2, sierraWork1, sierraWork2)
 
-    withLocalElasticsearchIndex(itemType = itemType) { esIndex =>
+    withLocalElasticsearchIndex { esIndex =>
       withIngestorWorkerService(esIndex) {
         case (QueuePair(queue, dlq), bucket) =>
           works.foreach { work =>
@@ -169,7 +169,7 @@ class IngestorWorkerServiceTest
       )
     )
 
-    withLocalElasticsearchIndex(itemType = itemType) { esIndex =>
+    withLocalElasticsearchIndex { esIndex =>
       withIngestorWorkerService(esIndex) {
         case (QueuePair(queue, dlq), bucket) =>
           sendMessage[IdentifiedBaseWork](
@@ -206,7 +206,7 @@ class IngestorWorkerServiceTest
 
     val works = List(miroWork, sierraWork, otherWork)
 
-    withLocalElasticsearchIndex(itemType = itemType) { esIndex =>
+    withLocalElasticsearchIndex { esIndex =>
       withIngestorWorkerService(esIndex) {
         case (QueuePair(queue, dlq), bucket) =>
           works.foreach { work =>
@@ -244,7 +244,7 @@ class IngestorWorkerServiceTest
 
     val works = List(sierraWork, oldSierraWork)
 
-    withLocalElasticsearchIndex(itemType = itemType) { esIndex =>
+    withLocalElasticsearchIndex { esIndex =>
       insertIntoElasticsearch(
         indexName = esIndex,
         itemType = itemType,
@@ -274,7 +274,7 @@ class IngestorWorkerServiceTest
   it("ingests lots of works") {
     val works = createIdentifiedWorks(count = 250)
 
-    withLocalElasticsearchIndex(itemType = itemType) { esIndex =>
+    withLocalElasticsearchIndex { esIndex =>
       withIngestorWorkerService(esIndex) {
         case (QueuePair(queue, dlq), bucket) =>
           works.foreach { work =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -223,9 +223,7 @@ class IngestorWorkerServiceTest
     val works = List(sierraWork, oldSierraWork)
 
     withLocalElasticsearchIndex { indexName =>
-      insertIntoElasticsearch(
-        indexName = indexName,
-        newSierraWork)
+      insertIntoElasticsearch(indexName = indexName, newSierraWork)
       withIngestorWorkerService(indexName) {
         case (QueuePair(queue, dlq), bucket) =>
           works.foreach { work =>
@@ -297,7 +295,9 @@ class IngestorWorkerServiceTest
               obj = work)
           }
 
-          assertElasticsearchNeverHasWork(indexName = indexName, workDoesNotMatchMapping)
+          assertElasticsearchNeverHasWork(
+            indexName = indexName,
+            workDoesNotMatchMapping)
           assertElasticsearchEventuallyHasWork(indexName = indexName, work)
           eventually {
             assertQueueEmpty(queue)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -312,32 +312,29 @@ class IngestorWorkerServiceTest
 
     val works = List(work, workDoesNotMatchMapping)
 
-    withLocalElasticsearchIndex(
-      subsetOfFieldsIndex,
-      indexName = (Random.alphanumeric take 10 mkString) toLowerCase) {
-      esIndex =>
-        withIngestorWorkerService(esIndex) {
-          case (QueuePair(queue, dlq), bucket) =>
-            works.foreach { work =>
-              sendMessage[IdentifiedBaseWork](
-                bucket = bucket,
-                queue = queue,
-                obj = work)
-            }
+    withLocalElasticsearchIndex(subsetOfFieldsIndex) { indexName =>
+      withIngestorWorkerService(indexName) {
+        case (QueuePair(queue, dlq), bucket) =>
+          works.foreach { work =>
+            sendMessage[IdentifiedBaseWork](
+              bucket = bucket,
+              queue = queue,
+              obj = work)
+          }
 
-            assertElasticsearchNeverHasWork(
-              indexName = esIndex,
-              itemType = itemType,
-              workDoesNotMatchMapping)
-            assertElasticsearchEventuallyHasWork(
-              indexName = esIndex,
-              itemType = itemType,
-              work)
-            eventually {
-              assertQueueEmpty(queue)
-              assertQueueHasSize(dlq, 1)
-            }
-        }
+          assertElasticsearchNeverHasWork(
+            indexName = indexName,
+            itemType = itemType,
+            workDoesNotMatchMapping)
+          assertElasticsearchEventuallyHasWork(
+            indexName = indexName,
+            itemType = itemType,
+            work)
+          eventually {
+            assertQueueEmpty(queue)
+            assertQueueHasSize(dlq, 1)
+          }
+      }
     }
   }
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -26,7 +26,6 @@ import uk.ac.wellcome.test.fixtures.TestWith
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import scala.util.Random
 
 class IngestorWorkerServiceTest
     extends FunSpec

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -55,10 +55,7 @@ class IngestorWorkerServiceTest
             queue = queue,
             obj = work)
 
-          assertElasticsearchEventuallyHasWork(
-            indexName = esIndex,
-            itemType = itemType,
-            work)
+          assertElasticsearchEventuallyHasWork(indexName = esIndex, work)
       }
     }
   }
@@ -76,10 +73,7 @@ class IngestorWorkerServiceTest
             queue = queue,
             obj = work)
 
-          assertElasticsearchEventuallyHasWork(
-            indexName = esIndex,
-            itemType = itemType,
-            work)
+          assertElasticsearchEventuallyHasWork(indexName = esIndex, work)
       }
     }
   }
@@ -97,10 +91,7 @@ class IngestorWorkerServiceTest
             queue = queue,
             obj = work)
 
-          assertElasticsearchEventuallyHasWork(
-            indexName = esIndex,
-            itemType = itemType,
-            work)
+          assertElasticsearchEventuallyHasWork(indexName = esIndex, work)
       }
     }
   }
@@ -118,10 +109,7 @@ class IngestorWorkerServiceTest
             queue = queue,
             obj = work)
 
-          assertElasticsearchEventuallyHasWork(
-            indexName = esIndex,
-            itemType = itemType,
-            work)
+          assertElasticsearchEventuallyHasWork(indexName = esIndex, work)
       }
     }
   }
@@ -152,10 +140,7 @@ class IngestorWorkerServiceTest
               obj = work)
           }
 
-          assertElasticsearchEventuallyHasWork(
-            indexName = esIndex,
-            itemType = itemType,
-            works: _*)
+          assertElasticsearchEventuallyHasWork(indexName = esIndex, works: _*)
 
           assertQueueEmpty(dlq)
       }
@@ -177,10 +162,7 @@ class IngestorWorkerServiceTest
             queue = queue,
             obj = work)
 
-          assertElasticsearchEventuallyHasWork(
-            indexName = esIndex,
-            itemType = itemType,
-            work)
+          assertElasticsearchEventuallyHasWork(indexName = esIndex, work)
 
           eventually {
             assertQueueEmpty(queue)
@@ -218,7 +200,6 @@ class IngestorWorkerServiceTest
 
           assertElasticsearchEventuallyHasWork(
             indexName = esIndex,
-            itemType = itemType,
             miroWork,
             sierraWork,
             otherWork)
@@ -247,7 +228,6 @@ class IngestorWorkerServiceTest
     withLocalElasticsearchIndex { esIndex =>
       insertIntoElasticsearch(
         indexName = esIndex,
-        itemType = itemType,
         newSierraWork)
       withIngestorWorkerService(esIndex) {
         case (QueuePair(queue, dlq), bucket) =>
@@ -260,7 +240,6 @@ class IngestorWorkerServiceTest
 
           assertElasticsearchEventuallyHasWork(
             indexName = esIndex,
-            itemType = itemType,
             sierraWork,
             newSierraWork)
           eventually {
@@ -286,10 +265,7 @@ class IngestorWorkerServiceTest
 
           eventually {
             works.foreach { work =>
-              assertElasticsearchEventuallyHasWork(
-                indexName = esIndex,
-                itemType = itemType,
-                work)
+              assertElasticsearchEventuallyHasWork(indexName = esIndex, work)
             }
           }
 
@@ -302,8 +278,10 @@ class IngestorWorkerServiceTest
   }
 
   it("only deletes successfully ingested works from the queue") {
-    val subsetOfFieldsIndex =
-      new SubsetOfFieldsWorksIndex(elasticClient, itemType)
+    val subsetOfFieldsIndex = new SubsetOfFieldsWorksIndex(
+      elasticClient = elasticClient,
+      documentType = documentType
+    )
 
     val work = createIdentifiedWork
     val workDoesNotMatchMapping = createIdentifiedWorkWith(
@@ -322,14 +300,8 @@ class IngestorWorkerServiceTest
               obj = work)
           }
 
-          assertElasticsearchNeverHasWork(
-            indexName = indexName,
-            itemType = itemType,
-            workDoesNotMatchMapping)
-          assertElasticsearchEventuallyHasWork(
-            indexName = indexName,
-            itemType = itemType,
-            work)
+          assertElasticsearchNeverHasWork(indexName = indexName, workDoesNotMatchMapping)
+          assertElasticsearchEventuallyHasWork(indexName = indexName, work)
           eventually {
             assertQueueEmpty(queue)
             assertQueueHasSize(dlq, 1)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -40,22 +40,20 @@ class IngestorWorkerServiceTest
     with WorksGenerators
     with CustomElasticsearchMapping {
 
-  val itemType = "work"
-
   it("inserts an Miro identified Work into the index") {
     val miroSourceIdentifier = createSourceIdentifier
 
     val work = createIdentifiedWorkWith(sourceIdentifier = miroSourceIdentifier)
 
-    withLocalElasticsearchIndex { esIndex =>
-      withIngestorWorkerService(esIndex) {
+    withLocalElasticsearchIndex { indexName =>
+      withIngestorWorkerService(indexName) {
         case (QueuePair(queue, _), bucket) =>
           sendMessage[IdentifiedBaseWork](
             bucket = bucket,
             queue = queue,
             obj = work)
 
-          assertElasticsearchEventuallyHasWork(indexName = esIndex, work)
+          assertElasticsearchEventuallyHasWork(indexName = indexName, work)
       }
     }
   }
@@ -65,15 +63,15 @@ class IngestorWorkerServiceTest
       sourceIdentifier = createSierraSystemSourceIdentifier
     )
 
-    withLocalElasticsearchIndex { esIndex =>
-      withIngestorWorkerService(esIndex) {
+    withLocalElasticsearchIndex { indexName =>
+      withIngestorWorkerService(indexName) {
         case (QueuePair(queue, _), bucket) =>
           sendMessage[IdentifiedBaseWork](
             bucket = bucket,
             queue = queue,
             obj = work)
 
-          assertElasticsearchEventuallyHasWork(indexName = esIndex, work)
+          assertElasticsearchEventuallyHasWork(indexName = indexName, work)
       }
     }
   }
@@ -83,15 +81,15 @@ class IngestorWorkerServiceTest
       sourceIdentifier = createSierraSystemSourceIdentifier
     )
 
-    withLocalElasticsearchIndex { esIndex =>
-      withIngestorWorkerService(esIndex) {
+    withLocalElasticsearchIndex { indexName =>
+      withIngestorWorkerService(indexName) {
         case (QueuePair(queue, _), bucket) =>
           sendMessage[IdentifiedBaseWork](
             bucket = bucket,
             queue = queue,
             obj = work)
 
-          assertElasticsearchEventuallyHasWork(indexName = esIndex, work)
+          assertElasticsearchEventuallyHasWork(indexName = indexName, work)
       }
     }
   }
@@ -101,15 +99,15 @@ class IngestorWorkerServiceTest
       sourceIdentifier = createSierraSystemSourceIdentifier
     )
 
-    withLocalElasticsearchIndex { esIndex =>
-      withIngestorWorkerService(esIndex) {
+    withLocalElasticsearchIndex { indexName =>
+      withIngestorWorkerService(indexName) {
         case (QueuePair(queue, _), bucket) =>
           sendMessage[IdentifiedBaseWork](
             bucket = bucket,
             queue = queue,
             obj = work)
 
-          assertElasticsearchEventuallyHasWork(indexName = esIndex, work)
+          assertElasticsearchEventuallyHasWork(indexName = indexName, work)
       }
     }
   }
@@ -130,8 +128,8 @@ class IngestorWorkerServiceTest
 
     val works = List(miroWork1, miroWork2, sierraWork1, sierraWork2)
 
-    withLocalElasticsearchIndex { esIndex =>
-      withIngestorWorkerService(esIndex) {
+    withLocalElasticsearchIndex { indexName =>
+      withIngestorWorkerService(indexName) {
         case (QueuePair(queue, dlq), bucket) =>
           works.foreach { work =>
             sendMessage[IdentifiedBaseWork](
@@ -140,7 +138,7 @@ class IngestorWorkerServiceTest
               obj = work)
           }
 
-          assertElasticsearchEventuallyHasWork(indexName = esIndex, works: _*)
+          assertElasticsearchEventuallyHasWork(indexName = indexName, works: _*)
 
           assertQueueEmpty(dlq)
       }
@@ -154,15 +152,15 @@ class IngestorWorkerServiceTest
       )
     )
 
-    withLocalElasticsearchIndex { esIndex =>
-      withIngestorWorkerService(esIndex) {
+    withLocalElasticsearchIndex { indexName =>
+      withIngestorWorkerService(indexName) {
         case (QueuePair(queue, dlq), bucket) =>
           sendMessage[IdentifiedBaseWork](
             bucket = bucket,
             queue = queue,
             obj = work)
 
-          assertElasticsearchEventuallyHasWork(indexName = esIndex, work)
+          assertElasticsearchEventuallyHasWork(indexName = indexName, work)
 
           eventually {
             assertQueueEmpty(queue)
@@ -188,8 +186,8 @@ class IngestorWorkerServiceTest
 
     val works = List(miroWork, sierraWork, otherWork)
 
-    withLocalElasticsearchIndex { esIndex =>
-      withIngestorWorkerService(esIndex) {
+    withLocalElasticsearchIndex { indexName =>
+      withIngestorWorkerService(indexName) {
         case (QueuePair(queue, dlq), bucket) =>
           works.foreach { work =>
             sendMessage[IdentifiedBaseWork](
@@ -199,7 +197,7 @@ class IngestorWorkerServiceTest
           }
 
           assertElasticsearchEventuallyHasWork(
-            indexName = esIndex,
+            indexName = indexName,
             miroWork,
             sierraWork,
             otherWork)
@@ -225,11 +223,11 @@ class IngestorWorkerServiceTest
 
     val works = List(sierraWork, oldSierraWork)
 
-    withLocalElasticsearchIndex { esIndex =>
+    withLocalElasticsearchIndex { indexName =>
       insertIntoElasticsearch(
-        indexName = esIndex,
+        indexName = indexName,
         newSierraWork)
-      withIngestorWorkerService(esIndex) {
+      withIngestorWorkerService(indexName) {
         case (QueuePair(queue, dlq), bucket) =>
           works.foreach { work =>
             sendMessage[IdentifiedBaseWork](
@@ -239,7 +237,7 @@ class IngestorWorkerServiceTest
           }
 
           assertElasticsearchEventuallyHasWork(
-            indexName = esIndex,
+            indexName = indexName,
             sierraWork,
             newSierraWork)
           eventually {
@@ -253,8 +251,8 @@ class IngestorWorkerServiceTest
   it("ingests lots of works") {
     val works = createIdentifiedWorks(count = 250)
 
-    withLocalElasticsearchIndex { esIndex =>
-      withIngestorWorkerService(esIndex) {
+    withLocalElasticsearchIndex { indexName =>
+      withIngestorWorkerService(indexName) {
         case (QueuePair(queue, dlq), bucket) =>
           works.foreach { work =>
             sendMessage[IdentifiedBaseWork](
@@ -265,7 +263,7 @@ class IngestorWorkerServiceTest
 
           eventually {
             works.foreach { work =>
-              assertElasticsearchEventuallyHasWork(indexName = esIndex, work)
+              assertElasticsearchEventuallyHasWork(indexName = indexName, work)
             }
           }
 
@@ -335,7 +333,7 @@ class IngestorWorkerServiceTest
                 )
 
                 withIngestorWorkerService[Assertion](
-                  esIndex = "works-v1",
+                  indexName = "works-v1",
                   actorSystem,
                   brokenWorkIndexer,
                   messageStream) { _ =>
@@ -359,7 +357,7 @@ class IngestorWorkerServiceTest
     }
   }
 
-  private def withIngestorWorkerService[R](esIndex: String)(
+  private def withIngestorWorkerService[R](indexName: String)(
     testWith: TestWith[(QueuePair, Bucket), R]): R = {
     withActorSystem { actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>
@@ -373,7 +371,7 @@ class IngestorWorkerServiceTest
                   queue,
                   metricsSender) { messageStream =>
                   withIngestorWorkerService[R](
-                    esIndex,
+                    indexName,
                     actorSystem,
                     workIndexer,
                     messageStream) { _ =>
@@ -388,7 +386,7 @@ class IngestorWorkerServiceTest
   }
 
   private def withIngestorWorkerService[R](
-    esIndex: String,
+    indexName: String,
     actorSystem: ActorSystem,
     workIndexer: WorkIndexer,
     messageStream: MessageStream[IdentifiedBaseWork])(
@@ -398,8 +396,8 @@ class IngestorWorkerServiceTest
       batchSize = 100,
       flushInterval = 5 seconds,
       elasticConfig = IngestElasticConfig(
-        documentType = itemType,
-        indexName = esIndex
+        documentType = documentType,
+        indexName = indexName
       )
     )
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -101,7 +101,9 @@ class WorkIndexerTest
 
         whenReady(future) { result =>
           result.right.get should contain(updatedWork)
-          assertElasticsearchEventuallyHasWork(indexName = indexName, updatedWork)
+          assertElasticsearchEventuallyHasWork(
+            indexName = indexName,
+            updatedWork)
         }
       }
     }
@@ -149,8 +151,12 @@ class WorkIndexerTest
         )
 
         whenReady(future) { result =>
-          assertElasticsearchEventuallyHasWork(indexName = indexName, validWorks: _*)
-          assertElasticsearchNeverHasWork(indexName = indexName, notMatchingMappingWork)
+          assertElasticsearchEventuallyHasWork(
+            indexName = indexName,
+            validWorks: _*)
+          assertElasticsearchNeverHasWork(
+            indexName = indexName,
+            notMatchingMappingWork)
           result.left.get should contain(notMatchingMappingWork)
         }
       }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -26,7 +26,7 @@ class WorkIndexerTest
     val work = createIdentifiedWork
 
     withLocalElasticsearchIndex(itemType = esType) { indexName =>
-      withWorkIndexerFixtures(esType) { workIndexer =>
+      withWorkIndexer { workIndexer =>
         val future = workIndexer.indexWorks(List(work), indexName, esType)
 
         whenReady(future) { result =>
@@ -44,7 +44,7 @@ class WorkIndexerTest
     val work = createIdentifiedWork
 
     withLocalElasticsearchIndex(itemType = esType) { indexName =>
-      withWorkIndexerFixtures(esType) { workIndexer =>
+      withWorkIndexer { workIndexer =>
         val future = Future.sequence(
           (1 to 2).map(
             _ =>
@@ -72,7 +72,7 @@ class WorkIndexerTest
     withLocalElasticsearchIndex(itemType = esType) { indexName =>
       insertIntoElasticsearch(indexName = indexName, itemType = esType, work)
 
-      withWorkIndexerFixtures(esType) { workIndexer =>
+      withWorkIndexer { workIndexer =>
         val future = workIndexer.indexWorks(
           works = List(olderWork),
           esIndex = indexName,
@@ -100,7 +100,7 @@ class WorkIndexerTest
     withLocalElasticsearchIndex(itemType = esType) { indexName =>
       insertIntoElasticsearch(indexName = indexName, itemType = esType, work)
 
-      withWorkIndexerFixtures(esType) { workIndexer =>
+      withWorkIndexer { workIndexer =>
         val future = workIndexer.indexWorks(
           works = List(updatedWork),
           esIndex = indexName,
@@ -122,7 +122,7 @@ class WorkIndexerTest
     val works = createIdentifiedWorks(count = 5)
 
     withLocalElasticsearchIndex(itemType = esType) { indexName =>
-      withWorkIndexerFixtures(esType) { workIndexer =>
+      withWorkIndexer { workIndexer =>
         val future = workIndexer.indexWorks(works, indexName, esType)
 
         whenReady(future) { successfullyInserted =>
@@ -152,7 +152,7 @@ class WorkIndexerTest
       subsetOfFieldsIndex,
       indexName = (Random.alphanumeric take 10 mkString) toLowerCase) {
       indexName =>
-        withWorkIndexerFixtures(esType) { workIndexer =>
+        withWorkIndexer { workIndexer =>
           val future = workIndexer.indexWorks(works, indexName, esType)
 
           whenReady(future) { result =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -26,7 +26,7 @@ class WorkIndexerTest
     val work = createIdentifiedWork
 
     withLocalElasticsearchIndex(itemType = esType) { indexName =>
-      withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
+      withWorkIndexerFixtures(esType) { workIndexer =>
         val future = workIndexer.indexWorks(List(work), indexName, esType)
 
         whenReady(future) { result =>
@@ -44,7 +44,7 @@ class WorkIndexerTest
     val work = createIdentifiedWork
 
     withLocalElasticsearchIndex(itemType = esType) { indexName =>
-      withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
+      withWorkIndexerFixtures(esType) { workIndexer =>
         val future = Future.sequence(
           (1 to 2).map(
             _ =>
@@ -72,7 +72,7 @@ class WorkIndexerTest
     withLocalElasticsearchIndex(itemType = esType) { indexName =>
       insertIntoElasticsearch(indexName = indexName, itemType = esType, work)
 
-      withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
+      withWorkIndexerFixtures(esType) { workIndexer =>
         val future = workIndexer.indexWorks(
           works = List(olderWork),
           esIndex = indexName,
@@ -100,7 +100,7 @@ class WorkIndexerTest
     withLocalElasticsearchIndex(itemType = esType) { indexName =>
       insertIntoElasticsearch(indexName = indexName, itemType = esType, work)
 
-      withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
+      withWorkIndexerFixtures(esType) { workIndexer =>
         val future = workIndexer.indexWorks(
           works = List(updatedWork),
           esIndex = indexName,
@@ -122,7 +122,7 @@ class WorkIndexerTest
     val works = createIdentifiedWorks(count = 5)
 
     withLocalElasticsearchIndex(itemType = esType) { indexName =>
-      withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
+      withWorkIndexerFixtures(esType) { workIndexer =>
         val future = workIndexer.indexWorks(works, indexName, esType)
 
         whenReady(future) { successfullyInserted =>
@@ -152,7 +152,7 @@ class WorkIndexerTest
       subsetOfFieldsIndex,
       indexName = (Random.alphanumeric take 10 mkString) toLowerCase) {
       indexName =>
-        withWorkIndexerFixtures(esType, elasticClient) { workIndexer =>
+        withWorkIndexerFixtures(esType) { workIndexer =>
           val future = workIndexer.indexWorks(works, indexName, esType)
 
           whenReady(future) { result =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -113,7 +113,11 @@ class WorkIndexerTest
 
     withLocalElasticsearchIndex { indexName =>
       withWorkIndexer { workIndexer =>
-        val future = workIndexer.indexWorks(works, indexName, esType)
+        val future = workIndexer.indexWorks(
+          works = works,
+          indexName = indexName,
+          documentType = documentType
+        )
 
         whenReady(future) { successfullyInserted =>
           assertElasticsearchEventuallyHasWork(indexName = indexName, works: _*)
@@ -125,8 +129,10 @@ class WorkIndexerTest
 
   it(
     "inserts a list of works into elasticsearch and return the list of works that failed inserting") {
-    val subsetOfFieldsIndex =
-      new SubsetOfFieldsWorksIndex(elasticClient, esType)
+    val subsetOfFieldsIndex = new SubsetOfFieldsWorksIndex(
+      elasticClient = elasticClient,
+      documentType = documentType
+    )
 
     val validWorks = createIdentifiedWorks(count = 5)
     val notMatchingMappingWork = createIdentifiedWorkWith(
@@ -137,7 +143,11 @@ class WorkIndexerTest
 
     withLocalElasticsearchIndex(subsetOfFieldsIndex) { indexName =>
       withWorkIndexer { workIndexer =>
-        val future = workIndexer.indexWorks(works, indexName, esType)
+        val future = workIndexer.indexWorks(
+          works = works,
+          indexName = indexName,
+          documentType = documentType
+        )
 
         whenReady(future) { result =>
           assertElasticsearchEventuallyHasWork(indexName = indexName, validWorks: _*)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -148,25 +148,22 @@ class WorkIndexerTest
 
     val works = validWorks :+ notMatchingMappingWork
 
-    withLocalElasticsearchIndex(
-      subsetOfFieldsIndex,
-      indexName = (Random.alphanumeric take 10 mkString) toLowerCase) {
-      indexName =>
-        withWorkIndexer { workIndexer =>
-          val future = workIndexer.indexWorks(works, indexName, esType)
+    withLocalElasticsearchIndex(subsetOfFieldsIndex) { indexName =>
+      withWorkIndexer { workIndexer =>
+        val future = workIndexer.indexWorks(works, indexName, esType)
 
-          whenReady(future) { result =>
-            assertElasticsearchEventuallyHasWork(
-              indexName = indexName,
-              itemType = esType,
-              validWorks: _*)
-            assertElasticsearchNeverHasWork(
-              indexName = indexName,
-              itemType = esType,
-              notMatchingMappingWork)
-            result.left.get should contain(notMatchingMappingWork)
-          }
+        whenReady(future) { result =>
+          assertElasticsearchEventuallyHasWork(
+            indexName = indexName,
+            itemType = esType,
+            validWorks: _*)
+          assertElasticsearchNeverHasWork(
+            indexName = indexName,
+            itemType = esType,
+            notMatchingMappingWork)
+          result.left.get should contain(notMatchingMappingWork)
         }
+      }
     }
   }
 }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -9,7 +9,6 @@ import uk.ac.wellcome.platform.ingestor.fixtures.WorkIndexerFixtures
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.Random
 
 class WorkIndexerTest
     extends FunSpec

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -20,12 +20,12 @@ class WorkIndexerTest
     with WorkIndexerFixtures
     with CustomElasticsearchMapping {
 
-  val esType = "work"
+  val esType = documentType
 
   it("inserts an identified Work into Elasticsearch") {
     val work = createIdentifiedWork
 
-    withLocalElasticsearchIndex(itemType = esType) { indexName =>
+    withLocalElasticsearchIndex { indexName =>
       withWorkIndexer { workIndexer =>
         val future = workIndexer.indexWorks(List(work), indexName, esType)
 
@@ -43,7 +43,7 @@ class WorkIndexerTest
   it("only adds one record when the same ID is ingested multiple times") {
     val work = createIdentifiedWork
 
-    withLocalElasticsearchIndex(itemType = esType) { indexName =>
+    withLocalElasticsearchIndex { indexName =>
       withWorkIndexer { workIndexer =>
         val future = Future.sequence(
           (1 to 2).map(
@@ -69,7 +69,7 @@ class WorkIndexerTest
     val work = createIdentifiedWorkWith(version = 3)
     val olderWork = work.copy(version = 1)
 
-    withLocalElasticsearchIndex(itemType = esType) { indexName =>
+    withLocalElasticsearchIndex { indexName =>
       insertIntoElasticsearch(indexName = indexName, itemType = esType, work)
 
       withWorkIndexer { workIndexer =>
@@ -97,7 +97,7 @@ class WorkIndexerTest
     val work = createIdentifiedWorkWith(version = 3)
     val updatedWork = work.copy(title = "a different title")
 
-    withLocalElasticsearchIndex(itemType = esType) { indexName =>
+    withLocalElasticsearchIndex { indexName =>
       insertIntoElasticsearch(indexName = indexName, itemType = esType, work)
 
       withWorkIndexer { workIndexer =>
@@ -121,7 +121,7 @@ class WorkIndexerTest
   it("inserts a list of works into elasticsearch and returns them") {
     val works = createIdentifiedWorks(count = 5)
 
-    withLocalElasticsearchIndex(itemType = esType) { indexName =>
+    withLocalElasticsearchIndex { indexName =>
       withWorkIndexer { workIndexer =>
         val future = workIndexer.indexWorks(works, indexName, esType)
 

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchWorksSource.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchWorksSource.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.json.JsonUtil._
 
 object ElasticsearchWorksSource extends Logging {
-  def apply(elasticClient: HttpClient, indexName: String, itemType: String)(
+  def apply(elasticClient: HttpClient, indexName: String, documentType: String)(
     implicit actorSystem: ActorSystem): Source[IdentifiedWork, NotUsed] = {
     val loggingSink = Flow[IdentifiedWork]
       .grouped(10000)
@@ -24,7 +24,7 @@ object ElasticsearchWorksSource extends Logging {
     Source
       .fromPublisher(
         elasticClient.publisher(
-          search(s"$indexName/$itemType")
+          search(s"$indexName/$documentType")
             .query(termQuery("type", "IdentifiedWork"))
             .scroll(keepAlive = "2m")
             // Increasing the size of each request from the

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/ServerTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/ServerTest.scala
@@ -17,7 +17,6 @@ class ServerTest
     with SQS
     with ScalaFutures
     with ElasticsearchFixtures {
-  val itemType = documentType
 
   it("shows the healthcheck message") {
     withFixtures { server =>

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/ServerTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/ServerTest.scala
@@ -17,7 +17,7 @@ class ServerTest
     with SQS
     with ScalaFutures
     with ElasticsearchFixtures {
-  val itemType = "work"
+  val itemType = documentType
 
   it("shows the healthcheck message") {
     withFixtures { server =>
@@ -35,8 +35,7 @@ class ServerTest
           withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
             val flags = snsLocalFlags(topic) ++ sqsLocalFlags(queue) ++ displayEsLocalFlags(
               indexNameV1,
-              indexNameV2,
-              itemType)
+              indexNameV2)
             withServer(flags) { server =>
               testWith(server)
             }

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/ServerTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/ServerTest.scala
@@ -31,8 +31,8 @@ class ServerTest
   private def withFixtures[R](testWith: TestWith[EmbeddedHttpServer, R]) =
     withLocalSqsQueue { queue =>
       withLocalSnsTopic { topic =>
-        withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
-          withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
+        withLocalElasticsearchIndex { indexNameV1 =>
+          withLocalElasticsearchIndex { indexNameV2 =>
             val flags = snsLocalFlags(topic) ++ sqsLocalFlags(queue) ++ displayEsLocalFlags(
               indexNameV1,
               indexNameV2)

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -43,7 +43,7 @@ class SnapshotGeneratorFeatureTest
     with DisplayV1SerialisationTestBase
     with WorksGenerators {
 
-  val itemType = "work"
+  val itemType = documentType
 
   it("completes a snapshot generation") {
     withFixtures {
@@ -118,8 +118,7 @@ class SnapshotGeneratorFeatureTest
             withLocalS3Bucket { bucket =>
               val flags = snsLocalFlags(topic) ++ sqsLocalFlags(queue) ++ displayEsLocalFlags(
                 indexNameV1,
-                indexNameV2,
-                itemType) ++ s3ClientLocalFlags
+                indexNameV2) ++ s3ClientLocalFlags
               withServer(flags) { _ =>
                 testWith((queue, topic, indexNameV1, indexNameV2, bucket))
               }

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -43,14 +43,12 @@ class SnapshotGeneratorFeatureTest
     with DisplayV1SerialisationTestBase
     with WorksGenerators {
 
-  val itemType = documentType
-
   it("completes a snapshot generation") {
     withFixtures {
       case (queue, topic, indexNameV1, _, publicBucket: Bucket) =>
         val works = createIdentifiedWorks(count = 3)
 
-        insertIntoElasticsearch(indexNameV1, itemType, works: _*)
+        insertIntoElasticsearch(indexNameV1, works: _*)
 
         val publicObjectKey = "target.txt.gz"
 

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -113,8 +113,8 @@ class SnapshotGeneratorFeatureTest
     testWith: TestWith[(Queue, Topic, String, String, Bucket), R]) =
     withLocalSqsQueue { queue =>
       withLocalSnsTopic { topic =>
-        withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
-          withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
+        withLocalElasticsearchIndex { indexNameV1 =>
+          withLocalElasticsearchIndex { indexNameV2 =>
             withLocalS3Bucket { bucket =>
               val flags = snsLocalFlags(topic) ++ sqsLocalFlags(queue) ++ displayEsLocalFlags(
                 indexNameV1,

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -78,8 +78,8 @@ class SnapshotServiceTest
     withActorSystem { actorSystem =>
       withMaterializer(actorSystem) { actorMaterialiser =>
         withS3AkkaClient(actorSystem, actorMaterialiser) { s3Client =>
-          withLocalElasticsearchIndex(itemType = itemType) { indexNameV1 =>
-            withLocalElasticsearchIndex(itemType = itemType) { indexNameV2 =>
+          withLocalElasticsearchIndex { indexNameV1 =>
+            withLocalElasticsearchIndex { indexNameV2 =>
               withLocalS3Bucket { bucket =>
                 withSnapshotService(
                   actorSystem,

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -19,7 +19,6 @@ import uk.ac.wellcome.display.models.{
 }
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
-import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.platform.snapshot_generator.finatra.modules.AkkaS3ClientModule
@@ -49,15 +48,12 @@ class SnapshotServiceTest
 
   val mapper = new ObjectMapper with ScalaObjectMapper
 
-  val itemType = "work"
-
   private def withSnapshotService[R](
     actorSystem: ActorSystem,
     s3AkkaClient: S3Client,
     indexNameV1: String,
-    indexNameV2: String)(testWith: TestWith[SnapshotService, R]) = {
-    val elasticConfig = DisplayElasticConfig(
-      documentType = itemType,
+    indexNameV2: String)(testWith: TestWith[SnapshotService, R]): R = {
+    val elasticConfig = createDisplayElasticConfigWith(
       indexV1name = indexNameV1,
       indexV2name = indexNameV2
     )
@@ -106,7 +102,7 @@ class SnapshotServiceTest
 
         val works = visibleWorks ++ notVisibleWorks
 
-        insertIntoElasticsearch(indexNameV1, itemType, works: _*)
+        insertIntoElasticsearch(indexNameV1, works: _*)
 
         val publicObjectKey = "target.txt.gz"
 
@@ -154,7 +150,7 @@ class SnapshotServiceTest
 
         val works = visibleWorks ++ notVisibleWorks
 
-        insertIntoElasticsearch(indexNameV2, itemType, works: _*)
+        insertIntoElasticsearch(indexNameV2, works: _*)
 
         val publicObjectKey = "target.txt.gz"
 
@@ -204,7 +200,7 @@ class SnapshotServiceTest
           )
         }
 
-        insertIntoElasticsearch(indexNameV1, itemType, works: _*)
+        insertIntoElasticsearch(indexNameV1, works: _*)
 
         val publicObjectKey = "target.txt.gz"
         val snapshotJob = SnapshotJob(
@@ -248,7 +244,7 @@ class SnapshotServiceTest
       case (snapshotService: SnapshotService, indexNameV1, _, _) =>
         val works = createIdentifiedWorks(count = 3)
 
-        insertIntoElasticsearch(indexNameV1, itemType, works: _*)
+        insertIntoElasticsearch(indexNameV1, works: _*)
 
         val snapshotJob = SnapshotJob(
           publicBucketName = "wrongBukkit",
@@ -271,8 +267,7 @@ class SnapshotServiceTest
       withMaterializer(actorSystem) { actorMaterialiser =>
         withS3AkkaClient(actorSystem, actorMaterialiser) { s3Client =>
           withLocalS3Bucket { bucket =>
-            val elasticConfig = DisplayElasticConfig(
-              documentType = itemType,
+            val elasticConfig = createDisplayElasticConfigWith(
               indexV1name = "wrong-index",
               indexV2name = "wrong-index"
             )
@@ -323,8 +318,7 @@ class SnapshotServiceTest
             secretKey = secretKey
           )
 
-          val elasticConfig = DisplayElasticConfig(
-            documentType = itemType,
+          val elasticConfig = createDisplayElasticConfigWith(
             indexV1name = "indexv1",
             indexV2name = "indexv2"
           )

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
@@ -62,12 +62,12 @@ class ElasticsearchSourceTest
     }
   }
 
-  private def withSource[R](actorSystem: ActorSystem, indexName: String)(testWith: TestWith[Source[IdentifiedWork, NotUsed], R]): R = {
+  private def withSource[R](actorSystem: ActorSystem, indexName: String)(
+    testWith: TestWith[Source[IdentifiedWork, NotUsed], R]): R = {
     val source = ElasticsearchWorksSource(
       elasticClient = elasticClient,
       indexName = indexName,
-      documentType = documentType)(
-      actorSystem)
+      documentType = documentType)(actorSystem)
     testWith(source)
   }
 

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.test.fixtures.Akka
 
-class ElastisearchSourceTest
+class ElasticsearchSourceTest
     extends FunSpec
     with Matchers
     with ScalaFutures

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElastisearchSourceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElastisearchSourceTest.scala
@@ -20,7 +20,7 @@ class ElastisearchSourceTest
     val itemType = "work"
     withActorSystem { actorSystem =>
       withMaterializer(actorSystem) { actorMaterialiser =>
-        withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+        withLocalElasticsearchIndex { indexName =>
           implicit val materialiser = actorMaterialiser
           val works = createIdentifiedWorks(count = 10)
           insertIntoElasticsearch(indexName, itemType, works: _*)
@@ -41,7 +41,7 @@ class ElastisearchSourceTest
     val itemType = "work"
     withActorSystem { actorSystem =>
       withMaterializer(actorSystem) { actorMaterialiser =>
-        withLocalElasticsearchIndex(itemType = itemType) { indexName =>
+        withLocalElasticsearchIndex { indexName =>
           implicit val materialiser = actorMaterialiser
           val visibleWorks = createIdentifiedWorks(count = 10)
           val invisibleWorks = createIdentifiedInvisibleWorks(count = 3)

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndexTest.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndexTest.scala
@@ -70,8 +70,7 @@ class ElasticsearchIndexTest
   }
 
   it("creates an index into which doc of the expected type can be put") {
-    val indexName = "working-index"
-    withLocalElasticsearchIndex(TestIndex, indexName = indexName) { indexName =>
+    withLocalElasticsearchIndex(TestIndex) { indexName =>
       val testObject = TestObject("id", "description", true)
       val testObjectJson = toJson(testObject).get
 
@@ -92,8 +91,7 @@ class ElasticsearchIndexTest
   }
 
   it("create an index where inserting a doc of an unexpected type fails") {
-    val indexName = "unexpected-type-index"
-    withLocalElasticsearchIndex(TestIndex, indexName = indexName) { indexName =>
+    withLocalElasticsearchIndex(TestIndex) { indexName =>
       val badTestObject = BadTestObject("id", 5)
       val badTestObjectJson = toJson(badTestObject).get
 
@@ -110,8 +108,7 @@ class ElasticsearchIndexTest
   }
 
   it("updates an already existing index with a compatible mapping") {
-    val indexName = "existing-index"
-    withLocalElasticsearchIndex(TestIndex, indexName = indexName) { _ =>
+    withLocalElasticsearchIndex(TestIndex) { indexName =>
       withLocalElasticsearchIndex(CompatibleTestIndex, indexName = indexName) {
         testIndexName =>
           val compatibleTestObject =

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexTest.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexTest.scala
@@ -31,7 +31,7 @@ class WorksIndexTest
 
   it("puts a valid work") {
     forAll { sampleWork: IdentifiedBaseWork =>
-      withLocalElasticsearchIndex(itemType = "work") { indexName =>
+      withLocalElasticsearchIndex { indexName =>
         val sampleWorkJson = toJson(sampleWork).get
 
         val futureIndexResponse = elasticClient.execute(
@@ -48,7 +48,7 @@ class WorksIndexTest
   // a bug in the mapping related to person subjects wasn't causght by the above test.
   // So let's add a specific one
   it("puts a work with a person subject") {
-    withLocalElasticsearchIndex(itemType = "work") { indexName =>
+    withLocalElasticsearchIndex { indexName =>
       val sampleWorkJson = toJson(createIdentifiedWorkWith(subjects = List(Subject("Daredevil", List(Unidentifiable(Person(label = "Daredevil", prefix = Some("Superhero"), numeration = Some("I")))))))).get
       val futureIndexResponse = elasticClient.execute(
         indexInto(indexName / "work").doc(sampleWorkJson))
@@ -60,7 +60,7 @@ class WorksIndexTest
   }
 
   it("does not put an invalid work") {
-    withLocalElasticsearchIndex(itemType = "work") { indexName =>
+    withLocalElasticsearchIndex { indexName =>
       val badTestObject = BadTestObject("id", 5)
       val badTestObjectJson = toJson(badTestObject).get
 

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -39,6 +39,8 @@ trait ElasticsearchFixtures
   private val esHost = "localhost"
   private val esPort = 9200
 
+  val documentType = "work"
+
   def displayEsLocalFlags(indexNameV1: String,
                           indexNameV2: String,
                           itemType: String) =

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -3,10 +3,19 @@ package uk.ac.wellcome.elasticsearch.test.fixtures
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.HttpClient
 import org.elasticsearch.index.VersionType
-import org.scalatest.concurrent.{Eventually, PatienceConfiguration, ScalaFutures}
+import org.scalatest.concurrent.{
+  Eventually,
+  PatienceConfiguration,
+  ScalaFutures
+}
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{Assertion, Matchers, Suite}
-import uk.ac.wellcome.elasticsearch.{DisplayElasticConfig, ElasticClientBuilder, ElasticsearchIndex, WorksIndex}
+import uk.ac.wellcome.elasticsearch.{
+  DisplayElasticConfig,
+  ElasticClientBuilder,
+  ElasticsearchIndex,
+  WorksIndex
+}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
@@ -32,8 +41,7 @@ trait ElasticsearchFixtures
 
   val documentType = "work"
 
-  def displayEsLocalFlags(indexNameV1: String,
-                          indexNameV2: String) =
+  def displayEsLocalFlags(indexNameV1: String, indexNameV2: String) =
     Map(
       "es.host" -> esHost,
       "es.port" -> esPort.toString,
@@ -164,7 +172,9 @@ trait ElasticsearchFixtures
     }
   }
 
-  def createDisplayElasticConfigWith(indexV1name: String, indexV2name: String): DisplayElasticConfig =
+  def createDisplayElasticConfigWith(
+    indexV1name: String,
+    indexV2name: String): DisplayElasticConfig =
     DisplayElasticConfig(
       documentType = documentType,
       indexV1name = indexV1name,

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -51,12 +51,12 @@ trait ElasticsearchFixtures
       "es.type" -> documentType
     )
 
-  def ingestEsLocalFlags(indexName: String, itemType: String) =
+  def ingestEsLocalFlags(indexName: String) =
     Map(
       "es.host" -> esHost,
       "es.port" -> esPort.toString,
       "es.index" -> indexName,
-      "es.type" -> itemType
+      "es.type" -> documentType
     )
 
   val elasticClient: HttpClient = ElasticClientBuilder.create(

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -93,7 +93,7 @@ trait ElasticsearchFixtures
 
   def withLocalElasticsearchIndex[R](
     index: ElasticsearchIndex,
-    indexName: String)(testWith: TestWith[String, R]): R = {
+    indexName: String = createIndexName)(testWith: TestWith[String, R]): R = {
 
     index.create(indexName).await
 

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -66,8 +66,7 @@ trait ElasticsearchFixtures
   def withLocalElasticsearchIndex[R](testWith: TestWith[String, R]): R = {
     val indexName = createIndexName
 
-    val elasticConfig = DisplayElasticConfig(
-      documentType = documentType,
+    val elasticConfig = createDisplayElasticConfigWith(
       indexV1name = indexName,
       indexV2name = s"$indexName-v2"
     )

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -72,9 +72,8 @@ trait ElasticsearchFixtures
     elasticClient.execute(clusterHealth()).await.numberOfNodes shouldBe 1
   }
 
-  def withLocalElasticsearchIndex[R](
-    indexName: String = (Random.alphanumeric take 10 mkString) toLowerCase,
-    itemType: String)(testWith: TestWith[String, R]): R = {
+  def withLocalElasticsearchIndex[R](itemType: String)(testWith: TestWith[String, R]): R = {
+    val indexName = createIndexName
 
     val elasticConfig = DisplayElasticConfig(
       documentType = itemType,
@@ -87,7 +86,9 @@ trait ElasticsearchFixtures
       rootIndexType = elasticConfig.documentType
     )
 
-    withLocalElasticsearchIndex(index, indexName)(testWith)
+    withLocalElasticsearchIndex(index, indexName) { indexName =>
+      testWith(indexName)
+    }
   }
 
   def withLocalElasticsearchIndex[R](
@@ -175,4 +176,7 @@ trait ElasticsearchFixtures
       }
     }
   }
+
+  private def createIndexName: String =
+    (Random.alphanumeric take 10 mkString) toLowerCase
 }

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -165,6 +165,13 @@ trait ElasticsearchFixtures
     }
   }
 
+  def createDisplayElasticConfigWith(indexV1name: String, indexV2name: String): DisplayElasticConfig =
+    DisplayElasticConfig(
+      documentType = documentType,
+      indexV1name = indexV1name,
+      indexV2name = indexV2name
+    )
+
   private def createIndexName: String =
     (Random.alphanumeric take 10 mkString) toLowerCase
 }

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -72,11 +72,11 @@ trait ElasticsearchFixtures
     elasticClient.execute(clusterHealth()).await.numberOfNodes shouldBe 1
   }
 
-  def withLocalElasticsearchIndex[R](itemType: String)(testWith: TestWith[String, R]): R = {
+  def withLocalElasticsearchIndex[R](testWith: TestWith[String, R]): R = {
     val indexName = createIndexName
 
     val elasticConfig = DisplayElasticConfig(
-      documentType = itemType,
+      documentType = documentType,
       indexV1name = indexName,
       indexV2name = s"$indexName-v2"
     )

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -42,14 +42,13 @@ trait ElasticsearchFixtures
   val documentType = "work"
 
   def displayEsLocalFlags(indexNameV1: String,
-                          indexNameV2: String,
-                          itemType: String) =
+                          indexNameV2: String) =
     Map(
       "es.host" -> esHost,
       "es.port" -> esPort.toString,
       "es.index.v1" -> indexNameV1,
       "es.index.v2" -> indexNameV2,
-      "es.type" -> itemType
+      "es.type" -> documentType
     )
 
   def ingestEsLocalFlags(indexName: String, itemType: String) =


### PR DESCRIPTION
We had a bunch of different names for the same Elasticsearch concept:

* **index** – esIndex, indexName
* **document type** – documentType, esType, itemType (?!)

And for the latter, we never use any value except “work”.

I started clearing them up as I was doing the Typesafe config for the ingestor, then decided to go the whole nine yards and clear up all of them. Tada!