### PR TITLE
[WIP] Miro transformer can read records from the unified VHS

### DIFF
--- a/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
@@ -39,9 +39,9 @@ class HybridRecordReceiverTest
 
   case class TestException(message: String) extends Exception(message)
   case class TestTransformable()
-  def transformToWork(transforrmable: TestTransformable, version: Int) =
+  def transformToWork(transformable: TestTransformable, version: Int) =
     Try(createUnidentifiedWorkWith(version = version))
-  def failingTransformToWork(transforrmable: TestTransformable, version: Int) =
+  def failingTransformToWork(transformable: TestTransformable, version: Int) =
     Try(throw TestException("BOOOM!"))
 
   it("receives a message and sends it to SNS client") {

--- a/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
@@ -124,9 +124,7 @@ class HybridRecordReceiverTest
         withHybridRecordReceiver[TestTransformable, Assertion](topic, bucket) {
           recordReceiver =>
             val future =
-              recordReceiver.receiveMessage(
-                invalidSqsMessage,
-                transformToWork)
+              recordReceiver.receiveMessage(invalidSqsMessage, transformToWork)
 
             whenReady(future.failed) { x =>
               x shouldBe a[TransformerException]
@@ -146,9 +144,7 @@ class HybridRecordReceiverTest
         withHybridRecordReceiver[TestTransformable, Assertion](topic, bucket) {
           recordReceiver =>
             val future =
-              recordReceiver.receiveMessage(
-                invalidSqsMessage,
-                transformToWork)
+              recordReceiver.receiveMessage(invalidSqsMessage, transformToWork)
 
             whenReady(future.failed) {
               _ shouldBe a[JsonDecodingError]

--- a/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.json.exceptions.JsonDecodingError
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.{
@@ -21,7 +22,7 @@ import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.vhs.HybridRecord
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.Try
+import scala.util.{Random, Try}
 
 class HybridRecordReceiverTest
     extends FunSpec
@@ -46,27 +47,25 @@ class HybridRecordReceiverTest
 
   it("receives a message and sends it to SNS client") {
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { _ =>
-        withLocalS3Bucket { bucket =>
-          val sqsMessage = createHybridRecordNotificationWith(
-            TestTransformable(),
-            s3Client = s3Client,
-            bucket = bucket
-          )
+      withLocalS3Bucket { bucket =>
+        val sqsMessage = createHybridRecordNotificationWith(
+          TestTransformable(),
+          s3Client = s3Client,
+          bucket = bucket
+        )
 
-          withHybridRecordReceiver[TestTransformable, List[Assertion]](
-            topic,
-            bucket) { recordReceiver =>
-            val future =
-              recordReceiver.receiveMessage(sqsMessage, transformToWork)
+        withHybridRecordReceiver[TestTransformable, List[Assertion]](
+          topic,
+          bucket) { recordReceiver =>
+          val future =
+            recordReceiver.receiveMessage(sqsMessage, transformToWork)
 
-            whenReady(future) { _ =>
-              val works = getMessages[TransformedBaseWork](topic)
-              works.size should be >= 1
+          whenReady(future) { _ =>
+            val works = getMessages[TransformedBaseWork](topic)
+            works.size should be >= 1
 
-              works.map { work =>
-                work shouldBe a[UnidentifiedWork]
-              }
+            works.map { work =>
+              work shouldBe a[UnidentifiedWork]
             }
           }
         }
@@ -78,30 +77,28 @@ class HybridRecordReceiverTest
     val version = 5
 
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { _ =>
-        withLocalS3Bucket { bucket =>
-          val notification = createHybridRecordNotificationWith(
-            TestTransformable(),
-            version = version,
-            s3Client = s3Client,
-            bucket = bucket
-          )
+      withLocalS3Bucket { bucket =>
+        val notification = createHybridRecordNotificationWith(
+          TestTransformable(),
+          version = version,
+          s3Client = s3Client,
+          bucket = bucket
+        )
 
-          withHybridRecordReceiver[TestTransformable, List[Assertion]](
-            topic,
-            bucket) { recordReceiver =>
-            val future =
-              recordReceiver.receiveMessage(notification, transformToWork)
+        withHybridRecordReceiver[TestTransformable, List[Assertion]](
+          topic,
+          bucket) { recordReceiver =>
+          val future =
+            recordReceiver.receiveMessage(notification, transformToWork)
 
-            whenReady(future) { _ =>
-              val works = getMessages[TransformedBaseWork](topic)
-              works.size should be >= 1
+          whenReady(future) { _ =>
+            val works = getMessages[TransformedBaseWork](topic)
+            works.size should be >= 1
 
-              works.map { actualWork =>
-                actualWork shouldBe a[UnidentifiedWork]
-                val unidentifiedWork = actualWork.asInstanceOf[UnidentifiedWork]
-                unidentifiedWork.version shouldBe version
-              }
+            works.map { actualWork =>
+              actualWork shouldBe a[UnidentifiedWork]
+              val unidentifiedWork = actualWork.asInstanceOf[UnidentifiedWork]
+              unidentifiedWork.version shouldBe version
             }
           }
         }
@@ -111,31 +108,51 @@ class HybridRecordReceiverTest
 
   it("returns a failed future if it's unable to parse the SQS message") {
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { _ =>
-        withLocalS3Bucket { bucket =>
-          val key = randomAlphanumeric(10)
-          s3Client.putObject(bucket.name, key, "not a JSON string")
+      withLocalS3Bucket { bucket =>
+        val key = randomAlphanumeric(10)
+        s3Client.putObject(bucket.name, key, "not a JSON string")
 
-          val hybridRecord = HybridRecord(
-            id = "testId",
-            version = 1,
-            location = ObjectLocation(namespace = bucket.name, key = key)
-          )
-          val invalidSqsMessage = createNotificationMessageWith(
-            message = hybridRecord
-          )
+        val hybridRecord = HybridRecord(
+          id = "testId",
+          version = 1,
+          location = ObjectLocation(namespace = bucket.name, key = key)
+        )
+        val invalidSqsMessage = createNotificationMessageWith(
+          message = hybridRecord
+        )
 
-          withHybridRecordReceiver[TestTransformable, Assertion](topic, bucket) {
-            recordReceiver =>
-              val future =
-                recordReceiver.receiveMessage(
-                  invalidSqsMessage,
-                  transformToWork)
+        withHybridRecordReceiver[TestTransformable, Assertion](topic, bucket) {
+          recordReceiver =>
+            val future =
+              recordReceiver.receiveMessage(
+                invalidSqsMessage,
+                transformToWork)
 
-              whenReady(future.failed) { x =>
-                x shouldBe a[TransformerException]
-              }
-          }
+            whenReady(future.failed) { x =>
+              x shouldBe a[TransformerException]
+            }
+        }
+      }
+    }
+  }
+
+  it("fails if it can't parse a HybridRecord from SNS") {
+    withLocalSnsTopic { topic =>
+      withLocalS3Bucket { bucket =>
+        val invalidSqsMessage = createNotificationMessageWith(
+          message = Random.alphanumeric take 50 mkString
+        )
+
+        withHybridRecordReceiver[TestTransformable, Assertion](topic, bucket) {
+          recordReceiver =>
+            val future =
+              recordReceiver.receiveMessage(
+                invalidSqsMessage,
+                transformToWork)
+
+            whenReady(future.failed) {
+              _ shouldBe a[JsonDecodingError]
+            }
         }
       }
     }
@@ -143,25 +160,23 @@ class HybridRecordReceiverTest
 
   it("fails if it's unable to perform a transformation") {
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { _ =>
-        withLocalS3Bucket { bucket =>
-          val failingSqsMessage = createHybridRecordNotificationWith(
-            TestTransformable(),
-            s3Client = s3Client,
-            bucket = bucket
-          )
+      withLocalS3Bucket { bucket =>
+        val failingSqsMessage = createHybridRecordNotificationWith(
+          TestTransformable(),
+          s3Client = s3Client,
+          bucket = bucket
+        )
 
-          withHybridRecordReceiver[TestTransformable, Assertion](topic, bucket) {
-            recordReceiver =>
-              val future =
-                recordReceiver.receiveMessage(
-                  failingSqsMessage,
-                  failingTransformToWork)
+        withHybridRecordReceiver[TestTransformable, Assertion](topic, bucket) {
+          recordReceiver =>
+            val future =
+              recordReceiver.receiveMessage(
+                failingSqsMessage,
+                failingTransformToWork)
 
-              whenReady(future.failed) { x =>
-                x shouldBe a[TestException]
-              }
-          }
+            whenReady(future.failed) {
+              _ shouldBe a[TestException]
+            }
         }
       }
     }
@@ -169,30 +184,28 @@ class HybridRecordReceiverTest
 
   it("fails if it's unable to publish the work") {
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { _ =>
-        withLocalS3Bucket { bucket =>
-          val message = createHybridRecordNotificationWith(
-            TestTransformable(),
-            s3Client = s3Client,
-            bucket = bucket
-          )
+      withLocalS3Bucket { bucket =>
+        val message = createHybridRecordNotificationWith(
+          TestTransformable(),
+          s3Client = s3Client,
+          bucket = bucket
+        )
 
-          withHybridRecordReceiver[TestTransformable, Assertion](
-            topic,
-            bucket,
-            mockSnsClientFailPublishMessage) { recordReceiver =>
-            val future = recordReceiver.receiveMessage(message, transformToWork)
+        withHybridRecordReceiver[TestTransformable, Assertion](
+          topic,
+          bucket,
+          mockSnsClientFailPublishMessage) { recordReceiver =>
+          val future = recordReceiver.receiveMessage(message, transformToWork)
 
-            whenReady(future.failed) { x =>
-              x.getMessage should be("Failed publishing message")
-            }
+          whenReady(future.failed) {
+            _.getMessage should be("Failed publishing message")
           }
         }
       }
     }
   }
 
-  private def mockSnsClientFailPublishMessage = {
+  private def mockSnsClientFailPublishMessage: AmazonSNS = {
     val mockSNSClient = mock[AmazonSNS]
     when(mockSNSClient.publish(any[PublishRequest]))
       .thenThrow(new RuntimeException("Failed publishing message"))

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformableTransformer.scala
@@ -4,7 +4,10 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.exceptions.ShouldNotTransformException
-import uk.ac.wellcome.platform.transformer.miro.models.{MiroMetadata, MiroTransformable}
+import uk.ac.wellcome.platform.transformer.miro.models.{
+  MiroMetadata,
+  MiroTransformable
+}
 import uk.ac.wellcome.platform.transformer.miro.source.MiroTransformableData
 
 import scala.util.Try
@@ -45,10 +48,9 @@ class MiroTransformableTransformer
         throw e
     }
 
-  private def doTransform(
-    data: MiroTransformableData,
-    metadata: MiroMetadata,
-    version: Int): Try[TransformedBaseWork] = {
+  private def doTransform(data: MiroTransformableData,
+                          metadata: MiroMetadata,
+                          version: Int): Try[TransformedBaseWork] = {
     val sourceIdentifier = SourceIdentifier(
       identifierType = IdentifierType("miro-image-number"),
       ontologyType = "Work",
@@ -75,8 +77,7 @@ class MiroTransformableTransformer
 
       UnidentifiedWork(
         sourceIdentifier = sourceIdentifier,
-        otherIdentifiers =
-          getOtherIdentifiers(miroData, data.miroId),
+        otherIdentifiers = getOtherIdentifiers(miroData, data.miroId),
         mergeCandidates = List(),
         title = title,
         workType = getWorkType,
@@ -84,8 +85,7 @@ class MiroTransformableTransformer
         physicalDescription = None,
         extent = None,
         lettering = miroData.suppLettering,
-        createdDate =
-          getCreatedDate(miroData, miroId = data.miroId),
+        createdDate = getCreatedDate(miroData, miroId = data.miroId),
         subjects = getSubjects(miroData),
         genres = getGenres(miroData),
         contributors = getContributors(

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformableTransformer.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.transformer.miro
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.exceptions.ShouldNotTransformException
-import uk.ac.wellcome.platform.transformer.miro.models.MiroTransformable
+import uk.ac.wellcome.platform.transformer.miro.models.{MiroMetadata, MiroTransformable}
 import uk.ac.wellcome.platform.transformer.miro.source.MiroTransformableData
 
 import scala.util.Try
@@ -24,7 +24,18 @@ class MiroTransformableTransformer
     transformable: MiroTransformable,
     version: Int
   ): Try[TransformedBaseWork] =
-    doTransform(transformable, version) map { transformed =>
+    transform(
+      transformable = transformable,
+      metadata = MiroMetadata(isClearedForCatalogueAPI = true),
+      version = version
+    )
+
+  def transform(
+    transformable: MiroTransformable,
+    metadata: MiroMetadata,
+    version: Int
+  ): Try[TransformedBaseWork] =
+    doTransform(transformable, metadata, version) map { transformed =>
       debug(s"Transformed record to $transformed")
       transformed
     } recover {
@@ -33,7 +44,10 @@ class MiroTransformableTransformer
         throw e
     }
 
-  def doTransform(miroTransformable: MiroTransformable, version: Int) = {
+  private def doTransform(
+    miroTransformable: MiroTransformable,
+    metadata: MiroMetadata,
+    version: Int): Try[TransformedBaseWork] = {
     val sourceIdentifier = SourceIdentifier(
       identifierType = IdentifierType("miro-image-number"),
       ontologyType = "Work",

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/models/MiroMetadata.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/models/MiroMetadata.scala
@@ -1,0 +1,5 @@
+package uk.ac.wellcome.platform.transformer.miro.models
+
+case class MiroMetadata(
+  isClearedForCatalogueAPI: Boolean
+)

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.transformer.miro.services
 
 import grizzled.slf4j.Logging
-import io.circe.ParsingFailure
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.json.exceptions.JsonDecodingError
 import uk.ac.wellcome.messaging.message.MessageWriter
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, PublishAttempt}
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
@@ -39,8 +39,8 @@ class MiroVHSRecordReceiver(
 
     futurePublishAttempt
       .recover {
-        case e: ParsingFailure =>
-          info("Recoverable failure parsing HybridRecord from message", e)
+        case e: JsonDecodingError =>
+          info("Recoverable failure parsing HybridRecord/MiroMetadata from JSON", e)
           throw TransformerException(e)
       }
       .map(_ => ())

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
@@ -1,0 +1,58 @@
+package uk.ac.wellcome.platform.transformer.miro.services
+
+import grizzled.slf4j.Logging
+import io.circe.ParsingFailure
+import uk.ac.wellcome.json.JsonUtil.fromJson
+import uk.ac.wellcome.messaging.message.MessageWriter
+import uk.ac.wellcome.messaging.sns.{NotificationMessage, PublishAttempt}
+import uk.ac.wellcome.models.work.internal.TransformedBaseWork
+import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
+import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
+import uk.ac.wellcome.platform.transformer.miro.source.MiroTransformableData
+import uk.ac.wellcome.storage.ObjectStore
+import uk.ac.wellcome.storage.vhs.HybridRecord
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+class MiroVHSRecordReceiver(
+  objectStore: ObjectStore[MiroTransformableData],
+  messageWriter: MessageWriter[TransformedBaseWork])(implicit ec: ExecutionContext)
+  extends Logging {
+
+  def receiveMessage(
+    message: NotificationMessage,
+    transformToWork: (MiroTransformableData, MiroMetadata, Int) => Try[TransformedBaseWork]): Future[Unit] = {
+    debug(s"Starting to process message $message")
+
+    val futurePublishAttempt = for {
+      hybridRecord <- Future.fromTry(fromJson[HybridRecord](message.body))
+      miroMetadata <- Future.fromTry(fromJson[MiroMetadata](message.body))
+      transformableRecord <- getTransformable(hybridRecord)
+      work <- Future.fromTry(
+        transformToWork(transformableRecord, miroMetadata, hybridRecord.version)
+      )
+      publishResult <- publishMessage(work)
+      _ = debug(
+        s"Published work: ${work.sourceIdentifier} with message $publishResult")
+    } yield publishResult
+
+    futurePublishAttempt
+      .recover {
+        case e: ParsingFailure =>
+          info("Recoverable failure parsing HybridRecord from message", e)
+          throw TransformerException(e)
+      }
+      .map(_ => ())
+
+  }
+
+  private def getTransformable(hybridRecord: HybridRecord): Future[MiroTransformableData] =
+    objectStore.get(hybridRecord.location)
+
+  private def publishMessage(work: TransformedBaseWork): Future[PublishAttempt] =
+    messageWriter.write(
+      message = work,
+      subject = s"source: ${this.getClass.getSimpleName}.publishMessage"
+    )
+}

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
@@ -15,14 +15,16 @@ import uk.ac.wellcome.storage.vhs.HybridRecord
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-class MiroVHSRecordReceiver(
-  objectStore: ObjectStore[MiroTransformableData],
-  messageWriter: MessageWriter[TransformedBaseWork])(implicit ec: ExecutionContext)
-  extends Logging {
+class MiroVHSRecordReceiver(objectStore: ObjectStore[MiroTransformableData],
+                            messageWriter: MessageWriter[TransformedBaseWork])(
+  implicit ec: ExecutionContext)
+    extends Logging {
 
-  def receiveMessage(
-    message: NotificationMessage,
-    transformToWork: (MiroTransformableData, MiroMetadata, Int) => Try[TransformedBaseWork]): Future[Unit] = {
+  def receiveMessage(message: NotificationMessage,
+                     transformToWork: (
+                       MiroTransformableData,
+                       MiroMetadata,
+                       Int) => Try[TransformedBaseWork]): Future[Unit] = {
     debug(s"Starting to process message $message")
 
     val futurePublishAttempt = for {
@@ -40,17 +42,21 @@ class MiroVHSRecordReceiver(
     futurePublishAttempt
       .recover {
         case e: JsonDecodingError =>
-          info("Recoverable failure parsing HybridRecord/MiroMetadata from JSON", e)
+          info(
+            "Recoverable failure parsing HybridRecord/MiroMetadata from JSON",
+            e)
           throw TransformerException(e)
       }
       .map(_ => ())
 
   }
 
-  private def getTransformable(hybridRecord: HybridRecord): Future[MiroTransformableData] =
+  private def getTransformable(
+    hybridRecord: HybridRecord): Future[MiroTransformableData] =
     objectStore.get(hybridRecord.location)
 
-  private def publishMessage(work: TransformedBaseWork): Future[PublishAttempt] =
+  private def publishMessage(
+    work: TransformedBaseWork): Future[PublishAttempt] =
     messageWriter.write(
       message = work,
       subject = s"source: ${this.getClass.getSimpleName}.publishMessage"

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.transformer.miro.services
 
 import grizzled.slf4j.Logging
 import io.circe.ParsingFailure
-import uk.ac.wellcome.json.JsonUtil.fromJson
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.message.MessageWriter
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, PublishAttempt}
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/source/MiroTransformableData.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/source/MiroTransformableData.scala
@@ -23,6 +23,7 @@ case class MiroTransformableData(
   @JsonKey("image_keywords") keywords: Option[List[String]] = None,
   @JsonKey("image_keywords_unauth") keywordsUnauth: Option[
     List[Option[String]]] = None,
+  @JsonKey("image_no_calc") miroId: String,
   @JsonKey("image_phys_format") physFormat: Option[String] = None,
   @JsonKey("image_lc_genre") lcGenre: Option[String] = None,
   @JsonKey("image_tech_file_size") techFileSize: Option[List[String]] = None,

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformerFeatureTest.scala
@@ -33,7 +33,7 @@ class MiroTransformerFeatureTest
     with MiroTransformableGenerators {
 
   it("transforms miro records and publishes the result to the given topic") {
-    val miroID = "M0000001"
+    val miroId = "M0000001"
     val title = "A guide for a giraffe"
 
     withLocalSnsTopic { topic =>
@@ -42,8 +42,8 @@ class MiroTransformerFeatureTest
           withLocalS3Bucket { messageBucket =>
             val miroHybridRecordMessage = createHybridRecordNotificationWith(
               createMiroTransformableWith(
-                miroId = miroID,
-                data = buildJSONForWork(s""""image_title": "$title"""")
+                miroId = miroId,
+                data = buildJSONForWork(miroId = miroId, s""""image_title": "$title"""")
               ),
               s3Client = s3Client,
               bucket = storageBucket
@@ -60,7 +60,7 @@ class MiroTransformerFeatureTest
                 works.length shouldBe >=(1)
 
                 works.map { actualWork =>
-                  actualWork.identifiers.head.value shouldBe miroID
+                  actualWork.identifiers.head.value shouldBe miroId
                   actualWork.title shouldBe title
                 }
               }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformerFeatureTest.scala
@@ -43,7 +43,9 @@ class MiroTransformerFeatureTest
             val miroHybridRecordMessage = createHybridRecordNotificationWith(
               createMiroTransformableWith(
                 miroId = miroId,
-                data = buildJSONForWork(miroId = miroId, s""""image_title": "$title"""")
+                data = buildJSONForWork(
+                  miroId = miroId,
+                  s""""image_title": "$title"""")
               ),
               s3Client = s3Client,
               bucket = storageBucket

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
@@ -15,8 +15,12 @@ import uk.ac.wellcome.test.fixtures.TestWith
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait MiroVHSRecordReceiverFixture extends Messaging with SNS with MiroTransformableGenerators {
-  def withMiroVHSRecordReceiver[R](topic: Topic, bucket: Bucket)(testWith: TestWith[MiroVHSRecordReceiver, R])(
+trait MiroVHSRecordReceiverFixture
+    extends Messaging
+    with SNS
+    with MiroTransformableGenerators {
+  def withMiroVHSRecordReceiver[R](topic: Topic, bucket: Bucket)(
+    testWith: TestWith[MiroVHSRecordReceiver, R])(
     implicit objectStore: ObjectStore[MiroTransformableData]): R =
     withMessageWriter[TransformedBaseWork, R](
       bucket,
@@ -30,7 +34,8 @@ trait MiroVHSRecordReceiverFixture extends Messaging with SNS with MiroTransform
       testWith(recordReceiver)
     }
 
-  def createMiroVHSRecordWith(bucket: Bucket, version: Int = 1): NotificationMessage = {
+  def createMiroVHSRecordWith(bucket: Bucket,
+                              version: Int = 1): NotificationMessage = {
     val hybridRecord = createHybridRecordWith(
       createMiroTransformableData,
       version = version,
@@ -48,7 +53,8 @@ trait MiroVHSRecordReceiverFixture extends Messaging with SNS with MiroTransform
          |  "id": "${hybridRecord.id}",
          |  "location": ${toJson(hybridRecord.location).get},
          |  "version": ${hybridRecord.version},
-         |  "isClearedForCatalogueAPI": ${toJson(miroMetadata.isClearedForCatalogueAPI).get}
+         |  "isClearedForCatalogueAPI": ${toJson(
+           miroMetadata.isClearedForCatalogueAPI).get}
          |}
        """.stripMargin
     )

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
@@ -1,0 +1,31 @@
+package uk.ac.wellcome.platform.transformer.miro.fixtures
+
+import com.amazonaws.services.sns.AmazonSNS
+import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS}
+import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
+import uk.ac.wellcome.models.work.internal.TransformedBaseWork
+import uk.ac.wellcome.platform.transformer.miro.services.MiroVHSRecordReceiver
+import uk.ac.wellcome.platform.transformer.miro.source.MiroTransformableData
+import uk.ac.wellcome.storage.ObjectStore
+import uk.ac.wellcome.storage.fixtures.S3.Bucket
+import uk.ac.wellcome.test.fixtures.TestWith
+
+trait MiroVHSRecordReceiverFixture extends Messaging with SNS {
+  def withMiroVHSRecordReceiver[R](
+    topic: Topic,
+    bucket: Bucket,
+    snsClient: AmazonSNS = snsClient
+  )(testWith: TestWith[MiroVHSRecordReceiver, R])(
+    implicit objectStore: ObjectStore[MiroTransformableData]): R =
+    withMessageWriter[TransformedBaseWork, R](
+      bucket,
+      topic,
+      writerSnsClient = snsClient) { messageWriter =>
+      val recordReceiver = new MiroVHSRecordReceiver(
+        objectStore = objectStore,
+        messageWriter = messageWriter
+      )
+
+      testWith(recordReceiver)
+    }
+}

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
@@ -5,6 +5,7 @@ import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS}
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
+import uk.ac.wellcome.platform.transformer.miro.generators.MiroTransformableGenerators
 import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
 import uk.ac.wellcome.platform.transformer.miro.services.MiroVHSRecordReceiver
 import uk.ac.wellcome.platform.transformer.miro.source.MiroTransformableData
@@ -14,7 +15,7 @@ import uk.ac.wellcome.test.fixtures.TestWith
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait MiroVHSRecordReceiverFixture extends Messaging with SNS {
+trait MiroVHSRecordReceiverFixture extends Messaging with SNS with MiroTransformableGenerators {
   def withMiroVHSRecordReceiver[R](topic: Topic, bucket: Bucket)(testWith: TestWith[MiroVHSRecordReceiver, R])(
     implicit objectStore: ObjectStore[MiroTransformableData]): R =
     withMessageWriter[TransformedBaseWork, R](
@@ -31,7 +32,7 @@ trait MiroVHSRecordReceiverFixture extends Messaging with SNS {
 
   def createMiroVHSRecordWith(bucket: Bucket, version: Int = 1): NotificationMessage = {
     val hybridRecord = createHybridRecordWith(
-      MiroTransformableData(),
+      createMiroTransformableData,
       version = version,
       s3Client = s3Client,
       bucket = bucket

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.transformer.miro.fixtures
 
 import com.amazonaws.services.sns.AmazonSNS
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS}
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
@@ -9,6 +10,8 @@ import uk.ac.wellcome.platform.transformer.miro.source.MiroTransformableData
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures.TestWith
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 trait MiroVHSRecordReceiverFixture extends Messaging with SNS {
   def withMiroVHSRecordReceiver[R](

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/generators/MiroTransformableGenerators.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/generators/MiroTransformableGenerators.scala
@@ -38,7 +38,8 @@ trait MiroTransformableGenerators {
   def createMiroTransformableData: MiroTransformableData =
     createMiroTransformableDataWith()
 
-  def buildJSONForWork(miroId: String = "M0000001", extraData: String): String = {
+  def buildJSONForWork(miroId: String = "M0000001",
+                       extraData: String): String = {
     val baseData =
       s"""
          |  "image_no_calc": "$miroId",

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/generators/MiroTransformableGenerators.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/generators/MiroTransformableGenerators.scala
@@ -20,6 +20,7 @@ trait MiroTransformableGenerators {
     libraryRefDepartment: List[Option[String]] = Nil,
     libraryRefId: List[Option[String]] = Nil): MiroTransformableData =
     MiroTransformableData(
+      copyrightCleared = Some("Y"),
       miroId = "M0000001",
       innopacID = innopacID,
       useRestrictions = useRestrictions,

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/generators/MiroTransformableGenerators.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/generators/MiroTransformableGenerators.scala
@@ -24,4 +24,21 @@ trait MiroTransformableGenerators {
 
   def createMiroTransformableData: MiroTransformableData =
     createMiroTransformableDataWith()
+
+  def buildJSONForWork(miroId: String = "M0000001", extraData: String): String = {
+    val baseData =
+      s"""
+         |  "image_no_calc": "$miroId",
+         |  "image_cleared": "Y",
+         |  "image_copyright_cleared": "Y",
+         |  "image_tech_file_size": ["1000000"],
+         |  "image_use_restrictions": "CC-BY"
+      """.stripMargin
+
+    if (extraData.isEmpty) s"""{$baseData}"""
+    else s"""{
+        $baseData,
+        $extraData
+      }"""
+  }
 }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/generators/MiroTransformableGenerators.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/generators/MiroTransformableGenerators.scala
@@ -14,14 +14,20 @@ trait MiroTransformableGenerators {
     )
 
   def createMiroTransformableDataWith(
+    title: Option[String] = None,
+    physFormat: Option[String] = None,
+    lcGenre: Option[String] = None,
+    useRestrictions: Option[String] = Some("CC-BY"),
     innopacID: Option[String] = None,
-    useRestrictions: Option[String] = None,
     sourceCode: Option[String] = None,
     libraryRefDepartment: List[Option[String]] = Nil,
     libraryRefId: List[Option[String]] = Nil): MiroTransformableData =
     MiroTransformableData(
+      title = title,
       copyrightCleared = Some("Y"),
       miroId = "M0000001",
+      physFormat = physFormat,
+      lcGenre = lcGenre,
       innopacID = innopacID,
       useRestrictions = useRestrictions,
       sourceCode = sourceCode,

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/generators/MiroTransformableGenerators.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/generators/MiroTransformableGenerators.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.transformer.miro.generators
 
 import uk.ac.wellcome.platform.transformer.miro.models.MiroTransformable
+import uk.ac.wellcome.platform.transformer.miro.source.MiroTransformableData
 
 trait MiroTransformableGenerators {
   def createMiroTransformableWith(
@@ -11,4 +12,16 @@ trait MiroTransformableGenerators {
       sourceId = miroId,
       data = data
     )
+
+  def createMiroTransformableDataWith(innopacID: Option[String] = None, useRestrictions: Option[String] = None, sourceCode: Option[String] = None): MiroTransformableData =
+    MiroTransformableData(
+
+      miroId = "M0000001",
+      innopacID = innopacID,
+      useRestrictions = useRestrictions,
+      sourceCode = sourceCode
+    )
+
+  def createMiroTransformableData: MiroTransformableData =
+    createMiroTransformableDataWith()
 }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/generators/MiroTransformableGenerators.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/generators/MiroTransformableGenerators.scala
@@ -13,13 +13,19 @@ trait MiroTransformableGenerators {
       data = data
     )
 
-  def createMiroTransformableDataWith(innopacID: Option[String] = None, useRestrictions: Option[String] = None, sourceCode: Option[String] = None): MiroTransformableData =
+  def createMiroTransformableDataWith(
+    innopacID: Option[String] = None,
+    useRestrictions: Option[String] = None,
+    sourceCode: Option[String] = None,
+    libraryRefDepartment: List[Option[String]] = Nil,
+    libraryRefId: List[Option[String]] = Nil): MiroTransformableData =
     MiroTransformableData(
-
       miroId = "M0000001",
       innopacID = innopacID,
       useRestrictions = useRestrictions,
-      sourceCode = sourceCode
+      sourceCode = sourceCode,
+      libraryRefDepartment = libraryRefDepartment,
+      libraryRefId = libraryRefId
     )
 
   def createMiroTransformableData: MiroTransformableData =

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -1,0 +1,194 @@
+package uk.ac.wellcome.platform.transformer.miro.services
+
+import com.amazonaws.services.sns.AmazonSNS
+import com.amazonaws.services.sns.model.PublishRequest
+import org.mockito.Matchers.any
+import org.mockito.Mockito.when
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
+import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWork}
+import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
+import uk.ac.wellcome.platform.transformer.miro.fixtures.MiroVHSRecordReceiverFixture
+import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
+import uk.ac.wellcome.platform.transformer.miro.source.MiroTransformableData
+import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.fixtures.S3
+import uk.ac.wellcome.storage.vhs.HybridRecord
+
+import scala.util.Try
+
+class MiroVHSRecordReceiverTest
+    extends FunSpec
+    with Matchers
+    with SQS
+    with SNS
+    with S3
+    with Messaging
+    with Eventually
+    with MiroVHSRecordReceiverFixture
+    with IntegrationPatience
+    with MockitoSugar
+    with ScalaFutures
+    with WorksGenerators {
+
+  case class TestException(message: String) extends Exception(message)
+  case class TestTransformable()
+
+  def transformToWork(transformable: MiroTransformableData, metadata: MiroMetadata, version: Int) =
+    Try(createUnidentifiedWorkWith(version = version))
+
+  def failingTransformToWork(transformable: MiroTransformableData, metadata: MiroMetadata, version: Int) =
+    Try(throw TestException("BOOOM!"))
+
+  it("receives a message and sends it to SNS client") {
+    withLocalSnsTopic { topic =>
+      withLocalSqsQueue { _ =>
+        withLocalS3Bucket { bucket =>
+          val sqsMessage = createHybridRecordNotificationWith(
+            TestTransformable(),
+            s3Client = s3Client,
+            bucket = bucket
+          )
+
+          withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
+            val future = recordReceiver
+              .receiveMessage(sqsMessage, transformToWork)
+
+            whenReady(future) { _ =>
+              val works = getMessages[TransformedBaseWork](topic)
+              works.size should be >= 1
+
+              works.map { work =>
+                work shouldBe a[UnidentifiedWork]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  it("receives a message and adds the version to the transformed work") {
+    val version = 5
+
+    withLocalSnsTopic { topic =>
+      withLocalSqsQueue { _ =>
+        withLocalS3Bucket { bucket =>
+          val notification = createHybridRecordNotificationWith(
+            TestTransformable(),
+            version = version,
+            s3Client = s3Client,
+            bucket = bucket
+          )
+
+          withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
+            val future =
+              recordReceiver.receiveMessage(notification, transformToWork)
+
+            whenReady(future) { _ =>
+              val works = getMessages[TransformedBaseWork](topic)
+              works.size should be >= 1
+
+              works.map { actualWork =>
+                actualWork shouldBe a[UnidentifiedWork]
+                val unidentifiedWork = actualWork.asInstanceOf[UnidentifiedWork]
+                unidentifiedWork.version shouldBe version
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  it("returns a failed future if it's unable to parse the SQS message") {
+    withLocalSnsTopic { topic =>
+      withLocalSqsQueue { _ =>
+        withLocalS3Bucket { bucket =>
+          val key = randomAlphanumeric(10)
+          s3Client.putObject(bucket.name, key, "not a JSON string")
+
+          val hybridRecord = HybridRecord(
+            id = "testId",
+            version = 1,
+            location = ObjectLocation(namespace = bucket.name, key = key)
+          )
+          val invalidSqsMessage = createNotificationMessageWith(
+            message = hybridRecord
+          )
+
+          withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
+            val future =
+              recordReceiver.receiveMessage(
+                invalidSqsMessage,
+                transformToWork)
+
+            whenReady(future.failed) { x =>
+              x shouldBe a[TransformerException]
+            }
+          }
+        }
+      }
+    }
+  }
+
+  it("fails if it's unable to perform a transformation") {
+    withLocalSnsTopic { topic =>
+      withLocalSqsQueue { _ =>
+        withLocalS3Bucket { bucket =>
+          val failingSqsMessage = createHybridRecordNotificationWith(
+            TestTransformable(),
+            s3Client = s3Client,
+            bucket = bucket
+          )
+
+          withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
+            val future =
+              recordReceiver.receiveMessage(
+                failingSqsMessage,
+                failingTransformToWork)
+
+            whenReady(future.failed) { x =>
+              x shouldBe a[TestException]
+            }
+          }
+        }
+      }
+    }
+  }
+
+  it("fails if it's unable to publish the work") {
+    withLocalSnsTopic { topic =>
+      withLocalSqsQueue { _ =>
+        withLocalS3Bucket { bucket =>
+          val message = createHybridRecordNotificationWith(
+            TestTransformable(),
+            s3Client = s3Client,
+            bucket = bucket
+          )
+
+          withMiroVHSRecordReceiver(
+            topic,
+            bucket,
+            mockSnsClientFailPublishMessage) { recordReceiver =>
+            val future = recordReceiver.receiveMessage(message, transformToWork)
+
+            whenReady(future.failed) { x =>
+              x.getMessage should be("Failed publishing message")
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private def mockSnsClientFailPublishMessage: AmazonSNS = {
+    val mockSNSClient = mock[AmazonSNS]
+    when(mockSNSClient.publish(any[PublishRequest]))
+      .thenThrow(new RuntimeException("Failed publishing message"))
+    mockSNSClient
+  }
+}

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -7,7 +7,10 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
-import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  TransformedBaseWork,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.miro.fixtures.MiroVHSRecordReceiverFixture
 import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
@@ -33,10 +36,14 @@ class MiroVHSRecordReceiverTest
 
   case class TestException(message: String) extends Exception(message)
 
-  def transformToWork(transformable: MiroTransformableData, metadata: MiroMetadata, version: Int) =
+  def transformToWork(transformable: MiroTransformableData,
+                      metadata: MiroMetadata,
+                      version: Int) =
     Try(createUnidentifiedWorkWith(version = version))
 
-  def failingTransformToWork(transformable: MiroTransformableData, metadata: MiroMetadata, version: Int) =
+  def failingTransformToWork(transformable: MiroTransformableData,
+                             metadata: MiroMetadata,
+                             version: Int) =
     Try(throw TestException("BOOOM!"))
 
   it("receives a message and sends it to SNS client") {
@@ -98,8 +105,8 @@ class MiroVHSRecordReceiverTest
         )
 
         withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
-          val future = recordReceiver.receiveMessage(
-            incompleteMessage, transformToWork)
+          val future =
+            recordReceiver.receiveMessage(incompleteMessage, transformToWork)
 
           whenReady(future.failed) {
             _ shouldBe a[TransformerException]
@@ -117,8 +124,8 @@ class MiroVHSRecordReceiverTest
         )
 
         withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
-          val future = recordReceiver.receiveMessage(
-            incompleteMessage, transformToWork)
+          val future =
+            recordReceiver.receiveMessage(incompleteMessage, transformToWork)
 
           whenReady(future.failed) {
             _ shouldBe a[TransformerException]
@@ -149,12 +156,13 @@ class MiroVHSRecordReceiverTest
     withLocalS3Bucket { bucket =>
       val message = createMiroVHSRecordWith(bucket = bucket)
 
-      withMiroVHSRecordReceiver(Topic("no-such-topic"), bucket) { recordReceiver =>
-        val future = recordReceiver.receiveMessage(message, transformToWork)
+      withMiroVHSRecordReceiver(Topic("no-such-topic"), bucket) {
+        recordReceiver =>
+          val future = recordReceiver.receiveMessage(message, transformToWork)
 
-        whenReady(future.failed) {
-          _.getMessage should include("Unknown topic: no-such-topic")
-        }
+          whenReady(future.failed) {
+            _.getMessage should include("Unknown topic: no-such-topic")
+          }
       }
     }
   }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -7,6 +7,7 @@ import org.mockito.Mockito.when
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWork}
@@ -18,6 +19,7 @@ import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.vhs.HybridRecord
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Try
 
 class MiroVHSRecordReceiverTest

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -92,7 +92,7 @@ class MiroVHSRecordReceiverTest
     withLocalSnsTopic { topic =>
       withLocalS3Bucket { bucket =>
         val incompleteMessage = createHybridRecordNotificationWith(
-          MiroTransformableData(),
+          createMiroTransformableData,
           s3Client = s3Client,
           bucket = bucket
         )

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -1,13 +1,10 @@
 package uk.ac.wellcome.platform.transformer.miro.services
 
-import com.amazonaws.services.sns.AmazonSNS
-import com.amazonaws.services.sns.model.PublishRequest
-import org.mockito.Matchers.any
-import org.mockito.Mockito.when
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWork}
@@ -15,9 +12,7 @@ import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.miro.fixtures.MiroVHSRecordReceiverFixture
 import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
 import uk.ac.wellcome.platform.transformer.miro.source.MiroTransformableData
-import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3
-import uk.ac.wellcome.storage.vhs.HybridRecord
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Try
@@ -37,7 +32,6 @@ class MiroVHSRecordReceiverTest
     with WorksGenerators {
 
   case class TestException(message: String) extends Exception(message)
-  case class TestTransformable()
 
   def transformToWork(transformable: MiroTransformableData, metadata: MiroMetadata, version: Int) =
     Try(createUnidentifiedWorkWith(version = version))
@@ -47,25 +41,18 @@ class MiroVHSRecordReceiverTest
 
   it("receives a message and sends it to SNS client") {
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { _ =>
-        withLocalS3Bucket { bucket =>
-          val sqsMessage = createHybridRecordNotificationWith(
-            TestTransformable(),
-            s3Client = s3Client,
-            bucket = bucket
-          )
+      withLocalS3Bucket { bucket =>
+        val message = createMiroVHSRecordWith(bucket = bucket)
 
-          withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
-            val future = recordReceiver
-              .receiveMessage(sqsMessage, transformToWork)
+        withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
+          val future = recordReceiver.receiveMessage(message, transformToWork)
 
-            whenReady(future) { _ =>
-              val works = getMessages[TransformedBaseWork](topic)
-              works.size should be >= 1
+          whenReady(future) { _ =>
+            val works = getMessages[TransformedBaseWork](topic)
+            works.size should be >= 1
 
-              works.map { work =>
-                work shouldBe a[UnidentifiedWork]
-              }
+            works.map { work =>
+              work shouldBe a[UnidentifiedWork]
             }
           }
         }
@@ -77,28 +64,23 @@ class MiroVHSRecordReceiverTest
     val version = 5
 
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { _ =>
-        withLocalS3Bucket { bucket =>
-          val notification = createHybridRecordNotificationWith(
-            TestTransformable(),
-            version = version,
-            s3Client = s3Client,
-            bucket = bucket
-          )
+      withLocalS3Bucket { bucket =>
+        val message = createMiroVHSRecordWith(
+          version = version,
+          bucket = bucket
+        )
 
-          withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
-            val future =
-              recordReceiver.receiveMessage(notification, transformToWork)
+        withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
+          val future = recordReceiver.receiveMessage(message, transformToWork)
 
-            whenReady(future) { _ =>
-              val works = getMessages[TransformedBaseWork](topic)
-              works.size should be >= 1
+          whenReady(future) { _ =>
+            val works = getMessages[TransformedBaseWork](topic)
+            works.size should be >= 1
 
-              works.map { actualWork =>
-                actualWork shouldBe a[UnidentifiedWork]
-                val unidentifiedWork = actualWork.asInstanceOf[UnidentifiedWork]
-                unidentifiedWork.version shouldBe version
-              }
+            works.map { actualWork =>
+              actualWork shouldBe a[UnidentifiedWork]
+              val unidentifiedWork = actualWork.asInstanceOf[UnidentifiedWork]
+              unidentifiedWork.version shouldBe version
             }
           }
         }
@@ -106,31 +88,40 @@ class MiroVHSRecordReceiverTest
     }
   }
 
-  it("returns a failed future if it's unable to parse the SQS message") {
+  it("returns a failed future if there's no MiroMetadata") {
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { _ =>
-        withLocalS3Bucket { bucket =>
-          val key = randomAlphanumeric(10)
-          s3Client.putObject(bucket.name, key, "not a JSON string")
+      withLocalS3Bucket { bucket =>
+        val incompleteMessage = createHybridRecordNotificationWith(
+          MiroTransformableData(),
+          s3Client = s3Client,
+          bucket = bucket
+        )
 
-          val hybridRecord = HybridRecord(
-            id = "testId",
-            version = 1,
-            location = ObjectLocation(namespace = bucket.name, key = key)
-          )
-          val invalidSqsMessage = createNotificationMessageWith(
-            message = hybridRecord
-          )
+        withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
+          val future = recordReceiver.receiveMessage(
+            incompleteMessage, transformToWork)
 
-          withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
-            val future =
-              recordReceiver.receiveMessage(
-                invalidSqsMessage,
-                transformToWork)
+          whenReady(future.failed) {
+            _ shouldBe a[TransformerException]
+          }
+        }
+      }
+    }
+  }
 
-            whenReady(future.failed) { x =>
-              x shouldBe a[TransformerException]
-            }
+  it("returns a failed future if there's no HybridRecord") {
+    withLocalSnsTopic { topic =>
+      withLocalS3Bucket { bucket =>
+        val incompleteMessage = createNotificationMessageWith(
+          message = MiroMetadata(isClearedForCatalogueAPI = false)
+        )
+
+        withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
+          val future = recordReceiver.receiveMessage(
+            incompleteMessage, transformToWork)
+
+          whenReady(future.failed) {
+            _ shouldBe a[TransformerException]
           }
         }
       }
@@ -139,23 +130,15 @@ class MiroVHSRecordReceiverTest
 
   it("fails if it's unable to perform a transformation") {
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { _ =>
-        withLocalS3Bucket { bucket =>
-          val failingSqsMessage = createHybridRecordNotificationWith(
-            TestTransformable(),
-            s3Client = s3Client,
-            bucket = bucket
-          )
+      withLocalS3Bucket { bucket =>
+        val message = createMiroVHSRecordWith(bucket = bucket)
 
-          withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
-            val future =
-              recordReceiver.receiveMessage(
-                failingSqsMessage,
-                failingTransformToWork)
+        withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
+          val future =
+            recordReceiver.receiveMessage(message, failingTransformToWork)
 
-            whenReady(future.failed) { x =>
-              x shouldBe a[TestException]
-            }
+          whenReady(future.failed) { x =>
+            x shouldBe a[TestException]
           }
         }
       }
@@ -163,34 +146,16 @@ class MiroVHSRecordReceiverTest
   }
 
   it("fails if it's unable to publish the work") {
-    withLocalSnsTopic { topic =>
-      withLocalSqsQueue { _ =>
-        withLocalS3Bucket { bucket =>
-          val message = createHybridRecordNotificationWith(
-            TestTransformable(),
-            s3Client = s3Client,
-            bucket = bucket
-          )
+    withLocalS3Bucket { bucket =>
+      val message = createMiroVHSRecordWith(bucket = bucket)
 
-          withMiroVHSRecordReceiver(
-            topic,
-            bucket,
-            mockSnsClientFailPublishMessage) { recordReceiver =>
-            val future = recordReceiver.receiveMessage(message, transformToWork)
+      withMiroVHSRecordReceiver(Topic("no-such-topic"), bucket) { recordReceiver =>
+        val future = recordReceiver.receiveMessage(message, transformToWork)
 
-            whenReady(future.failed) { x =>
-              x.getMessage should be("Failed publishing message")
-            }
-          }
+        whenReady(future.failed) {
+          _.getMessage should be("Failed publishing message")
         }
       }
     }
-  }
-
-  private def mockSnsClientFailPublishMessage: AmazonSNS = {
-    val mockSNSClient = mock[AmazonSNS]
-    when(mockSNSClient.publish(any[PublishRequest]))
-      .thenThrow(new RuntimeException("Failed publishing message"))
-    mockSNSClient
   }
 }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -153,7 +153,7 @@ class MiroVHSRecordReceiverTest
         val future = recordReceiver.receiveMessage(message, transformToWork)
 
         whenReady(future.failed) {
-          _.getMessage should be("Failed publishing message")
+          _.getMessage should include("Unknown topic: no-such-topic")
         }
       }
     }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/source/MiroTransformableDataTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/source/MiroTransformableDataTest.scala
@@ -2,31 +2,29 @@ package uk.ac.wellcome.platform.transformer.miro.source
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.transformer.miro.generators.MiroTransformableGenerators
 
-class MiroTransformableDataTest extends FunSpec with Matchers {
+class MiroTransformableDataTest extends FunSpec with Matchers with MiroTransformableGenerators {
 
   // This is based on failures we've seen in the pipeline.
   // Examples: L0068740, V0014729.
   it("parses a JSON string with nulls in the image_keywords_unauth field") {
-    val jsonString =
+    val jsonString = buildJSONForWork(extraData =
       """
-        |{
-        |    "image_keywords_unauth": [null, null]
-        |}
-        |
+        |  "image_keywords_unauth": [null, null]
       """.stripMargin
+    )
 
     fromJson[MiroTransformableData](jsonString).isSuccess shouldBe true
   }
 
   // This is based on bugs from data in the pipeline.
   it("corrects the entities in Adêle Mongrédien's name") {
-    val jsonString =
+    val jsonString = buildJSONForWork(extraData =
       """
-        |{
         |  "image_creator": ["Ad\u00c3\u00aale Mongr\u00c3\u00a9dien"]
-        |}
       """.stripMargin
+    )
 
     MiroTransformableData.create(jsonString).creator shouldBe Some(
       List(Some("Adêle Mongrédien")))

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/source/MiroTransformableDataTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/source/MiroTransformableDataTest.scala
@@ -4,27 +4,28 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.transformer.miro.generators.MiroTransformableGenerators
 
-class MiroTransformableDataTest extends FunSpec with Matchers with MiroTransformableGenerators {
+class MiroTransformableDataTest
+    extends FunSpec
+    with Matchers
+    with MiroTransformableGenerators {
 
   // This is based on failures we've seen in the pipeline.
   // Examples: L0068740, V0014729.
   it("parses a JSON string with nulls in the image_keywords_unauth field") {
-    val jsonString = buildJSONForWork(extraData =
-      """
+    val jsonString =
+      buildJSONForWork(extraData = """
         |  "image_keywords_unauth": [null, null]
-      """.stripMargin
-    )
+      """.stripMargin)
 
     fromJson[MiroTransformableData](jsonString).isSuccess shouldBe true
   }
 
   // This is based on bugs from data in the pipeline.
   it("corrects the entities in Adêle Mongrédien's name") {
-    val jsonString = buildJSONForWork(extraData =
-      """
+    val jsonString = buildJSONForWork(
+      extraData = """
         |  "image_creator": ["Ad\u00c3\u00aale Mongr\u00c3\u00a9dien"]
-      """.stripMargin
-    )
+      """.stripMargin)
 
     MiroTransformableData.create(jsonString).creator shouldBe Some(
       List(Some("Adêle Mongrédien")))

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroGenresTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroGenresTest.scala
@@ -1,13 +1,7 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers
 
-import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal.{
-  AbstractConcept,
-  Concept,
-  Genre,
-  MaybeDisplayable,
-  Unidentifiable
-}
+import org.scalatest.{Assertion, FunSpec, Matchers}
+import uk.ac.wellcome.models.work.internal.{Concept, Genre, Unidentifiable}
 
 class MiroGenresTest
     extends FunSpec
@@ -16,64 +10,60 @@ class MiroGenresTest
 
   it("has an empty genre list on records without keywords") {
     transformRecordAndCheckGenres(
-      data = s""""image_title": "The giraffe's genre is gone'"""",
+      title = "The giraffe's genre is gone'",
       expectedGenres = List()
     )
   }
 
   it("uses the image_phys_format field if present") {
     transformRecordAndCheckGenres(
-      data = s"""
-        "image_title": "A goat grazes on some grass",
-        "image_phys_format": "painting"
-      """,
-      expectedGenres =
-        List(Genre("painting", List(Unidentifiable(Concept("painting")))))
+      title = "A goat grazes on some grass",
+      physFormat = "painting",
+      expectedGenres = List("painting")
     )
   }
 
   it("uses the image_lc_genre field if present") {
     transformRecordAndCheckGenres(
-      data = s"""
-        "image_title": "Grouchy geese are good as guards",
-        "image_lc_genre": "sculpture"
-      """,
-      expectedGenres =
-        List(Genre("sculpture", List(Unidentifiable(Concept("sculpture")))))
+      title = "Grouchy geese are good as guards",
+      lcGenre = "sculpture",
+      expectedGenres = List("sculpture")
     )
   }
 
   it("uses the image_phys_format and image_lc_genre fields if both present") {
     transformRecordAndCheckGenres(
-      data = s"""
-        "image_title": "A gorilla and a gibbon in a garden",
-        "image_phys_format": "etching",
-        "image_lc_genre": "woodwork"
-      """,
-      expectedGenres = List(
-        Genre("etching", List(Unidentifiable(Concept("etching")))),
-        Genre("woodwork", List(Unidentifiable(Concept("woodwork"))))
-      )
+      title = "A gorilla and a gibbon in a garden",
+      physFormat = "etching",
+      lcGenre = "woodwork",
+      expectedGenres = List("etching", "woodwork")
     )
   }
 
   it("deduplicates entries in the genre field") {
     transformRecordAndCheckGenres(
-      data = s"""
-        "image_title": "A duality of dancing dodos",
-        "image_phys_format": "oil painting",
-        "image_lc_genre": "oil painting"
-      """,
-      expectedGenres = List(
-        Genre("oil painting", List(Unidentifiable(Concept("oil painting")))))
+      title = "A duality of dancing dodos",
+      lcGenre = "oil painting",
+      physFormat = "oil painting",
+      expectedGenres = List("oil painting")
     )
   }
 
   private def transformRecordAndCheckGenres(
-    data: String,
-    expectedGenres: List[Genre[MaybeDisplayable[AbstractConcept]]]
-  ) = {
-    val transformedWork = transformWork(data = data)
-    transformedWork.genres shouldBe expectedGenres
+    title: String,
+    physFormat: String = "",
+    lcGenre: String = "",
+    expectedGenres: List[String]
+  ): Assertion = {
+    val transformable = createMiroTransformableDataWith(
+      title = Some(title),
+      physFormat = if (physFormat.isEmpty) None else Some(physFormat),
+      lcGenre = if (lcGenre.isEmpty) None else Some(lcGenre)
+    )
+
+    val expectedGenreObjects = expectedGenres
+      .map { g: String => Genre(g, List(Unidentifiable(Concept(g)))) }
+
+    transformWork(transformable).genres shouldBe expectedGenreObjects
   }
 }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroGenresTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroGenresTest.scala
@@ -62,7 +62,9 @@ class MiroGenresTest
     )
 
     val expectedGenreObjects = expectedGenres
-      .map { g: String => Genre(g, List(Unidentifiable(Concept(g)))) }
+      .map { g: String =>
+        Genre(g, List(Unidentifiable(Concept(g))))
+      }
 
     transformWork(transformable).genres shouldBe expectedGenreObjects
   }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroIdentifiersTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroIdentifiersTest.scala
@@ -2,15 +2,16 @@ package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
-import uk.ac.wellcome.platform.transformer.miro.source.MiroTransformableData
+import uk.ac.wellcome.platform.transformer.miro.generators.MiroTransformableGenerators
 
 class MiroIdentifiersTest
     extends FunSpec
     with Matchers
-    with IdentifiersGenerators {
+    with IdentifiersGenerators
+    with MiroTransformableGenerators {
 
   it("fixes the malformed INNOPAC ID on L0035411") {
-    val miroData = MiroTransformableData(
+    val miroData = createMiroTransformableDataWith(
       innopacID = Some("L 35411 \n\n15551040")
     )
 

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItemsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItemsTest.scala
@@ -5,7 +5,11 @@ import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.miro.generators.MiroTransformableGenerators
 
-class MiroItemsTest extends FunSpec with Matchers with IdentifiersGenerators with MiroTransformableGenerators {
+class MiroItemsTest
+    extends FunSpec
+    with Matchers
+    with IdentifiersGenerators
+    with MiroTransformableGenerators {
   val transformer = new MiroItems {}
 
   describe("getItemsV1") {

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItemsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItemsTest.scala
@@ -3,19 +3,18 @@ package uk.ac.wellcome.platform.transformer.miro.transformers
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.miro.source.MiroTransformableData
+import uk.ac.wellcome.platform.transformer.miro.generators.MiroTransformableGenerators
 
-class MiroItemsTest extends FunSpec with Matchers with IdentifiersGenerators {
+class MiroItemsTest extends FunSpec with Matchers with IdentifiersGenerators with MiroTransformableGenerators {
   val transformer = new MiroItems {}
 
   describe("getItemsV1") {
     it("extracts an identifiable item") {
       transformer.getItemsV1(
         miroId = "B0011308",
-        miroData = MiroTransformableData(
-          creditLine = None,
-          sourceCode = Some("FDN"),
-          useRestrictions = Some("CC-0")
+        miroData = createMiroTransformableDataWith(
+          useRestrictions = Some("CC-0"),
+          sourceCode = Some("FDN")
         )) shouldBe List(
         Identifiable(
           agent = Item(locations = List(DigitalLocation(
@@ -34,10 +33,9 @@ class MiroItemsTest extends FunSpec with Matchers with IdentifiersGenerators {
     it("extracts an unidentifiable item") {
       transformer.getItems(
         miroId = "B0011308",
-        miroData = MiroTransformableData(
-          creditLine = None,
-          sourceCode = Some("FDN"),
-          useRestrictions = Some("CC-0")
+        miroData = createMiroTransformableDataWith(
+          useRestrictions = Some("CC-0"),
+          sourceCode = Some("FDN")
         )) shouldBe List(
         Unidentifiable(
           agent = Item(locations = List(DigitalLocation(

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocationsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocationsTest.scala
@@ -1,23 +1,18 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal.{
-  DigitalLocation,
-  License_CC0,
-  LocationType
-}
-import uk.ac.wellcome.platform.transformer.miro.source.MiroTransformableData
+import uk.ac.wellcome.models.work.internal.{DigitalLocation, License_CC0, LocationType}
+import uk.ac.wellcome.platform.transformer.miro.generators.MiroTransformableGenerators
 
-class MiroLocationsTest extends FunSpec with Matchers {
+class MiroLocationsTest extends FunSpec with Matchers with MiroTransformableGenerators {
   val transformer = new MiroLocations {}
   it(
     "extracts the digital location and finds the credit line for an image-specific contributor code") {
     transformer.getLocations(
       miroId = "B0011308",
-      miroData = MiroTransformableData(
-        creditLine = None,
-        sourceCode = Some("FDN"),
-        useRestrictions = Some("CC-0")
+      miroData = createMiroTransformableDataWith(
+        useRestrictions = Some("CC-0"),
+        sourceCode = Some("FDN")
       )
     ) shouldBe List(
       DigitalLocation(

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocationsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocationsTest.scala
@@ -1,10 +1,17 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal.{DigitalLocation, License_CC0, LocationType}
+import uk.ac.wellcome.models.work.internal.{
+  DigitalLocation,
+  License_CC0,
+  LocationType
+}
 import uk.ac.wellcome.platform.transformer.miro.generators.MiroTransformableGenerators
 
-class MiroLocationsTest extends FunSpec with Matchers with MiroTransformableGenerators {
+class MiroLocationsTest
+    extends FunSpec
+    with Matchers
+    with MiroTransformableGenerators {
   val transformer = new MiroLocations {}
   it(
     "extracts the digital location and finds the credit line for an image-specific contributor code") {

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableTransformerTest.scala
@@ -228,13 +228,13 @@ class MiroTransformableTransformerTest
     it("if usage restrictions mean we suppress the image") {
       assertTransformReturnsInvisibleWork(
         miroId = "M0000001",
-        data =
-          buildJSONForWork(
-            miroId = "M0000001",
-            extraData = """
+        data = buildJSONForWork(
+          miroId = "M0000001",
+          extraData = """
         "image_title": "Private pictures of perilous penguins",
         "image_use_restrictions": "Do not use"
-      """)
+      """
+        )
       )
     }
 
@@ -252,8 +252,7 @@ class MiroTransformableTransformerTest
     it("if the image isn't copyright cleared") {
       assertTransformReturnsInvisibleWork(
         miroId = "M0000001",
-        data =
-          """{
+        data = """{
         "image_cleared": "Y",
         "image_copyright_cleared": "N",
         "image_no_calc": "M0000001",
@@ -330,7 +329,8 @@ class MiroTransformableTransformerTest
     )
   }
 
-  private def assertTransformReturnsInvisibleWork(miroId: String, data: String): Assertion = {
+  private def assertTransformReturnsInvisibleWork(miroId: String,
+                                                  data: String): Assertion = {
     val miroTransformable = createMiroTransformableWith(
       miroId = miroId,
       data = data

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableTransformerTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import org.scalatest.prop.TableDrivenPropertyChecks._
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.models.work.internal._
 
@@ -227,9 +227,11 @@ class MiroTransformableTransformerTest
 
     it("if usage restrictions mean we suppress the image") {
       assertTransformReturnsInvisibleWork(
+        miroId = "M0000001",
         data =
           buildJSONForWork(
-            """
+            miroId = "M0000001",
+            extraData = """
         "image_title": "Private pictures of perilous penguins",
         "image_use_restrictions": "Do not use"
       """)
@@ -240,7 +242,8 @@ class MiroTransformableTransformerTest
       assertTransformReturnsInvisibleWork(
         miroId = "B0009891",
         data = buildJSONForWork(
-          """
+          miroId = "B0009891",
+          extraData = """
         "image_source_code": "GUS"
       """)
       )
@@ -248,10 +251,12 @@ class MiroTransformableTransformerTest
 
     it("if the image isn't copyright cleared") {
       assertTransformReturnsInvisibleWork(
+        miroId = "M0000001",
         data =
           """{
         "image_cleared": "Y",
         "image_copyright_cleared": "N",
+        "image_no_calc": "M0000001",
         "image_tech_file_size": ["1000000"],
         "image_use_restrictions": "CC-BY"
       }"""
@@ -325,8 +330,7 @@ class MiroTransformableTransformerTest
     )
   }
 
-  private def assertTransformReturnsInvisibleWork(miroId: String = "G0000001",
-                                                  data: String) = {
+  private def assertTransformReturnsInvisibleWork(miroId: String, data: String): Assertion = {
     val miroTransformable = createMiroTransformableWith(
       miroId = miroId,
       data = data

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableTransformerTest.scala
@@ -223,35 +223,40 @@ class MiroTransformableTransformerTest
     )
   }
 
-  it(
-    "returns an InvisibleWork if usage restrictions mean we suppress the image") {
-    assertTransformReturnsInvisibleWork(
-      data =
-        buildJSONForWork("""
+  describe("returns an InvisibleWork when appropriate") {
+
+    it("if usage restrictions mean we suppress the image") {
+      assertTransformReturnsInvisibleWork(
+        data =
+          buildJSONForWork(
+            """
         "image_title": "Private pictures of perilous penguins",
         "image_use_restrictions": "Do not use"
       """)
-    )
-  }
+      )
+    }
 
-  it("returns an InvisibleWork for images from contributor GUS") {
-    assertTransformReturnsInvisibleWork(
-      miroId = "B0009891",
-      data = buildJSONForWork("""
+    it("if the image is from from contributor GUS") {
+      assertTransformReturnsInvisibleWork(
+        miroId = "B0009891",
+        data = buildJSONForWork(
+          """
         "image_source_code": "GUS"
       """)
-    )
-  }
+      )
+    }
 
-  it("returns an InvisibleWork for images without copyright clearance") {
-    assertTransformReturnsInvisibleWork(
-      data = """{
+    it("if the image isn't copyright cleared") {
+      assertTransformReturnsInvisibleWork(
+        data =
+          """{
         "image_cleared": "Y",
         "image_copyright_cleared": "N",
         "image_tech_file_size": ["1000000"],
         "image_use_restrictions": "CC-BY"
       }"""
-    )
+      )
+    }
   }
 
   it(

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableTransformerTest.scala
@@ -74,28 +74,28 @@ class MiroTransformableTransformerTest
 
     it("with mismatched ref IDs/department") {
       assertTransformWorkFails(
-        data = """
-          "image_library_ref_department": ["External Reference"],
-          "image_library_ref_id": ["Sanskrit ID 1924", "1234"]
-        """
+        createMiroTransformableDataWith(
+          libraryRefDepartment = List(Some("External Reference")),
+          libraryRefId = List(Some("Sanskrit ID 1924"), Some("1234"))
+        )
       )
     }
 
     it("with ref IDs null but department non-null") {
       assertTransformWorkFails(
-        data = """
-          "image_library_ref_department": ["External Reference"],
-          "image_library_ref_id": null
-        """
+        createMiroTransformableDataWith(
+          libraryRefDepartment = List(Some("External Reference")),
+          libraryRefId = Nil
+        )
       )
     }
 
     it("with ref IDs non-null but department null") {
       assertTransformWorkFails(
-        data = """
-          "image_library_ref_department": null,
-          "image_library_ref_id": ["Sanskrit ID 1924", "1234"]
-        """
+        createMiroTransformableDataWith(
+          libraryRefDepartment = Nil,
+          libraryRefId = List(Some("Sanskrit ID 1924"), Some("1234"))
+        )
       )
     }
   }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
@@ -31,8 +31,11 @@ trait MiroTransformableWrapper
     val jsonString = buildJSONForWork(miroId = miroId, data)
     val transformable = fromJson[MiroTransformableData](jsonString).get
 
-    transformToWork(transformable = transformable).asInstanceOf[UnidentifiedWork]
+    transformWork(transformable)
   }
+
+  def transformWork(transformable: MiroTransformableData): UnidentifiedWork =
+    transformToWork(transformable).asInstanceOf[UnidentifiedWork]
 
   def assertTransformWorkFails(transformable: MiroTransformableData): Assertion =
     transformer

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
@@ -24,21 +24,6 @@ trait MiroTransformableWrapper
     with MiroTransformableGenerators { this: Suite =>
 
   val transformer = new MiroTransformableTransformer
-  def buildJSONForWork(extraData: String): String = {
-    val baseData =
-      """
-        |"image_cleared": "Y",
-        |        "image_copyright_cleared": "Y",
-        |        "image_tech_file_size": ["1000000"],
-        |        "image_use_restrictions": "CC-BY"
-      """.stripMargin
-
-    if (extraData.isEmpty) s"""{$baseData}"""
-    else s"""{
-        $baseData,
-        $extraData
-      }"""
-  }
 
   def transformWork(
     miroId: String = "M0000001",
@@ -46,7 +31,7 @@ trait MiroTransformableWrapper
   ): UnidentifiedWork = {
     val miroTransformable = createMiroTransformableWith(
       miroId = miroId,
-      data = buildJSONForWork(data)
+      data = buildJSONForWork(miroId = miroId, data)
     )
 
     transformToWork(miroTransformable).asInstanceOf[UnidentifiedWork]
@@ -54,7 +39,7 @@ trait MiroTransformableWrapper
 
   def assertTransformWorkFails(data: String): Assertion = {
     val miroTransformable = createMiroTransformableWith(
-      data = buildJSONForWork(data)
+      data = buildJSONForWork(extraData = data)
     )
 
     assertTransformToWorkFails(miroTransformable)

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import org.scalatest.{Assertion, Matchers, Suite}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  TransformedBaseWork,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.miro.MiroTransformableTransformer
 import uk.ac.wellcome.platform.transformer.miro.generators.MiroTransformableGenerators
@@ -37,12 +40,17 @@ trait MiroTransformableWrapper
   def transformWork(transformable: MiroTransformableData): UnidentifiedWork =
     transformToWork(transformable).asInstanceOf[UnidentifiedWork]
 
-  def assertTransformWorkFails(transformable: MiroTransformableData): Assertion =
+  def assertTransformWorkFails(
+    transformable: MiroTransformableData): Assertion =
     transformer
-      .transform(transformable, metadata = MiroMetadata(isClearedForCatalogueAPI = true), version = 1)
+      .transform(
+        transformable,
+        metadata = MiroMetadata(isClearedForCatalogueAPI = true),
+        version = 1)
       .isSuccess shouldBe false
 
-  private def transformToWork(transformable: MiroTransformableData): TransformedBaseWork = {
+  private def transformToWork(
+    transformable: MiroTransformableData): TransformedBaseWork = {
     val triedWork: Try[TransformedBaseWork] = transformer.transform(
       transformable,
       metadata = MiroMetadata(isClearedForCatalogueAPI = true),

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWor
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.miro.MiroTransformableTransformer
 import uk.ac.wellcome.platform.transformer.miro.generators.MiroTransformableGenerators
-import uk.ac.wellcome.platform.transformer.miro.models.{MiroMetadata, MiroTransformable}
+import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
 import uk.ac.wellcome.platform.transformer.miro.source.MiroTransformableData
 
 import scala.util.Try
@@ -14,9 +14,9 @@ import scala.util.Try
 /** MiroTransformable looks for several fields in the source JSON -- if they're
   *  missing or have the wrong values, it rejects the record.
   *
-  *  This trait provides a single method `transform()` which adds the necessary
-  *  fields before transformation, allowing tests to focus on only the fields
-  *  that are interesting for that test.
+  *  This trait provides a single method `transformToWork()` which adds the
+  *  necessary fields before transformation, allowing tests to focus on only
+  *  the fields that are interesting for that test.
   */
 trait MiroTransformableWrapper
     extends Matchers
@@ -28,8 +28,8 @@ trait MiroTransformableWrapper
     miroId: String = "M0000001",
     data: String = ""
   ): UnidentifiedWork = {
-    val data = buildJSONForWork(miroId = miroId, data)
-    val transformable = fromJson[MiroTransformableData](data).get
+    val jsonString = buildJSONForWork(miroId = miroId, data)
+    val transformable = fromJson[MiroTransformableData](jsonString).get
 
     transformToWork(transformable = transformable).asInstanceOf[UnidentifiedWork]
   }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
@@ -35,11 +35,11 @@ trait MiroTransformableWrapper
   }
 
   def assertTransformWorkFails(data: String): Assertion = {
-    val miroTransformable = createMiroTransformableWith(
-      data = buildJSONForWork(extraData = data)
-    )
 
-    assertTransformToWorkFails(miroTransformable)
+    val transformable = fromJson[MiroTransformableData](data).get
+    transformer
+      .transform(transformable, metadata = MiroMetadata(isClearedForCatalogueAPI = true), version = 1)
+      .isSuccess shouldBe false
   }
 
   private def transformToWork(transformable: MiroTransformableData): TransformedBaseWork = {
@@ -58,12 +58,4 @@ trait MiroTransformableWrapper
     triedWork.isSuccess shouldBe true
     triedWork.get
   }
-
-  def assertTransformToWorkFails(
-    transformable: MiroTransformable): Assertion = {
-    transformer
-      .transform(transformable, version = 1)
-      .isSuccess shouldBe false
-  }
-
 }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
@@ -34,13 +34,10 @@ trait MiroTransformableWrapper
     transformToWork(transformable = transformable).asInstanceOf[UnidentifiedWork]
   }
 
-  def assertTransformWorkFails(data: String): Assertion = {
-
-    val transformable = fromJson[MiroTransformableData](data).get
+  def assertTransformWorkFails(transformable: MiroTransformableData): Assertion =
     transformer
       .transform(transformable, metadata = MiroMetadata(isClearedForCatalogueAPI = true), version = 1)
       .isSuccess shouldBe false
-  }
 
   private def transformToWork(transformable: MiroTransformableData): TransformedBaseWork = {
     val triedWork: Try[TransformedBaseWork] = transformer.transform(


### PR DESCRIPTION
This is a rather chunky patch for the Miro transformer. The key change is that it reads from a VHS whose entries are the Miro source data, rather than the weird MiroTransformable wrapper we created.

Unfortunately that wrapper is everywhere, so getting it out is rather tricky!

I might break this into multiple patches.

Part of #3038.