### PR TITLE
Refactor the reindexer core to pass around table name/topic ARN

### DIFF
--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/Main.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/Main.scala
@@ -43,7 +43,7 @@ object Main extends App with Logging {
   )
 
   val hybridRecordSender = new BulkSNSSender(
-    snsWriter = SNSBuilder.buildSNSWriter(config)
+    snsMessageWriter = SNSBuilder.buildSNSMessageWriter(config)
   )
 
   val workerService = new ReindexWorkerService(

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/Main.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/Main.scala
@@ -33,16 +33,12 @@ object Main extends App with Logging {
     dynamoDBClient = DynamoBuilder.buildDynamoClient(config)
   )
 
-  val dynamoConfig = DynamoBuilder.buildDynamoConfig(config)
-
   val recordReader = new RecordReader(
     maxRecordsScanner = new MaxRecordsScanner(
-      scanSpecScanner = scanSpecScanner,
-      dynamoConfig = dynamoConfig
+      scanSpecScanner = scanSpecScanner
     ),
     parallelScanner = new ParallelScanner(
-      scanSpecScanner = scanSpecScanner,
-      dynamoConfig = dynamoConfig
+      scanSpecScanner = scanSpecScanner
     )
   )
 
@@ -54,7 +50,7 @@ object Main extends App with Logging {
     recordReader = recordReader,
     bulkSNSSender = hybridRecordSender,
     sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
-    dynamoConfig = dynamoConfig,
+    dynamoConfig = DynamoBuilder.buildDynamoConfig(config),
     snsConfig = SNSBuilder.buildSNSConfig(config)
   )
 

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/Main.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/Main.scala
@@ -33,14 +33,16 @@ object Main extends App with Logging {
     dynamoDBClient = DynamoBuilder.buildDynamoClient(config)
   )
 
+  val dynamoConfig = DynamoBuilder.buildDynamoConfig(config)
+
   val recordReader = new RecordReader(
     maxRecordsScanner = new MaxRecordsScanner(
       scanSpecScanner = scanSpecScanner,
-      dynamoConfig = DynamoBuilder.buildDynamoConfig(config)
+      dynamoConfig = dynamoConfig
     ),
     parallelScanner = new ParallelScanner(
       scanSpecScanner = scanSpecScanner,
-      dynamoConfig = DynamoBuilder.buildDynamoConfig(config)
+      dynamoConfig = dynamoConfig
     )
   )
 
@@ -51,7 +53,9 @@ object Main extends App with Logging {
   val workerService = new ReindexWorkerService(
     recordReader = recordReader,
     bulkSNSSender = hybridRecordSender,
-    sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config)
+    sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
+    dynamoConfig = dynamoConfig,
+    snsConfig = SNSBuilder.buildSNSConfig(config)
   )
 
   try {

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/MaxRecordsScanner.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/MaxRecordsScanner.scala
@@ -1,23 +1,21 @@
 package uk.ac.wellcome.platform.reindex.reindex_worker.dynamo
 
 import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
-import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
 import scala.concurrent.Future
 
-class MaxRecordsScanner(scanSpecScanner: ScanSpecScanner,
-                        dynamoConfig: DynamoConfig) {
+class MaxRecordsScanner(scanSpecScanner: ScanSpecScanner) {
 
   /** Run a DynamoDB Scan that returns at most `maxResults` values.
     *
     * It may return less if there aren't enough results in the table, or if
     * `maxResults` is larger than the maximum page size.
     */
-  def scan(maxRecords: Int): Future[List[String]] = {
+  def scan(maxRecords: Int)(tableName: String): Future[List[String]] = {
 
     val scanSpec = new ScanSpec()
       .withMaxResultSize(maxRecords)
 
-    scanSpecScanner.scan(scanSpec = scanSpec, tableName = dynamoConfig.table)
+    scanSpecScanner.scan(scanSpec = scanSpec, tableName = tableName)
   }
 }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ParallelScanner.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ParallelScanner.scala
@@ -26,7 +26,8 @@ class ParallelScanner(scanSpecScanner: ScanSpecScanner) {
     * Note that this returns a Future[List], so results will be cached in-memory.
     * Choose segment count accordingly.
     */
-  def scan(segment: Int, totalSegments: Int)(tableName: String): Future[List[String]] = {
+  def scan(segment: Int, totalSegments: Int)(
+    tableName: String): Future[List[String]] = {
 
     // Create the ScanSpec configuration and the DynamoDB table.  This is
     // based on the Java example of a Parallel Scan from the AWS docs:

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ParallelScanner.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/ParallelScanner.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.reindex.reindex_worker.dynamo
 
 import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
-import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
 import scala.concurrent.Future
 
@@ -12,8 +11,7 @@ import scala.concurrent.Future
   *
   * https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan
   */
-class ParallelScanner(scanSpecScanner: ScanSpecScanner,
-                      dynamoConfig: DynamoConfig) {
+class ParallelScanner(scanSpecScanner: ScanSpecScanner) {
 
   /** Run a Parallel Scan for a single worker.
     *
@@ -28,7 +26,7 @@ class ParallelScanner(scanSpecScanner: ScanSpecScanner,
     * Note that this returns a Future[List], so results will be cached in-memory.
     * Choose segment count accordingly.
     */
-  def scan(segment: Int, totalSegments: Int): Future[List[String]] = {
+  def scan(segment: Int, totalSegments: Int)(tableName: String): Future[List[String]] = {
 
     // Create the ScanSpec configuration and the DynamoDB table.  This is
     // based on the Java example of a Parallel Scan from the AWS docs:
@@ -38,6 +36,6 @@ class ParallelScanner(scanSpecScanner: ScanSpecScanner,
       .withTotalSegments(totalSegments)
       .withSegment(segment)
 
-    scanSpecScanner.scan(scanSpec = scanSpec, tableName = dynamoConfig.table)
+    scanSpecScanner.scan(scanSpec = scanSpec, tableName = tableName)
   }
 }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/models/ReindexJob.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/models/ReindexJob.scala
@@ -1,23 +1,10 @@
 package uk.ac.wellcome.platform.reindex.reindex_worker.models
 
-/** A request to reindex some or all of the records in a table.
-  *
-  * The two classes represent the two ways you might use the reindexer:
-  *
-  *   1) For a "complete" reindex -- every record in the table should be sent
-  *      to the downstream applications.  Use this when you want to reprocess
-  *      the entire data set.
-  *   2) For a "partial" reindex -- when you want to test the downstream
-  *      applications without swamping them with records.  Use this for smoke tests.
-  *
-  */
-sealed trait ReindexJob
+import uk.ac.wellcome.messaging.sns.SNSConfig
+import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
-case class CompleteReindexJob(
-  segment: Int,
-  totalSegments: Int
-) extends ReindexJob
-
-case class PartialReindexJob(
-  maxRecords: Int
-) extends ReindexJob
+case class ReindexJob(
+  parameters: ReindexParameters,
+  dynamoConfig: DynamoConfig,
+  snsConfig: SNSConfig
+)

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/models/ReindexParameters.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/models/ReindexParameters.scala
@@ -21,4 +21,3 @@ case class CompleteReindexParameters(
 case class PartialReindexParameters(
   maxRecords: Int
 ) extends ReindexParameters
-

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/models/ReindexParameters.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/models/ReindexParameters.scala
@@ -1,0 +1,24 @@
+package uk.ac.wellcome.platform.reindex.reindex_worker.models
+
+/** A request to reindex some or all of the records in a table.
+  *
+  * The two classes represent the two ways you might use the reindexer:
+  *
+  *   1) For a "complete" reindex -- every record in the table should be sent
+  *      to the downstream applications.  Use this when you want to reprocess
+  *      the entire data set.
+  *   2) For a "partial" reindex -- when you want to test the downstream
+  *      applications without swamping them with records.  Use this for smoke tests.
+  *
+  */
+sealed trait ReindexParameters
+
+case class CompleteReindexParameters(
+  segment: Int,
+  totalSegments: Int
+) extends ReindexParameters
+
+case class PartialReindexParameters(
+  maxRecords: Int
+) extends ReindexParameters
+

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/BulkSNSSender.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/BulkSNSSender.scala
@@ -8,8 +8,10 @@ import uk.ac.wellcome.messaging.sns.{
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class BulkSNSSender(snsMessageWriter: SNSMessageWriter)(implicit ec: ExecutionContext) {
-  def sendToSNS(messages: List[String], snsConfig: SNSConfig): Future[List[PublishAttempt]] = {
+class BulkSNSSender(snsMessageWriter: SNSMessageWriter)(
+  implicit ec: ExecutionContext) {
+  def sendToSNS(messages: List[String],
+                snsConfig: SNSConfig): Future[List[PublishAttempt]] = {
     Future.sequence {
       messages
         .map { message: String =>

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/BulkSNSSender.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/BulkSNSSender.scala
@@ -1,18 +1,23 @@
 package uk.ac.wellcome.platform.reindex.reindex_worker.services
 
-import uk.ac.wellcome.messaging.sns.{PublishAttempt, SNSWriter}
+import uk.ac.wellcome.messaging.sns.{
+  PublishAttempt,
+  SNSConfig,
+  SNSMessageWriter
+}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class BulkSNSSender(snsWriter: SNSWriter)(implicit ec: ExecutionContext) {
-  def sendToSNS(messages: List[String]): Future[List[PublishAttempt]] = {
+class BulkSNSSender(snsMessageWriter: SNSMessageWriter)(implicit ec: ExecutionContext) {
+  def sendToSNS(messages: List[String], snsConfig: SNSConfig): Future[List[PublishAttempt]] = {
     Future.sequence {
       messages
         .map { message: String =>
-          snsWriter
+          snsMessageWriter
             .writeMessage(
               message = message,
-              subject = this.getClass.getSimpleName
+              subject = this.getClass.getSimpleName,
+              snsConfig = snsConfig
             )
         }
     }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/RecordReader.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/RecordReader.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.reindex.reindex_worker.services
 
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.platform.reindex.reindex_worker.dynamo.{MaxRecordsScanner, ParallelScanner}
+import uk.ac.wellcome.platform.reindex.reindex_worker.dynamo.{
+  MaxRecordsScanner,
+  ParallelScanner
+}
 import uk.ac.wellcome.platform.reindex.reindex_worker.models._
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
@@ -25,7 +28,8 @@ class RecordReader(
             totalSegments = totalSegments
           )(tableName = dynamoConfig.table)
       case PartialReindexParameters(maxRecords) =>
-        maxRecordsScanner.scan(maxRecords = maxRecords)(tableName = dynamoConfig.table)
+        maxRecordsScanner.scan(maxRecords = maxRecords)(
+          tableName = dynamoConfig.table)
     }
   }
 }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/RecordReader.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/RecordReader.scala
@@ -5,11 +5,7 @@ import uk.ac.wellcome.platform.reindex.reindex_worker.dynamo.{
   MaxRecordsScanner,
   ParallelScanner
 }
-import uk.ac.wellcome.platform.reindex.reindex_worker.models.{
-  CompleteReindexJob,
-  PartialReindexJob,
-  ReindexJob
-}
+import uk.ac.wellcome.platform.reindex.reindex_worker.models._
 
 import scala.concurrent.Future
 
@@ -26,14 +22,14 @@ class RecordReader(
   def findRecordsForReindexing(reindexJob: ReindexJob): Future[List[String]] = {
     debug(s"Finding records that need reindexing for $reindexJob")
 
-    reindexJob match {
-      case CompleteReindexJob(segment, totalSegments) =>
+    reindexJob.parameters match {
+      case CompleteReindexParameters(segment, totalSegments) =>
         parallelScanner
           .scan(
             segment = segment,
             totalSegments = totalSegments
           )
-      case PartialReindexJob(maxRecords) =>
+      case PartialReindexParameters(maxRecords) =>
         maxRecordsScanner.scan(maxRecords = maxRecords)
     }
   }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/RecordReader.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/RecordReader.scala
@@ -19,10 +19,10 @@ class RecordReader(
   parallelScanner: ParallelScanner
 ) extends Logging {
 
-  def findRecordsForReindexing(reindexJob: ReindexJob): Future[List[String]] = {
-    debug(s"Finding records that need reindexing for $reindexJob")
+  def findRecordsForReindexing(reindexParameters: ReindexParameters): Future[List[String]] = {
+    debug(s"Finding records that need reindexing for $reindexParameters")
 
-    reindexJob.parameters match {
+    reindexParameters match {
       case CompleteReindexParameters(segment, totalSegments) =>
         parallelScanner
           .scan(

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/RecordReader.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/RecordReader.scala
@@ -1,25 +1,20 @@
 package uk.ac.wellcome.platform.reindex.reindex_worker.services
 
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.platform.reindex.reindex_worker.dynamo.{
-  MaxRecordsScanner,
-  ParallelScanner
-}
+import uk.ac.wellcome.platform.reindex.reindex_worker.dynamo.{MaxRecordsScanner, ParallelScanner}
 import uk.ac.wellcome.platform.reindex.reindex_worker.models._
+import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
 import scala.concurrent.Future
 
-/** Find IDs for records in the SourceData table that need reindexing.
-  *
-  * This class should only be doing reading -- deciding how to act on records
-  * that need reindexing is the responsibility of another class.
-  */
 class RecordReader(
   maxRecordsScanner: MaxRecordsScanner,
   parallelScanner: ParallelScanner
 ) extends Logging {
 
-  def findRecordsForReindexing(reindexParameters: ReindexParameters): Future[List[String]] = {
+  def findRecordsForReindexing(
+    reindexParameters: ReindexParameters,
+    dynamoConfig: DynamoConfig): Future[List[String]] = {
     debug(s"Finding records that need reindexing for $reindexParameters")
 
     reindexParameters match {
@@ -28,9 +23,9 @@ class RecordReader(
           .scan(
             segment = segment,
             totalSegments = totalSegments
-          )
+          )(tableName = dynamoConfig.table)
       case PartialReindexParameters(maxRecords) =>
-        maxRecordsScanner.scan(maxRecords = maxRecords)
+        maxRecordsScanner.scan(maxRecords = maxRecords)(tableName = dynamoConfig.table)
     }
   }
 }

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerService.scala
@@ -2,23 +2,31 @@ package uk.ac.wellcome.platform.reindex.reindex_worker.services
 
 import akka.Done
 import akka.actor.ActorSystem
-import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 import uk.ac.wellcome.messaging.sqs.SQSStream
-import uk.ac.wellcome.platform.reindex.reindex_worker.models.ReindexParameters
+import uk.ac.wellcome.platform.reindex.reindex_worker.models.{ReindexJob, ReindexParameters}
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class ReindexWorkerService(
   recordReader: RecordReader,
   bulkSNSSender: BulkSNSSender,
-  sqsStream: SQSStream[NotificationMessage]
+  sqsStream: SQSStream[NotificationMessage],
+  dynamoConfig: DynamoConfig,
+  snsConfig: SNSConfig
 )(implicit val actorSystem: ActorSystem, ec: ExecutionContext) {
 
   private def processMessage(message: NotificationMessage): Future[Unit] =
     for {
       reindexParameters: ReindexParameters <- Future.fromTry(
         fromJson[ReindexParameters](message.body))
+      reindexJob = ReindexJob(
+        parameters = reindexParameters,
+        dynamoConfig = dynamoConfig,
+        snsConfig = snsConfig
+      )
       recordsToSend: List[String] <- recordReader
         .findRecordsForReindexing(reindexJob)
       _ <- bulkSNSSender.sendToSNS(messages = recordsToSend)

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerService.scala
@@ -32,7 +32,10 @@ class ReindexWorkerService(
           reindexParameters = reindexJob.parameters,
           dynamoConfig = reindexJob.dynamoConfig
         )
-      _ <- bulkSNSSender.sendToSNS(messages = recordsToSend)
+      _ <- bulkSNSSender.sendToSNS(
+        messages = recordsToSend,
+        snsConfig = reindexJob.snsConfig
+      )
     } yield ()
 
   def run(): Future[Done] =

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerService.scala
@@ -28,7 +28,7 @@ class ReindexWorkerService(
         snsConfig = snsConfig
       )
       recordsToSend: List[String] <- recordReader
-        .findRecordsForReindexing(reindexJob)
+        .findRecordsForReindexing(reindexJob.parameters)
       _ <- bulkSNSSender.sendToSNS(messages = recordsToSend)
     } yield ()
 

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerService.scala
@@ -28,7 +28,10 @@ class ReindexWorkerService(
         snsConfig = snsConfig
       )
       recordsToSend: List[String] <- recordReader
-        .findRecordsForReindexing(reindexJob.parameters)
+        .findRecordsForReindexing(
+          reindexParameters = reindexJob.parameters,
+          dynamoConfig = reindexJob.dynamoConfig
+        )
       _ <- bulkSNSSender.sendToSNS(messages = recordsToSend)
     } yield ()
 

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerService.scala
@@ -4,7 +4,10 @@ import akka.Done
 import akka.actor.ActorSystem
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 import uk.ac.wellcome.messaging.sqs.SQSStream
-import uk.ac.wellcome.platform.reindex.reindex_worker.models.{ReindexJob, ReindexParameters}
+import uk.ac.wellcome.platform.reindex.reindex_worker.models.{
+  ReindexJob,
+  ReindexParameters
+}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerService.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerService.scala
@@ -4,7 +4,7 @@ import akka.Done
 import akka.actor.ActorSystem
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
-import uk.ac.wellcome.platform.reindex.reindex_worker.models.ReindexJob
+import uk.ac.wellcome.platform.reindex.reindex_worker.models.ReindexParameters
 import uk.ac.wellcome.json.JsonUtil._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -17,8 +17,8 @@ class ReindexWorkerService(
 
   private def processMessage(message: NotificationMessage): Future[Unit] =
     for {
-      reindexJob: ReindexJob <- Future.fromTry(
-        fromJson[ReindexJob](message.body))
+      reindexParameters: ReindexParameters <- Future.fromTry(
+        fromJson[ReindexParameters](message.body))
       recordsToSend: List[String] <- recordReader
         .findRecordsForReindexing(reindexJob)
       _ <- bulkSNSSender.sendToSNS(messages = recordsToSend)

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/ReindexWorkerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/ReindexWorkerFeatureTest.scala
@@ -57,7 +57,8 @@ class ReindexWorkerFeatureTest
           withWorkerService(queue, table, topic) { _ =>
             val testRecords = createReindexableData(table)
 
-            val reindexParameters = CompleteReindexParameters(segment = 0, totalSegments = 1)
+            val reindexParameters =
+              CompleteReindexParameters(segment = 0, totalSegments = 1)
 
             sendNotificationToSQS[ReindexParameters](
               queue = queue,
@@ -143,7 +144,8 @@ class ReindexWorkerFeatureTest
         }
         withLocalSnsTopic { topic =>
           withWorkerService(queue, table, topic) { _ =>
-            val reindexParameters = CompleteReindexParameters(segment = 0, totalSegments = 1)
+            val reindexParameters =
+              CompleteReindexParameters(segment = 0, totalSegments = 1)
 
             sendNotificationToSQS[ReindexParameters](
               queue = queue,

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/ReindexWorkerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/ReindexWorkerFeatureTest.scala
@@ -8,9 +8,9 @@ import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.reindex.reindex_worker.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.platform.reindex.reindex_worker.models.{
-  CompleteReindexJob,
-  PartialReindexJob,
-  ReindexJob
+  CompleteReindexParameters,
+  PartialReindexParameters,
+  ReindexParameters
 }
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDbVersioned
@@ -57,11 +57,11 @@ class ReindexWorkerFeatureTest
           withWorkerService(queue, table, topic) { _ =>
             val testRecords = createReindexableData(table)
 
-            val reindexJob = CompleteReindexJob(segment = 0, totalSegments = 1)
+            val reindexParameters = CompleteReindexParameters(segment = 0, totalSegments = 1)
 
-            sendNotificationToSQS[ReindexJob](
+            sendNotificationToSQS[ReindexParameters](
               queue = queue,
-              message = reindexJob
+              message = reindexParameters
             )
 
             eventually {
@@ -86,11 +86,11 @@ class ReindexWorkerFeatureTest
           withWorkerService(queue, table, topic) { _ =>
             val testRecords = createReindexableData(table)
 
-            val reindexJob = PartialReindexJob(maxRecords = 1)
+            val reindexParameters = PartialReindexParameters(maxRecords = 1)
 
-            sendNotificationToSQS[ReindexJob](
+            sendNotificationToSQS[ReindexParameters](
               queue = queue,
-              message = reindexJob
+              message = reindexParameters
             )
 
             eventually {
@@ -143,11 +143,11 @@ class ReindexWorkerFeatureTest
         }
         withLocalSnsTopic { topic =>
           withWorkerService(queue, table, topic) { _ =>
-            val reindexJob = CompleteReindexJob(segment = 0, totalSegments = 1)
+            val reindexParameters = CompleteReindexParameters(segment = 0, totalSegments = 1)
 
-            sendNotificationToSQS[ReindexJob](
+            sendNotificationToSQS[ReindexParameters](
               queue = queue,
-              message = reindexJob
+              message = reindexParameters
             )
 
             eventually {

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/MaxRecordsScannerTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/dynamo/MaxRecordsScannerTest.scala
@@ -17,12 +17,12 @@ class MaxRecordsScannerTest
 
   it("reads a table with a single record") {
     withLocalDynamoDbTable { table =>
-      withMaxRecordsScanner(table) { maxResultScanner =>
+      withMaxRecordsScanner { maxResultScanner =>
         val record =
           TestVersioned(id = "123", data = "hello world", version = 1)
         Scanamo.put(dynamoDbClient)(table.name)(record)
 
-        val futureResult = maxResultScanner.scan(maxRecords = 1)
+        val futureResult = maxResultScanner.scan(maxRecords = 1)(table.name)
 
         whenReady(futureResult) { result =>
           result.map { fromJson[TestVersioned](_).get } shouldBe List(record)
@@ -33,7 +33,7 @@ class MaxRecordsScannerTest
 
   it("handles being asked for more records than are in the table") {
     withLocalDynamoDbTable { table =>
-      withMaxRecordsScanner(table) { maxResultScanner =>
+      withMaxRecordsScanner { maxResultScanner =>
         val records = (1 to 5).map { id =>
           TestVersioned(id = id.toString, data = "Hello world", version = 1)
         }
@@ -42,7 +42,7 @@ class MaxRecordsScannerTest
           Scanamo.put(dynamoDbClient)(table.name)(record)
         }
 
-        val futureResult = maxResultScanner.scan(maxRecords = 10)
+        val futureResult = maxResultScanner.scan(maxRecords = 10)(table.name)
 
         whenReady(futureResult) { result =>
           result.map { fromJson[TestVersioned](_).get } should contain theSameElementsAs records

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/fixtures/BulkSNSSenderFixture.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/fixtures/BulkSNSSenderFixture.scala
@@ -1,0 +1,17 @@
+package uk.ac.wellcome.platform.reindex.reindex_worker.fixtures
+
+import uk.ac.wellcome.messaging.test.fixtures.SNS
+import uk.ac.wellcome.platform.reindex.reindex_worker.services.BulkSNSSender
+import uk.ac.wellcome.test.fixtures.TestWith
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+trait BulkSNSSenderFixture extends SNS {
+  def withBulkSNSSender[R](testWith: TestWith[BulkSNSSender, R]): R =
+    withSNSMessageWriter { snsMessageWriter =>
+      val bulkSNSSender = new BulkSNSSender(
+        snsMessageWriter = snsMessageWriter
+      )
+      testWith(bulkSNSSender)
+    }
+}

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/fixtures/DynamoFixtures.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/fixtures/DynamoFixtures.scala
@@ -6,7 +6,6 @@ import uk.ac.wellcome.platform.reindex.reindex_worker.dynamo.{
   ScanSpecScanner
 }
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb
-import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.test.fixtures.TestWith
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -18,24 +17,16 @@ trait DynamoFixtures extends LocalDynamoDb {
     testWith(scanner)
   }
 
-  def withParallelScanner[R](table: Table)(
-    testWith: TestWith[ParallelScanner, R]): R =
+  def withParallelScanner[R](testWith: TestWith[ParallelScanner, R]): R =
     withScanSpecScanner { scanSpecScanner =>
-      val scanner = new ParallelScanner(
-        scanSpecScanner = scanSpecScanner,
-        dynamoConfig = createDynamoConfigWith(table)
-      )
+      val scanner = new ParallelScanner(scanSpecScanner = scanSpecScanner)
 
       testWith(scanner)
     }
 
-  def withMaxRecordsScanner[R](table: Table)(
-    testWith: TestWith[MaxRecordsScanner, R]): R =
+  def withMaxRecordsScanner[R](testWith: TestWith[MaxRecordsScanner, R]): R =
     withScanSpecScanner { scanSpecScanner =>
-      val scanner = new MaxRecordsScanner(
-        scanSpecScanner = scanSpecScanner,
-        dynamoConfig = createDynamoConfigWith(table)
-      )
+      val scanner = new MaxRecordsScanner(scanSpecScanner = scanSpecScanner)
 
       testWith(scanner)
     }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/fixtures/RecordReaderFixture.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/fixtures/RecordReaderFixture.scala
@@ -1,0 +1,18 @@
+package uk.ac.wellcome.platform.reindex.reindex_worker.fixtures
+
+import uk.ac.wellcome.platform.reindex.reindex_worker.services.RecordReader
+import uk.ac.wellcome.test.fixtures.TestWith
+
+trait RecordReaderFixture extends DynamoFixtures {
+  def withRecordReader[R](testWith: TestWith[RecordReader, R]): R =
+    withMaxRecordsScanner { maxRecordsScanner =>
+      withParallelScanner { parallelScanner =>
+        val reader = new RecordReader(
+          maxRecordsScanner = maxRecordsScanner,
+          parallelScanner = parallelScanner
+        )
+
+        testWith(reader)
+      }
+    }
+}

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/fixtures/WorkerServiceFixture.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/fixtures/WorkerServiceFixture.scala
@@ -10,7 +10,11 @@ import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait WorkerServiceFixture extends Akka with BulkSNSSenderFixture with RecordReaderFixture with SQS {
+trait WorkerServiceFixture
+    extends Akka
+    with BulkSNSSenderFixture
+    with RecordReaderFixture
+    with SQS {
   def withWorkerService[R](queue: Queue, table: Table, topic: Topic)(
     testWith: TestWith[ReindexWorkerService, R]): R =
     withActorSystem { actorSystem =>

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/fixtures/WorkerServiceFixture.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/fixtures/WorkerServiceFixture.scala
@@ -34,7 +34,9 @@ trait WorkerServiceFixture extends Akka with DynamoFixtures with SNS with SQS {
               val workerService = new ReindexWorkerService(
                 recordReader = recordReader,
                 bulkSNSSender = hybridRecordSender,
-                sqsStream = sqsStream
+                sqsStream = sqsStream,
+                dynamoConfig = createDynamoConfigWith(table),
+                snsConfig = createSNSConfigWith(topic)
               )(actorSystem = actorSystem, ec = global)
 
               workerService.run()

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/fixtures/WorkerServiceFixture.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/fixtures/WorkerServiceFixture.scala
@@ -2,31 +2,24 @@ package uk.ac.wellcome.platform.reindex.reindex_worker.fixtures
 
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
-import uk.ac.wellcome.messaging.test.fixtures.{SNS, SQS}
+import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.messaging.test.fixtures.SQS.Queue
-import uk.ac.wellcome.platform.reindex.reindex_worker.services.{
-  BulkSNSSender,
-  ReindexWorkerService
-}
+import uk.ac.wellcome.platform.reindex.reindex_worker.services.ReindexWorkerService
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait WorkerServiceFixture extends Akka with RecordReaderFixture with SNS with SQS {
+trait WorkerServiceFixture extends Akka with BulkSNSSenderFixture with RecordReaderFixture with SQS {
   def withWorkerService[R](queue: Queue, table: Table, topic: Topic)(
     testWith: TestWith[ReindexWorkerService, R]): R =
     withActorSystem { actorSystem =>
       withSQSStream[NotificationMessage, R](actorSystem, queue) { sqsStream =>
         withRecordReader { recordReader =>
-          withSNSWriter(topic) { snsWriter =>
-            val hybridRecordSender = new BulkSNSSender(
-              snsWriter = snsWriter
-            )
-
+          withBulkSNSSender { bulkSNSSender =>
             val workerService = new ReindexWorkerService(
               recordReader = recordReader,
-              bulkSNSSender = hybridRecordSender,
+              bulkSNSSender = bulkSNSSender,
               sqsStream = sqsStream,
               dynamoConfig = createDynamoConfigWith(table),
               snsConfig = createSNSConfigWith(topic)

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/BulkSNSSenderTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/BulkSNSSenderTest.scala
@@ -7,15 +7,14 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.test.fixtures.SNS
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
-import uk.ac.wellcome.test.fixtures.TestWith
-
-import scala.concurrent.ExecutionContext.Implicits.global
+import uk.ac.wellcome.platform.reindex.reindex_worker.fixtures.BulkSNSSenderFixture
 
 class BulkSNSSenderTest
     extends FunSpec
     with Matchers
     with MockitoSugar
     with ScalaFutures
+    with BulkSNSSenderFixture
     with IdentifiersGenerators
     with IntegrationPatience
     with SNS {
@@ -26,8 +25,11 @@ class BulkSNSSenderTest
 
   it("sends messages for the provided IDs") {
     withLocalSnsTopic { topic =>
-      withBulkSNSSender(topic) { bulkSNSSender =>
-        val future = bulkSNSSender.sendToSNS(messages = messages)
+      withBulkSNSSender { bulkSNSSender =>
+        val future = bulkSNSSender.sendToSNS(
+          messages = messages,
+          snsConfig = createSNSConfigWith(topic)
+        )
 
         whenReady(future) { _ =>
           val actualRecords = listMessagesReceivedFromSNS(topic).map {
@@ -41,18 +43,16 @@ class BulkSNSSenderTest
   }
 
   it("returns a failed Future[SdkClientException] if there's an SNS error") {
-    withBulkSNSSender(Topic("no-such-topic")) { bulkSNSSender =>
-      val future = bulkSNSSender.sendToSNS(messages = messages)
+    val badTopic = Topic("no-such-topic")
+    withBulkSNSSender { bulkSNSSender =>
+      val future = bulkSNSSender.sendToSNS(
+        messages = messages,
+        snsConfig = createSNSConfigWith(badTopic)
+      )
+
       whenReady(future.failed) {
         _ shouldBe a[SdkClientException]
       }
     }
   }
-
-  private def withBulkSNSSender[R](topic: Topic)(
-    testWith: TestWith[BulkSNSSender, R]): R =
-    withSNSWriter(topic) { snsWriter =>
-      val bulkSNSSender = new BulkSNSSender(snsWriter = snsWriter)
-      testWith(bulkSNSSender)
-    }
 }

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -15,8 +15,8 @@ import uk.ac.wellcome.platform.reindex.reindex_worker.fixtures.{
 import uk.ac.wellcome.test.fixtures._
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.reindex.reindex_worker.models.{
-  CompleteReindexJob,
-  ReindexJob
+  CompleteReindexParameters,
+  ReindexParameters
 }
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
@@ -49,14 +49,16 @@ class ReindexWorkerServiceTest
         withLocalSqsQueueAndDlq {
           case QueuePair(queue, dlq) =>
             withWorkerService(queue, table, topic) { _ =>
-              val reindexJob =
-                CompleteReindexJob(segment = 0, totalSegments = 1)
+              val reindexParameters = CompleteReindexParameters(
+                segment = 0,
+                totalSegments = 1
+              )
 
               Scanamo.put(dynamoDbClient)(table.name)(exampleRecord)
 
-              sendNotificationToSQS[ReindexJob](
+              sendNotificationToSQS[ReindexParameters](
                 queue = queue,
-                message = reindexJob
+                message = reindexParameters
               )
 
               eventually {
@@ -104,11 +106,14 @@ class ReindexWorkerServiceTest
     withLocalSqsQueueAndDlq {
       case QueuePair(queue, dlq) =>
         withWorkerService(queue, badTable, badTopic) { _ =>
-          val reindexJob = CompleteReindexJob(segment = 5, totalSegments = 10)
+          val reindexParameters = CompleteReindexParameters(
+            segment = 5,
+            totalSegments = 10
+          )
 
-          sendNotificationToSQS[ReindexJob](
+          sendNotificationToSQS[ReindexParameters](
             queue = queue,
-            message = reindexJob
+            message = reindexParameters
           )
 
           eventually {

--- a/reindexer/trigger_reindex.py
+++ b/reindexer/trigger_reindex.py
@@ -51,7 +51,7 @@ def all_complete_messages(total_segments):
         yield {
             "segment": i,
             "totalSegments": total_segments,
-            "type": "CompleteReindexJob",
+            "type": "CompleteReindexParameters",
         }
 
 
@@ -160,7 +160,7 @@ def main():
         )
     else:
         messages = [
-            {"maxRecords": int(args["--max_records"]), "type": "PartialReindexJob"}
+            {"maxRecords": int(args["--max_records"]), "type": "PartialReindexParameters"}
         ]
         slack_message = (
             f"*{username}* started a partial reindex in *{source_name}*\n"

--- a/reindexer/trigger_reindex.py
+++ b/reindexer/trigger_reindex.py
@@ -160,7 +160,10 @@ def main():
         )
     else:
         messages = [
-            {"maxRecords": int(args["--max_records"]), "type": "PartialReindexParameters"}
+            {
+                "maxRecords": int(args["--max_records"]),
+                "type": "PartialReindexParameters",
+            }
         ]
         slack_message = (
             f"*{username}* started a partial reindex in *{source_name}*\n"

--- a/sbt_common/config/messaging/src/main/scala/uk/ac/wellcome/config/messaging/builders/SNSBuilder.scala
+++ b/sbt_common/config/messaging/src/main/scala/uk/ac/wellcome/config/messaging/builders/SNSBuilder.scala
@@ -34,8 +34,7 @@ object SNSBuilder extends AWSClientConfigBuilder {
     )
 
   def buildSNSMessageWriter(config: Config): SNSMessageWriter =
-    new SNSMessageWriter(
-      snsClient = buildSNSClient(config))(
+    new SNSMessageWriter(snsClient = buildSNSClient(config))(
       ec = AkkaBuilder.buildExecutionContext())
 
   def buildSNSWriter(config: Config): SNSWriter =

--- a/sbt_common/config/messaging/src/main/scala/uk/ac/wellcome/config/messaging/builders/SNSBuilder.scala
+++ b/sbt_common/config/messaging/src/main/scala/uk/ac/wellcome/config/messaging/builders/SNSBuilder.scala
@@ -33,11 +33,14 @@ object SNSBuilder extends AWSClientConfigBuilder {
       awsClientConfig = buildAWSClientConfig(config, namespace = "sns")
     )
 
+  def buildSNSMessageWriter(config: Config): SNSMessageWriter =
+    new SNSMessageWriter(
+      snsClient = buildSNSClient(config))(
+      ec = AkkaBuilder.buildExecutionContext())
+
   def buildSNSWriter(config: Config): SNSWriter =
     new SNSWriter(
-      snsMessageWriter = new SNSMessageWriter(
-        snsClient = buildSNSClient(config)
-      )(ec = AkkaBuilder.buildExecutionContext()),
+      snsMessageWriter = buildSNSMessageWriter(config),
       snsConfig = buildSNSConfig(config)
     )
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSMessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSMessageWriter.scala
@@ -22,7 +22,8 @@ class SNSMessageWriter @Inject()(snsClient: AmazonSNS)(
     Future {
       blocking {
         debug(s"Publishing message $message to ${snsConfig.topicArn}")
-        snsClient.publish(new PublishRequest(snsConfig.topicArn, message, subject))
+        snsClient.publish(
+          new PublishRequest(snsConfig.topicArn, message, subject))
       }
     }.map { publishResult =>
         debug(

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSMessageWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSMessageWriter.scala
@@ -18,15 +18,15 @@ class SNSMessageWriter @Inject()(snsClient: AmazonSNS)(
     extends Logging {
   def writeMessage(message: String,
                    subject: String,
-                   topicArn: String): Future[PublishAttempt] =
+                   snsConfig: SNSConfig): Future[PublishAttempt] =
     Future {
       blocking {
-        debug(s"Publishing message $message to $topicArn")
-        snsClient.publish(new PublishRequest(topicArn, message, subject))
+        debug(s"Publishing message $message to ${snsConfig.topicArn}")
+        snsClient.publish(new PublishRequest(snsConfig.topicArn, message, subject))
       }
     }.map { publishResult =>
         debug(
-          s"Published message $message to $topicArn (${publishResult.getMessageId})")
+          s"Published message $message to ${snsConfig.topicArn} (${publishResult.getMessageId})")
         PublishAttempt(Right(message))
       }
       .recover {
@@ -35,11 +35,11 @@ class SNSMessageWriter @Inject()(snsClient: AmazonSNS)(
           throw e
       }
 
-  def writeMessage[T](message: T, subject: String, topicArn: String)(
+  def writeMessage[T](message: T, subject: String, snsConfig: SNSConfig)(
     implicit encoder: Encoder[T]): Future[PublishAttempt] =
     writeMessage(
       message = toJson[T](message).get,
-      topicArn = topicArn,
-      subject = subject
+      subject = subject,
+      snsConfig = snsConfig
     )
 }

--- a/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
+++ b/sbt_common/messaging/src/main/scala/uk/ac/wellcome/messaging/sns/SNSWriter.scala
@@ -18,7 +18,7 @@ class SNSWriter @Inject()(snsMessageWriter: SNSMessageWriter,
     snsMessageWriter.writeMessage(
       message = message,
       subject = subject,
-      topicArn = snsConfig.topicArn
+      snsConfig = snsConfig
     )
 
   def writeMessage[T](message: T, subject: String)(
@@ -26,6 +26,6 @@ class SNSWriter @Inject()(snsMessageWriter: SNSMessageWriter,
     snsMessageWriter.writeMessage[T](
       message = message,
       subject = subject,
-      topicArn = snsConfig.topicArn
+      snsConfig = snsConfig
     )
 }


### PR DESCRIPTION
This is the first step towards a reindexer wish list item: being able to pass the table name/topic ARN in the message sent to the reindexer.

It doesn't change the reindexer interface (except renaming "ReindexJob" to "ReindexParameters"), but the internal classes now expect to get DynamoDB/SNS config with each message, rather than configured once upfront and never changed. Later we can pass the parameters directly from the queue message into the classes.