### PR TITLE
Fix storage-api security groups

### DIFF
--- a/archive/terraform/main.tf
+++ b/archive/terraform/main.tf
@@ -178,7 +178,7 @@ module "migrator" {
 
   environment_variables = {
     # Private DNS
-    INGEST_API_URL = "http://progress_http.archive-storage:9001/progress"
+    INGEST_API_URL = "http://storage-api-ingests.archive-storage:9000/progress"
     ARCHIVE_SPACE  = "digitised"
   }
 

--- a/archive/terraform/main.tf
+++ b/archive/terraform/main.tf
@@ -276,6 +276,5 @@ module "storage_api" {
   ingests_nginx_container_image      = "${local.nginx_image_uri}"
   ingests_nginx_container_port       = "9000"
   storage_static_content_bucket_name = "${local.storage_static_content_bucket_name}"
-
   interservice_security_group_id = "${aws_security_group.interservice_security_group.id}"
 }

--- a/archive/terraform/main.tf
+++ b/archive/terraform/main.tf
@@ -276,4 +276,6 @@ module "storage_api" {
   ingests_nginx_container_image      = "${local.nginx_image_uri}"
   ingests_nginx_container_port       = "9000"
   storage_static_content_bucket_name = "${local.storage_static_content_bucket_name}"
+
+  interservice_security_group_id = "${aws_security_group.interservice_security_group.id}"
 }

--- a/archive/terraform/main.tf
+++ b/archive/terraform/main.tf
@@ -276,5 +276,5 @@ module "storage_api" {
   ingests_nginx_container_image      = "${local.nginx_image_uri}"
   ingests_nginx_container_port       = "9000"
   storage_static_content_bucket_name = "${local.storage_static_content_bucket_name}"
-  interservice_security_group_id = "${aws_security_group.interservice_security_group.id}"
+  interservice_security_group_id     = "${aws_security_group.interservice_security_group.id}"
 }

--- a/archive/terraform/storage_api/main.tf
+++ b/archive/terraform/storage_api/main.tf
@@ -23,12 +23,12 @@ module "services" {
 
   # Ingests endpoint
 
-  ingests_container_image       = "${var.ingests_container_image}"
-  ingests_container_port        = "${var.ingests_container_port}"
-  ingests_env_vars              = "${var.ingests_env_vars}"
-  ingests_env_vars_length       = "${var.ingests_env_vars_length}"
-  ingests_nginx_container_port  = "${var.ingests_nginx_container_port}"
-  ingests_nginx_container_image = "${var.ingests_nginx_container_image}"
-  ingests_listener_port         = "${local.ingests_listener_port}"
+  ingests_container_image        = "${var.ingests_container_image}"
+  ingests_container_port         = "${var.ingests_container_port}"
+  ingests_env_vars               = "${var.ingests_env_vars}"
+  ingests_env_vars_length        = "${var.ingests_env_vars_length}"
+  ingests_nginx_container_port   = "${var.ingests_nginx_container_port}"
+  ingests_nginx_container_image  = "${var.ingests_nginx_container_image}"
+  ingests_listener_port          = "${local.ingests_listener_port}"
   interservice_security_group_id = "${var.interservice_security_group_id}"
 }

--- a/archive/terraform/storage_api/main.tf
+++ b/archive/terraform/storage_api/main.tf
@@ -30,6 +30,5 @@ module "services" {
   ingests_nginx_container_port  = "${var.ingests_nginx_container_port}"
   ingests_nginx_container_image = "${var.ingests_nginx_container_image}"
   ingests_listener_port         = "${local.ingests_listener_port}"
-
   interservice_security_group_id = "${var.interservice_security_group_id}"
 }

--- a/archive/terraform/storage_api/main.tf
+++ b/archive/terraform/storage_api/main.tf
@@ -30,4 +30,6 @@ module "services" {
   ingests_nginx_container_port  = "${var.ingests_nginx_container_port}"
   ingests_nginx_container_image = "${var.ingests_nginx_container_image}"
   ingests_listener_port         = "${local.ingests_listener_port}"
+
+  interservice_security_group_id = "${var.interservice_security_group_id}"
 }

--- a/archive/terraform/storage_api/services/bags.tf
+++ b/archive/terraform/storage_api/services/bags.tf
@@ -13,7 +13,7 @@ module "bags" {
 
   security_group_ids = [
     "${aws_security_group.service_lb_ingress_security_group.id}",
-    "${aws_security_group.interservice_security_group.id}",
+    "${var.interservice_security_group_id}",
   ]
 
   service_egress_security_group_id = "${aws_security_group.service_egress_security_group.id}"

--- a/archive/terraform/storage_api/services/ingests.tf
+++ b/archive/terraform/storage_api/services/ingests.tf
@@ -13,7 +13,7 @@ module "ingests" {
 
   security_group_ids = [
     "${aws_security_group.service_lb_ingress_security_group.id}",
-    "${aws_security_group.interservice_security_group.id}",
+    "${var.interservice_security_group_id}",
   ]
 
   service_egress_security_group_id = "${aws_security_group.service_egress_security_group.id}"

--- a/archive/terraform/storage_api/services/security_groups.tf
+++ b/archive/terraform/storage_api/services/security_groups.tf
@@ -31,4 +31,3 @@ resource "aws_security_group" "service_lb_ingress_security_group" {
     Name = "${var.namespace}-lb-ingress"
   }
 }
-

--- a/archive/terraform/storage_api/services/security_groups.tf
+++ b/archive/terraform/storage_api/services/security_groups.tf
@@ -32,19 +32,3 @@ resource "aws_security_group" "service_lb_ingress_security_group" {
   }
 }
 
-resource "aws_security_group" "interservice_security_group" {
-  name        = "${var.namespace}-interservice_security_group"
-  description = "Allow traffic between services"
-  vpc_id      = "${var.vpc_id}"
-
-  ingress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
-    self      = true
-  }
-
-  tags {
-    Name = "${var.namespace}-interservice"
-  }
-}

--- a/archive/terraform/storage_api/services/variables.tf
+++ b/archive/terraform/storage_api/services/variables.tf
@@ -49,3 +49,5 @@ variable "bags_env_vars" {
 }
 
 variable "bags_env_vars_length" {}
+
+variable "interservice_security_group_id" {}

--- a/archive/terraform/storage_api/variables.tf
+++ b/archive/terraform/storage_api/variables.tf
@@ -43,3 +43,4 @@ variable "auth_scopes" {
 }
 
 variable "storage_static_content_bucket_name" {}
+variable "interservice_security_group_id" {}


### PR DESCRIPTION
### What is this PR trying to achieve?

Security groups are win

### Who is this change for?

The storage API does not share the inter-service security group with the other archive services.

This fix shares an inter-service security group in order that the migrator can talk to the ingests/progress API.
