### PR TITLE
Support "In copyright" licenses in the Miro transformer

### DIFF
--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
@@ -32,11 +32,12 @@ trait MiroLicenses {
         useRestrictions match {
 
           // Certain strings map directly onto license types
-          case "CC-0"        => License_CC0
-          case "CC-BY"       => License_CCBY
-          case "CC-BY-NC"    => License_CCBYNC
-          case "CC-BY-NC-ND" => License_CCBYNCND
-          case "PDM"         => License_PDM
+          case "CC-0"         => License_CC0
+          case "CC-BY"        => License_CCBY
+          case "CC-BY-NC"     => License_CCBYNC
+          case "CC-BY-NC-ND"  => License_CCBYNCND
+          case "PDM"          => License_PDM
+          case "In copyright" => License_CopyrightNotCleared
 
           // These mappings are defined in Christy's document
           case "Academics" => License_CCBYNC

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicensesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicensesTest.scala
@@ -1,7 +1,11 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal.{License, License_CC0, License_CopyrightNotCleared}
+import uk.ac.wellcome.models.work.internal.{
+  License,
+  License_CC0,
+  License_CopyrightNotCleared
+}
 import uk.ac.wellcome.platform.transformer.exceptions.ShouldNotTransformException
 
 class MiroLicensesTest extends FunSpec with Matchers {
@@ -32,7 +36,9 @@ class MiroLicensesTest extends FunSpec with Matchers {
   }
 
   private def chooseLicense(maybeUseRestrictions: Option[String]): License =
-    transformer.chooseLicense(miroId = "A1234567", maybeUseRestrictions = maybeUseRestrictions)
+    transformer.chooseLicense(
+      miroId = "A1234567",
+      maybeUseRestrictions = maybeUseRestrictions)
 
   val transformer = new MiroLicenses {}
 }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicensesTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicensesTest.scala
@@ -1,33 +1,38 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.work.internal.License_CC0
+import uk.ac.wellcome.models.work.internal.{License, License_CC0, License_CopyrightNotCleared}
 import uk.ac.wellcome.platform.transformer.exceptions.ShouldNotTransformException
 
 class MiroLicensesTest extends FunSpec with Matchers {
-  val miroId = "V00001"
-
   it("finds a recognised license") {
-    transformer.chooseLicense(miroId, Some("CC-0")) shouldBe License_CC0
+    chooseLicense(Some("CC-0")) shouldBe License_CC0
+  }
+
+  it("accepts an 'In Copyright' record") {
+    chooseLicense(Some("In copyright")) shouldBe License_CopyrightNotCleared
   }
 
   it("rejects restrictions 'Do not use'") {
     intercept[ShouldNotTransformException] {
-      transformer.chooseLicense(miroId, Some("Do not use"))
+      chooseLicense(Some("Do not use"))
     }
   }
 
   it("rejects restrictions 'Image withdrawn, see notes'") {
     intercept[ShouldNotTransformException] {
-      transformer.chooseLicense(miroId, Some("Image withdrawn, see notes"))
+      chooseLicense(Some("Image withdrawn, see notes"))
     }
   }
 
   it("rejects the record if the usage restrictions are unspecified") {
     intercept[ShouldNotTransformException] {
-      transformer.chooseLicense(miroId, None)
+      chooseLicense(maybeUseRestrictions = None)
     }
   }
+
+  private def chooseLicense(maybeUseRestrictions: Option[String]): License =
+    transformer.chooseLicense(miroId = "A1234567", maybeUseRestrictions = maybeUseRestrictions)
 
   val transformer = new MiroLicenses {}
 }

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1.scala
@@ -21,7 +21,7 @@ case class DisplayLicenseV1(
   ) label: String,
   @ApiModelProperty(
     value = "URL to the full text of a license"
-  ) url: String,
+  ) url: Option[String],
   @ApiModelProperty(readOnly = true, value = "A type of thing")
   @JsonProperty("type") @JsonKey("type") ontologyType: String = "License"
 )

