### PR TITLE
Downgrade a chatty log line to debug()

### DIFF
--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformableTransformer.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformableTransformer.scala
@@ -91,7 +91,7 @@ class MiroTransformableTransformer
       )
     }.recover {
       case e: ShouldNotTransformException =>
-        info(s"Should not transform: ${e.getMessage}")
+        debug(s"Should not transform: ${e.getMessage}")
         UnidentifiedInvisibleWork(
           sourceIdentifier = sourceIdentifier,
           version = version


### PR DESCRIPTION
Because we now have a 3:1 ratio of invisible:visible Miro works in the Miro VHS, this line is spamming the logs.  It doesn't tell us anything especially useful, so downgrade this line to debug.