### PR TITLE
“What do you mean, even smaller?”

### DIFF
--- a/catalogue_pipeline/terraform/pipelines/service/main.tf
+++ b/catalogue_pipeline/terraform/pipelines/service/main.tf
@@ -19,7 +19,7 @@ module "service" {
   ecs_cluster_name = "${var.cluster_name}"
 
   cpu    = 256
-  memory = 1024
+  memory = 512
 
   env_vars        = "${var.env_vars}"
   env_vars_length = "${var.env_vars_length}"

--- a/sierra_adapter/terraform/bib_merger/main.tf
+++ b/sierra_adapter/terraform/bib_merger/main.tf
@@ -22,7 +22,7 @@ module "sierra_merger_service" {
   ecs_cluster_name = "${var.cluster_name}"
 
   cpu    = 256
-  memory = 1024
+  memory = 512
 
   env_vars = {
     windows_queue_url = "${module.updates_queue.id}"

--- a/sierra_adapter/terraform/item_merger/main.tf
+++ b/sierra_adapter/terraform/item_merger/main.tf
@@ -22,7 +22,7 @@ module "sierra_merger_service" {
   ecs_cluster_name = "${var.cluster_name}"
 
   cpu    = 256
-  memory = 1024
+  memory = 512
 
   env_vars = {
     windows_queue_url   = "${module.updates_queue.id}"

--- a/sierra_adapter/terraform/items_to_dynamo/main.tf
+++ b/sierra_adapter/terraform/items_to_dynamo/main.tf
@@ -22,7 +22,7 @@ module "sierra_to_dynamo_service" {
   ecs_cluster_name = "${var.cluster_name}"
 
   cpu    = 256
-  memory = 1024
+  memory = 512
 
   env_vars = {
     demultiplexer_queue_url = "${module.demultiplexer_queue.id}"

--- a/sierra_adapter/terraform/sierra_reader/main.tf
+++ b/sierra_adapter/terraform/sierra_reader/main.tf
@@ -16,7 +16,7 @@ module "sierra_reader_service" {
   ]
 
   cpu    = 256
-  memory = 1024
+  memory = 512
 
   source_queue_name = "${module.windows_queue.name}"
   source_queue_arn  = "${module.windows_queue.arn}"


### PR DESCRIPTION
Despite turning down the memory assigned to each of our Scala apps, they're still wasting memory. I looked at the metrics, and they're barely using 30% of what we're giving them. WASTEFUL.

This turns them down another notch, although I think any more than this and we'll start having out-of-memory errors.