### PR TITLE
Start tidying up a registrar fixture

### DIFF
--- a/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/RegistrarFeatureTest.scala
+++ b/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/RegistrarFeatureTest.scala
@@ -12,7 +12,12 @@ import org.scalatest.{FunSpec, Inside, Matchers}
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
-import uk.ac.wellcome.platform.archive.common.models.{ArchiveComplete, BagId, BagLocation, BagPath}
+import uk.ac.wellcome.platform.archive.common.models.{
+  ArchiveComplete,
+  BagId,
+  BagLocation,
+  BagPath
+}
 import uk.ac.wellcome.platform.archive.common.progress.ProgressUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.progress.models.Progress
 import uk.ac.wellcome.platform.archive.registrar.async.fixtures.StorageManifestAssertions

--- a/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/RegistrarFeatureTest.scala
+++ b/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/RegistrarFeatureTest.scala
@@ -12,11 +12,7 @@ import org.scalatest.{FunSpec, Inside, Matchers}
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
-import uk.ac.wellcome.platform.archive.common.models.{
-  ArchiveComplete,
-  BagLocation,
-  BagPath
-}
+import uk.ac.wellcome.platform.archive.common.models.{ArchiveComplete, BagId, BagLocation, BagPath}
 import uk.ac.wellcome.platform.archive.common.progress.ProgressUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.progress.models.Progress
 import uk.ac.wellcome.platform.archive.registrar.async.fixtures.StorageManifestAssertions
@@ -54,11 +50,17 @@ class RegistrarFeatureTest
           vhs
           ) =>
         val requestId = randomUUID
+        val storageSpace = randomStorageSpace
         val createdAfterDate = Instant.now()
 
