### PR TITLE
What if we didn't have to use Jackson to encode our display models as JSON?

### DIFF
--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
@@ -1,13 +1,10 @@
 package uk.ac.wellcome.display.json
 
-import io.circe.generic.extras.{AutoDerivation, Configuration}
+import io.circe.generic.extras.AutoDerivation
 import io.circe.{Encoder, Printer}
 import io.circe.syntax._
-import uk.ac.wellcome.display.models.v1.{
-  DisplayDigitalLocationV1,
-  DisplayLocationV1,
-  DisplayPhysicalLocationV1
-}
+import uk.ac.wellcome.display.models.DisplayWork
+import uk.ac.wellcome.display.models.v1._
 import uk.ac.wellcome.display.models.v2._
 
 /** Format JSON objects as suitable for display.
@@ -25,9 +22,10 @@ object DisplayJsonUtil extends AutoDerivation {
     dropNullValues = true
   )
 
-  implicit val customConfig: Configuration =
-    Configuration.default.withDefaults
-//      .withDiscriminator("type2")
+  def toJson[T](value: T)(implicit encoder: Encoder[T]): String = {
+    assert(encoder != null)
+    printer.pretty(value.asJson)
+  }
 
   // Circe wants to add a type discriminator, and we don't want it to!  Doing so
   // would expose internal names like "DisplayDigitalLocationV1" in the public JSON.
@@ -65,8 +63,8 @@ object DisplayJsonUtil extends AutoDerivation {
     case physicalLocation: DisplayPhysicalLocationV2 => physicalLocation.asJson
   }
 
-  def toJson[T](value: T)(implicit encoder: Encoder[T]): String = {
-    assert(encoder != null)
-    printer.pretty(value.asJson)
+  implicit val displayWorkEncoder: Encoder[DisplayWork] = {
+    case work: DisplayWorkV1 => work.asJson
+    case work: DisplayWorkV2 => work.asJson
   }
 }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
@@ -20,6 +20,9 @@ object DisplayJsonUtil extends AutoDerivation {
     dropNullValues = true
   )
 
+  implicit val customConfig: Configuration =
+    Configuration.default.withDefaults
+
   implicit val abstractRootConceptEncoder: Encoder[DisplayAbstractRootConcept] = {
     case agent: DisplayAbstractAgentV2 => agent.asJson
     case concept: DisplayAbstractConcept => concept.asJson

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.display.json
 import io.circe.generic.extras.{AutoDerivation, Configuration}
 import io.circe.{Encoder, Printer}
 import io.circe.syntax._
-import uk.ac.wellcome.display.models.v1.{DisplayDigitalLocationV1, DisplayLocationV1, DisplayPhysicalLocationV1}
+import uk.ac.wellcome.display.models.v1.{
+  DisplayDigitalLocationV1,
+  DisplayLocationV1,
+  DisplayPhysicalLocationV1
+}
 import uk.ac.wellcome.display.models.v2._
 
 /** Format JSON objects as suitable for display.
@@ -34,29 +38,30 @@ object DisplayJsonUtil extends AutoDerivation {
   // https://circe.github.io/circe/codecs/adt.html
 
   implicit val locationV1Encoder: Encoder[DisplayLocationV1] = {
-    case digitalLocation: DisplayDigitalLocationV1 => digitalLocation.asJson
+    case digitalLocation: DisplayDigitalLocationV1   => digitalLocation.asJson
     case physicalLocation: DisplayPhysicalLocationV1 => physicalLocation.asJson
   }
 
   implicit val abstractAgentEncoder: Encoder[DisplayAbstractAgentV2] = {
-    case agent: DisplayAgentV2 => agent.asJson
-    case person: DisplayPersonV2 => person.asJson
+    case agent: DisplayAgentV2               => agent.asJson
+    case person: DisplayPersonV2             => person.asJson
     case organisation: DisplayOrganisationV2 => organisation.asJson
   }
 
   implicit val abstractConceptEncoder: Encoder[DisplayAbstractConcept] = {
     case concept: DisplayConcept => concept.asJson
-    case place: DisplayPlace => place.asJson
-    case period: DisplayPeriod => period.asJson
+    case place: DisplayPlace     => place.asJson
+    case period: DisplayPeriod   => period.asJson
   }
 
-  implicit val abstractRootConceptEncoder: Encoder[DisplayAbstractRootConcept] = {
-    case agent: DisplayAbstractAgentV2 => agent.asJson
+  implicit val abstractRootConceptEncoder
+    : Encoder[DisplayAbstractRootConcept] = {
+    case agent: DisplayAbstractAgentV2   => agent.asJson
     case concept: DisplayAbstractConcept => concept.asJson
   }
 
   implicit val locationV2Encoder: Encoder[DisplayLocationV2] = {
-    case digitalLocation: DisplayDigitalLocationV2 => digitalLocation.asJson
+    case digitalLocation: DisplayDigitalLocationV2   => digitalLocation.asJson
     case physicalLocation: DisplayPhysicalLocationV2 => physicalLocation.asJson
   }
 

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
@@ -1,0 +1,27 @@
+package uk.ac.wellcome.display.json
+
+import io.circe.{Encoder, Printer}
+import io.circe.generic.extras.AutoDerivation
+import io.circe.syntax._
+
+/** Format JSON objects as suitable for display.
+  *
+  * This is different from `JsonUtil` for a couple of reasons:
+  *
+  *   - We enable autoderivation for a smaller number of types.  We should never
+  *     see `URL` or `UUID` in our display models, so we don't have encoders here.
+  *   - We omit null values, but display empty lists.  For internal apps, we always
+  *     render the complete value for disambiguation.
+  *
+  */
+object DisplayJsonUtil extends AutoDerivation {
+  private val printer = Printer.noSpaces.copy(
+    dropNullValues = true
+  )
+
+  def toJson[T](value: T)(implicit encoder: Encoder[T]): String = {
+    assert(encoder != null)
+
+    printer.pretty(value.asJson)
+  }
+}

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
@@ -23,21 +23,32 @@ object DisplayJsonUtil extends AutoDerivation {
 
   implicit val customConfig: Configuration =
     Configuration.default.withDefaults
-      .withDiscriminator("type")
+//      .withDiscriminator("type2")
 
   // Circe wants to add a type discriminator, and we don't want it to!  Doing so
   // would expose internal names like "DisplayDigitalLocationV1" in the public JSON.
   // So instead we have to do the slightly less nice thing of encoding all the subclasses
   // here by hand.  Annoying, it is.
+  //
+  // It is the "recommended: approach in the Circe docs:
+  // https://circe.github.io/circe/codecs/adt.html
 
   implicit val locationV1Encoder: Encoder[DisplayLocationV1] = {
     case digitalLocation: DisplayDigitalLocationV1 => digitalLocation.asJson
     case physicalLocation: DisplayPhysicalLocationV1 => physicalLocation.asJson
   }
 
+  implicit val abstractAgentEncoder: Encoder[DisplayAbstractAgentV2] = {
+    case agent: DisplayAgentV2 => agent.asJson
+    case person: DisplayPersonV2 => person.asJson
+    case organisation: DisplayOrganisationV2 => organisation.asJson
+  }
+
   implicit val abstractRootConceptEncoder: Encoder[DisplayAbstractRootConcept] = {
     case agent: DisplayAbstractAgentV2 => agent.asJson
-    case concept: DisplayAbstractConcept => concept.asJson
+    case concept: DisplayConcept => concept.asJson
+    case place: DisplayPlace => place.asJson
+    case period: DisplayPeriod => period.asJson
   }
 
   implicit val locationV2Encoder: Encoder[DisplayLocationV2] = {

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
@@ -20,10 +20,6 @@ object DisplayJsonUtil extends AutoDerivation {
     dropNullValues = true
   )
 
-  implicit val customConfig: Configuration =
-    Configuration.default.withDefaults
-      .withDiscriminator("type")
-
   implicit val abstractRootConceptEncoder: Encoder[DisplayAbstractRootConcept] = {
     case agent: DisplayAbstractAgentV2 => agent.asJson
     case concept: DisplayAbstractConcept => concept.asJson

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.display.json
 
-import io.circe.generic.extras.AutoDerivation
+import io.circe.generic.extras.{AutoDerivation, Configuration}
 import io.circe.{Encoder, Printer}
 import io.circe.syntax._
 import uk.ac.wellcome.display.models.DisplayWork
@@ -21,6 +21,9 @@ object DisplayJsonUtil extends AutoDerivation {
   private val printer = Printer.noSpaces.copy(
     dropNullValues = true
   )
+
+  implicit val customConfig: Configuration =
+    Configuration.default.withDefaults
 
   def toJson[T](value: T)(implicit encoder: Encoder[T]): String = {
     assert(encoder != null)

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
@@ -1,8 +1,9 @@
 package uk.ac.wellcome.display.json
 
 import io.circe.{Encoder, Printer}
-import io.circe.generic.extras.AutoDerivation
+import io.circe.generic.extras._
 import io.circe.syntax._
+import uk.ac.wellcome.display.models.v2._
 
 /** Format JSON objects as suitable for display.
   *
@@ -19,9 +20,22 @@ object DisplayJsonUtil extends AutoDerivation {
     dropNullValues = true
   )
 
+  implicit val customConfig: Configuration =
+    Configuration.default.withDefaults
+      .withDiscriminator("type")
+
+  implicit val abstractRootConceptEncoder: Encoder[DisplayAbstractRootConcept] = {
+    case agent: DisplayAbstractAgentV2 => agent.asJson
+    case concept: DisplayAbstractConcept => concept.asJson
+  }
+
+  implicit val digitalLocationEncoder: Encoder[DisplayLocationV2] = {
+    case digitalLocation: DisplayDigitalLocationV2 => digitalLocation.asJson
+    case physicalLocation: DisplayPhysicalLocationV2 => physicalLocation.asJson
+  }
+
   def toJson[T](value: T)(implicit encoder: Encoder[T]): String = {
     assert(encoder != null)
-
     printer.pretty(value.asJson)
   }
 }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonUtil.scala
@@ -44,11 +44,15 @@ object DisplayJsonUtil extends AutoDerivation {
     case organisation: DisplayOrganisationV2 => organisation.asJson
   }
 
-  implicit val abstractRootConceptEncoder: Encoder[DisplayAbstractRootConcept] = {
-    case agent: DisplayAbstractAgentV2 => agent.asJson
+  implicit val abstractConceptEncoder: Encoder[DisplayAbstractConcept] = {
     case concept: DisplayConcept => concept.asJson
     case place: DisplayPlace => place.asJson
     case period: DisplayPeriod => period.asJson
+  }
+
+  implicit val abstractRootConceptEncoder: Encoder[DisplayAbstractRootConcept] = {
+    case agent: DisplayAbstractAgentV2 => agent.asJson
+    case concept: DisplayAbstractConcept => concept.asJson
   }
 
   implicit val locationV2Encoder: Encoder[DisplayLocationV2] = {

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLanguage.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLanguage.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal.Language
 
@@ -15,11 +16,10 @@ case class DisplayLanguage(
   ) id: String,
   @ApiModelProperty(
     value = "The name of a language"
-  ) label: String
-) {
+  ) label: String,
   @ApiModelProperty(readOnly = true, value = "A type of thing")
-  @JsonProperty("type") val ontologyType: String = "Language"
-}
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Language"
+)
 
 case object DisplayLanguage {
   def apply(language: Language): DisplayLanguage = DisplayLanguage(

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWorkType.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWorkType.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal.WorkType
 
@@ -15,10 +16,9 @@ case class DisplayWorkType(
   ) id: String,
   @ApiModelProperty(
     dataType = "String"
-  ) label: String
-) {
-  @JsonProperty("type") val ontologyType: String = "WorkType"
-}
+  ) label: String,
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "WorkType"
+)
 
 case object DisplayWorkType {
   def apply(workType: WorkType): DisplayWorkType = DisplayWorkType(

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayAgentV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayAgentV1.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal._
 
@@ -21,7 +22,7 @@ case class DisplayAgentV1(
   @ApiModelProperty(
     value = "The name of the agent"
   ) label: String,
-  @JsonProperty("type") ontologyType: String = "Agent"
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Agent"
 )
 
 case object DisplayAgentV1 {

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayConceptV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayConceptV1.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal._
 
@@ -11,10 +12,9 @@ import uk.ac.wellcome.models.work.internal._
 case class DisplayConceptV1(
   @ApiModelProperty(
     dataType = "String"
-  ) label: String
-) {
-  @JsonProperty("type") val ontologyType: String = "Concept"
-}
+  ) label: String,
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Concept"
+)
 
 case object DisplayConceptV1 {
   def apply(concept: Displayable[AbstractRootConcept]): DisplayConceptV1 = {

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayIdentifierV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayIdentifierV1.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal.SourceIdentifier
 
@@ -12,10 +13,10 @@ import uk.ac.wellcome.models.work.internal.SourceIdentifier
 case class DisplayIdentifierV1(
   @ApiModelProperty(value =
     "Relates a Identifier to a particular authoritative source identifier scheme: for example, if the identifier is MS.49 this property might indicate that this identifier has its origins in the Wellcome Library's CALM archive management system.") identifierScheme: String,
-  @ApiModelProperty(value = "The value of the thing. e.g. an identifier") value: String) {
+  @ApiModelProperty(value = "The value of the thing. e.g. an identifier") value: String,
   @ApiModelProperty(readOnly = true, value = "A type of thing")
-  @JsonProperty("type") val ontologyType: String = "Identifier"
-}
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Identifier"
+)
 
 object DisplayIdentifierV1 {
   def apply(sourceIdentifier: SourceIdentifier): DisplayIdentifierV1 =

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayItemV1.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal._
 
@@ -20,11 +21,10 @@ case class DisplayItemV1(
   ) identifiers: Option[List[DisplayIdentifierV1]] = None,
   @ApiModelProperty(
     value = "List of locations that provide access to the item"
-  ) locations: List[DisplayLocationV1] = List()
-) {
+  ) locations: List[DisplayLocationV1] = List(),
   @ApiModelProperty(readOnly = true, value = "A type of thing")
-  @JsonProperty("type") val ontologyType: String = "Item"
-}
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Item"
+)
 
 object DisplayItemV1 {
   def apply(item: Identified[Item],

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal.License
 
@@ -20,11 +21,10 @@ case class DisplayLicenseV1(
   ) label: String,
   @ApiModelProperty(
     value = "URL to the full text of a license"
-  ) url: String
-) {
+  ) url: String,
   @ApiModelProperty(readOnly = true, value = "A type of thing")
-  @JsonProperty("type") val ontologyType: String = "License"
-}
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "License"
+)
 
 case object DisplayLicenseV1 {
   def apply(license: License): DisplayLicenseV1 = DisplayLicenseV1(

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLocationV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLocationV1.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.display.models.v1
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.work.internal.{DigitalLocation, Location, PhysicalLocation}
+import uk.ac.wellcome.models.work.internal.{
+  DigitalLocation,
+  Location,
+  PhysicalLocation
+}
 
 @ApiModel(
   value = "Location",
@@ -51,7 +55,8 @@ case class DisplayDigitalLocationV1(
       "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
   ) license: Option[DisplayLicenseV1] = None,
   @ApiModelProperty(readOnly = true, value = "A type of thing")
-  @JsonProperty("type") @JsonKey("type") ontologyType: String = "DigitalLocation"
+  @JsonProperty("type") @JsonKey("type") ontologyType: String =
+    "DigitalLocation"
 ) extends DisplayLocationV1
 
 @ApiModel(
@@ -68,5 +73,6 @@ case class DisplayPhysicalLocationV1(
     value = "The title or other short name of the location."
   ) label: String,
   @ApiModelProperty(readOnly = true, value = "A type of thing")
-  @JsonProperty("type") @JsonKey("type") ontologyType: String = "PhysicalLocation"
+  @JsonProperty("type") @JsonKey("type") ontologyType: String =
+    "PhysicalLocation"
 ) extends DisplayLocationV1

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLocationV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLocationV1.scala
@@ -1,12 +1,9 @@
 package uk.ac.wellcome.display.models.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.work.internal.{
-  DigitalLocation,
-  Location,
-  PhysicalLocation
-}
+import uk.ac.wellcome.models.work.internal.{DigitalLocation, Location, PhysicalLocation}
 
 @ApiModel(
   value = "Location",
@@ -52,11 +49,10 @@ case class DisplayDigitalLocationV1(
   @ApiModelProperty(
     value =
       "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
-  ) license: Option[DisplayLicenseV1] = None
-) extends DisplayLocationV1 {
+  ) license: Option[DisplayLicenseV1] = None,
   @ApiModelProperty(readOnly = true, value = "A type of thing")
-  @JsonProperty("type") val ontologyType: String = "DigitalLocation"
-}
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "DigitalLocation"
+) extends DisplayLocationV1
 
 @ApiModel(
   value = "PhysicalLocation",
@@ -70,8 +66,7 @@ case class DisplayPhysicalLocationV1(
   @ApiModelProperty(
     dataType = "String",
     value = "The title or other short name of the location."
-  ) label: String
-) extends DisplayLocationV1 {
+  ) label: String,
   @ApiModelProperty(readOnly = true, value = "A type of thing")
-  @JsonProperty("type") val ontologyType: String = "PhysicalLocation"
-}
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "PhysicalLocation"
+) extends DisplayLocationV1

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayPeriodV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayPeriodV1.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal.Period
 
@@ -11,10 +12,9 @@ import uk.ac.wellcome.models.work.internal.Period
 case class DisplayPeriodV1(
   @ApiModelProperty(
     dataType = "String"
-  ) label: String
-) {
-  @JsonProperty("type") val ontologyType: String = "Period"
-}
+  ) label: String,
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Period"
+)
 
 case object DisplayPeriodV1 {
   def apply(period: Period): DisplayPeriodV1 = DisplayPeriodV1(

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayPlaceV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayPlaceV1.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal.Place
 
@@ -11,10 +12,9 @@ import uk.ac.wellcome.models.work.internal.Place
 case class DisplayPlaceV1(
   @ApiModelProperty(
     dataType = "String"
-  ) label: String
-) {
-  @JsonProperty("type") val ontologyType: String = "Place"
-}
+  ) label: String,
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Place"
+)
 
 case object DisplayPlaceV1 {
   def apply(place: Place): DisplayPlaceV1 = DisplayPlaceV1(

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
@@ -4,7 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.display.models._
-import uk.ac.wellcome.models.work.internal.{AbstractAgent, Contributor, Displayable, IdentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  AbstractAgent,
+  Contributor,
+  Displayable,
+  IdentifiedWork
+}
 
 @ApiModel(
   value = "Work",

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
@@ -93,7 +93,7 @@ case class DisplayWorkV1(
     value =
       "A broad, top-level description of the form of a work: namely, whether it is a printed book, archive, painting, photograph, moving image, etc."
   )
-  @JsonKey("type") @JsonProperty("type") ontologyType: String = "Work"
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Work"
 ) extends DisplayWork
 
 case object DisplayWorkV1 {

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1.scala
@@ -1,14 +1,10 @@
 package uk.ac.wellcome.display.models.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.display.models._
-import uk.ac.wellcome.models.work.internal.{
-  AbstractAgent,
-  Contributor,
-  Displayable,
-  IdentifiedWork
-}
+import uk.ac.wellcome.models.work.internal.{AbstractAgent, Contributor, Displayable, IdentifiedWork}
 
 @ApiModel(
   value = "Work",
@@ -91,15 +87,14 @@ case class DisplayWorkV1(
   ) language: Option[DisplayLanguage] = None,
   @ApiModelProperty(
     dataType = "String"
-  ) dimensions: Option[String] = None
-) extends DisplayWork {
+  ) dimensions: Option[String] = None,
   @ApiModelProperty(
     readOnly = true,
     value =
       "A broad, top-level description of the form of a work: namely, whether it is a printed book, archive, painting, photograph, moving image, etc."
   )
-  @JsonProperty("type") val ontologyType: String = "Work"
-}
+  @JsonKey("type") @JsonProperty("type") ontologyType: String = "Work"
+) extends DisplayWork
 
 case object DisplayWorkV1 {
   def apply(work: IdentifiedWork, includes: V1WorksIncludes): DisplayWorkV1 = {

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractAgentV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractAgentV2.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal._
 
@@ -18,7 +19,7 @@ case class DisplayAgentV2(
   @ApiModelProperty(
     value = "The name of the agent"
   ) label: String,
-  @JsonProperty("type") ontologyType: String = "Agent"
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Agent"
 ) extends DisplayAbstractAgentV2
 
 case object DisplayAbstractAgentV2 {
@@ -114,7 +115,7 @@ case class DisplayPersonV2(
     dataType = "String",
     value = "The numeration of the person"
   ) numeration: Option[String] = None,
-  @JsonProperty("type") ontologyType: String = "Person")
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Person")
     extends DisplayAbstractAgentV2
 
 @ApiModel(
@@ -133,5 +134,5 @@ case class DisplayOrganisationV2(
   @ApiModelProperty(
     value = "The name of the organisation"
   ) label: String,
-  @JsonProperty("type") ontologyType: String = "Organisation")
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Organisation")
     extends DisplayAbstractAgentV2

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal._
 
@@ -116,10 +117,10 @@ case class DisplayPeriod(
   ) identifiers: Option[List[DisplayIdentifierV2]] = None,
   @ApiModelProperty(
     dataType = "String"
-  ) label: String
-) extends DisplayAbstractConcept {
-  @JsonProperty("type") val ontologyType: String = "Period"
-}
+  ) label: String,
+  @JsonProperty("type") @JsonKey("type") val ontologyType: String = "Period"
+) extends DisplayAbstractConcept
+
 case object DisplayPeriod {
   def apply(period: Period): DisplayPeriod = DisplayPeriod(
     label = period.label
@@ -142,10 +143,10 @@ case class DisplayPlace(
   ) identifiers: Option[List[DisplayIdentifierV2]] = None,
   @ApiModelProperty(
     dataType = "String"
-  ) label: String
-) extends DisplayAbstractConcept {
-  @JsonProperty("type") val ontologyType: String = "Place"
-}
+  ) label: String,
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Place"
+) extends DisplayAbstractConcept
+
 case object DisplayPlace {
   def apply(place: Place): DisplayPlace = DisplayPlace(
     label = place.label

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConcept.scala
@@ -96,10 +96,9 @@ case class DisplayConcept(
   ) identifiers: Option[List[DisplayIdentifierV2]] = None,
   @ApiModelProperty(
     dataType = "String"
-  ) label: String
-) extends DisplayAbstractConcept {
-  @JsonProperty("type") val ontologyType: String = "Concept"
-}
+  ) label: String,
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Concept"
+) extends DisplayAbstractConcept
 
 @ApiModel(
   value = "Period",
@@ -118,7 +117,7 @@ case class DisplayPeriod(
   @ApiModelProperty(
     dataType = "String"
   ) label: String,
-  @JsonProperty("type") @JsonKey("type") val ontologyType: String = "Period"
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Period"
 ) extends DisplayAbstractConcept
 
 case object DisplayPeriod {

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayContributionRole.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayContributionRole.scala
@@ -13,7 +13,8 @@ case class DisplayContributionRole(
   @ApiModelProperty(
     value = "The name of the agent"
   ) label: String,
-  @JsonProperty("type") @JsonKey("type") ontologyType: String = "ContributionRole"
+  @JsonProperty("type") @JsonKey("type") ontologyType: String =
+    "ContributionRole"
 )
 
 object DisplayContributionRole {

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayContributionRole.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayContributionRole.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal.ContributionRole
 
@@ -12,7 +13,7 @@ case class DisplayContributionRole(
   @ApiModelProperty(
     value = "The name of the agent"
   ) label: String,
-  @JsonProperty("type") ontologyType: String = "ContributionRole"
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "ContributionRole"
 )
 
 object DisplayContributionRole {

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayContributor.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayContributor.scala
@@ -1,12 +1,9 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.work.internal.{
-  AbstractAgent,
-  Contributor,
-  Displayable
-}
+import uk.ac.wellcome.models.work.internal.{AbstractAgent, Contributor, Displayable}
 
 @ApiModel(
   value = "Contributor",
@@ -16,7 +13,7 @@ case class DisplayContributor(
   @ApiModelProperty(value = "The agent.") agent: DisplayAbstractAgentV2,
   @ApiModelProperty(value = "The list of contribution roles.") roles: List[
     DisplayContributionRole],
-  @JsonProperty("type") ontologyType: String = "Contributor"
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Contributor"
 )
 
 object DisplayContributor {

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayContributor.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayContributor.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.display.models.v2
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.work.internal.{AbstractAgent, Contributor, Displayable}
+import uk.ac.wellcome.models.work.internal.{
+  AbstractAgent,
+  Contributor,
+  Displayable
+}
 
 @ApiModel(
   value = "Contributor",

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayGenre.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayGenre.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal.{AbstractConcept, Displayable, Genre}
 
@@ -12,7 +13,8 @@ case class DisplayGenre(
   @ApiModelProperty(value = "A label given to a thing.") label: String,
   @ApiModelProperty(value = "Relates a genre to a list of concepts.") concepts: List[
     DisplayAbstractConcept],
-  @JsonProperty("type") ontologyType: String = "Genre")
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Genre"
+)
 
 object DisplayGenre {
   def apply(genre: Genre[Displayable[AbstractConcept]],

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayIdentifierType.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayIdentifierType.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal.IdentifierType
 
@@ -9,10 +10,9 @@ import uk.ac.wellcome.models.work.internal.IdentifierType
 )
 case class DisplayIdentifierType(
   @ApiModelProperty id: String,
-  @ApiModelProperty label: String
-) {
-  @JsonProperty("type") val ontologyType: String = "IdentifierType"
-}
+  @ApiModelProperty label: String,
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "IdentifierType"
+)
 
 object DisplayIdentifierType {
   def apply(identifierType: IdentifierType): DisplayIdentifierType =

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayIdentifierV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayIdentifierV2.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal.SourceIdentifier
 
@@ -12,10 +13,10 @@ import uk.ac.wellcome.models.work.internal.SourceIdentifier
 case class DisplayIdentifierV2(
   @ApiModelProperty(value =
     "Relates a Identifier to a particular authoritative source identifier scheme: for example, if the identifier is MS.49 this property might indicate that this identifier has its origins in the Wellcome Library's CALM archive management system.") identifierType: DisplayIdentifierType,
-  @ApiModelProperty(value = "The value of the thing. e.g. an identifier") value: String) {
+  @ApiModelProperty(value = "The value of the thing. e.g. an identifier") value: String,
   @ApiModelProperty(readOnly = true, value = "A type of thing")
-  @JsonProperty("type") val ontologyType: String = "Identifier"
-}
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Identifier"
+)
 
 object DisplayIdentifierV2 {
   def apply(sourceIdentifier: SourceIdentifier): DisplayIdentifierV2 =

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal._
 
@@ -20,11 +21,10 @@ case class DisplayItemV2(
   ) identifiers: Option[List[DisplayIdentifierV2]] = None,
   @ApiModelProperty(
     value = "List of locations that provide access to the item"
-  ) locations: List[DisplayLocationV2] = List()
-) {
+  ) locations: List[DisplayLocationV2] = List(),
   @ApiModelProperty(readOnly = true, value = "A type of thing")
-  @JsonProperty("type") val ontologyType: String = "Item"
-}
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Item"
+)
 
 object DisplayItemV2 {
   def apply(item: Displayable[Item],

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLicenseV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLicenseV2.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal.License
 
@@ -20,11 +21,10 @@ case class DisplayLicenseV2(
   ) label: String,
   @ApiModelProperty(
     value = "URL to the full text of a license"
-  ) url: String
-) {
+  ) url: String,
   @ApiModelProperty(readOnly = true, value = "A type of thing")
-  @JsonProperty("type") val ontologyType: String = "License"
-}
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "License"
+)
 
 case object DisplayLicenseV2 {
   def apply(license: License): DisplayLicenseV2 = DisplayLicenseV2(

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLocationType.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLocationType.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal.LocationType
 
@@ -9,10 +10,9 @@ import uk.ac.wellcome.models.work.internal.LocationType
 )
 case class DisplayLocationType(
   @ApiModelProperty id: String,
-  @ApiModelProperty label: String
-) {
-  @JsonProperty("type") val ontologyType: String = "LocationType"
-}
+  @ApiModelProperty label: String,
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "LocationType"
+)
 
 object DisplayLocationType {
   def apply(locationType: LocationType): DisplayLocationType =

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLocationV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLocationV2.scala
@@ -1,12 +1,9 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.work.internal.{
-  DigitalLocation,
-  Location,
-  PhysicalLocation
-}
+import uk.ac.wellcome.models.work.internal.{DigitalLocation, Location, PhysicalLocation}
 
 @ApiModel(
   value = "Location",
@@ -52,11 +49,10 @@ case class DisplayDigitalLocationV2(
   @ApiModelProperty(
     value =
       "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
-  ) license: Option[DisplayLicenseV2] = None
-) extends DisplayLocationV2 {
+  ) license: Option[DisplayLicenseV2] = None,
   @ApiModelProperty(readOnly = true, value = "A type of thing")
-  @JsonProperty("type") val ontologyType: String = "DigitalLocation"
-}
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "DigitalLocation"
+) extends DisplayLocationV2
 
 @ApiModel(
   value = "PhysicalLocation",
@@ -70,8 +66,7 @@ case class DisplayPhysicalLocationV2(
   @ApiModelProperty(
     dataType = "String",
     value = "The title or other short name of the location."
-  ) label: String
-) extends DisplayLocationV2 {
+  ) label: String,
   @ApiModelProperty(readOnly = true, value = "A type of thing")
-  @JsonProperty("type") val ontologyType: String = "PhysicalLocation"
-}
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "PhysicalLocation"
+) extends DisplayLocationV2

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLocationV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLocationV2.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.display.models.v2
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.work.internal.{DigitalLocation, Location, PhysicalLocation}
+import uk.ac.wellcome.models.work.internal.{
+  DigitalLocation,
+  Location,
+  PhysicalLocation
+}
 
 @ApiModel(
   value = "Location",
@@ -51,7 +55,8 @@ case class DisplayDigitalLocationV2(
       "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
   ) license: Option[DisplayLicenseV2] = None,
   @ApiModelProperty(readOnly = true, value = "A type of thing")
-  @JsonProperty("type") @JsonKey("type") ontologyType: String = "DigitalLocation"
+  @JsonProperty("type") @JsonKey("type") ontologyType: String =
+    "DigitalLocation"
 ) extends DisplayLocationV2
 
 @ApiModel(
@@ -68,5 +73,6 @@ case class DisplayPhysicalLocationV2(
     value = "The title or other short name of the location."
   ) label: String,
   @ApiModelProperty(readOnly = true, value = "A type of thing")
-  @JsonProperty("type") @JsonKey("type") ontologyType: String = "PhysicalLocation"
+  @JsonProperty("type") @JsonKey("type") ontologyType: String =
+    "PhysicalLocation"
 ) extends DisplayLocationV2

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayProductionEvent.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayProductionEvent.scala
@@ -17,7 +17,8 @@ case class DisplayProductionEvent(
   @ApiModelProperty(
     dataType = "uk.ac.wellcome.display.models.v2.DisplayAbstractConcept"
   ) function: Option[DisplayAbstractConcept],
-  @JsonProperty("type") @JsonKey("type") ontologyType: String = "ProductionEvent"
+  @JsonProperty("type") @JsonKey("type") ontologyType: String =
+    "ProductionEvent"
 )
 
 object DisplayProductionEvent {

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayProductionEvent.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayProductionEvent.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.models.work.internal._
 
@@ -15,9 +16,9 @@ case class DisplayProductionEvent(
   @ApiModelProperty dates: List[DisplayPeriod],
   @ApiModelProperty(
     dataType = "uk.ac.wellcome.display.models.v2.DisplayAbstractConcept"
-  ) function: Option[DisplayAbstractConcept]) {
-  @JsonProperty("type") val ontologyType: String = "ProductionEvent"
-}
+  ) function: Option[DisplayAbstractConcept],
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "ProductionEvent"
+)
 
 object DisplayProductionEvent {
   def apply(productionEvent: ProductionEvent[Displayable[AbstractAgent]],

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplaySubject.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplaySubject.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.display.models.v2
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.work.internal.{AbstractRootConcept, Displayable, Subject}
+import uk.ac.wellcome.models.work.internal.{
+  AbstractRootConcept,
+  Displayable,
+  Subject
+}
 
 @ApiModel(
   value = "Subject",

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplaySubject.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplaySubject.scala
@@ -1,12 +1,9 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import uk.ac.wellcome.models.work.internal.{
-  AbstractRootConcept,
-  Displayable,
-  Subject
-}
+import uk.ac.wellcome.models.work.internal.{AbstractRootConcept, Displayable, Subject}
 
 @ApiModel(
   value = "Subject",
@@ -16,7 +13,8 @@ case class DisplaySubject(
   @ApiModelProperty(value = "A label given to a thing.") label: String,
   @ApiModelProperty(value = "Relates a subject to a list of concepts.") concepts: List[
     DisplayAbstractRootConcept],
-  @JsonProperty("type") ontologyType: String = "Subject")
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Subject"
+)
 
 object DisplaySubject {
   def apply(subject: Subject[Displayable[AbstractRootConcept]],

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
@@ -78,15 +79,14 @@ case class DisplayWorkV2(
   ) language: Option[DisplayLanguage] = None,
   @ApiModelProperty(
     dataType = "String"
-  ) dimensions: Option[String] = None
-) extends DisplayWork {
+  ) dimensions: Option[String] = None,
   @ApiModelProperty(
     readOnly = true,
     value =
       "A broad, top-level description of the form of a work: namely, whether it is a printed book, archive, painting, photograph, moving image, etc."
   )
-  @JsonProperty("type") val ontologyType: String = "Work"
-}
+  @JsonKey("type") @JsonProperty("type") ontologyType: String = "Work"
+) extends DisplayWork
 
 case object DisplayWorkV2 {
 

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
@@ -85,7 +85,7 @@ case class DisplayWorkV2(
     value =
       "A broad, top-level description of the form of a work: namely, whether it is a printed book, archive, painting, photograph, moving image, etc."
   )
-  @JsonKey("type") @JsonProperty("type") ontologyType: String = "Work"
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Work"
 ) extends DisplayWork
 
 case object DisplayWorkV2 {

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/json/DisplayJsonUtilTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/json/DisplayJsonUtilTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.display.json
 
+import io.circe.generic.auto._
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.json.utils.JsonAssertions
 
 class DisplayJsonUtilTest extends FunSpec with Matchers with JsonAssertions {

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/json/DisplayJsonUtilTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/json/DisplayJsonUtilTest.scala
@@ -23,7 +23,7 @@ class DisplayJsonUtilTest extends FunSpec with Matchers with JsonAssertions {
     val triangle = Shape(name = "triangle", colours = None, sides = 3)
     assertJsonStringsAreEqual(
       DisplayJsonUtil.toJson(triangle),
-      """{"name":"triangle", "colours": [], "sides": 3}"""
+      """{"name":"triangle", "sides": 3}"""
     )
   }
 }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/json/DisplayJsonUtilTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/json/DisplayJsonUtilTest.scala
@@ -1,0 +1,29 @@
+package uk.ac.wellcome.display.json
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.display.json.DisplayJsonUtil._
+import uk.ac.wellcome.json.utils.JsonAssertions
+
+class DisplayJsonUtilTest extends FunSpec with Matchers with JsonAssertions {
+  case class Shape(
+    name: String,
+    colours: Option[List[String]],
+    sides: Int
+  )
+
+  it("includes empty lists") {
+    val square = Shape(name = "square", colours = Some(List()), sides = 4)
+    assertJsonStringsAreEqual(
+      DisplayJsonUtil.toJson(square),
+      """{"name":"square", "colours": [], "sides": 4}"""
+    )
+  }
+
+  it("omits null values") {
+    val triangle = Shape(name = "triangle", colours = None, sides = 3)
+    assertJsonStringsAreEqual(
+      DisplayJsonUtil.toJson(triangle),
+      """{"name":"triangle", "colours": [], "sides": 3}"""
+    )
+  }
+}

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.display.models.v1
 
-import io.circe.generic.auto._
 import org.scalatest.FunSpec
+import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayCreatorsV1SerialisationTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.display.models.v1
 
+import io.circe.generic.auto._
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.generators.WorksGenerators

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.display.models.v1
 
-import io.circe.generic.auto._
 import org.scalatest.{Assertion, FunSpec}
+import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.display.models.V1WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.generators.WorksGenerators

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLocationsV1SerialisationTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.display.models.v1
 
+import io.circe.generic.auto._
 import org.scalatest.{Assertion, FunSpec}
 import uk.ac.wellcome.display.models.V1WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.display.models.v1
 
-import io.circe.generic.auto._
 import org.scalatest.FunSpec
+import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.display.models.V1WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.generators.WorksGenerators

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.display.models.v1
 
+import io.circe.generic.auto._
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.V1WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
-import io.circe.generic.auto._
 import org.scalatest.FunSpec
+import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.models.work.internal._

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayAbstractConceptSerialisationTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.display.models.v2
 
+import io.circe.generic.auto._
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
-import io.circe.generic.auto._
 import org.scalatest.FunSpec
+import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.models.work.internal._

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayGenreV2SerialisationTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.display.models.v2
 
+import io.circe.generic.auto._
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationsV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationsV2SerialisationTest.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.{Assertion, FunSpec}
+import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.display.models.V2WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.generators.WorksGenerators

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
+import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.models.work.internal._

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.FunSpec
+import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.display.models.V2WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.generators.WorksGenerators

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/test/util/JsonMapperTestUtil.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/test/util/JsonMapperTestUtil.scala
@@ -14,14 +14,11 @@ trait JsonMapperTestUtil extends JsonAssertions {
   private val objectMapper: ObjectMapper =
     injector.getInstance(classOf[ObjectMapper])
 
-  def assertObjectMapsToJson[T](
-    value: T,
-    expectedJson: String)(implicit encoder: Encoder[T]): Assertion = {
+  def assertObjectMapsToJson[T](value: T, expectedJson: String)(
+    implicit encoder: Encoder[T]): Assertion = {
 
     // First test it with Circe...
-    assertJsonStringsAreEqual(
-      DisplayJsonUtil.toJson(value),
-      expectedJson)
+    assertJsonStringsAreEqual(DisplayJsonUtil.toJson(value), expectedJson)
 
     // ...and then with Jackson
     assertJsonStringsAreEqual(

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/test/util/JsonMapperTestUtil.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/test/util/JsonMapperTestUtil.scala
@@ -1,15 +1,31 @@
 package uk.ac.wellcome.display.test.util
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.inject.{Guice, Injector}
 import io.circe.Encoder
 import org.scalatest.Assertion
 import uk.ac.wellcome.display.json.DisplayJsonUtil
+import uk.ac.wellcome.display.modules.DisplayJacksonModule
 import uk.ac.wellcome.json.utils.JsonAssertions
 
 trait JsonMapperTestUtil extends JsonAssertions {
+
+  private val injector: Injector = Guice.createInjector(DisplayJacksonModule)
+  private val objectMapper: ObjectMapper =
+    injector.getInstance(classOf[ObjectMapper])
+
   def assertObjectMapsToJson[T](
     value: T,
-    expectedJson: String)(implicit encoder: Encoder[T]): Assertion =
+    expectedJson: String)(implicit encoder: Encoder[T]): Assertion = {
+
+    // First test it with Circe...
     assertJsonStringsAreEqual(
       DisplayJsonUtil.toJson(value),
       expectedJson)
+
+    // ...and then with Jackson
+    assertJsonStringsAreEqual(
+      objectMapper.writeValueAsString(value),
+      expectedJson)
+  }
 }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/test/util/JsonMapperTestUtil.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/test/util/JsonMapperTestUtil.scala
@@ -1,20 +1,15 @@
 package uk.ac.wellcome.display.test.util
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.google.inject.{Guice, Injector}
+import io.circe.Encoder
 import org.scalatest.Assertion
-import uk.ac.wellcome.display.modules.DisplayJacksonModule
+import uk.ac.wellcome.display.json.DisplayJsonUtil
 import uk.ac.wellcome.json.utils.JsonAssertions
 
 trait JsonMapperTestUtil extends JsonAssertions {
-
-  private val injector: Injector = Guice.createInjector(DisplayJacksonModule)
-  private val objectMapper: ObjectMapper =
-    injector.getInstance(classOf[ObjectMapper])
-
-  def assertObjectMapsToJson(displayObject: Any,
-                             expectedJson: String): Assertion =
+  def assertObjectMapsToJson[T](
+    value: T,
+    expectedJson: String)(implicit encoder: Encoder[T]): Assertion =
     assertJsonStringsAreEqual(
-      objectMapper.writeValueAsString(displayObject),
+      DisplayJsonUtil.toJson(value),
       expectedJson)
 }


### PR DESCRIPTION
The Jackson ObjectMapper is one of the moderately fiddly bits left that’s tying us to Guice and Finatra. It’s also a bit odd – why do we use Circe everywhere else, then defer to Jackson at the last moment.

What if we didn’t?

This patch adds the necessary pieces to encode display models using Circe, and adds appropriate tests to the display library. If and when I get it passing, we should have two encoders that produce identical output.

Actually using this is left for after I’m back from holiday, unless somebody has a burning desire to do it while I’m away.