### PR TITLE
Fixes for SNS fixtures

### DIFF
--- a/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/progress/ProgressUpdateAssertions.scala
+++ b/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/progress/ProgressUpdateAssertions.scala
@@ -12,11 +12,11 @@ import uk.ac.wellcome.platform.archive.common.progress.models._
 import scala.util.Try
 
 trait ProgressUpdateAssertions extends SNS with Inside with Logging {
-  def assertTopicReceivesProgressStatusUpdate[R](
-    requestId: UUID,
-    progressTopic: SNS.Topic,
-    status: Progress.Status,
-    expectedBag: Option[BagId] = None)(
+  def assertTopicReceivesProgressStatusUpdate[R](requestId: UUID,
+                                                 progressTopic: SNS.Topic,
+                                                 status: Progress.Status,
+                                                 expectedBag: Option[BagId] =
+                                                   None)(
     assert: Seq[ProgressEvent] => R): Assertion = {
     val progressUpdates =
       listObjectsReceivedFromSNS[ProgressUpdate](progressTopic).distinct

--- a/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/progress/ProgressUpdateAssertions.scala
+++ b/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/progress/ProgressUpdateAssertions.scala
@@ -12,12 +12,12 @@ import uk.ac.wellcome.platform.archive.common.progress.models._
 import scala.util.Try
 
 trait ProgressUpdateAssertions extends SNS with Inside with Logging {
-  def assertTopicReceivesProgressStatusUpdate(
+  def assertTopicReceivesProgressStatusUpdate[R](
     requestId: UUID,
     progressTopic: SNS.Topic,
     status: Progress.Status,
     expectedBag: Option[BagId] = None)(
-    assert: Seq[ProgressEvent] => Assertion): Assertion = {
+    assert: Seq[ProgressEvent] => R): Assertion = {
     val progressUpdates =
       listObjectsReceivedFromSNS[ProgressUpdate](progressTopic).distinct
     progressUpdates.size should be > 0

--- a/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/progress/ProgressUpdateAssertions.scala
+++ b/archive/common/src/test/scala/uk/ac/wellcome/platform/archive/common/progress/ProgressUpdateAssertions.scala
@@ -1,4 +1,5 @@
 package uk.ac.wellcome.platform.archive.common.progress
+
 import java.util.UUID
 
 import grizzled.slf4j.Logging
@@ -11,16 +12,14 @@ import uk.ac.wellcome.platform.archive.common.progress.models._
 import scala.util.Try
 
 trait ProgressUpdateAssertions extends SNS with Inside with Logging {
-  def assertTopicReceivesProgressStatusUpdate[R](requestId: UUID,
-                                                 progressTopic: SNS.Topic,
-                                                 status: Progress.Status,
-                                                 expectedBag: Option[BagId] =
-                                                   None)(
-    assert: Seq[ProgressEvent] => R): Assertion = {
-    val messages = listMessagesReceivedFromSNS(progressTopic)
-    val progressUpdates = messages.map { messageinfo =>
-      fromJson[ProgressUpdate](messageinfo.message).get
-    }.distinct
+  def assertTopicReceivesProgressStatusUpdate(
+    requestId: UUID,
+    progressTopic: SNS.Topic,
+    status: Progress.Status,
+    expectedBag: Option[BagId] = None)(
+    assert: Seq[ProgressEvent] => Assertion): Assertion = {
+    val progressUpdates =
+      listObjectsReceivedFromSNS[ProgressUpdate](progressTopic).distinct
     progressUpdates.size should be > 0
 
     val (success, failure) = progressUpdates
@@ -41,10 +40,8 @@ trait ProgressUpdateAssertions extends SNS with Inside with Logging {
   def assertTopicReceivesProgressEventUpdate(requestId: UUID,
                                              progressTopic: SNS.Topic)(
     assert: Seq[ProgressEvent] => Assertion): Assertion = {
-    val messages = listMessagesReceivedFromSNS(progressTopic)
-    val progressUpdates = messages.map { messageinfo =>
-      fromJson[ProgressUpdate](messageinfo.message).get
-    }
+    val progressUpdates =
+      listObjectsReceivedFromSNS[ProgressUpdate](progressTopic).distinct
     progressUpdates.size should be > 0
 
     val (success, failure) = progressUpdates

--- a/archive/progress_http/src/test/scala/uk/ac/wellcome/platform/archive/progress_http/ProgressHttpFeatureTest.scala
+++ b/archive/progress_http/src/test/scala/uk/ac/wellcome/platform/archive/progress_http/ProgressHttpFeatureTest.scala
@@ -206,8 +206,7 @@ class ProgressHttpFeatureTest
                   }
 
                   val requests =
-                    listMessagesReceivedFromSNS(topic).map(messageInfo =>
-                      fromJson[IngestBagRequest](messageInfo.message).get)
+                    listObjectsReceivedFromSNS[IngestBagRequest](topic)
 
                   requests shouldBe List(
                     IngestBagRequest(

--- a/archive/progress_http/src/test/scala/uk/ac/wellcome/platform/archive/progress_http/ProgressStarterTest.scala
+++ b/archive/progress_http/src/test/scala/uk/ac/wellcome/platform/archive/progress_http/ProgressStarterTest.scala
@@ -40,8 +40,7 @@ class ProgressStarterTest
             assertTableOnlyHasItem(progress, table)
 
             val requests =
-              listMessagesReceivedFromSNS(topic).map(messageInfo =>
-                fromJson[IngestBagRequest](messageInfo.message).get)
+              listObjectsReceivedFromSNS[IngestBagRequest](topic)
 
             requests shouldBe List(IngestBagRequest(
               p.id,

--- a/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/RegistrarFeatureTest.scala
+++ b/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/RegistrarFeatureTest.scala
@@ -47,12 +47,12 @@ class RegistrarFeatureTest
   it(
     "registers an archived BagIt bag from S3 and notifies the progress tracker") {
     withRegistrar {
-      case (storageBucket, queuePair, progressTopic, vhs) =>
+      case (storageBucket, QueuePair(queue, _), progressTopic, vhs) =>
         val requestId = randomUUID
         val storageSpace = randomStorageSpace
         val createdAfterDate = Instant.now()
 
-        withBagNotification(queuePair, storageBucket, requestId, storageSpace) {
+        withBagNotification(queue, storageBucket, requestId, storageSpace) {
           case (bagLocation, bagInfo) =>
             val bagId = BagId(
               space = storageSpace,
@@ -128,13 +128,9 @@ class RegistrarFeatureTest
 
   it("discards messages if it fails writing to the VHS") {
     withRegistrarAndBrokenVHS {
-      case (
-          storageBucket,
-          queuePair @ QueuePair(queue, dlq),
-          progressTopic,
-          _) =>
-        withBagNotification(queuePair, storageBucket) { _ =>
-          withBagNotification(queuePair, storageBucket) { _ =>
+      case (storageBucket, QueuePair(queue, dlq), progressTopic, _) =>
+        withBagNotification(queue, storageBucket) { _ =>
+          withBagNotification(queue, storageBucket) { _ =>
             eventually {
               assertSnsReceivesNothing(progressTopic)
 

--- a/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/RegistrarFeatureTest.scala
+++ b/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/RegistrarFeatureTest.scala
@@ -136,7 +136,7 @@ class RegistrarFeatureTest
         withBagNotification(queuePair, storageBucket) { _ =>
           withBagNotification(queuePair, storageBucket) { _ =>
             eventually {
-              listMessagesReceivedFromSNS(progressTopic) shouldBe empty
+              assertSnsReceivesNothing(topic)
 
               assertQueueEmpty(queue)
               assertQueueHasSize(dlq, 2)

--- a/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/RegistrarFeatureTest.scala
+++ b/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/RegistrarFeatureTest.scala
@@ -136,7 +136,7 @@ class RegistrarFeatureTest
         withBagNotification(queuePair, storageBucket) { _ =>
           withBagNotification(queuePair, storageBucket) { _ =>
             eventually {
-              assertSnsReceivesNothing(topic)
+              assertSnsReceivesNothing(progressTopic)
 
               assertQueueEmpty(queue)
               assertQueueHasSize(dlq, 2)

--- a/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/fixtures/RegistrarFixtures.scala
+++ b/archive/registrar_async/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/fixtures/RegistrarFixtures.scala
@@ -4,14 +4,13 @@ import java.util.UUID
 import com.amazonaws.services.dynamodbv2.model._
 import uk.ac.wellcome.messaging.test.fixtures.Messaging
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
-import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
+import uk.ac.wellcome.messaging.test.fixtures.SQS.{Queue, QueuePair}
 import uk.ac.wellcome.platform.archive.common.models._
 import uk.ac.wellcome.platform.archive.registrar.async.Registrar
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import uk.ac.wellcome.storage.fixtures.{LocalDynamoDb, S3}
 import uk.ac.wellcome.test.fixtures.TestWith
-
 import uk.ac.wellcome.platform.archive.common.messaging.MessageStream
 import uk.ac.wellcome.platform.archive.registrar.fixtures.StorageManifestVHSFixture
 
@@ -23,7 +22,7 @@ trait RegistrarFixtures
     with StorageManifestVHSFixture {
 
   def withBagNotification[R](
-    queuePair: QueuePair,
+    queue: Queue,
     storageBucket: Bucket,
     archiveRequestId: UUID = randomUUID,
     storageSpace: StorageSpace = randomStorageSpace
@@ -36,10 +35,7 @@ trait RegistrarFixtures
           bagLocation = bagLocation
         )
 
-        sendNotificationToSQS(
-          queuePair.queue,
-          archiveComplete
-        )
+        sendNotificationToSQS(queue, archiveComplete)
         testWith((bagLocation, bagInfo))
     }
 

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -33,15 +33,17 @@ class MatcherFeatureTest
           sendMessage[TransformedBaseWork](queue = queue, work)
 
           eventually {
-            val matcherResults = listObjectsReceivedFromSNS[MatcherResult](topic)
+            val matcherResults =
+              listObjectsReceivedFromSNS[MatcherResult](topic)
             matcherResults.size should be >= 1
 
             matcherResults.map { identifiersList =>
               identifiersList shouldBe
                 MatcherResult(
-                  Set(MatchedIdentifiers(
-                    Set(WorkIdentifier(work))
-                  ))
+                  Set(
+                    MatchedIdentifiers(
+                      Set(WorkIdentifier(work))
+                    ))
                 )
             }
           }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -33,18 +33,16 @@ class MatcherFeatureTest
           sendMessage[TransformedBaseWork](queue = queue, work)
 
           eventually {
-            val snsMessages = listMessagesReceivedFromSNS(topic)
-            snsMessages.size should be >= 1
+            val matcherResults = listObjectsReceivedFromSNS[MatcherResult](topic)
+            matcherResults.size should be >= 1
 
-            snsMessages.map { snsMessage =>
-              val identifiersList =
-                fromJson[MatcherResult](snsMessage.message).get
-
+            matcherResults.map { identifiersList =>
               identifiersList shouldBe
                 MatcherResult(
                   Set(MatchedIdentifiers(
                     Set(WorkIdentifier(work))
-                  )))
+                  ))
+                )
             }
           }
         }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -76,7 +76,7 @@ class MatcherFeatureTest
             eventually {
               noMessagesAreWaitingIn(queuePair.queue)
               noMessagesAreWaitingIn(queuePair.dlq)
-              listMessagesReceivedFromSNS(topic).size shouldBe 0
+              assertSnsReceivesNothing(topic)
             }
           }
         }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
@@ -1,16 +1,12 @@
 package uk.ac.wellcome.platform.matcher.services
 
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
-import uk.ac.wellcome.models.matcher.{
-  MatchedIdentifiers,
-  MatcherResult,
-  WorkIdentifier
-}
+import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult, WorkIdentifier}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
@@ -346,14 +342,10 @@ class MatcherWorkerServiceTest
 
   private def assertLastMatchedResultIs(
     topic: Topic,
-    expectedMatcherResult: MatcherResult) = {
+    expectedMatcherResult: MatcherResult): Assertion = {
+    val matcherResults = listObjectsReceivedFromSNS[MatcherResult](topic)
+    matcherResults.size should be >= 1
 
-    val snsMessages = listMessagesReceivedFromSNS(topic)
-    snsMessages.size should be >= 1
-
-    val actualMatcherResults = snsMessages.map { snsMessage =>
-      fromJson[MatcherResult](snsMessage.message).get
-    }
-    actualMatcherResults.last shouldBe expectedMatcherResult
+    matcherResults.last shouldBe expectedMatcherResult
   }
 }

--- a/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
+++ b/catalogue_pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
@@ -6,7 +6,11 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.test.fixtures.SQS
 import uk.ac.wellcome.messaging.test.fixtures.SQS.QueuePair
-import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult, WorkIdentifier}
+import uk.ac.wellcome.models.matcher.{
+  MatchedIdentifiers,
+  MatcherResult,
+  WorkIdentifier
+}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures

--- a/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/catalogue_pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -109,7 +109,7 @@ class MergerWorkerServiceTest
         eventually {
           assertQueueEmpty(queue)
           assertQueueHasSize(dlq, 1)
-          listMessagesReceivedFromSNS(topic) shouldBe empty
+          assertSnsReceivesNothing(topic)
 
           verify(metricsSender, times(3))
             .countFailure(any[String])

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerFeatureTest.scala
@@ -68,9 +68,6 @@ class SierraTransformerFeatureTest
 
             withWorkerService(topic, messagingBucket, queue) { _ =>
               eventually {
-                val snsMessages = listMessagesReceivedFromSNS(topic)
-                snsMessages.size should be >= 1
-
                 val sourceIdentifier = createSierraSystemSourceIdentifierWith(
                   value = id.withCheckDigit
                 )
@@ -81,7 +78,7 @@ class SierraTransformerFeatureTest
                   )
 
                 val works = getMessages[UnidentifiedWork](topic)
-                works.length shouldBe >=(1)
+                works.length should be >= 1
 
                 works.map { actualWork =>
                   actualWork.sourceIdentifier shouldBe sourceIdentifier

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -91,17 +91,15 @@ class SnapshotGeneratorFeatureTest
               assertJsonStringsAreEqual(actualLine, expectedLine)
           }
 
-          val receivedMessages = listMessagesReceivedFromSNS(topic)
-          receivedMessages.size should be >= 1
+          val receivedJobs = listObjectsReceivedFromSNS[CompletedSnapshotJob](topic)
+          receivedJobs.size should be >= 1
 
           val expectedJob = CompletedSnapshotJob(
             snapshotJob = snapshotJob,
             targetLocation =
               s"http://localhost:33333/${publicBucket.name}/$publicObjectKey"
           )
-          val actualJob =
-            fromJson[CompletedSnapshotJob](receivedMessages.head.message).get
-          actualJob shouldBe expectedJob
+          receivedJobs.head shouldBe expectedJob
         }
     }
 

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -91,7 +91,8 @@ class SnapshotGeneratorFeatureTest
               assertJsonStringsAreEqual(actualLine, expectedLine)
           }
 
-          val receivedJobs = listObjectsReceivedFromSNS[CompletedSnapshotJob](topic)
+          val receivedJobs =
+            listObjectsReceivedFromSNS[CompletedSnapshotJob](topic)
           receivedJobs.size should be >= 1
 
           val expectedJob = CompletedSnapshotJob(

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/ReindexWorkerFeatureTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/ReindexWorkerFeatureTest.scala
@@ -68,10 +68,7 @@ class ReindexWorkerFeatureTest
 
             eventually {
               val actualRecords: Seq[HybridRecord] =
-                listMessagesReceivedFromSNS(topic)
-                  .map { _.message }
-                  .map { fromJson[HybridRecord](_).get }
-                  .distinct
+                listObjectsReceivedFromSNS[HybridRecord](topic).distinct
 
               actualRecords should contain theSameElementsAs testRecords
             }
@@ -97,10 +94,7 @@ class ReindexWorkerFeatureTest
 
             eventually {
               val actualRecords: Seq[HybridRecord] =
-                listMessagesReceivedFromSNS(topic)
-                  .map { _.message }
-                  .map { fromJson[HybridRecord](_).get }
-                  .distinct
+                listObjectsReceivedFromSNS[HybridRecord](topic).distinct
 
               actualRecords should have length 1
               actualRecords should contain theSameElementsAs List(

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -62,10 +62,7 @@ class ReindexWorkerServiceTest
 
               eventually {
                 val actualRecords: Seq[HybridRecord] =
-                  listMessagesReceivedFromSNS(topic)
-                    .map { _.message }
-                    .map { fromJson[HybridRecord](_).get }
-                    .distinct
+                  listObjectsReceivedFromSNS[HybridRecord](topic).distinct
 
                 actualRecords shouldBe List(exampleRecord)
                 assertQueueEmpty(queue)

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageWriterTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageWriterTest.scala
@@ -186,7 +186,8 @@ class MessageWriterTest
 
             whenReady(Future.sequence(List(eventualAttempt1, eventualAttempt2))) {
               _ =>
-                val notifications = listObjectsReceivedFromSNS[MessageNotification](topic)
+                val notifications =
+                  listObjectsReceivedFromSNS[MessageNotification](topic)
                 notifications should have size 2
 
                 val locations = notifications

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageWriterTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageWriterTest.scala
@@ -186,13 +186,10 @@ class MessageWriterTest
 
             whenReady(Future.sequence(List(eventualAttempt1, eventualAttempt2))) {
               _ =>
-                val messages = listMessagesReceivedFromSNS(topic)
-                messages should have size (2)
+                val notifications = listObjectsReceivedFromSNS[MessageNotification](topic)
+                notifications should have size 2
 
-                val locations = messages
-                  .map { msg =>
-                    fromJson[MessageNotification](msg.message).get
-                  }
+                val locations = notifications
                   .map { _.asInstanceOf[RemoteNotification] }
                   .map { _.location }
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageWriterTest.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageWriterTest.scala
@@ -168,7 +168,7 @@ class MessageWriterTest
           val eventualAttempt = messageWriter.write(largeMessage, subject)
 
           whenReady(eventualAttempt.failed) { _ =>
-            listMessagesReceivedFromSNS(topic) should be('empty)
+            assertSnsReceivesNothing(topic)
           }
         }
       }

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -50,24 +50,13 @@ trait Messaging
       }
     )
 
-  def messageReaderLocalFlags(queue: Queue): Map[String, String] =
-    Map(
-      "aws.message.reader.sqs.queue.url" -> queue.url,
-    ) ++ s3ClientLocalFlags ++ sqsLocalClientFlags
-
-  def messageWriterLocalFlags(bucket: Bucket, topic: Topic) =
-    Map(
-      "aws.message.writer.sns.topic.arn" -> topic.arn,
-      "aws.message.writer.s3.bucketName" -> bucket.name
-    ) ++ s3ClientLocalFlags ++ snsLocalClientFlags
-
   def withExampleObjectMessageWriter[R](bucket: Bucket,
                                         topic: Topic,
                                         writerSnsClient: AmazonSNS = snsClient)(
-    testWith: TestWith[MessageWriter[ExampleObject], R]) = {
-    withMessageWriter[ExampleObject, R](bucket, topic, writerSnsClient)(
-      testWith)
-  }
+    testWith: TestWith[MessageWriter[ExampleObject], R]): R =
+    withMessageWriter[ExampleObject, R](bucket, topic, writerSnsClient) { writer =>
+      testWith(writer)
+    }
 
   def withMessageWriter[T, R](bucket: Bucket,
                               topic: Topic,

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -120,17 +120,13 @@ trait Messaging
     * to objects in S3, return the unpacked objects.
     */
   def getMessages[T](topic: Topic)(implicit decoder: Decoder[T]): List[T] =
-    listMessagesReceivedFromSNS(topic).map { messageInfo =>
-      fromJson[MessageNotification](messageInfo.message) match {
-        case Success(RemoteNotification(location)) =>
-          getObjectFromS3[T](location)
-        case Success(InlineNotification(jsonString)) =>
-          fromJson[T](jsonString).get
-        case _ =>
-          throw new RuntimeException(
-            s"Unrecognised message: ${messageInfo.message}"
-          )
-      }
+    listObjectsReceivedFromSNS[MessageNotification](topic).map {
+      case RemoteNotification(location) =>
+        getObjectFromS3[T](location)
+      case InlineNotification(jsonString) =>
+        fromJson[T](jsonString).get
+      case _ =>
+        throw new RuntimeException(s"Unrecognised message!")
     }.toList
 
   /** Send a MessageNotification to SQS.

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -20,7 +20,6 @@ import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures._
 
-import scala.util.Success
 import uk.ac.wellcome.json.JsonUtil._
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/Messaging.scala
@@ -54,8 +54,9 @@ trait Messaging
                                         topic: Topic,
                                         writerSnsClient: AmazonSNS = snsClient)(
     testWith: TestWith[MessageWriter[ExampleObject], R]): R =
-    withMessageWriter[ExampleObject, R](bucket, topic, writerSnsClient) { writer =>
-      testWith(writer)
+    withMessageWriter[ExampleObject, R](bucket, topic, writerSnsClient) {
+      writer =>
+        testWith(writer)
     }
 
   def withMessageWriter[T, R](bucket: Bucket,

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.messaging.test.fixtures
 import com.amazonaws.services.sns.AmazonSNS
 import grizzled.slf4j.Logging
 import io.circe.generic.extras.JsonKey
-import io.circe.{yaml, Decoder, Json, ParsingFailure}
+import io.circe.{Decoder, Json, ParsingFailure, yaml}
 import org.scalatest.Matchers
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.{
@@ -140,6 +140,10 @@ trait SNS extends Matchers with Logging {
         _.topicArn == topic.arn
       }
   }
+
+  def listObjectsReceivedFromSNS[T](topic: Topic)(implicit decoder: Decoder[T]): Seq[T] =
+    listMessagesReceivedFromSNS(topic)
+      .map { messageInfo: MessageInfo => fromJson[T](messageInfo.message).get }
 
   def assertSnsReceivesOnly[T](expectedMessage: T, topic: SNS.Topic)(
     implicit decoderT: Decoder[T]) = {

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.sns.AmazonSNS
 import grizzled.slf4j.Logging
 import io.circe.generic.extras.JsonKey
 import io.circe.{Decoder, Json, ParsingFailure, yaml}
-import org.scalatest.Matchers
+import org.scalatest.{Assertion, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.{
   SNSClientFactory,
@@ -146,13 +146,11 @@ trait SNS extends Matchers with Logging {
       .map { messageInfo: MessageInfo => fromJson[T](messageInfo.message).get }
 
   def assertSnsReceivesOnly[T](expectedMessage: T, topic: SNS.Topic)(
-    implicit decoderT: Decoder[T]) = {
+    implicit decoderT: Decoder[T]): Assertion =
     assertSnsReceives(Set(expectedMessage), topic)
-  }
 
-  def assertSnsReceivesNothing(topic: SNS.Topic) = {
+  def assertSnsReceivesNothing(topic: SNS.Topic): Assertion =
     notificationCount(topic) shouldBe 0
-  }
 
   def assertSnsReceives[T, I[T] <: Iterable[T]](
     expectedMessages: I[T],

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
@@ -16,8 +16,9 @@ import uk.ac.wellcome.test.fixtures._
 
 import scala.language.higherKinds
 import scala.collection.immutable.Seq
+import scala.util.{Random, Success}
+
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{Random, Success, Try}
 
 object SNS {
 

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.messaging.test.fixtures
 import com.amazonaws.services.sns.AmazonSNS
 import grizzled.slf4j.Logging
 import io.circe.generic.extras.JsonKey
-import io.circe.{Decoder, Json, ParsingFailure, yaml}
+import io.circe.{yaml, Decoder, Json, ParsingFailure}
 import org.scalatest.{Assertion, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.{
@@ -141,9 +141,12 @@ trait SNS extends Matchers with Logging {
       }
   }
 
-  def listObjectsReceivedFromSNS[T](topic: Topic)(implicit decoder: Decoder[T]): Seq[T] =
+  def listObjectsReceivedFromSNS[T](topic: Topic)(
+    implicit decoder: Decoder[T]): Seq[T] =
     listMessagesReceivedFromSNS(topic)
-      .map { messageInfo: MessageInfo => fromJson[T](messageInfo.message).get }
+      .map { messageInfo: MessageInfo =>
+        fromJson[T](messageInfo.message).get
+      }
 
   def assertSnsReceivesOnly[T](expectedMessage: T, topic: SNS.Topic)(
     implicit decoderT: Decoder[T]): Assertion =

--- a/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
+++ b/sbt_common/messaging/src/test/scala/uk/ac/wellcome/messaging/test/fixtures/SNS.scala
@@ -154,7 +154,7 @@ trait SNS extends Matchers with Logging {
 
   def assertSnsReceives[T, I[T] <: Iterable[T]](
     expectedMessages: I[T],
-    topic: SNS.Topic)(implicit decoderT: Decoder[T]) = {
+    topic: SNS.Topic)(implicit decoderT: Decoder[T]): Assertion = {
     val triedReceiptsT = listObjectsReceivedFromSNS[T](topic).toSet
 
     debug(s"SNS $topic received $triedReceiptsT")

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraAdapterHelpers.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraAdapterHelpers.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.sierra_adapter.utils
 
 import io.circe.Decoder
 import org.scalatest.Assertion
-import uk.ac.wellcome.messaging.test.fixtures.{MessageInfo, Messaging}
+import uk.ac.wellcome.messaging.test.fixtures.Messaging
 import uk.ac.wellcome.messaging.test.fixtures.SNS.Topic
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.SierraTransformable._
@@ -76,9 +76,7 @@ trait SierraAdapterHelpers extends LocalVersionedHybridStore with Messaging {
       hybridRecord.location.key)
     storedTransformable shouldBe t
 
-    listMessagesReceivedFromSNS(topic).map { info: MessageInfo =>
-      fromJson[HybridRecord](info.message).get
-    } should contain(hybridRecord)
+    listObjectsReceivedFromSNS[HybridRecord](topic) should contain(hybridRecord)
   }
 
   def assertStoredAndSent(transformable: SierraTransformable,


### PR DESCRIPTION
We often want to get messages from SNS, then decode them as a case class – this cleans up some repeated code for doing that.