-        withBagNotification(queuePair, storageBucket, requestId) {
-          case (bagLocation, bagInfo, bagId) =>
+        withBagNotification(queuePair, storageBucket, requestId, storageSpace) {
+          case (bagLocation, bagInfo) =>
             registrar.run()
+
+            val bagId = BagId(
+              space = storageSpace,
+              externalIdentifier = bagInfo.externalIdentifier
+            )
 
             eventually {
               val futureMaybeManifest = vhs.getRecord(bagId.toString)

--- a/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/RegistrarFeatureTest.scala
+++ b/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/RegistrarFeatureTest.scala
@@ -56,11 +56,7 @@ class RegistrarFeatureTest
         val requestId = randomUUID
         val createdAfterDate = Instant.now()
 
-        withBagNotification(
-          requestId,
-          queuePair,
-          storageBucket
-        ) {
+        withBagNotification(queuePair, storageBucket, requestId) {
           case (bagLocation, bagInfo, bagId) =>
             registrar.run()
 
@@ -142,11 +138,8 @@ class RegistrarFeatureTest
           progressTopic,
           registrar,
           _) =>
-        val requestId1 = randomUUID
-        val requestId2 = randomUUID
-
-        withBagNotification(requestId1, queuePair, storageBucket) { _ =>
-          withBagNotification(requestId2, queuePair, storageBucket) { _ =>
+        withBagNotification(queuePair, storageBucket) { _ =>
+          withBagNotification(queuePair, storageBucket) { _ =>
             registrar.run()
 
             eventually {

--- a/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/fixtures/RegistrarFixtures.scala
+++ b/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/fixtures/RegistrarFixtures.scala
@@ -37,18 +37,19 @@ trait RegistrarFixtures
     archiveRequestId: UUID = randomUUID,
     storageSpace: StorageSpace = randomStorageSpace
   )(testWith: TestWith[(BagLocation, BagInfo), R]): R =
-    withBag(storageBucket) { case (bagLocation, bagInfo, _) =>
-      val archiveComplete = ArchiveComplete(
-        archiveRequestId = archiveRequestId,
-        space = storageSpace,
-        bagLocation = bagLocation
-      )
+    withBag(storageBucket) {
+      case (bagLocation, bagInfo, _) =>
+        val archiveComplete = ArchiveComplete(
+          archiveRequestId = archiveRequestId,
+          space = storageSpace,
+          bagLocation = bagLocation
+        )
 
-      sendNotificationToSQS(
-        queuePair.queue,
-        archiveComplete
-      )
-      testWith((bagLocation, bagInfo))
+        sendNotificationToSQS(
+          queuePair.queue,
+          archiveComplete
+        )
+        testWith((bagLocation, bagInfo))
     }
 
   override def createTable(table: Table) = {

--- a/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/fixtures/RegistrarFixtures.scala
+++ b/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/fixtures/RegistrarFixtures.scala
@@ -40,9 +40,11 @@ trait RegistrarFixtures
       ArchiveComplete(requestId, storageSpace, bagLocation)
     )
 
-  def withBagNotification[R](requestId: UUID,
-                             queuePair: QueuePair,
-                             storageBucket: Bucket)(
+  def withBagNotification[R](
+    queuePair: QueuePair,
+    storageBucket: Bucket,
+    requestId: UUID = randomUUID
+  )(
     testWith: TestWith[(BagLocation, BagInfo, BagId), R]): R =
     withBag(storageBucket) { case (bagLocation, bagInfo, bagId) =>
       sendNotification(requestId, bagId.space, bagLocation, queuePair)

--- a/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/fixtures/RegistrarFixtures.scala
+++ b/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/fixtures/RegistrarFixtures.scala
@@ -31,24 +31,24 @@ trait RegistrarFixtures
     with BagLocationFixtures
     with LocalDynamoDb {
 
-  def sendNotification(requestId: UUID,
-                       storageSpace: StorageSpace,
-                       bagLocation: BagLocation,
-                       queuePair: QueuePair) =
-    sendNotificationToSQS(
-      queuePair.queue,
-      ArchiveComplete(requestId, storageSpace, bagLocation)
-    )
-
   def withBagNotification[R](
     queuePair: QueuePair,
     storageBucket: Bucket,
-    requestId: UUID = randomUUID
-  )(
-    testWith: TestWith[(BagLocation, BagInfo, BagId), R]): R =
-    withBag(storageBucket) { case (bagLocation, bagInfo, bagId) =>
-      sendNotification(requestId, bagId.space, bagLocation, queuePair)
-      testWith((bagLocation, bagInfo, bagId))
+    archiveRequestId: UUID = randomUUID,
+    storageSpace: StorageSpace = randomStorageSpace
+  )(testWith: TestWith[(BagLocation, BagInfo), R]): R =
+    withBag(storageBucket) { case (bagLocation, bagInfo, _) =>
+      val archiveComplete = ArchiveComplete(
+        archiveRequestId = archiveRequestId,
+        space = storageSpace,
+        bagLocation = bagLocation
+      )
+
+      sendNotificationToSQS(
+        queuePair.queue,
+        archiveComplete
+      )
+      testWith((bagLocation, bagInfo))
     }
 
   override def createTable(table: Table) = {

--- a/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/fixtures/RegistrarFixtures.scala
+++ b/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/fixtures/RegistrarFixtures.scala
@@ -42,10 +42,9 @@ trait RegistrarFixtures
 
   def withBagNotification[R](requestId: UUID,
                              queuePair: QueuePair,
-                             storageBucket: Bucket,
-                             dataFileCount: Int = 1)(
+                             storageBucket: Bucket)(
     testWith: TestWith[(BagLocation, BagInfo, BagId), R]) = {
-    withBag(storageBucket, dataFileCount) {
+    withBag(storageBucket) {
       case (bagLocation, bagInfo, bagId) =>
         sendNotification(requestId, bagId.space, bagLocation, queuePair)
         testWith((bagLocation, bagInfo, bagId))

--- a/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/fixtures/RegistrarFixtures.scala
+++ b/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/fixtures/RegistrarFixtures.scala
@@ -43,13 +43,11 @@ trait RegistrarFixtures
   def withBagNotification[R](requestId: UUID,
                              queuePair: QueuePair,
                              storageBucket: Bucket)(
-    testWith: TestWith[(BagLocation, BagInfo, BagId), R]) = {
-    withBag(storageBucket) {
-      case (bagLocation, bagInfo, bagId) =>
-        sendNotification(requestId, bagId.space, bagLocation, queuePair)
-        testWith((bagLocation, bagInfo, bagId))
+    testWith: TestWith[(BagLocation, BagInfo, BagId), R]) =
+    withBag(storageBucket) { case (bagLocation, bagInfo, bagId) =>
+      sendNotification(requestId, bagId.space, bagLocation, queuePair)
+      testWith((bagLocation, bagInfo, bagId))
     }
-  }
 
   override def createTable(table: Table) = {
     dynamoDbClient.createTable(

--- a/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/fixtures/RegistrarFixtures.scala
+++ b/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/fixtures/RegistrarFixtures.scala
@@ -43,7 +43,7 @@ trait RegistrarFixtures
   def withBagNotification[R](requestId: UUID,
                              queuePair: QueuePair,
                              storageBucket: Bucket)(
-    testWith: TestWith[(BagLocation, BagInfo, BagId), R]) =
+    testWith: TestWith[(BagLocation, BagInfo, BagId), R]): R =
     withBag(storageBucket) { case (bagLocation, bagInfo, bagId) =>
       sendNotification(requestId, bagId.space, bagLocation, queuePair)
       testWith((bagLocation, bagInfo, bagId))


### PR DESCRIPTION
Part of the yak shave started in #3095; I've been looking at the archive fixtures and some of them pass a lot of state around. I think fixtures are better when they're simpler (and don't emit so much stuff!). This is a first step towards that.

* Don't emit a `BagId`; be explicit that the space is randomly generated when we care about it
* Don't require a request ID, because in some cases we don't care what it is and can default it