### PR TITLE
Don’t remove the iiif-image location on merged Miro/Sierra works

### DIFF
--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRule.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRule.scala
@@ -49,7 +49,6 @@ trait SierraMiroMerger extends Logging with MergerLogging {
         val mergedWork = sierraWork.copy(
           otherIdentifiers = mergeIdentifiers(sierraWork, miroWork),
           items = mergeItems(sierraItem, miroItem),
-
           // We always copy across the thumbnail from the Miro work, at least
           // for now -- it's never populated on Sierra, always populated in Miro.
           // Later we may use the iiif-presentation item location to populate
@@ -67,8 +66,9 @@ trait SierraMiroMerger extends Logging with MergerLogging {
     }
   }
 
-  private def mergeItems(sierraItem: MaybeDisplayable[Item],
-                         miroItem: Unidentifiable[Item]): List[MaybeDisplayable[Item]] = {
+  private def mergeItems(
+    sierraItem: MaybeDisplayable[Item],
+    miroItem: Unidentifiable[Item]): List[MaybeDisplayable[Item]] = {
 
     // We always use the locations from the Sierra and the Miro records.
     //

--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRule.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRule.scala
@@ -12,10 +12,9 @@ import uk.ac.wellcome.platform.merger.logging.MergerLogging
   *
   *   - We copy across all the identifiers from the Miro work (except
   *     those which contain Sierra identifiers)
-  *   - We copy across the Miro location to the Sierra work *if* the
-  *     Sierra work doesn't already have a digital location.
-  *     In this case, the Sierra digital location supersedes the one
-  *     from Miro.
+  *
+  *   - We combine the locations on the items, and use the Miro iiif-image
+  *     location for the thumbnail.
   *
   */
 object SierraMiroMergeRule extends SierraMiroMerger with SierraMiroPartitioner {

--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRule.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRule.scala
@@ -48,7 +48,13 @@ trait SierraMiroMerger extends Logging with MergerLogging {
 
         val mergedWork = sierraWork.copy(
           otherIdentifiers = mergeIdentifiers(sierraWork, miroWork),
-          items = mergeItems(sierraItem, miroItem)
+          items = mergeItems(sierraItem, miroItem),
+
+          // We always copy across the thumbnail from the Miro work, at least
+          // for now -- it's never populated on Sierra, always populated in Miro.
+          // Later we may use the iiif-presentation item location to populate
+          // this field, but right now it's empty on all Sierra works.
+          thumbnail = miroWork.thumbnail
         )
 
         Some(

--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRule.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRule.scala
@@ -62,23 +62,25 @@ trait SierraMiroMerger extends Logging with MergerLogging {
   }
 
   private def mergeItems(sierraItem: MaybeDisplayable[Item],
-                         miroItem: Unidentifiable[Item]) = {
-    val sierraDigitalLocations = sierraItem.agent.locations.collect {
-      case location: DigitalLocation => location
-    }
+                         miroItem: Unidentifiable[Item]): List[MaybeDisplayable[Item]] = {
 
-    val items = sierraDigitalLocations match {
-      case Nil =>
-        val agent: Item = sierraItem.agent.copy(
-          locations = sierraItem.agent.locations ++ miroItem.agent.locations
-        )
-        List(copyItem(sierraItem, agent))
-      case _ =>
-        debug(
-          s"Sierra work already has digital location $sierraDigitalLocations takes precedence over Miro location.")
-        List(sierraItem)
-    }
-    items
+    // We always use the locations from the Sierra and the Miro records.
+    //
+    // We may sometimes have digital locations from both records:
+    //
+    //   * a iiif-image location from Miro
+    //   * a iiif-presentation location from Sierra
+    //
+    // This is when an image has been through the digitisation workflow
+    // after it came from Sierra.  We may remove the iiif-image later
+    // (strictly speaking the -presentation replaces it), but we leave
+    // it for now, so the website can still use it.
+    val locations = sierraItem.agent.locations ++ miroItem.agent.locations
+
+    val agent: Item = sierraItem.agent.copy(
+      locations = locations
+    )
+    List(copyItem(sierraItem, agent))
   }
 
   /**

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRuleTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRuleTest.scala
@@ -81,6 +81,12 @@ class SierraMiroMergeRuleTest
           )
         ))
       }
+
+      it("copies across the thumbnail from the Miro work") {
+        miroWork.thumbnail.isDefined shouldBe true
+        mergedWork.thumbnail.isDefined shouldBe true
+        mergedWork.thumbnail shouldBe miroWork.thumbnail
+      }
     }
 
     describe("order: sierraWork, miroWork (order doesn't matter)") {

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRuleTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRuleTest.scala
@@ -71,10 +71,15 @@ class SierraMiroMergeRuleTest
           ))
       }
 
-      it("doesn't copy across the Miro location if the Sierra work already has a DigitalLocation") {
+      it("copies across the Miro location if the Sierra work already has a DigitalLocation") {
         val mergedWork = getMergedWork(sierraDigitalWork, miroWork)
 
-        mergedWork.items shouldBe sierraDigitalWork.items
+        mergedWork.items shouldBe List(sierraDigitalItem.copy(
+          agent = sierraDigitalItem.agent.copy(
+            locations =
+              sierraDigitalItem.agent.locations ++ miroWork.items.head.agent.locations
+          )
+        ))
       }
     }
 

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRuleTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRuleTest.scala
@@ -74,12 +74,13 @@ class SierraMiroMergeRuleTest
       it("copies across the Miro location if the Sierra work already has a DigitalLocation") {
         val mergedWork = getMergedWork(sierraDigitalWork, miroWork)
 
-        mergedWork.items shouldBe List(sierraDigitalItem.copy(
-          agent = sierraDigitalItem.agent.copy(
-            locations =
-              sierraDigitalItem.agent.locations ++ miroWork.items.head.agent.locations
-          )
-        ))
+        mergedWork.items shouldBe List(
+          sierraDigitalItem.copy(
+            agent = sierraDigitalItem.agent.copy(
+              locations =
+                sierraDigitalItem.agent.locations ++ miroWork.items.head.agent.locations
+            )
+          ))
       }
 
       it("copies across the thumbnail from the Miro work") {

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -54,6 +54,7 @@ class MergerTest extends FunSpec with WorksGenerators with Matchers {
 
     val expectedMergedWork = sierraPhysicalWork.copy(
       otherIdentifiers = sierraPhysicalWork.otherIdentifiers ++ miroWork.identifiers,
+      thumbnail = miroWork.thumbnail,
       items = List(
         sierraItem.copy(
           agent = sierraItem.agent.copy(
@@ -79,7 +80,15 @@ class MergerTest extends FunSpec with WorksGenerators with Matchers {
     result.size shouldBe 2
 
     val expectedMergedWork = sierraDigitalWork.copy(
-      otherIdentifiers = sierraDigitalWork.otherIdentifiers ++ miroWork.identifiers
+      otherIdentifiers = sierraDigitalWork.otherIdentifiers ++ miroWork.identifiers,
+      thumbnail = miroWork.thumbnail,
+      items = List(
+        sierraItem.copy(
+          agent = sierraItem.agent.copy(
+            locations = sierraItem.agent.locations ++ miroItem.agent.locations
+          )
+        )
+      )
     )
 
     val expectedRedirectedWork =
@@ -104,10 +113,11 @@ class MergerTest extends FunSpec with WorksGenerators with Matchers {
 
     val expectedMergedWork = sierraPhysicalWork.copy(
       otherIdentifiers = sierraPhysicalWork.otherIdentifiers ++ sierraDigitalWork.identifiers ++ miroWork.identifiers,
+      thumbnail = miroWork.thumbnail,
       items = List(
         sierraItem.copy(
           agent = sierraItem.agent.copy(
-            locations = sierraItem.agent.locations ++ digitalItem.agent.locations
+            locations = sierraItem.agent.locations ++ digitalItem.agent.locations ++ miroItem.agent.locations
           )
         )
       )

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -80,7 +80,7 @@ class MergerTest extends FunSpec with WorksGenerators with Matchers {
     result.size shouldBe 2
 
     val sierraItem =
-      sierraDigitalWork.items.head.asInstanceOf[Identifiable[Item]]
+      sierraDigitalWork.items.head.asInstanceOf[Unidentifiable[Item]]
     val miroItem = miroWork.items.head
 
     val expectedMergedWork = sierraDigitalWork.copy(

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -79,6 +79,10 @@ class MergerTest extends FunSpec with WorksGenerators with Matchers {
 
     result.size shouldBe 2
 
+    val sierraItem =
+      sierraDigitalWork.items.head.asInstanceOf[Identifiable[Item]]
+    val miroItem = miroWork.items.head
+
     val expectedMergedWork = sierraDigitalWork.copy(
       otherIdentifiers = sierraDigitalWork.otherIdentifiers ++ miroWork.identifiers,
       thumbnail = miroWork.thumbnail,
@@ -110,6 +114,7 @@ class MergerTest extends FunSpec with WorksGenerators with Matchers {
     val sierraItem =
       sierraPhysicalWork.items.head.asInstanceOf[Identifiable[Item]]
     val digitalItem = sierraDigitalWork.items.head
+    val miroItem = miroWork.items.head
 
     val expectedMergedWork = sierraPhysicalWork.copy(
       otherIdentifiers = sierraPhysicalWork.otherIdentifiers ++ sierraDigitalWork.identifiers ++ miroWork.identifiers,

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -74,6 +74,7 @@ trait WorksGenerators extends ItemsGenerators {
     description: Option[String] = None,
     lettering: Option[String] = None,
     workType: Option[WorkType] = None,
+    thumbnail: Option[Location] = None,
     contributors: List[Contributor[MaybeDisplayable[AbstractAgent]]] = List(),
     production: List[ProductionEvent[MaybeDisplayable[AbstractAgent]]] = List(),
     items: List[MaybeDisplayable[Item]] = List(),
@@ -93,7 +94,7 @@ trait WorksGenerators extends ItemsGenerators {
       subjects = List(),
       genres = List(),
       contributors = contributors,
-      thumbnail = None,
+      thumbnail = thumbnail,
       production = production,
       language = None,
       dimensions = None,
@@ -191,6 +192,11 @@ trait WorksGenerators extends ItemsGenerators {
     createUnidentifiedWorkWith(
       sourceIdentifier = createMiroSourceIdentifier,
       otherIdentifiers = otherIdentifiers,
+      thumbnail = Some(DigitalLocation(
+        url = "https://iiif.wellcomecollection.org/V01234.jpg",
+        locationType = LocationType("thumbnail-image"),
+        license = Some(License_CCBY)
+      )),
       items = List(
         createUnidentifiableItemWith(locations = List(
           createDigitalLocationWith(locationType = createImageLocationType))))

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -192,11 +192,12 @@ trait WorksGenerators extends ItemsGenerators {
     createUnidentifiedWorkWith(
       sourceIdentifier = createMiroSourceIdentifier,
       otherIdentifiers = otherIdentifiers,
-      thumbnail = Some(DigitalLocation(
-        url = "https://iiif.wellcomecollection.org/V01234.jpg",
-        locationType = LocationType("thumbnail-image"),
-        license = Some(License_CCBY)
-      )),
+      thumbnail = Some(
+        DigitalLocation(
+          url = "https://iiif.wellcomecollection.org/V01234.jpg",
+          locationType = LocationType("thumbnail-image"),
+          license = Some(License_CCBY)
+        )),
       items = List(
         createUnidentifiableItemWith(locations = List(
           createDigitalLocationWith(locationType = createImageLocationType))))


### PR DESCRIPTION
Code changes for #2994.