### PR TITLE
Have the reindexer emit the entire row as a JSON string, not just case classes

### DIFF
--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/Main.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/Main.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.platform.reindex.reindex_worker.dynamo.{
   ScanSpecScanner
 }
 import uk.ac.wellcome.platform.reindex.reindex_worker.services.{
-  HybridRecordSender,
+  BulkSNSSender,
   RecordReader,
   ReindexWorkerService
 }
@@ -44,13 +44,13 @@ object Main extends App with Logging {
     )
   )
 
-  val hybridRecordSender = new HybridRecordSender(
+  val hybridRecordSender = new BulkSNSSender(
     snsWriter = SNSBuilder.buildSNSWriter(config)
   )
 
   val workerService = new ReindexWorkerService(
     recordReader = recordReader,
-    hybridRecordSender = hybridRecordSender,
+    bulkSNSSender = hybridRecordSender,
     sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config)
   )
 

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/MaxRecordsScanner.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/MaxRecordsScanner.scala
@@ -1,13 +1,13 @@
 package uk.ac.wellcome.platform.reindex.reindex_worker.dynamo
 
 import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
-import com.google.inject.Inject
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
 import scala.concurrent.Future
 
-class MaxRecordsScanner @Inject()(scanSpecScanner: ScanSpecScanner,
-                                  dynamoConfig: DynamoConfig) {
+class MaxRecordsScanner(
+  scanSpecScanner: ScanSpecScanner,
+  dynamoConfig: DynamoConfig) {
 
   /** Run a DynamoDB Scan that returns at most `maxResults` values.
     *

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/MaxRecordsScanner.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/MaxRecordsScanner.scala
@@ -2,8 +2,6 @@ package uk.ac.wellcome.platform.reindex.reindex_worker.dynamo
 
 import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
 import com.google.inject.Inject
-import com.gu.scanamo.error.DynamoReadError
-import com.gu.scanamo.DynamoFormat
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
 import scala.concurrent.Future
@@ -16,8 +14,7 @@ class MaxRecordsScanner @Inject()(scanSpecScanner: ScanSpecScanner,
     * It may return less if there aren't enough results in the table, or if
     * `maxResults` is larger than the maximum page size.
     */
-  def scan[T](maxRecords: Int)(implicit dynamoFormat: DynamoFormat[T])
-    : Future[List[Either[DynamoReadError, T]]] = {
+  def scan(maxRecords: Int): Future[List[String]] = {
 
     val scanSpec = new ScanSpec()
       .withMaxResultSize(maxRecords)

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/MaxRecordsScanner.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/MaxRecordsScanner.scala
@@ -5,9 +5,8 @@ import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
 import scala.concurrent.Future
 
-class MaxRecordsScanner(
-  scanSpecScanner: ScanSpecScanner,
-  dynamoConfig: DynamoConfig) {
+class MaxRecordsScanner(scanSpecScanner: ScanSpecScanner,
+                        dynamoConfig: DynamoConfig) {
 
   /** Run a DynamoDB Scan that returns at most `maxResults` values.
     *

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ParallelScanner.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ParallelScanner.scala
@@ -12,9 +12,8 @@ import scala.concurrent.Future
   *
   * https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan
   */
-class ParallelScanner(
-  scanSpecScanner: ScanSpecScanner,
-  dynamoConfig: DynamoConfig) {
+class ParallelScanner(scanSpecScanner: ScanSpecScanner,
+                      dynamoConfig: DynamoConfig) {
 
   /** Run a Parallel Scan for a single worker.
     *

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ParallelScanner.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ParallelScanner.scala
@@ -2,8 +2,6 @@ package uk.ac.wellcome.platform.reindex.reindex_worker.dynamo
 
 import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
 import com.google.inject.Inject
-import com.gu.scanamo.error.DynamoReadError
-import com.gu.scanamo.DynamoFormat
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
 import scala.concurrent.Future
@@ -31,9 +29,7 @@ class ParallelScanner @Inject()(scanSpecScanner: ScanSpecScanner,
     * Note that this returns a Future[List], so results will be cached in-memory.
     * Choose segment count accordingly.
     */
-  def scan[T](segment: Int, totalSegments: Int)(
-    implicit dynamoFormat: DynamoFormat[T])
-    : Future[List[Either[DynamoReadError, T]]] = {
+  def scan(segment: Int, totalSegments: Int): Future[List[String]] = {
 
     // Create the ScanSpec configuration and the DynamoDB table.  This is
     // based on the Java example of a Parallel Scan from the AWS docs:

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ParallelScanner.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ParallelScanner.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.reindex.reindex_worker.dynamo
 
 import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
-import com.google.inject.Inject
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
 import scala.concurrent.Future
@@ -13,8 +12,9 @@ import scala.concurrent.Future
   *
   * https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan
   */
-class ParallelScanner @Inject()(scanSpecScanner: ScanSpecScanner,
-                                dynamoConfig: DynamoConfig) {
+class ParallelScanner(
+  scanSpecScanner: ScanSpecScanner,
+  dynamoConfig: DynamoConfig) {
 
   /** Run a Parallel Scan for a single worker.
     *

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ScanSpecScanner.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ScanSpecScanner.scala
@@ -1,25 +1,17 @@
 package uk.ac.wellcome.platform.reindex.reindex_worker.dynamo
 
-import java.util
-
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.amazonaws.services.dynamodbv2.document.internal.InternalUtils
+import com.amazonaws.services.dynamodbv2.document._
 import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
-import com.amazonaws.services.dynamodbv2.document.{DynamoDB, Item}
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import com.google.inject.Inject
-import com.gu.scanamo.error.DynamoReadError
-import com.gu.scanamo.{DynamoFormat, ScanamoFree}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
 /** Implements a wrapper for DynamoDB Scan operations using a ScanSpec.
   *
-  * A ScanSpec is a way to fully specify the parameters of a Scan operation, which
-  * is very flexible -- but then we lose the serialisation of Scanamo case classes.
-  * This class combines the best of both worlds: it allows the flexibility of using
-  * ScanSpec, but also handles case class serialisation.
+  * This wrapper provides a list of JSON strings, which can be sent directly
+  * to a downstream application.
   *
   * For the options allowed by ScanSpec, see:
   * https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/dynamodbv2/document/spec/ScanSpec.html
@@ -34,39 +26,12 @@ class ScanSpecScanner @Inject()(dynamoDBClient: AmazonDynamoDB)(
     * Note that this returns a Future[List], so results will be cached in-memory.
     * Design your spec accordingly.
     */
-  def scan[T](scanSpec: ScanSpec, tableName: String)(
-    implicit dynamoFormat: DynamoFormat[T])
-    : Future[List[Either[DynamoReadError, T]]] = {
-    val table = dynamoDB.getTable(tableName)
-
-    Future {
-
-      // Actually run the Scan operation.  Again, this is based on the
-      // Java example from the AWS docs.
-      val itemCollection: List[Item] = table
-        .scan(scanSpec)
-        .asScala
-        .toList
-
-      itemCollection.map { item: Item =>
-        // Convert the "Item" (a collection of attributes) into a map of
-        // strings to AttributeValues, which we need for Scanamo.  Here we're
-        // using the internal utilities from the AWS DynamoDB SDK.
-        //
-        // I got this from SO, although it's an incidental part of the answer:
-        // https://stackoverflow.com/a/27538483/1558022
-        //
-        val attributeValues: util.Map[String, AttributeValue] =
-          InternalUtils.toAttributeValues(item)
-
-        // Take the Map[String, AttributeValue], and convert it into an
-        // instance of the case class `T`.  This is using a Scanamo helper --
-        // I worked this out by looking at [[ScanamoFree.get]].
-        //
-        // https://github.com/scanamo/scanamo/blob/12554b8e24ef8839d5e9dd9a4f42ae130e29b42b/scanamo/src/main/scala/com/gu/scanamo/ScanamoFree.scala#L62
-        //
-        ScanamoFree.read[T](attributeValues)
-      }
-    }
+  def scan(scanSpec: ScanSpec, tableName: String): Future[List[String]] = {
+    for {
+      table <- Future.successful { dynamoDB.getTable(tableName) }
+      scanResult: ItemCollection[ScanOutcome] <- Future { table.scan(scanSpec) }
+      items: List[Item] = scanResult.asScala.toList
+      jsonStrings = items.map { _.toJSON }
+    } yield jsonStrings
   }
 }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ScanSpecScanner.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ScanSpecScanner.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.reindex.reindex_worker.dynamo
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.document._
 import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
-import com.google.inject.Inject
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -16,7 +15,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * For the options allowed by ScanSpec, see:
   * https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/dynamodbv2/document/spec/ScanSpec.html
   */
-class ScanSpecScanner @Inject()(dynamoDBClient: AmazonDynamoDB)(
+class ScanSpecScanner(dynamoDBClient: AmazonDynamoDB)(
   implicit ec: ExecutionContext) {
 
   val dynamoDB = new DynamoDB(dynamoDBClient)

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/BulkSNSSender.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/BulkSNSSender.scala
@@ -1,21 +1,19 @@
 package uk.ac.wellcome.platform.reindex.reindex_worker.services
 
 import com.amazonaws.SdkClientException
-import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.{PublishAttempt, SNSWriter}
 import uk.ac.wellcome.platform.reindex.reindex_worker.exceptions.ReindexerException
-import uk.ac.wellcome.storage.vhs.HybridRecord
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class HybridRecordSender(snsWriter: SNSWriter)(implicit ec: ExecutionContext) {
-  def sendToSNS(records: List[HybridRecord]): Future[List[PublishAttempt]] = {
+class BulkSNSSender(snsWriter: SNSWriter)(implicit ec: ExecutionContext) {
+  def sendToSNS(messages: List[String]): Future[List[PublishAttempt]] = {
     Future.sequence {
-      records
-        .map { record: HybridRecord =>
+      messages
+        .map { message: String =>
           snsWriter
             .writeMessage(
-              message = record,
+              message = message,
               subject = this.getClass.getSimpleName
             )
             .recover {

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/RecordReader.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/RecordReader.scala
@@ -1,18 +1,15 @@
 package uk.ac.wellcome.platform.reindex.reindex_worker.services
 
-import com.gu.scanamo.error.DynamoReadError
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.reindex.reindex_worker.dynamo.{
   MaxRecordsScanner,
   ParallelScanner
 }
-import uk.ac.wellcome.platform.reindex.reindex_worker.exceptions.ReindexerException
 import uk.ac.wellcome.platform.reindex.reindex_worker.models.{
   CompleteReindexJob,
   PartialReindexJob,
   ReindexJob
 }
-import uk.ac.wellcome.storage.vhs.HybridRecord
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -27,37 +24,18 @@ class RecordReader(
 )(implicit ec: ExecutionContext)
     extends Logging {
 
-  def findRecordsForReindexing(
-    reindexJob: ReindexJob): Future[List[HybridRecord]] = {
+  def findRecordsForReindexing(reindexJob: ReindexJob): Future[List[String]] = {
     debug(s"Finding records that need reindexing for $reindexJob")
 
-    for {
-      // We start by querying DynamoDB for every record we want to reindex.
-      // If we requested reindexing a particularly large shard, this might
-      // cause out-of-memory errors -- in practice, we're hoping that the
-      // shards/individual records are small enough for this not to be a problem.
-      results: List[Either[DynamoReadError, HybridRecord]] <- reindexJob match {
-        case CompleteReindexJob(segment, totalSegments) =>
-          parallelScanner
-            .scan[HybridRecord](
-              segment = segment,
-              totalSegments = totalSegments
-            )
-        case PartialReindexJob(maxRecords) =>
-          maxRecordsScanner.scan[HybridRecord](maxRecords = maxRecords)
-      }
-
-      recordsToReindex = results.map(extractRecord)
-    } yield recordsToReindex
-  }
-
-  private def extractRecord(
-    scanamoResult: Either[DynamoReadError, HybridRecord]): HybridRecord =
-    scanamoResult match {
-      case Left(err: DynamoReadError) => {
-        warn(s"Failed to read Dynamo records: $err")
-        throw ReindexerException(s"Error in the DynamoDB query: $err")
-      }
-      case Right(hr: HybridRecord) => hr
+    reindexJob match {
+      case CompleteReindexJob(segment, totalSegments) =>
+        parallelScanner
+          .scan(
+            segment = segment,
+            totalSegments = totalSegments
+          )
+      case PartialReindexJob(maxRecords) =>
+        maxRecordsScanner.scan(maxRecords = maxRecords)
     }
+  }
 }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/RecordReader.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/RecordReader.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.platform.reindex.reindex_worker.models.{
   ReindexJob
 }
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 /** Find IDs for records in the SourceData table that need reindexing.
   *
@@ -21,8 +21,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class RecordReader(
   maxRecordsScanner: MaxRecordsScanner,
   parallelScanner: ParallelScanner
-)(implicit ec: ExecutionContext)
-    extends Logging {
+) extends Logging {
 
   def findRecordsForReindexing(reindexJob: ReindexJob): Future[List[String]] = {
     debug(s"Finding records that need reindexing for $reindexJob")

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerService.scala
@@ -6,7 +6,6 @@ import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.platform.reindex.reindex_worker.models.ReindexJob
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.storage.vhs.HybridRecord
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/ReindexWorkerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/ReindexWorkerFeatureTest.scala
@@ -30,7 +30,7 @@ class ReindexWorkerFeatureTest
     with WorkerServiceFixture {
 
   private def createHybridRecords: Seq[HybridRecord] =
-    (1 to 10).map(i => {
+    (1 to 4).map(i => {
       HybridRecord(
         id = s"id$i",
         location = ObjectLocation(

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/MaxRecordsScannerTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/MaxRecordsScannerTest.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.reindex.reindex_worker.dynamo
 import com.gu.scanamo.Scanamo
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.reindex.reindex_worker.fixtures.DynamoFixtures
 import uk.ac.wellcome.storage.dynamo.TestVersioned
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDbVersioned
@@ -24,7 +25,7 @@ class MaxRecordsScannerTest
         val futureResult = maxResultScanner.scan(maxRecords = 1)
 
         whenReady(futureResult) { result =>
-          result shouldBe List(Right(record))
+          result.map { fromJson[TestVersioned](_).get } shouldBe List(record)
         }
       }
     }
@@ -44,7 +45,7 @@ class MaxRecordsScannerTest
         val futureResult = maxResultScanner.scan(maxRecords = 10)
 
         whenReady(futureResult) { result =>
-          result should contain theSameElementsAs records
+          result.map { fromJson[TestVersioned](_).get } should contain theSameElementsAs records
         }
       }
     }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/MaxRecordsScannerTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/MaxRecordsScannerTest.scala
@@ -21,7 +21,7 @@ class MaxRecordsScannerTest
           TestVersioned(id = "123", data = "hello world", version = 1)
         Scanamo.put(dynamoDbClient)(table.name)(record)
 
-        val futureResult = maxResultScanner.scan[TestVersioned](maxRecords = 1)
+        val futureResult = maxResultScanner.scan(maxRecords = 1)
 
         whenReady(futureResult) { result =>
           result shouldBe List(Right(record))
@@ -41,10 +41,10 @@ class MaxRecordsScannerTest
           Scanamo.put(dynamoDbClient)(table.name)(record)
         }
 
-        val futureResult = maxResultScanner.scan[TestVersioned](maxRecords = 10)
+        val futureResult = maxResultScanner.scan(maxRecords = 10)
 
         whenReady(futureResult) { result =>
-          result.map { _.right.get } should contain theSameElementsAs records
+          result should contain theSameElementsAs records
         }
       }
     }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ParallelScannerTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ParallelScannerTest.scala
@@ -84,8 +84,9 @@ class ParallelScannerTest
           )
         }
 
-        whenReady(Future.sequence(futureResults)) { actualRecords: Seq[List[String]] =>
-          actualRecords.flatten.map { fromJson[TestVersioned](_).get } should contain theSameElementsAs records
+        whenReady(Future.sequence(futureResults)) {
+          actualRecords: Seq[List[String]] =>
+            actualRecords.flatten.map { fromJson[TestVersioned](_).get } should contain theSameElementsAs records
         }
       }
     }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ParallelScannerTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ParallelScannerTest.scala
@@ -4,6 +4,7 @@ import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
 import com.gu.scanamo.Scanamo
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Assertion, FunSpec, Matchers}
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.reindex.reindex_worker.fixtures.DynamoFixtures
 import uk.ac.wellcome.storage.dynamo.TestVersioned
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDbVersioned
@@ -31,7 +32,7 @@ class ParallelScannerTest
         )
 
         whenReady(futureResult) { result =>
-          result shouldBe List(Right(record))
+          result.map { fromJson[TestVersioned](_).get } shouldBe List(record)
         }
       }
     }
@@ -83,8 +84,8 @@ class ParallelScannerTest
           )
         }
 
-        whenReady(Future.sequence(futureResults)) { actualRecords =>
-          actualRecords should contain theSameElementsAs records
+        whenReady(Future.sequence(futureResults)) { actualRecords: Seq[List[String]] =>
+          actualRecords.flatten.map { fromJson[TestVersioned](_).get } should contain theSameElementsAs records
         }
       }
     }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ParallelScannerTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ParallelScannerTest.scala
@@ -25,7 +25,7 @@ class ParallelScannerTest
           TestVersioned(id = "123", data = "hello world", version = 1)
         Scanamo.put(dynamoDbClient)(table.name)(record)
 
-        val futureResult = parallelScanner.scan[TestVersioned](
+        val futureResult = parallelScanner.scan(
           segment = 0,
           totalSegments = 1
         )
@@ -49,7 +49,7 @@ class ParallelScannerTest
     "returns a failed future if asked for a segment that's greater than totalSegments") {
     withLocalDynamoDbTable { table =>
       withParallelScanner(table) { parallelScanner =>
-        val future = parallelScanner.scan[TestVersioned](
+        val future = parallelScanner.scan(
           segment = 10,
           totalSegments = 5
         )
@@ -76,18 +76,14 @@ class ParallelScannerTest
         }
 
         // Note that segments are 0-indexed
-        val futureResults = (0 to segmentCount - 1).map { segment =>
-          parallelScanner.scan[TestVersioned](
+        val futureResults = (0 until segmentCount).map { segment =>
+          parallelScanner.scan(
             segment = segment,
             totalSegments = segmentCount
           )
         }
 
-        whenReady(Future.sequence(futureResults)) { results =>
-          val actualRecords: List[TestVersioned] = results.flatten.toList
-            .map {
-              _.right.get
-            }
+        whenReady(Future.sequence(futureResults)) { actualRecords =>
           actualRecords should contain theSameElementsAs records
         }
       }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/fixtures/WorkerServiceFixture.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/fixtures/WorkerServiceFixture.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
 import uk.ac.wellcome.platform.reindex.reindex_worker.services.{
-  HybridRecordSender,
+  BulkSNSSender,
   RecordReader,
   ReindexWorkerService
 }
@@ -27,13 +27,13 @@ trait WorkerServiceFixture extends Akka with DynamoFixtures with SNS with SQS {
             )
 
             withSNSWriter(topic) { snsWriter =>
-              val hybridRecordSender = new HybridRecordSender(
+              val hybridRecordSender = new BulkSNSSender(
                 snsWriter = snsWriter
               )
 
               val workerService = new ReindexWorkerService(
                 recordReader = recordReader,
-                hybridRecordSender = hybridRecordSender,
+                bulkSNSSender = hybridRecordSender,
                 sqsStream = sqsStream
               )(actorSystem = actorSystem, ec = global)
 

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/BulkSNSSenderTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/BulkSNSSenderTest.scala
@@ -20,7 +20,9 @@ class BulkSNSSenderTest
     with IntegrationPatience
     with SNS {
 
-  val messages: List[String] = (1 to 3).map { _ => randomAlphanumeric(15) }.toList
+  val messages: List[String] = (1 to 3).map { _ =>
+    randomAlphanumeric(15)
+  }.toList
 
   it("sends messages for the provided IDs") {
     withLocalSnsTopic { topic =>
@@ -28,9 +30,9 @@ class BulkSNSSenderTest
         val future = bulkSNSSender.sendToSNS(messages = messages)
 
         whenReady(future) { _ =>
-          val actualRecords = listMessagesReceivedFromSNS(topic)
-            .map { _.message }
-            .distinct
+          val actualRecords = listMessagesReceivedFromSNS(topic).map {
+            _.message
+          }.distinct
 
           actualRecords should contain theSameElementsAs messages
         }
@@ -47,7 +49,8 @@ class BulkSNSSenderTest
     }
   }
 
-  private def withBulkSNSSender[R](topic: Topic)(testWith: TestWith[BulkSNSSender, R]): R =
+  private def withBulkSNSSender[R](topic: Topic)(
+    testWith: TestWith[BulkSNSSender, R]): R =
     withSNSWriter(topic) { snsWriter =>
       val bulkSNSSender = new BulkSNSSender(snsWriter = snsWriter)
       testWith(bulkSNSSender)

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/BulkSNSSenderTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/BulkSNSSenderTest.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.storage.vhs.HybridRecord
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class HybridRecordSenderTest
+class BulkSNSSenderTest
     extends FunSpec
     with Matchers
     with MockitoSugar
@@ -34,7 +34,7 @@ class HybridRecordSenderTest
   it("sends messages for the provided IDs") {
     withLocalSnsTopic { topic =>
       withSNSWriter(topic) { snsWriter =>
-        val hybridRecordSender = new HybridRecordSender(
+        val hybridRecordSender = new BulkSNSSender(
           snsWriter = snsWriter
         )
 
@@ -56,7 +56,7 @@ class HybridRecordSenderTest
 
   it("returns a failed Future[ReindexerException] if there's an SNS error") {
     withSNSWriter(Topic("no-such-topic")) { snsWriter =>
-      val hybridRecordSender = new HybridRecordSender(
+      val hybridRecordSender = new BulkSNSSender(
         snsWriter = snsWriter
       )
 

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/RecordReaderTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/RecordReaderTest.scala
@@ -4,6 +4,7 @@ import com.amazonaws.services.dynamodbv2.model._
 import com.gu.scanamo.Scanamo
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.reindex.reindex_worker.fixtures.{
   DynamoFixtures,
   ReindexableTable
@@ -49,7 +50,7 @@ class RecordReaderTest
 
         whenReady(reader.findRecordsForReindexing(reindexJob)) {
           actualRecords =>
-            actualRecords should contain theSameElementsAs records
+            actualRecords.map { fromJson[HybridRecord](_).get } should contain theSameElementsAs records
         }
       }
     }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/RecordReaderTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/RecordReaderTest.scala
@@ -17,8 +17,6 @@ import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.vhs.HybridRecord
 import uk.ac.wellcome.test.fixtures.TestWith
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 class RecordReaderTest
     extends FunSpec
     with ScalaFutures

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -62,12 +62,8 @@ class ReindexWorkerServiceTest
               eventually {
                 val actualRecords: Seq[HybridRecord] =
                   listMessagesReceivedFromSNS(topic)
-                    .map {
-                      _.message
-                    }
-                    .map {
-                      fromJson[HybridRecord](_).get
-                    }
+                    .map { _.message }
+                    .map { fromJson[HybridRecord](_).get }
                     .distinct
 
                 actualRecords shouldBe List(exampleRecord)


### PR DESCRIPTION
This is a required piece for #2984 – we can now put metadata in the VHS and have it be available to the downstream applications via the reindexer.

This returns a flat structure, i.e.

```json
{"id": "...", "location": "...", "version": "...", "miroMetadata: "..."}
```

Do we particular care about that vs nested results? (i.e. VHSEntry replicas)

Closes #2998.