### PR TITLE
Receive HybridRecord and MiroMetadata from the VHS, not a MiroTransformable

### DIFF
--- a/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
@@ -39,9 +39,9 @@ class HybridRecordReceiverTest
 
   case class TestException(message: String) extends Exception(message)
   case class TestTransformable()
-  def transformToWork(transforrmable: TestTransformable, version: Int) =
+  def transformToWork(transformable: TestTransformable, version: Int) =
     Try(createUnidentifiedWorkWith(version = version))
-  def failingTransformToWork(transforrmable: TestTransformable, version: Int) =
+  def failingTransformToWork(transformable: TestTransformable, version: Int) =
     Try(throw TestException("BOOOM!"))
 
   it("receives a message and sends it to SNS client") {

--- a/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
@@ -124,9 +124,7 @@ class HybridRecordReceiverTest
         withHybridRecordReceiver[TestTransformable, Assertion](topic, bucket) {
           recordReceiver =>
             val future =
-              recordReceiver.receiveMessage(
-                invalidSqsMessage,
-                transformToWork)
+              recordReceiver.receiveMessage(invalidSqsMessage, transformToWork)
 
             whenReady(future.failed) { x =>
               x shouldBe a[TransformerException]
@@ -146,9 +144,7 @@ class HybridRecordReceiverTest
         withHybridRecordReceiver[TestTransformable, Assertion](topic, bucket) {
           recordReceiver =>
             val future =
-              recordReceiver.receiveMessage(
-                invalidSqsMessage,
-                transformToWork)
+              recordReceiver.receiveMessage(invalidSqsMessage, transformToWork)
 
             whenReady(future.failed) {
               _ shouldBe a[JsonDecodingError]

--- a/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/platform/transformer/receive/HybridRecordReceiverTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.json.exceptions.JsonDecodingError
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.{
@@ -21,7 +22,7 @@ import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.vhs.HybridRecord
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.Try
+import scala.util.{Random, Try}
 
 class HybridRecordReceiverTest
     extends FunSpec
@@ -46,27 +47,25 @@ class HybridRecordReceiverTest
 
   it("receives a message and sends it to SNS client") {
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { _ =>
-        withLocalS3Bucket { bucket =>
-          val sqsMessage = createHybridRecordNotificationWith(
-            TestTransformable(),
-            s3Client = s3Client,
-            bucket = bucket
-          )
+      withLocalS3Bucket { bucket =>
+        val sqsMessage = createHybridRecordNotificationWith(
+          TestTransformable(),
+          s3Client = s3Client,
+          bucket = bucket
+        )
 
-          withHybridRecordReceiver[TestTransformable, List[Assertion]](
-            topic,
-            bucket) { recordReceiver =>
-            val future =
-              recordReceiver.receiveMessage(sqsMessage, transformToWork)
+        withHybridRecordReceiver[TestTransformable, List[Assertion]](
+          topic,
+          bucket) { recordReceiver =>
+          val future =
+            recordReceiver.receiveMessage(sqsMessage, transformToWork)
 
-            whenReady(future) { _ =>
-              val works = getMessages[TransformedBaseWork](topic)
-              works.size should be >= 1
+          whenReady(future) { _ =>
+            val works = getMessages[TransformedBaseWork](topic)
+            works.size should be >= 1
 
-              works.map { work =>
-                work shouldBe a[UnidentifiedWork]
-              }
+            works.map { work =>
+              work shouldBe a[UnidentifiedWork]
             }
           }
         }
@@ -78,30 +77,28 @@ class HybridRecordReceiverTest
     val version = 5
 
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { _ =>
-        withLocalS3Bucket { bucket =>
-          val notification = createHybridRecordNotificationWith(
-            TestTransformable(),
-            version = version,
-            s3Client = s3Client,
-            bucket = bucket
-          )
+      withLocalS3Bucket { bucket =>
+        val notification = createHybridRecordNotificationWith(
+          TestTransformable(),
+          version = version,
+          s3Client = s3Client,
+          bucket = bucket
+        )
 
-          withHybridRecordReceiver[TestTransformable, List[Assertion]](
-            topic,
-            bucket) { recordReceiver =>
-            val future =
-              recordReceiver.receiveMessage(notification, transformToWork)
+        withHybridRecordReceiver[TestTransformable, List[Assertion]](
+          topic,
+          bucket) { recordReceiver =>
+          val future =
+            recordReceiver.receiveMessage(notification, transformToWork)
 
-            whenReady(future) { _ =>
-              val works = getMessages[TransformedBaseWork](topic)
-              works.size should be >= 1
+          whenReady(future) { _ =>
+            val works = getMessages[TransformedBaseWork](topic)
+            works.size should be >= 1
 
-              works.map { actualWork =>
-                actualWork shouldBe a[UnidentifiedWork]
-                val unidentifiedWork = actualWork.asInstanceOf[UnidentifiedWork]
-                unidentifiedWork.version shouldBe version
-              }
+            works.map { actualWork =>
+              actualWork shouldBe a[UnidentifiedWork]
+              val unidentifiedWork = actualWork.asInstanceOf[UnidentifiedWork]
+              unidentifiedWork.version shouldBe version
             }
           }
         }
@@ -111,31 +108,51 @@ class HybridRecordReceiverTest
 
   it("returns a failed future if it's unable to parse the SQS message") {
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { _ =>
-        withLocalS3Bucket { bucket =>
-          val key = randomAlphanumeric(10)
-          s3Client.putObject(bucket.name, key, "not a JSON string")
+      withLocalS3Bucket { bucket =>
+        val key = randomAlphanumeric(10)
+        s3Client.putObject(bucket.name, key, "not a JSON string")
 
-          val hybridRecord = HybridRecord(
-            id = "testId",
-            version = 1,
-            location = ObjectLocation(namespace = bucket.name, key = key)
-          )
-          val invalidSqsMessage = createNotificationMessageWith(
-            message = hybridRecord
-          )
+        val hybridRecord = HybridRecord(
+          id = "testId",
+          version = 1,
+          location = ObjectLocation(namespace = bucket.name, key = key)
+        )
+        val invalidSqsMessage = createNotificationMessageWith(
+          message = hybridRecord
+        )
 
-          withHybridRecordReceiver[TestTransformable, Assertion](topic, bucket) {
-            recordReceiver =>
-              val future =
-                recordReceiver.receiveMessage(
-                  invalidSqsMessage,
-                  transformToWork)
+        withHybridRecordReceiver[TestTransformable, Assertion](topic, bucket) {
+          recordReceiver =>
+            val future =
+              recordReceiver.receiveMessage(
+                invalidSqsMessage,
+                transformToWork)
 
-              whenReady(future.failed) { x =>
-                x shouldBe a[TransformerException]
-              }
-          }
+            whenReady(future.failed) { x =>
+              x shouldBe a[TransformerException]
+            }
+        }
+      }
+    }
+  }
+
+  it("fails if it can't parse a HybridRecord from SNS") {
+    withLocalSnsTopic { topic =>
+      withLocalS3Bucket { bucket =>
+        val invalidSqsMessage = createNotificationMessageWith(
+          message = Random.alphanumeric take 50 mkString
+        )
+
+        withHybridRecordReceiver[TestTransformable, Assertion](topic, bucket) {
+          recordReceiver =>
+            val future =
+              recordReceiver.receiveMessage(
+                invalidSqsMessage,
+                transformToWork)
+
+            whenReady(future.failed) {
+              _ shouldBe a[JsonDecodingError]
+            }
         }
       }
     }
@@ -143,25 +160,23 @@ class HybridRecordReceiverTest
 
   it("fails if it's unable to perform a transformation") {
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { _ =>
-        withLocalS3Bucket { bucket =>
-          val failingSqsMessage = createHybridRecordNotificationWith(
-            TestTransformable(),
-            s3Client = s3Client,
-            bucket = bucket
-          )
+      withLocalS3Bucket { bucket =>
+        val failingSqsMessage = createHybridRecordNotificationWith(
+          TestTransformable(),
+          s3Client = s3Client,
+          bucket = bucket
+        )
 
-          withHybridRecordReceiver[TestTransformable, Assertion](topic, bucket) {
-            recordReceiver =>
-              val future =
-                recordReceiver.receiveMessage(
-                  failingSqsMessage,
-                  failingTransformToWork)
+        withHybridRecordReceiver[TestTransformable, Assertion](topic, bucket) {
+          recordReceiver =>
+            val future =
+              recordReceiver.receiveMessage(
+                failingSqsMessage,
+                failingTransformToWork)
 
-              whenReady(future.failed) { x =>
-                x shouldBe a[TestException]
-              }
-          }
+            whenReady(future.failed) {
+              _ shouldBe a[TestException]
+            }
         }
       }
     }
@@ -169,30 +184,28 @@ class HybridRecordReceiverTest
 
   it("fails if it's unable to publish the work") {
     withLocalSnsTopic { topic =>
-      withLocalSqsQueue { _ =>
-        withLocalS3Bucket { bucket =>
-          val message = createHybridRecordNotificationWith(
-            TestTransformable(),
-            s3Client = s3Client,
-            bucket = bucket
-          )
+      withLocalS3Bucket { bucket =>
+        val message = createHybridRecordNotificationWith(
+          TestTransformable(),
+          s3Client = s3Client,
+          bucket = bucket
+        )
 
-          withHybridRecordReceiver[TestTransformable, Assertion](
-            topic,
-            bucket,
-            mockSnsClientFailPublishMessage) { recordReceiver =>
-            val future = recordReceiver.receiveMessage(message, transformToWork)
+        withHybridRecordReceiver[TestTransformable, Assertion](
+          topic,
+          bucket,
+          mockSnsClientFailPublishMessage) { recordReceiver =>
+          val future = recordReceiver.receiveMessage(message, transformToWork)
 
-            whenReady(future.failed) { x =>
-              x.getMessage should be("Failed publishing message")
-            }
+          whenReady(future.failed) {
+            _.getMessage should be("Failed publishing message")
           }
         }
       }
     }
   }
 
-  private def mockSnsClientFailPublishMessage = {
+  private def mockSnsClientFailPublishMessage: AmazonSNS = {
     val mockSNSClient = mock[AmazonSNS]
     when(mockSNSClient.publish(any[PublishRequest]))
       .thenThrow(new RuntimeException("Failed publishing message"))

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
@@ -9,9 +9,8 @@ import uk.ac.wellcome.config.storage.builders.S3Builder
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
-import uk.ac.wellcome.platform.transformer.miro.models.MiroTransformable
-import uk.ac.wellcome.platform.transformer.miro.services.MiroTransformerWorkerService
-import uk.ac.wellcome.platform.transformer.receive.HybridRecordReceiver
+import uk.ac.wellcome.platform.transformer.miro.services.{MiroTransformerWorkerService, MiroVHSRecordReceiver}
+import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration.Duration
@@ -24,14 +23,14 @@ object Main extends App with Logging {
   implicit val executionContext: ExecutionContext =
     AkkaBuilder.buildExecutionContext()
 
-  val messageReceiver = new HybridRecordReceiver[MiroTransformable](
+  val vhsRecordReceiver = new MiroVHSRecordReceiver(
     messageWriter =
       MessagingBuilder.buildMessageWriter[TransformedBaseWork](config),
-    objectStore = S3Builder.buildObjectStore[MiroTransformable](config)
+    objectStore = S3Builder.buildObjectStore[MiroRecord](config)
   )
 
   val workerService = new MiroTransformerWorkerService(
-    messageReceiver = messageReceiver,
+    vhsRecordReceiver = vhsRecordReceiver,
     miroTransformer = new MiroTransformableTransformer,
     sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config)
   )

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
@@ -9,7 +9,10 @@ import uk.ac.wellcome.config.storage.builders.S3Builder
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
-import uk.ac.wellcome.platform.transformer.miro.services.{MiroTransformerWorkerService, MiroVHSRecordReceiver}
+import uk.ac.wellcome.platform.transformer.miro.services.{
+  MiroTransformerWorkerService,
+  MiroVHSRecordReceiver
+}
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 
 import scala.concurrent.{Await, ExecutionContext}

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformableTransformer.scala
@@ -51,6 +51,14 @@ class MiroTransformableTransformer
     )
 
     Try {
+      // Any records that aren't cleared for the Catalogue API should be
+      // discarded immediately.
+      if (!miroMetadata.isClearedForCatalogueAPI) {
+        throw new ShouldNotTransformException(
+          s"Image ${originalMiroRecord.imageNumber} is not cleared for the API!"
+        )
+      }
+
       // This is an utterly awful hack we have to live with until we get
       // these corrected in the source data.
       val miroRecord = MiroRecord.create(toJson(originalMiroRecord).get)

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformableTransformer.scala
@@ -22,14 +22,6 @@ class MiroTransformableTransformer
     with Logging {
 
   def transform(miroRecord: MiroRecord,
-                version: Int): Try[TransformedBaseWork] =
-    transform(
-      miroRecord = miroRecord,
-      miroMetadata = MiroMetadata(isClearedForCatalogueAPI = true),
-      version = version
-    )
-
-  def transform(miroRecord: MiroRecord,
                 miroMetadata: MiroMetadata,
                 version: Int): Try[TransformedBaseWork] =
     doTransform(miroRecord, miroMetadata, version) map { transformed =>

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/models/MiroMetadata.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/models/MiroMetadata.scala
@@ -1,0 +1,5 @@
+package uk.ac.wellcome.platform.transformer.miro.models
+
+case class MiroMetadata(
+  isClearedForCatalogueAPI: Boolean
+)

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/models/MiroTransformable.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/models/MiroTransformable.scala
@@ -1,6 +1,0 @@
-package uk.ac.wellcome.platform.transformer.miro.models
-
-case class MiroTransformable(
-  sourceId: String,
-  data: String
-)

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerService.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerService.scala
@@ -4,17 +4,12 @@ import akka.Done
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
-import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.transformer.miro.MiroTransformableTransformer
-import uk.ac.wellcome.platform.transformer.miro.models.MiroTransformable
-import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
-import uk.ac.wellcome.platform.transformer.receive.HybridRecordReceiver
 
 import scala.concurrent.Future
-import scala.util.Try
 
 class MiroTransformerWorkerService(
-  messageReceiver: HybridRecordReceiver[MiroTransformable],
+  messageReceiver: MiroVHSRecordReceiver,
   miroTransformer: MiroTransformableTransformer,
   sqsStream: SQSStream[NotificationMessage]
 ) {
@@ -23,14 +18,5 @@ class MiroTransformerWorkerService(
     sqsStream.foreach(this.getClass.getSimpleName, processMessage)
 
   private def processMessage(message: NotificationMessage): Future[Unit] =
-    messageReceiver.receiveMessage(message, transform)
-
-  private def transform(
-    transformable: MiroTransformable,
-    version: Int
-  ): Try[TransformedBaseWork] =
-    miroTransformer.transform(
-      miroRecord = MiroRecord.create(transformable.data),
-      version = version
-    )
+    messageReceiver.receiveMessage(message, miroTransformer.transform)
 }

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerService.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerService.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.platform.transformer.miro.MiroTransformableTransformer
 import scala.concurrent.Future
 
 class MiroTransformerWorkerService(
-  messageReceiver: MiroVHSRecordReceiver,
+  vhsRecordReceiver: MiroVHSRecordReceiver,
   miroTransformer: MiroTransformableTransformer,
   sqsStream: SQSStream[NotificationMessage]
 ) {
@@ -18,5 +18,5 @@ class MiroTransformerWorkerService(
     sqsStream.foreach(this.getClass.getSimpleName, processMessage)
 
   private def processMessage(message: NotificationMessage): Future[Unit] =
-    messageReceiver.receiveMessage(message, miroTransformer.transform)
+    vhsRecordReceiver.receiveMessage(message, miroTransformer.transform)
 }

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.transformer.miro.services
 
 import grizzled.slf4j.Logging
-import io.circe.ParsingFailure
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.json.exceptions.JsonDecodingError
 import uk.ac.wellcome.messaging.message.MessageWriter
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, PublishAttempt}
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
@@ -39,8 +39,8 @@ class MiroVHSRecordReceiver(
 
     futurePublishAttempt
       .recover {
-        case e: ParsingFailure =>
-          info("Recoverable failure parsing HybridRecord from message", e)
+        case e: JsonDecodingError =>
+          info("Recoverable failure parsing HybridRecord/MiroMetadata from JSON", e)
           throw TransformerException(e)
       }
       .map(_ => ())

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
@@ -15,14 +15,16 @@ import uk.ac.wellcome.storage.vhs.HybridRecord
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-class MiroVHSRecordReceiver(
-  objectStore: ObjectStore[MiroRecord],
-  messageWriter: MessageWriter[TransformedBaseWork])(implicit ec: ExecutionContext)
-  extends Logging {
+class MiroVHSRecordReceiver(objectStore: ObjectStore[MiroRecord],
+                            messageWriter: MessageWriter[TransformedBaseWork])(
+  implicit ec: ExecutionContext)
+    extends Logging {
 
-  def receiveMessage(
-    message: NotificationMessage,
-    transformToWork: (MiroRecord, MiroMetadata, Int) => Try[TransformedBaseWork]): Future[Unit] = {
+  def receiveMessage(message: NotificationMessage,
+                     transformToWork: (
+                       MiroRecord,
+                       MiroMetadata,
+                       Int) => Try[TransformedBaseWork]): Future[Unit] = {
     debug(s"Starting to process message $message")
 
     val futurePublishAttempt = for {
@@ -40,7 +42,9 @@ class MiroVHSRecordReceiver(
     futurePublishAttempt
       .recover {
         case e: JsonDecodingError =>
-          info("Recoverable failure parsing HybridRecord/MiroMetadata from JSON", e)
+          info(
+            "Recoverable failure parsing HybridRecord/MiroMetadata from JSON",
+            e)
           throw TransformerException(e)
       }
       .map(_ => ())
@@ -50,7 +54,8 @@ class MiroVHSRecordReceiver(
   private def getTransformable(hybridRecord: HybridRecord): Future[MiroRecord] =
     objectStore.get(hybridRecord.location)
 
-  private def publishMessage(work: TransformedBaseWork): Future[PublishAttempt] =
+  private def publishMessage(
+    work: TransformedBaseWork): Future[PublishAttempt] =
     messageWriter.write(
       message = work,
       subject = s"source: ${this.getClass.getSimpleName}.publishMessage"

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.transformer.miro.services
 
 import grizzled.slf4j.Logging
 import io.circe.ParsingFailure
-import uk.ac.wellcome.json.JsonUtil.fromJson
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.message.MessageWriter
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, PublishAttempt}
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
@@ -1,0 +1,58 @@
+package uk.ac.wellcome.platform.transformer.miro.services
+
+import grizzled.slf4j.Logging
+import io.circe.ParsingFailure
+import uk.ac.wellcome.json.JsonUtil.fromJson
+import uk.ac.wellcome.messaging.message.MessageWriter
+import uk.ac.wellcome.messaging.sns.{NotificationMessage, PublishAttempt}
+import uk.ac.wellcome.models.work.internal.TransformedBaseWork
+import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
+import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
+import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
+import uk.ac.wellcome.storage.ObjectStore
+import uk.ac.wellcome.storage.vhs.HybridRecord
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+class MiroVHSRecordReceiver(
+  objectStore: ObjectStore[MiroRecord],
+  messageWriter: MessageWriter[TransformedBaseWork])(implicit ec: ExecutionContext)
+  extends Logging {
+
+  def receiveMessage(
+    message: NotificationMessage,
+    transformToWork: (MiroRecord, MiroMetadata, Int) => Try[TransformedBaseWork]): Future[Unit] = {
+    debug(s"Starting to process message $message")
+
+    val futurePublishAttempt = for {
+      hybridRecord <- Future.fromTry(fromJson[HybridRecord](message.body))
+      miroMetadata <- Future.fromTry(fromJson[MiroMetadata](message.body))
+      transformableRecord <- getTransformable(hybridRecord)
+      work <- Future.fromTry(
+        transformToWork(transformableRecord, miroMetadata, hybridRecord.version)
+      )
+      publishResult <- publishMessage(work)
+      _ = debug(
+        s"Published work: ${work.sourceIdentifier} with message $publishResult")
+    } yield publishResult
+
+    futurePublishAttempt
+      .recover {
+        case e: ParsingFailure =>
+          info("Recoverable failure parsing HybridRecord from message", e)
+          throw TransformerException(e)
+      }
+      .map(_ => ())
+
+  }
+
+  private def getTransformable(hybridRecord: HybridRecord): Future[MiroRecord] =
+    objectStore.get(hybridRecord.location)
+
+  private def publishMessage(work: TransformedBaseWork): Future[PublishAttempt] =
+    messageWriter.write(
+      message = work,
+      subject = s"source: ${this.getClass.getSimpleName}.publishMessage"
+    )
+}

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformerFeatureTest.scala
@@ -39,13 +39,14 @@ class MiroTransformerFeatureTest
       withLocalSqsQueue { queue =>
         withLocalS3Bucket { storageBucket =>
           withLocalS3Bucket { messageBucket =>
-            val miroHybridRecordMessage = createMiroVHSRecordNotificationMessageWith(
-              miroRecord = createMiroRecordWith(
-                title = Some(title),
-                imageNumber = miroID
-              ),
-              bucket = storageBucket
-            )
+            val miroHybridRecordMessage =
+              createMiroVHSRecordNotificationMessageWith(
+                miroRecord = createMiroRecordWith(
+                  title = Some(title),
+                  imageNumber = miroID
+                ),
+                bucket = storageBucket
+              )
 
             sendSqsMessage(
               queue = queue,
@@ -75,32 +76,34 @@ class MiroTransformerFeatureTest
     withLocalSnsTopic { topic =>
       withLocalSqsQueue { queue =>
         withLocalS3Bucket { storageBucket =>
-          val miroHybridRecordMessage1 = createMiroVHSRecordNotificationMessageWith(
-            miroRecord = createMiroRecordWith(
-              title = Some("Antonio Dionisi"),
-              description = Some("Antonio Dionisi"),
-              physFormat = Some("Book"),
-              copyrightCleared = Some("Y"),
-              imageNumber = "L0011975",
-              useRestrictions = Some("CC-BY"),
-              innopacID = Some("12917175"),
-              creditLine = Some("Wellcome Library, London")
-            ),
-            bucket = storageBucket
-          )
-          val miroHybridRecordMessage2 = createMiroVHSRecordNotificationMessageWith(
-            miroRecord = createMiroRecordWith(
-              title =
-                Some("Greenfield Sluder, Tonsillectomy..., use of guillotine"),
-              description = Some("Use of the guillotine"),
-              copyrightCleared = Some("Y"),
-              imageNumber = "L0023034",
-              useRestrictions = Some("CC-BY"),
-              innopacID = Some("12074536"),
-              creditLine = Some("Wellcome Library, London")
-            ),
-            bucket = storageBucket
-          )
+          val miroHybridRecordMessage1 =
+            createMiroVHSRecordNotificationMessageWith(
+              miroRecord = createMiroRecordWith(
+                title = Some("Antonio Dionisi"),
+                description = Some("Antonio Dionisi"),
+                physFormat = Some("Book"),
+                copyrightCleared = Some("Y"),
+                imageNumber = "L0011975",
+                useRestrictions = Some("CC-BY"),
+                innopacID = Some("12917175"),
+                creditLine = Some("Wellcome Library, London")
+              ),
+              bucket = storageBucket
+            )
+          val miroHybridRecordMessage2 =
+            createMiroVHSRecordNotificationMessageWith(
+              miroRecord = createMiroRecordWith(
+                title = Some(
+                  "Greenfield Sluder, Tonsillectomy..., use of guillotine"),
+                description = Some("Use of the guillotine"),
+                copyrightCleared = Some("Y"),
+                imageNumber = "L0023034",
+                useRestrictions = Some("CC-BY"),
+                innopacID = Some("12074536"),
+                creditLine = Some("Wellcome Library, London")
+              ),
+              bucket = storageBucket
+            )
 
           withLocalS3Bucket { messageBucket =>
             withWorkerService(topic, messageBucket, queue) { _ =>
@@ -121,19 +124,18 @@ class MiroTransformerFeatureTest
   def withWorkerService[R](topic: Topic, bucket: Bucket, queue: Queue)(
     testWith: TestWith[MiroTransformerWorkerService, R]): R =
     withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
-        withActorSystem { actorSystem =>
-          withSQSStream[NotificationMessage, R](actorSystem, queue) {
-            sqsStream =>
-              val workerService = new MiroTransformerWorkerService(
-                vhsRecordReceiver = recordReceiver,
-                miroTransformer = new MiroTransformableTransformer,
-                sqsStream = sqsStream
-              )
+      withActorSystem { actorSystem =>
+        withSQSStream[NotificationMessage, R](actorSystem, queue) { sqsStream =>
+          val workerService = new MiroTransformerWorkerService(
+            vhsRecordReceiver = recordReceiver,
+            miroTransformer = new MiroTransformableTransformer,
+            sqsStream = sqsStream
+          )
 
-              workerService.run()
+          workerService.run()
 
-              testWith(workerService)
-          }
+          testWith(workerService)
         }
+      }
     }
 }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
@@ -30,9 +30,13 @@ trait MiroVHSRecordReceiverFixture extends Messaging with SNS with MiroRecordGen
       testWith(recordReceiver)
     }
 
-  def createMiroVHSRecordWith(bucket: Bucket, version: Int = 1): NotificationMessage = {
+  def createMiroVHSRecordNotificationMessageWith(
+    miroRecord: MiroRecord = createMiroRecord,
+    bucket: Bucket,
+    version: Int = 1
+  ): NotificationMessage = {
     val hybridRecord = createHybridRecordWith(
-      createMiroRecord,
+      miroRecord,
       version = version,
       s3Client = s3Client,
       bucket = bucket

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
@@ -1,0 +1,31 @@
+package uk.ac.wellcome.platform.transformer.miro.fixtures
+
+import com.amazonaws.services.sns.AmazonSNS
+import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS}
+import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
+import uk.ac.wellcome.models.work.internal.TransformedBaseWork
+import uk.ac.wellcome.platform.transformer.miro.services.MiroVHSRecordReceiver
+import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
+import uk.ac.wellcome.storage.ObjectStore
+import uk.ac.wellcome.storage.fixtures.S3.Bucket
+import uk.ac.wellcome.test.fixtures.TestWith
+
+trait MiroVHSRecordReceiverFixture extends Messaging with SNS {
+  def withMiroVHSRecordReceiver[R](
+    topic: Topic,
+    bucket: Bucket,
+    snsClient: AmazonSNS = snsClient
+  )(testWith: TestWith[MiroVHSRecordReceiver, R])(
+    implicit objectStore: ObjectStore[MiroRecord]): R =
+    withMessageWriter[TransformedBaseWork, R](
+      bucket,
+      topic,
+      writerSnsClient = snsClient) { messageWriter =>
+      val recordReceiver = new MiroVHSRecordReceiver(
+        objectStore = objectStore,
+        messageWriter = messageWriter
+      )
+
+      testWith(recordReceiver)
+    }
+}

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
@@ -15,8 +15,12 @@ import uk.ac.wellcome.test.fixtures.TestWith
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait MiroVHSRecordReceiverFixture extends Messaging with SNS with MiroRecordGenerators {
-  def withMiroVHSRecordReceiver[R](topic: Topic, bucket: Bucket)(testWith: TestWith[MiroVHSRecordReceiver, R])(
+trait MiroVHSRecordReceiverFixture
+    extends Messaging
+    with SNS
+    with MiroRecordGenerators {
+  def withMiroVHSRecordReceiver[R](topic: Topic, bucket: Bucket)(
+    testWith: TestWith[MiroVHSRecordReceiver, R])(
     implicit objectStore: ObjectStore[MiroRecord]): R =
     withMessageWriter[TransformedBaseWork, R](
       bucket,
@@ -52,7 +56,8 @@ trait MiroVHSRecordReceiverFixture extends Messaging with SNS with MiroRecordGen
          |  "id": "${hybridRecord.id}",
          |  "location": ${toJson(hybridRecord.location).get},
          |  "version": ${hybridRecord.version},
-         |  "isClearedForCatalogueAPI": ${toJson(miroMetadata.isClearedForCatalogueAPI).get}
+         |  "isClearedForCatalogueAPI": ${toJson(
+           miroMetadata.isClearedForCatalogueAPI).get}
          |}
        """.stripMargin
     )

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
@@ -1,10 +1,12 @@
 package uk.ac.wellcome.platform.transformer.miro.fixtures
 
-import com.amazonaws.services.sns.AmazonSNS
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS}
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
+import uk.ac.wellcome.platform.transformer.miro.generators.MiroRecordGenerators
+import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
 import uk.ac.wellcome.platform.transformer.miro.services.MiroVHSRecordReceiver
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 import uk.ac.wellcome.storage.ObjectStore
@@ -13,12 +15,8 @@ import uk.ac.wellcome.test.fixtures.TestWith
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait MiroVHSRecordReceiverFixture extends Messaging with SNS {
-  def withMiroVHSRecordReceiver[R](
-    topic: Topic,
-    bucket: Bucket,
-    snsClient: AmazonSNS = snsClient
-  )(testWith: TestWith[MiroVHSRecordReceiver, R])(
+trait MiroVHSRecordReceiverFixture extends Messaging with SNS with MiroRecordGenerators {
+  def withMiroVHSRecordReceiver[R](topic: Topic, bucket: Bucket)(testWith: TestWith[MiroVHSRecordReceiver, R])(
     implicit objectStore: ObjectStore[MiroRecord]): R =
     withMessageWriter[TransformedBaseWork, R](
       bucket,
@@ -31,4 +29,28 @@ trait MiroVHSRecordReceiverFixture extends Messaging with SNS {
 
       testWith(recordReceiver)
     }
+
+  def createMiroVHSRecordWith(bucket: Bucket, version: Int = 1): NotificationMessage = {
+    val hybridRecord = createHybridRecordWith(
+      createMiroRecord,
+      version = version,
+      s3Client = s3Client,
+      bucket = bucket
+    )
+
+    val miroMetadata = MiroMetadata(isClearedForCatalogueAPI = true)
+
+    // Yes creating the JSON here manually is a bit icky, but it means this is
+    // a fixed, easy-to-read output, and saves us mucking around with Circe encoders.
+    createNotificationMessageWith(
+      s"""
+         |{
+         |  "id": "${hybridRecord.id}",
+         |  "location": ${toJson(hybridRecord.location).get},
+         |  "version": ${hybridRecord.version},
+         |  "isClearedForCatalogueAPI": ${toJson(miroMetadata.isClearedForCatalogueAPI).get}
+         |}
+       """.stripMargin
+    )
+  }
 }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.transformer.miro.fixtures
 
 import com.amazonaws.services.sns.AmazonSNS
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS}
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
@@ -9,6 +10,8 @@ import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures.TestWith
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 trait MiroVHSRecordReceiverFixture extends Messaging with SNS {
   def withMiroVHSRecordReceiver[R](

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -44,7 +44,7 @@ class MiroVHSRecordReceiverTest
   it("receives a message and sends it to SNS client") {
     withLocalSnsTopic { topic =>
       withLocalS3Bucket { bucket =>
-        val message = createMiroVHSRecordWith(bucket = bucket)
+        val message = createMiroVHSRecordNotificationMessageWith(bucket = bucket)
 
         withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
           val future = recordReceiver.receiveMessage(message, transformToWork)
@@ -67,7 +67,7 @@ class MiroVHSRecordReceiverTest
 
     withLocalSnsTopic { topic =>
       withLocalS3Bucket { bucket =>
-        val message = createMiroVHSRecordWith(
+        val message = createMiroVHSRecordNotificationMessageWith(
           version = version,
           bucket = bucket
         )
@@ -133,7 +133,7 @@ class MiroVHSRecordReceiverTest
   it("fails if it's unable to perform a transformation") {
     withLocalSnsTopic { topic =>
       withLocalS3Bucket { bucket =>
-        val message = createMiroVHSRecordWith(bucket = bucket)
+        val message = createMiroVHSRecordNotificationMessageWith(bucket = bucket)
 
         withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
           val future =
@@ -149,7 +149,7 @@ class MiroVHSRecordReceiverTest
 
   it("fails if it's unable to publish the work") {
     withLocalS3Bucket { bucket =>
-      val message = createMiroVHSRecordWith(bucket = bucket)
+      val message = createMiroVHSRecordNotificationMessageWith(bucket = bucket)
 
       withMiroVHSRecordReceiver(Topic("no-such-topic"), bucket) { recordReceiver =>
         val future = recordReceiver.receiveMessage(message, transformToWork)

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -7,6 +7,7 @@ import org.mockito.Mockito.when
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWork}
@@ -18,6 +19,7 @@ import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.vhs.HybridRecord
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Try
 
 class MiroVHSRecordReceiverTest

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -155,7 +155,7 @@ class MiroVHSRecordReceiverTest
         val future = recordReceiver.receiveMessage(message, transformToWork)
 
         whenReady(future.failed) {
-          _.getMessage should be("Failed publishing message")
+          _.getMessage should include("Unknown topic: no-such-topic")
         }
       }
     }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -1,0 +1,194 @@
+package uk.ac.wellcome.platform.transformer.miro.services
+
+import com.amazonaws.services.sns.AmazonSNS
+import com.amazonaws.services.sns.model.PublishRequest
+import org.mockito.Matchers.any
+import org.mockito.Mockito.when
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
+import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWork}
+import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
+import uk.ac.wellcome.platform.transformer.miro.fixtures.MiroVHSRecordReceiverFixture
+import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
+import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
+import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.fixtures.S3
+import uk.ac.wellcome.storage.vhs.HybridRecord
+
+import scala.util.Try
+
+class MiroVHSRecordReceiverTest
+    extends FunSpec
+    with Matchers
+    with SQS
+    with SNS
+    with S3
+    with Messaging
+    with Eventually
+    with MiroVHSRecordReceiverFixture
+    with IntegrationPatience
+    with MockitoSugar
+    with ScalaFutures
+    with WorksGenerators {
+
+  case class TestException(message: String) extends Exception(message)
+  case class TestTransformable()
+
+  def transformToWork(miroRecord: MiroRecord, metadata: MiroMetadata, version: Int) =
+    Try(createUnidentifiedWorkWith(version = version))
+
+  def failingTransformToWork(miroRecord: MiroRecord, metadata: MiroMetadata, version: Int) =
+    Try(throw TestException("BOOOM!"))
+
+  it("receives a message and sends it to SNS client") {
+    withLocalSnsTopic { topic =>
+      withLocalSqsQueue { _ =>
+        withLocalS3Bucket { bucket =>
+          val sqsMessage = createHybridRecordNotificationWith(
+            TestTransformable(),
+            s3Client = s3Client,
+            bucket = bucket
+          )
+
+          withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
+            val future = recordReceiver
+              .receiveMessage(sqsMessage, transformToWork)
+
+            whenReady(future) { _ =>
+              val works = getMessages[TransformedBaseWork](topic)
+              works.size should be >= 1
+
+              works.map { work =>
+                work shouldBe a[UnidentifiedWork]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  it("receives a message and adds the version to the transformed work") {
+    val version = 5
+
+    withLocalSnsTopic { topic =>
+      withLocalSqsQueue { _ =>
+        withLocalS3Bucket { bucket =>
+          val notification = createHybridRecordNotificationWith(
+            TestTransformable(),
+            version = version,
+            s3Client = s3Client,
+            bucket = bucket
+          )
+
+          withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
+            val future =
+              recordReceiver.receiveMessage(notification, transformToWork)
+
+            whenReady(future) { _ =>
+              val works = getMessages[TransformedBaseWork](topic)
+              works.size should be >= 1
+
+              works.map { actualWork =>
+                actualWork shouldBe a[UnidentifiedWork]
+                val unidentifiedWork = actualWork.asInstanceOf[UnidentifiedWork]
+                unidentifiedWork.version shouldBe version
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  it("returns a failed future if it's unable to parse the SQS message") {
+    withLocalSnsTopic { topic =>
+      withLocalSqsQueue { _ =>
+        withLocalS3Bucket { bucket =>
+          val key = randomAlphanumeric(10)
+          s3Client.putObject(bucket.name, key, "not a JSON string")
+
+          val hybridRecord = HybridRecord(
+            id = "testId",
+            version = 1,
+            location = ObjectLocation(namespace = bucket.name, key = key)
+          )
+          val invalidSqsMessage = createNotificationMessageWith(
+            message = hybridRecord
+          )
+
+          withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
+            val future =
+              recordReceiver.receiveMessage(
+                invalidSqsMessage,
+                transformToWork)
+
+            whenReady(future.failed) { x =>
+              x shouldBe a[TransformerException]
+            }
+          }
+        }
+      }
+    }
+  }
+
+  it("fails if it's unable to perform a transformation") {
+    withLocalSnsTopic { topic =>
+      withLocalSqsQueue { _ =>
+        withLocalS3Bucket { bucket =>
+          val failingSqsMessage = createHybridRecordNotificationWith(
+            TestTransformable(),
+            s3Client = s3Client,
+            bucket = bucket
+          )
+
+          withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
+            val future =
+              recordReceiver.receiveMessage(
+                failingSqsMessage,
+                failingTransformToWork)
+
+            whenReady(future.failed) { x =>
+              x shouldBe a[TestException]
+            }
+          }
+        }
+      }
+    }
+  }
+
+  it("fails if it's unable to publish the work") {
+    withLocalSnsTopic { topic =>
+      withLocalSqsQueue { _ =>
+        withLocalS3Bucket { bucket =>
+          val message = createHybridRecordNotificationWith(
+            TestTransformable(),
+            s3Client = s3Client,
+            bucket = bucket
+          )
+
+          withMiroVHSRecordReceiver(
+            topic,
+            bucket,
+            mockSnsClientFailPublishMessage) { recordReceiver =>
+            val future = recordReceiver.receiveMessage(message, transformToWork)
+
+            whenReady(future.failed) { x =>
+              x.getMessage should be("Failed publishing message")
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private def mockSnsClientFailPublishMessage: AmazonSNS = {
+    val mockSNSClient = mock[AmazonSNS]
+    when(mockSNSClient.publish(any[PublishRequest]))
+      .thenThrow(new RuntimeException("Failed publishing message"))
+    mockSNSClient
+  }
+}

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -7,7 +7,10 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SNS, SQS}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
-import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  TransformedBaseWork,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.miro.fixtures.MiroVHSRecordReceiverFixture
 import uk.ac.wellcome.platform.transformer.miro.generators.MiroRecordGenerators
@@ -35,16 +38,21 @@ class MiroVHSRecordReceiverTest
 
   case class TestException(message: String) extends Exception(message)
 
-  def transformToWork(miroRecord: MiroRecord, metadata: MiroMetadata, version: Int) =
+  def transformToWork(miroRecord: MiroRecord,
+                      metadata: MiroMetadata,
+                      version: Int) =
     Try(createUnidentifiedWorkWith(version = version))
 
-  def failingTransformToWork(miroRecord: MiroRecord, metadata: MiroMetadata, version: Int) =
+  def failingTransformToWork(miroRecord: MiroRecord,
+                             metadata: MiroMetadata,
+                             version: Int) =
     Try(throw TestException("BOOOM!"))
 
   it("receives a message and sends it to SNS client") {
     withLocalSnsTopic { topic =>
       withLocalS3Bucket { bucket =>
-        val message = createMiroVHSRecordNotificationMessageWith(bucket = bucket)
+        val message =
+          createMiroVHSRecordNotificationMessageWith(bucket = bucket)
 
         withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
           val future = recordReceiver.receiveMessage(message, transformToWork)
@@ -100,8 +108,8 @@ class MiroVHSRecordReceiverTest
         )
 
         withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
-          val future = recordReceiver.receiveMessage(
-            incompleteMessage, transformToWork)
+          val future =
+            recordReceiver.receiveMessage(incompleteMessage, transformToWork)
 
           whenReady(future.failed) {
             _ shouldBe a[TransformerException]
@@ -119,8 +127,8 @@ class MiroVHSRecordReceiverTest
         )
 
         withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
-          val future = recordReceiver.receiveMessage(
-            incompleteMessage, transformToWork)
+          val future =
+            recordReceiver.receiveMessage(incompleteMessage, transformToWork)
 
           whenReady(future.failed) {
             _ shouldBe a[TransformerException]
@@ -133,7 +141,8 @@ class MiroVHSRecordReceiverTest
   it("fails if it's unable to perform a transformation") {
     withLocalSnsTopic { topic =>
       withLocalS3Bucket { bucket =>
-        val message = createMiroVHSRecordNotificationMessageWith(bucket = bucket)
+        val message =
+          createMiroVHSRecordNotificationMessageWith(bucket = bucket)
 
         withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
           val future =
@@ -151,12 +160,13 @@ class MiroVHSRecordReceiverTest
     withLocalS3Bucket { bucket =>
       val message = createMiroVHSRecordNotificationMessageWith(bucket = bucket)
 
-      withMiroVHSRecordReceiver(Topic("no-such-topic"), bucket) { recordReceiver =>
-        val future = recordReceiver.receiveMessage(message, transformToWork)
+      withMiroVHSRecordReceiver(Topic("no-such-topic"), bucket) {
+        recordReceiver =>
+          val future = recordReceiver.receiveMessage(message, transformToWork)
 
-        whenReady(future.failed) {
-          _.getMessage should include("Unknown topic: no-such-topic")
-        }
+          whenReady(future.failed) {
+            _.getMessage should include("Unknown topic: no-such-topic")
+          }
       }
     }
   }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableTransformerTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.miro.generators.MiroRecordGenerators
+import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 
 class MiroTransformableTransformerTest
@@ -240,6 +241,13 @@ class MiroTransformableTransformerTest
         )
       )
     }
+
+    it("if the image isn't cleared for the catalogue API") {
+      assertTransformReturnsInvisibleWork(
+        createMiroRecord,
+        miroMetadata = MiroMetadata(isClearedForCatalogueAPI = false)
+      )
+    }
   }
 
   it(
@@ -306,8 +314,15 @@ class MiroTransformableTransformerTest
   }
 
   private def assertTransformReturnsInvisibleWork(
-    miroRecord: MiroRecord): Assertion = {
-    val triedMaybeWork = transformer.transform(miroRecord, version = 1)
+    miroRecord: MiroRecord,
+    miroMetadata: MiroMetadata = MiroMetadata(isClearedForCatalogueAPI = true)
+  ): Assertion = {
+    val triedMaybeWork = transformer.transform(
+      miroRecord = miroRecord,
+      miroMetadata = miroMetadata,
+      version = 1
+    )
+
     triedMaybeWork.isSuccess shouldBe true
 
     triedMaybeWork.get shouldBe UnidentifiedInvisibleWork(

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
@@ -1,12 +1,10 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import org.scalatest.{Assertion, Matchers, Suite}
-import uk.ac.wellcome.models.work.internal.{
-  TransformedBaseWork,
-  UnidentifiedWork
-}
+import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWork}
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.miro.MiroTransformableTransformer
+import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 
 import scala.util.Try
@@ -16,7 +14,11 @@ trait MiroTransformableWrapper extends Matchers { this: Suite =>
 
   def transformWork(miroRecord: MiroRecord): UnidentifiedWork = {
     val triedWork: Try[TransformedBaseWork] =
-      transformer.transform(miroRecord, version = 1)
+      transformer.transform(
+        miroRecord = miroRecord,
+        miroMetadata = MiroMetadata(isClearedForCatalogueAPI = true),
+        version = 1
+      )
 
     if (triedWork.isFailure) {
       triedWork.failed.get.printStackTrace()
@@ -30,6 +32,10 @@ trait MiroTransformableWrapper extends Matchers { this: Suite =>
 
   def assertTransformWorkFails(miroRecord: MiroRecord): Assertion =
     transformer
-      .transform(miroRecord, version = 1)
+      .transform(
+        miroRecord = miroRecord,
+        miroMetadata = MiroMetadata(isClearedForCatalogueAPI = true),
+        version = 1
+      )
       .isSuccess shouldBe false
 }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import org.scalatest.{Assertion, Matchers, Suite}
-import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  TransformedBaseWork,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.platform.transformer.exceptions.TransformerException
 import uk.ac.wellcome.platform.transformer.miro.MiroTransformableTransformer
 import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata


### PR DESCRIPTION
This allows the Miro transformer to read from the new VHS.

Once merged, I'll deploy it and run a small reindex before exposing it to the entire data set.

Follows #3084. Part of #3038.