--- a/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLicenseV2.scala
+++ b/sbt_common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayLicenseV2.scala
@@ -21,7 +21,7 @@ case class DisplayLicenseV2(
   ) label: String,
   @ApiModelProperty(
     value = "URL to the full text of a license"
-  ) url: String,
+  ) url: Option[String],
   @ApiModelProperty(readOnly = true, value = "A type of thing")
   @JsonProperty("type") @JsonKey("type") ontologyType: String = "License"
 )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -8,11 +8,15 @@ import uk.ac.wellcome.models.work.internal._
 
 trait DisplaySerialisationTestBase { this: Suite =>
 
-  def optionalString(fieldName: String, maybeStringValue: Option[String]) =
-    maybeStringValue map { p =>
+  def optionalString(
+    fieldName: String,
+    maybeStringValue: Option[String],
+    trailingComma: Boolean = true): Option[String] =
+    maybeStringValue.map { p =>
       s"""
-           "$fieldName": "$p"
-         """
+        "$fieldName": "$p"
+        ${if (trailingComma) "," else ""}
+      """
     }
 
   def optionalObject[T](fieldName: String,
@@ -124,12 +128,8 @@ trait DisplaySerialisationTestBase { this: Suite =>
   def person(p: Person) = {
     s"""{
         "type": "Person",
-        ${optionalString("prefix", p.prefix)
-      .map(str => s"$str, ")
-      .getOrElse("")}
-        ${optionalString("numeration", p.numeration)
-      .map(str => s"$str, ")
-      .getOrElse("")}
+        ${optionalString("prefix", p.prefix)}
+        ${optionalString("numeration", p.numeration)}
         "label": "${p.label}"
       }"""
   }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -8,10 +8,9 @@ import uk.ac.wellcome.models.work.internal._
 
 trait DisplaySerialisationTestBase { this: Suite =>
 
-  def optionalString(
-    fieldName: String,
-    maybeStringValue: Option[String],
-    trailingComma: Boolean = true): String =
+  def optionalString(fieldName: String,
+                     maybeStringValue: Option[String],
+                     trailingComma: Boolean = true): String =
     maybeStringValue match {
       case None => ""
       case Some(value) =>

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -8,14 +8,17 @@ import uk.ac.wellcome.models.work.internal._
 
 trait DisplaySerialisationTestBase { this: Suite =>
 
-  def optionalString(fieldName: String,
-                     maybeStringValue: Option[String],
-                     trailingComma: Boolean = true): Option[String] =
-    maybeStringValue.map { p =>
-      s"""
-        "$fieldName": "$p"
-        ${if (trailingComma) "," else ""}
-      """
+  def optionalString(
+    fieldName: String,
+    maybeStringValue: Option[String],
+    trailingComma: Boolean = true): String =
+    maybeStringValue match {
+      case None => ""
+      case Some(value) =>
+        s"""
+          "$fieldName": "$value"
+          ${if (trailingComma) "," else ""}
+        """
     }
 
   def optionalObject[T](fieldName: String,

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -8,10 +8,9 @@ import uk.ac.wellcome.models.work.internal._
 
 trait DisplaySerialisationTestBase { this: Suite =>
 
-  def optionalString(
-    fieldName: String,
-    maybeStringValue: Option[String],
-    trailingComma: Boolean = true): Option[String] =
+  def optionalString(fieldName: String,
+                     maybeStringValue: Option[String],
+                     trailingComma: Boolean = true): Option[String] =
     maybeStringValue.map { p =>
       s"""
         "$fieldName": "$p"

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1Test.scala
@@ -13,7 +13,7 @@ class DisplayLicenseV1Test extends FunSpec with Matchers {
     // internal model changes.
     displayLicense.licenseType shouldBe "CC-BY"
     displayLicense.label shouldBe "Attribution 4.0 International (CC BY 4.0)"
-    displayLicense.url shouldBe "http://creativecommons.org/licenses/by/4.0/"
+    displayLicense.url shouldBe Some("http://creativecommons.org/licenses/by/4.0/")
     displayLicense.ontologyType shouldBe "License"
   }
 }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayLicenseV1Test.scala
@@ -13,7 +13,8 @@ class DisplayLicenseV1Test extends FunSpec with Matchers {
     // internal model changes.
     displayLicense.licenseType shouldBe "CC-BY"
     displayLicense.label shouldBe "Attribution 4.0 International (CC BY 4.0)"
-    displayLicense.url shouldBe Some("http://creativecommons.org/licenses/by/4.0/")
+    displayLicense.url shouldBe Some(
+      "http://creativecommons.org/licenses/by/4.0/")
     displayLicense.ontologyType shouldBe "License"
   }
 }

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayV1SerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayV1SerialisationTestBase.scala
@@ -15,8 +15,8 @@ trait DisplayV1SerialisationTestBase extends DisplaySerialisationTestBase {
     s"""{
       "label": "${license.label}",
       "licenseType": "${license.id.toUpperCase}",
-      "type": "${license.ontologyType}",
-      "url": "${license.url}"
+      ${optionalString("url", license.url)}
+      "type": "${license.ontologyType}"
     }"""
 
   def identifier(identifier: SourceIdentifier) =

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayV2SerialisationTestBase.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayV2SerialisationTestBase.scala
@@ -15,8 +15,8 @@ trait DisplayV2SerialisationTestBase extends DisplaySerialisationTestBase {
     s"""{
       "id": "${license.id}",
       "label": "${license.label}",
-      "type": "${license.ontologyType}",
-      "url": "${license.url}"
+      ${optionalString("url", license.url)}
+      "type": "${license.ontologyType}"
     }"""
 
   def identifier(identifier: SourceIdentifier) =

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -17,10 +17,7 @@ class WorksIndex(client: HttpClient, rootIndexType: String)(
   val httpClient: HttpClient = client
 
   val license = objectField("license").fields(
-    keywordField("ontologyType"),
-    keywordField("id"),
-    textField("label"),
-    textField("url")
+    keywordField("id")
   )
 
   def sourceIdentifierFields = Seq(

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
@@ -26,12 +26,13 @@ object License {
 
   def createLicense(id: String): License = {
     id match {
-      case s: String if s == License_CCBY.id     => License_CCBY
-      case s: String if s == License_CCBYNC.id   => License_CCBYNC
-      case s: String if s == License_CCBYNCND.id => License_CCBYNCND
-      case s: String if s == License_CC0.id      => License_CC0
-      case s: String if s == License_PDM.id      => License_PDM
-      case id =>
+      case s: String if s == License_CCBY.id                => License_CCBY
+      case s: String if s == License_CCBYNC.id              => License_CCBYNC
+      case s: String if s == License_CCBYNCND.id            => License_CCBYNCND
+      case s: String if s == License_CC0.id                 => License_CC0
+      case s: String if s == License_PDM.id                 => License_PDM
+      case s: String if s == License_CopyrightNotCleared.id => License_CopyrightNotCleared
+      case _ =>
         val errorMessage = s"$id is not a valid id"
         throw new Exception(errorMessage)
     }
@@ -67,4 +68,10 @@ case object License_PDM extends License {
   val id = "pdm"
   val label = "Public Domain Mark"
   val url = Some("https://creativecommons.org/share-your-work/public-domain/pdm/")
+}
+
+case object License_CopyrightNotCleared extends License {
+  val id = "copyright-not-cleared"
+  val label = "Copyright not cleared"
+  val url: Option[String] = None
 }

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
@@ -13,11 +13,9 @@ object License {
   implicit val licenseEncoder = Encoder.instance[License](
     license =>
       Json.obj(
-        ("id", Json.fromString(license.id)),
-        ("label", Json.fromString(license.label)),
-        ("url", Json.fromString(license.url)),
-        ("ontologyType", Json.fromString(license.ontologyType))
-    ))
+        ("id", Json.fromString(license.id))
+      )
+  )
 
   implicit val licenseDecoder = Decoder.instance[License](cursor =>
     for {

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
@@ -5,7 +5,7 @@ import io.circe.{Decoder, Encoder, Json}
 sealed trait License {
   val id: String
   val label: String
-  val url: String
+  val url: Option[String]
   val ontologyType: String = "License"
 }
 
@@ -41,30 +41,30 @@ object License {
 case object License_CCBY extends License {
   val id = "cc-by"
   val label = "Attribution 4.0 International (CC BY 4.0)"
-  val url = "http://creativecommons.org/licenses/by/4.0/"
+  val url = Some("http://creativecommons.org/licenses/by/4.0/")
 }
 
 case object License_CCBYNC extends License {
   val id = "cc-by-nc"
   val label = "Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)"
-  val url = "https://creativecommons.org/licenses/by-nc/4.0/"
+  val url = Some("https://creativecommons.org/licenses/by-nc/4.0/")
 }
 
 case object License_CCBYNCND extends License {
   val id = "cc-by-nc-nd"
   val label =
     "Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)"
-  val url = "https://creativecommons.org/licenses/by-nc-nd/4.0/"
+  val url = Some("https://creativecommons.org/licenses/by-nc-nd/4.0/")
 }
 
 case object License_CC0 extends License {
   val id = "cc-0"
   val label = "CC0 1.0 Universal"
-  val url = "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
+  val url = Some("https://creativecommons.org/publicdomain/zero/1.0/legalcode")
 }
 
 case object License_PDM extends License {
   val id = "pdm"
   val label = "Public Domain Mark"
-  val url = "https://creativecommons.org/share-your-work/public-domain/pdm/"
+  val url = Some("https://creativecommons.org/share-your-work/public-domain/pdm/")
 }

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
@@ -14,7 +14,7 @@ object License {
     license =>
       Json.obj(
         ("id", Json.fromString(license.id))
-      )
+    )
   )
 
   implicit val licenseDecoder = Decoder.instance[License](cursor =>
@@ -26,12 +26,13 @@ object License {
 
   def createLicense(id: String): License = {
     id match {
-      case s: String if s == License_CCBY.id                => License_CCBY
-      case s: String if s == License_CCBYNC.id              => License_CCBYNC
-      case s: String if s == License_CCBYNCND.id            => License_CCBYNCND
-      case s: String if s == License_CC0.id                 => License_CC0
-      case s: String if s == License_PDM.id                 => License_PDM
-      case s: String if s == License_CopyrightNotCleared.id => License_CopyrightNotCleared
+      case s: String if s == License_CCBY.id     => License_CCBY
+      case s: String if s == License_CCBYNC.id   => License_CCBYNC
+      case s: String if s == License_CCBYNCND.id => License_CCBYNCND
+      case s: String if s == License_CC0.id      => License_CC0
+      case s: String if s == License_PDM.id      => License_PDM
+      case s: String if s == License_CopyrightNotCleared.id =>
+        License_CopyrightNotCleared
       case _ =>
         val errorMessage = s"$id is not a valid id"
         throw new Exception(errorMessage)
@@ -67,7 +68,8 @@ case object License_CC0 extends License {
 case object License_PDM extends License {
   val id = "pdm"
   val label = "Public Domain Mark"
-  val url = Some("https://creativecommons.org/share-your-work/public-domain/pdm/")
+  val url = Some(
+    "https://creativecommons.org/share-your-work/public-domain/pdm/")
 }
 
 case object License_CopyrightNotCleared extends License {

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LicenseTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LicenseTest.scala
@@ -1,34 +1,22 @@
 package uk.ac.wellcome.models.work.internal
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 
 class LicenseTest extends FunSpec with Matchers {
 
-  it("serialises a License as JSON") {
-    val result = toJson[License](License_CCBY)
-    result.isSuccess shouldBe true
-    result.get shouldBe """{"id":"cc-by","label":"Attribution 4.0 International (CC BY 4.0)","url":"http://creativecommons.org/licenses/by/4.0/","ontologyType":"License"}"""
+  it("can serialise and then deserialise a CC-BY license as JSON") {
+    assertRoundTripsLicenseCorrectly(License_CCBY)
   }
 
-  it("deserialises a JSON string as a License") {
-    val id = License_CC0.id
-    val label = License_CC0.label
-    val url = License_CC0.url
-
-    val jsonString = s"""
-      {
-        "id": "$id",
-        "label": "$label",
-        "url": "$url",
-        "ontologyType": "License"
-      }"""
-    val result = fromJson[License](jsonString)
+  def assertRoundTripsLicenseCorrectly(license: License): Assertion = {
+    val result = toJson[License](license)
     result.isSuccess shouldBe true
 
-    val license = result.get
-    license.id shouldBe id
-    license.label shouldBe label
-    license.url shouldBe url
+    val jsonString = result.get
+    val parsedLicense = fromJson[License](jsonString)
+    parsedLicense.isSuccess shouldBe true
+
+    parsedLicense.get shouldBe license
   }
 }

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LicenseTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LicenseTest.scala
@@ -9,6 +9,10 @@ class LicenseTest extends FunSpec with Matchers {
     assertRoundTripsLicenseCorrectly(License_CCBY)
   }
 
+  it("can serialise and then deserialise a copyright-not-cleared license as JSON") {
+    assertRoundTripsLicenseCorrectly(License_CopyrightNotCleared)
+  }
+
   def assertRoundTripsLicenseCorrectly(license: License): Assertion = {
     val result = toJson[License](license)
     result.isSuccess shouldBe true

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LicenseTest.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LicenseTest.scala
@@ -9,7 +9,8 @@ class LicenseTest extends FunSpec with Matchers {
     assertRoundTripsLicenseCorrectly(License_CCBY)
   }
 
-  it("can serialise and then deserialise a copyright-not-cleared license as JSON") {
+  it(
+    "can serialise and then deserialise a copyright-not-cleared license as JSON") {
     assertRoundTripsLicenseCorrectly(License_CopyrightNotCleared)
   }
 


### PR DESCRIPTION
This is why quite a few of the Miro records are failing; I added this text as part of #2790.

See https://github.com/wellcometrust/wellcomecollection.org/blob/master/common/data/licenses.js#L3-L6 – this is already supported in the front end.