### PR TITLE
Simplify some fixtures in the archivist

### DIFF
--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/bag/ArchiveJobCreatorTest.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/bag/ArchiveJobCreatorTest.scala
@@ -20,35 +20,33 @@ class ArchiveJobCreatorTest
     with Inside
     with IngestBagRequestGenerators {
   it("creates an archive job") {
-    withBagItZip() {
-      case (_, zipFile) =>
-        val bucketName = "bucket"
-        val ingestRequest = createIngestBagRequest
-        inside(
-          ArchiveJobCreator
-            .create(
-              zipFile,
-              createBagUploaderConfigWith(Bucket(bucketName)),
-              ingestRequest
-            )) {
-          case Right(
-              ArchiveJob(
-                bagIdentifier,
-                actualZipFile,
-                bagLocation,
-                bagItConfig,
-                bagManifestLocations)) =>
-            actualZipFile shouldBe zipFile
-            bagLocation shouldBe BagLocation(
-              bucketName,
-              "archive",
-              BagPath(s"${ingestRequest.storageSpace}/$bagIdentifier"))
-            bagItConfig shouldBe BagItConfig()
-            bagManifestLocations should contain only (BagManifestLocation(
-              "tagmanifest-sha256.txt"), BagManifestLocation(
-              "manifest-sha256.txt"))
-        }
+    withBagItZip() { zipFile =>
+      val bucketName = "bucket"
+      val ingestRequest = createIngestBagRequest
+      inside(
+        ArchiveJobCreator
+          .create(
+            zipFile,
+            createBagUploaderConfigWith(Bucket(bucketName)),
+            ingestRequest
+          )) {
+        case Right(
+        ArchiveJob(
+        bagIdentifier,
+        actualZipFile,
+        bagLocation,
+        bagItConfig,
+        bagManifestLocations)) =>
+          actualZipFile shouldBe zipFile
+          bagLocation shouldBe BagLocation(
+            bucketName,
+            "archive",
+            BagPath(s"${ingestRequest.storageSpace}/$bagIdentifier"))
+          bagItConfig shouldBe BagItConfig()
+          bagManifestLocations should contain only(BagManifestLocation(
+            "tagmanifest-sha256.txt"), BagManifestLocation(
+            "manifest-sha256.txt"))
+      }
     }
   }
-
 }

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/bag/ArchiveJobCreatorTest.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/bag/ArchiveJobCreatorTest.scala
@@ -31,19 +31,19 @@ class ArchiveJobCreatorTest
             ingestRequest
           )) {
         case Right(
-        ArchiveJob(
-        bagIdentifier,
-        actualZipFile,
-        bagLocation,
-        bagItConfig,
-        bagManifestLocations)) =>
+            ArchiveJob(
+              bagIdentifier,
+              actualZipFile,
+              bagLocation,
+              bagItConfig,
+              bagManifestLocations)) =>
           actualZipFile shouldBe zipFile
           bagLocation shouldBe BagLocation(
             bucketName,
             "archive",
             BagPath(s"${ingestRequest.storageSpace}/$bagIdentifier"))
           bagItConfig shouldBe BagItConfig()
-          bagManifestLocations should contain only(BagManifestLocation(
+          bagManifestLocations should contain only (BagManifestLocation(
             "tagmanifest-sha256.txt"), BagManifestLocation(
             "manifest-sha256.txt"))
       }

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ArchivistFixtures.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ArchivistFixtures.scala
@@ -14,7 +14,6 @@ import uk.ac.wellcome.platform.archive.common.generators.IngestBagRequestGenerat
 import uk.ac.wellcome.platform.archive.common.messaging.MessageStream
 import uk.ac.wellcome.platform.archive.common.models.{
   BagInfo,
-  ExternalIdentifier,
   IngestBagRequest,
   NotificationMessage
 }
@@ -65,7 +64,7 @@ trait ArchivistFixtures
       createValidDataManifest,
     createBagItFile: => Option[FileEntry] = createValidBagItFile,
     createBagInfoFile: BagInfo => Option[FileEntry] = createValidBagInfoFile)(
-    testWith: TestWith[(IngestBagRequest, ExternalIdentifier), R]): R =
+    testWith: TestWith[IngestBagRequest, R]): R =
     withBagItZip(
       bagInfo = bagInfo,
       dataFileCount = dataFileCount,
@@ -76,7 +75,7 @@ trait ArchivistFixtures
       createBagInfoFile = createBagInfoFile
     ) { zipFile =>
       sendBag(zipFile, ingestBucket, queuePair) { ingestBagRequest =>
-        testWith((ingestBagRequest, bagInfo.externalIdentifier))
+        testWith(ingestBagRequest)
       }
     }
 

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ArchivistFixtures.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ArchivistFixtures.scala
@@ -56,6 +56,7 @@ trait ArchivistFixtures
   def createAndSendBag[R](
     ingestBucket: Bucket,
     queuePair: QueuePair,
+    bagInfo: BagInfo = randomBagInfo,
     dataFileCount: Int = 12,
     createDigest: String => String = createValidDigest,
     createTagManifest: List[(String, String)] => Option[FileEntry] =
@@ -64,8 +65,7 @@ trait ArchivistFixtures
       createValidDataManifest,
     createBagItFile: => Option[FileEntry] = createValidBagItFile,
     createBagInfoFile: BagInfo => Option[FileEntry] = createValidBagInfoFile)(
-    testWith: TestWith[(IngestBagRequest, ExternalIdentifier), R]): Boolean = {
-    val bagInfo = randomBagInfo
+    testWith: TestWith[(IngestBagRequest, ExternalIdentifier), R]): R =
     withBagItZip(
       bagInfo = bagInfo,
       dataFileCount = dataFileCount,
@@ -75,10 +75,10 @@ trait ArchivistFixtures
       createBagItFile = createBagItFile,
       createBagInfoFile = createBagInfoFile
     ) { zipFile =>
-      sendBag(zipFile, ingestBucket, queuePair)(ingestBagRequest =>
-         testWith((ingestBagRequest, bagInfo.externalIdentifier)))
+      sendBag(zipFile, ingestBucket, queuePair) { ingestBagRequest =>
+        testWith((ingestBagRequest, bagInfo.externalIdentifier))
+      }
     }
-  }
 
   def withApp[R](storageBucket: Bucket,
                  queuePair: QueuePair,

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ArchivistFixtures.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ArchivistFixtures.scala
@@ -74,10 +74,9 @@ trait ArchivistFixtures
       createDataManifest = createDataManifest,
       createBagItFile = createBagItFile,
       createBagInfoFile = createBagInfoFile
-    ) {
-      case (_, zipFile) =>
-        sendBag(zipFile, ingestBucket, queuePair)(ingestBagRequest =>
-          testWith((ingestBagRequest, bagInfo.externalIdentifier)))
+    ) { zipFile =>
+      sendBag(zipFile, ingestBucket, queuePair)(ingestBagRequest =>
+         testWith((ingestBagRequest, bagInfo.externalIdentifier)))
     }
   }
 

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ArchivistFixtures.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ArchivistFixtures.scala
@@ -64,8 +64,10 @@ trait ArchivistFixtures
       createValidDataManifest,
     createBagItFile: => Option[FileEntry] = createValidBagItFile,
     createBagInfoFile: BagInfo => Option[FileEntry] = createValidBagInfoFile)(
-    testWith: TestWith[(IngestBagRequest, ExternalIdentifier), R]): Boolean =
+    testWith: TestWith[(IngestBagRequest, ExternalIdentifier), R]): Boolean = {
+    val bagInfo = randomBagInfo
     withBagItZip(
+      bagInfo = bagInfo,
       dataFileCount = dataFileCount,
       createTagManifest = createTagManifest,
       createDigest = createDigest,
@@ -73,10 +75,11 @@ trait ArchivistFixtures
       createBagItFile = createBagItFile,
       createBagInfoFile = createBagInfoFile
     ) {
-      case (bagIdentifier, zipFile) =>
+      case (_, zipFile) =>
         sendBag(zipFile, ingestBucket, queuePair)(ingestBagRequest =>
-          testWith((ingestBagRequest, bagIdentifier)))
+          testWith((ingestBagRequest, bagInfo.externalIdentifier)))
     }
+  }
 
   def withApp[R](storageBucket: Bucket,
                  queuePair: QueuePair,

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ZipBagItFixture.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ZipBagItFixture.scala
@@ -10,29 +10,30 @@ import uk.ac.wellcome.test.fixtures._
 
 trait ZipBagItFixture extends BagIt with Logging {
 
-  def withZipFile[R](files: Seq[FileEntry]): Fixture[ZipFile, R] = fixture[ZipFile, R](
-    create = {
-      val file = File.createTempFile(randomAlphanumeric(), ".zip")
-      val zipFileOutputStream = new FileOutputStream(file)
-      val zipOutputStream = new ZipOutputStream(zipFileOutputStream)
-      files.foreach {
-        case FileEntry(name, contents) =>
-          info(s"Adding $name to zip contents")
-          val zipEntry = new ZipEntry(name)
-          zipOutputStream.putNextEntry(zipEntry)
-          zipOutputStream.write(contents.getBytes)
-          zipOutputStream.closeEntry()
-      }
-      zipOutputStream.close()
-      val zipFile = new ZipFile(file)
+  def withZipFile[R](files: Seq[FileEntry]): Fixture[ZipFile, R] =
+    fixture[ZipFile, R](
+      create = {
+        val file = File.createTempFile(randomAlphanumeric(), ".zip")
+        val zipFileOutputStream = new FileOutputStream(file)
+        val zipOutputStream = new ZipOutputStream(zipFileOutputStream)
+        files.foreach {
+          case FileEntry(name, contents) =>
+            info(s"Adding $name to zip contents")
+            val zipEntry = new ZipEntry(name)
+            zipOutputStream.putNextEntry(zipEntry)
+            zipOutputStream.write(contents.getBytes)
+            zipOutputStream.closeEntry()
+        }
+        zipOutputStream.close()
+        val zipFile = new ZipFile(file)
 
-      info(s"zipfile full path: ${file.getAbsolutePath}")
-      zipFile
-    },
-    destroy = { zf: ZipFile =>
-      new File(zf.getName).delete()
-    }
-  )
+        info(s"zipfile full path: ${file.getAbsolutePath}")
+        zipFile
+      },
+      destroy = { zf: ZipFile =>
+        new File(zf.getName).delete()
+      }
+    )
 
   def withBagItZip[R](
     bagInfo: BagInfo = randomBagInfo,

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ZipBagItFixture.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ZipBagItFixture.scala
@@ -5,10 +5,7 @@ import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
 
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.fixtures.{BagIt, FileEntry}
-import uk.ac.wellcome.platform.archive.common.models.{
-  BagInfo,
-  ExternalIdentifier
-}
+import uk.ac.wellcome.platform.archive.common.models.BagInfo
 import uk.ac.wellcome.test.fixtures.TestWith
 
 trait ZipBagItFixture extends BagIt with Logging {
@@ -43,7 +40,7 @@ trait ZipBagItFixture extends BagIt with Logging {
       createValidTagManifest,
     createBagItFile: => Option[FileEntry] = createValidBagItFile,
     createBagInfoFile: BagInfo => Option[FileEntry] = createValidBagInfoFile
-  )(testWith: TestWith[(ExternalIdentifier, ZipFile), R]) = {
+  )(testWith: TestWith[ZipFile, R]): R = {
     info(s"Creating bag ${bagInfo.externalIdentifier}")
 
     val allFiles = createBag(
@@ -57,7 +54,7 @@ trait ZipBagItFixture extends BagIt with Logging {
     )
     info(s"Adding files $allFiles to bag ${bagInfo.externalIdentifier}")
     withZipFile(allFiles) { zipFile =>
-      testWith((bagInfo.externalIdentifier, zipFile))
+      testWith(zipFile)
     }
   }
 }

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ZipBagItFixture.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ZipBagItFixture.scala
@@ -6,29 +6,33 @@ import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.fixtures.{BagIt, FileEntry}
 import uk.ac.wellcome.platform.archive.common.models.BagInfo
-import uk.ac.wellcome.test.fixtures.TestWith
+import uk.ac.wellcome.test.fixtures._
 
 trait ZipBagItFixture extends BagIt with Logging {
 
-  def withZipFile[R](files: Seq[FileEntry])(testWith: TestWith[ZipFile, R]) = {
-    val file = File.createTempFile(randomAlphanumeric(), ".zip")
-    val zipFileOutputStream = new FileOutputStream(file)
-    val zipOutputStream = new ZipOutputStream(zipFileOutputStream)
-    files.foreach {
-      case FileEntry(name, contents) =>
-        info(s"Adding $name to zip contents")
-        val zipEntry = new ZipEntry(name)
-        zipOutputStream.putNextEntry(zipEntry)
-        zipOutputStream.write(contents.getBytes)
-        zipOutputStream.closeEntry()
-    }
-    zipOutputStream.close()
-    val zipFile = new ZipFile(file)
+  def withZipFile[R](files: Seq[FileEntry]): Fixture[ZipFile, R] = fixture[ZipFile, R](
+    create = {
+      val file = File.createTempFile(randomAlphanumeric(), ".zip")
+      val zipFileOutputStream = new FileOutputStream(file)
+      val zipOutputStream = new ZipOutputStream(zipFileOutputStream)
+      files.foreach {
+        case FileEntry(name, contents) =>
+          info(s"Adding $name to zip contents")
+          val zipEntry = new ZipEntry(name)
+          zipOutputStream.putNextEntry(zipEntry)
+          zipOutputStream.write(contents.getBytes)
+          zipOutputStream.closeEntry()
+      }
+      zipOutputStream.close()
+      val zipFile = new ZipFile(file)
 
-    info(s"zipfile full path: ${file.getAbsolutePath}")
-    testWith(zipFile)
-    file.delete()
-  }
+      info(s"zipfile full path: ${file.getAbsolutePath}")
+      zipFile
+    },
+    destroy = { zf: ZipFile =>
+      new File(zf.getName).delete()
+    }
+  )
 
   def withBagItZip[R](
     bagInfo: BagInfo = randomBagInfo,

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ZipBagItFixture.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ZipBagItFixture.scala
@@ -44,7 +44,6 @@ trait ZipBagItFixture extends BagIt with Logging {
     createBagItFile: => Option[FileEntry] = createValidBagItFile,
     createBagInfoFile: BagInfo => Option[FileEntry] = createValidBagInfoFile
   )(testWith: TestWith[(ExternalIdentifier, ZipFile), R]) = {
-
     info(s"Creating bag ${bagInfo.externalIdentifier}")
 
     val allFiles = createBag(

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveJobDigestItemsFlowTest.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveJobDigestItemsFlowTest.scala
@@ -77,12 +77,12 @@ class ArchiveJobDigestItemsFlowTest
             whenReady(eventualArchiveJobs) { archiveJobs =>
               inside(archiveJobs.toList) {
                 case List(
-                Left(
-                ArchiveJobError(
-                actualArchiveJob,
-                List(FileNotFoundError(
-                "this/does/not/exists.jpg",
-                archiveItemJob))))) =>
+                    Left(
+                      ArchiveJobError(
+                        actualArchiveJob,
+                        List(FileNotFoundError(
+                          "this/does/not/exists.jpg",
+                          archiveItemJob))))) =>
                   actualArchiveJob shouldBe archiveJob
                   archiveItemJob.bagDigestItem.location shouldBe EntryPath(
                     "this/does/not/exists.jpg")

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveJobDigestItemsFlowTest.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveJobDigestItemsFlowTest.scala
@@ -32,27 +32,26 @@ class ArchiveJobDigestItemsFlowTest
     withActorSystem { implicit actorSystem =>
       withMaterializer(actorSystem) { implicit materializer =>
         withLocalS3Bucket { bucket =>
-          withBagItZip(dataFileCount = 2) {
-            case (_, zipFile) =>
-              val ingestRequest = createIngestBagRequest
-              val archiveJob = createArchiveJobWith(
-                zipFile = zipFile,
-                bucket = bucket
-              )
-              val source = Source.single(archiveJob)
-              val flow = createFlow(ingestRequest)
-              val eventualArchiveJobs = source via flow runWith Sink.seq
-              whenReady(eventualArchiveJobs) { archiveJobs =>
-                archiveJobs shouldBe List(
-                  Right(
-                    ArchiveComplete(
-                      ingestRequest.archiveRequestId,
-                      ingestRequest.storageSpace,
-                      archiveJob.bagLocation
-                    )
+          withBagItZip(dataFileCount = 2) { zipFile =>
+            val ingestRequest = createIngestBagRequest
+            val archiveJob = createArchiveJobWith(
+              zipFile = zipFile,
+              bucket = bucket
+            )
+            val source = Source.single(archiveJob)
+            val flow = createFlow(ingestRequest)
+            val eventualArchiveJobs = source via flow runWith Sink.seq
+            whenReady(eventualArchiveJobs) { archiveJobs =>
+              archiveJobs shouldBe List(
+                Right(
+                  ArchiveComplete(
+                    ingestRequest.archiveRequestId,
+                    ingestRequest.storageSpace,
+                    archiveJob.bagLocation
                   )
                 )
-              }
+              )
+            }
           }
         }
       }
@@ -66,32 +65,31 @@ class ArchiveJobDigestItemsFlowTest
         withLocalS3Bucket { bucket =>
           withBagItZip(
             dataFileCount = 2,
-            createDataManifest = dataManifestWithNonExistingFile) {
-            case (_, zipFile) =>
-              val ingestRequest = createIngestBagRequest
-              val archiveJob = createArchiveJobWith(
-                zipFile = zipFile,
-                bucket = bucket
-              )
-              val source = Source.single(archiveJob)
-              val flow = createFlow(ingestRequest)
-              val eventualArchiveJobs = source via flow runWith Sink.seq
-              whenReady(eventualArchiveJobs) { archiveJobs =>
-                inside(archiveJobs.toList) {
-                  case List(
-                      Left(
-                        ArchiveJobError(
-                          actualArchiveJob,
-                          List(FileNotFoundError(
-                            "this/does/not/exists.jpg",
-                            archiveItemJob))))) =>
-                    actualArchiveJob shouldBe archiveJob
-                    archiveItemJob.bagDigestItem.location shouldBe EntryPath(
-                      "this/does/not/exists.jpg")
-                    archiveItemJob.archiveJob shouldBe archiveJob
-                }
-
+            createDataManifest = dataManifestWithNonExistingFile) { zipFile =>
+            val ingestRequest = createIngestBagRequest
+            val archiveJob = createArchiveJobWith(
+              zipFile = zipFile,
+              bucket = bucket
+            )
+            val source = Source.single(archiveJob)
+            val flow = createFlow(ingestRequest)
+            val eventualArchiveJobs = source via flow runWith Sink.seq
+            whenReady(eventualArchiveJobs) { archiveJobs =>
+              inside(archiveJobs.toList) {
+                case List(
+                Left(
+                ArchiveJobError(
+                actualArchiveJob,
+                List(FileNotFoundError(
+                "this/does/not/exists.jpg",
+                archiveItemJob))))) =>
+                  actualArchiveJob shouldBe archiveJob
+                  archiveItemJob.bagDigestItem.location shouldBe EntryPath(
+                    "this/does/not/exists.jpg")
+                  archiveItemJob.archiveJob shouldBe archiveJob
               }
+
+            }
           }
         }
       }
@@ -104,7 +102,7 @@ class ArchiveJobDigestItemsFlowTest
       withMaterializer(actorSystem) { implicit materializer =>
         withLocalS3Bucket { bucket =>
           withBagItZip(dataFileCount = 2, createDigest = _ => "bad-digest") {
-            case (_, zipFile) =>
+            zipFile =>
               val ingestRequest = createIngestBagRequest
               val archiveJob = createArchiveJobWith(
                 zipFile = zipFile,
@@ -146,36 +144,35 @@ class ArchiveJobDigestItemsFlowTest
         withLocalS3Bucket { bucket =>
           withBagItZip(
             dataFileCount = 2,
-            createDataManifest = dataManifestWithWrongChecksum) {
-            case (_, zipFile) =>
-              val ingestRequest = createIngestBagRequest
-              val manifestZipEntry = zipFile.getEntry("manifest-sha256.txt")
-              val badChecksumLine = IOUtils
-                .toString(zipFile.getInputStream(manifestZipEntry), "UTF-8")
-                .split("\n")
-                .filter(_.contains("badDigest"))
-                .head
-              val filepath = badChecksumLine.replace("badDigest", "").trim
+            createDataManifest = dataManifestWithWrongChecksum) { zipFile =>
+            val ingestRequest = createIngestBagRequest
+            val manifestZipEntry = zipFile.getEntry("manifest-sha256.txt")
+            val badChecksumLine = IOUtils
+              .toString(zipFile.getInputStream(manifestZipEntry), "UTF-8")
+              .split("\n")
+              .filter(_.contains("badDigest"))
+              .head
+            val filepath = badChecksumLine.replace("badDigest", "").trim
 
-              val archiveJob = createArchiveJobWith(
-                zipFile = zipFile,
-                bucket = bucket
-              )
-              val source = Source.single(archiveJob)
-              val flow = createFlow(ingestRequest)
-              val eventualArchiveJobs = source via flow runWith Sink.seq
-              whenReady(eventualArchiveJobs) { archiveJobs =>
-                inside(archiveJobs.toList) {
-                  case List(Left(ArchiveJobError(job, List(error)))) =>
-                    error shouldBe a[ChecksumNotMatchedOnUploadError]
-                    val checksumNotMatchedOnUploadError =
-                      error.asInstanceOf[ChecksumNotMatchedOnUploadError]
-                    checksumNotMatchedOnUploadError.t.archiveJob shouldBe archiveJob
-                    checksumNotMatchedOnUploadError.t.bagDigestItem.location shouldBe EntryPath(
-                      filepath)
-                    job shouldBe archiveJob
-                }
+            val archiveJob = createArchiveJobWith(
+              zipFile = zipFile,
+              bucket = bucket
+            )
+            val source = Source.single(archiveJob)
+            val flow = createFlow(ingestRequest)
+            val eventualArchiveJobs = source via flow runWith Sink.seq
+            whenReady(eventualArchiveJobs) { archiveJobs =>
+              inside(archiveJobs.toList) {
+                case List(Left(ArchiveJobError(job, List(error)))) =>
+                  error shouldBe a[ChecksumNotMatchedOnUploadError]
+                  val checksumNotMatchedOnUploadError =
+                    error.asInstanceOf[ChecksumNotMatchedOnUploadError]
+                  checksumNotMatchedOnUploadError.t.archiveJob shouldBe archiveJob
+                  checksumNotMatchedOnUploadError.t.bagDigestItem.location shouldBe EntryPath(
+                    filepath)
+                  job shouldBe archiveJob
               }
+            }
           }
         }
       }
@@ -187,7 +184,7 @@ class ArchiveJobDigestItemsFlowTest
       withMaterializer(actorSystem) { implicit materializer =>
         withLocalS3Bucket { bucket =>
           withBagItZip(dataFileCount = 2, createDataManifest = _ => None) {
-            case (_, zipFile) =>
+            zipFile =>
               val ingestRequest = createIngestBagRequest
               val archiveJob = createArchiveJobWith(
                 zipFile = zipFile,
@@ -216,7 +213,7 @@ class ArchiveJobDigestItemsFlowTest
             dataFileCount = 2,
             createDataManifest = _ =>
               Some(FileEntry("manifest-sha256.txt", randomAlphanumeric()))) {
-            case (_, zipFile) =>
+            zipFile =>
               val ingestRequest = createIngestBagRequest
               val archiveJob = createArchiveJobWith(
                 zipFile = zipFile,
@@ -242,7 +239,7 @@ class ArchiveJobDigestItemsFlowTest
       withMaterializer(actorSystem) { implicit materializer =>
         withLocalS3Bucket { bucket =>
           withBagItZip(dataFileCount = 2, createTagManifest = _ => None) {
-            case (_, zipFile) =>
+            zipFile =>
               val ingestRequest = createIngestBagRequest
               val archiveJob = createArchiveJobWith(
                 zipFile = zipFile,
@@ -271,7 +268,7 @@ class ArchiveJobDigestItemsFlowTest
             dataFileCount = 2,
             createTagManifest = _ =>
               Some(FileEntry("tagmanifest-sha256.txt", randomAlphanumeric()))) {
-            case (_, zipFile) =>
+            zipFile =>
               val ingestRequest = createIngestBagRequest
               val archiveJob = createArchiveJobWith(
                 zipFile = zipFile,

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveTagManifestFlowTest.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveTagManifestFlowTest.scala
@@ -34,27 +34,26 @@ class ArchiveTagManifestFlowTest
     withLocalS3Bucket { bucket =>
       withActorSystem { implicit actorSystem =>
         withMaterializer(actorSystem) { implicit materializer =>
-          withBagItZip(dataFileCount = 2) {
-            case (_, zipFile) =>
-              val archiveJob = createArchiveJobWith(
-                zipFile = zipFile,
-                bucket = bucket
-              )
+          withBagItZip(dataFileCount = 2) { zipFile =>
+            val archiveJob = createArchiveJobWith(
+              zipFile = zipFile,
+              bucket = bucket
+            )
 
-              val source = Source.single(archiveJob)
-              val futureResult = source via flow runWith Sink.head
+            val source = Source.single(archiveJob)
+            val futureResult = source via flow runWith Sink.head
 
-              whenReady(futureResult) { result =>
-                result shouldBe Right(archiveJob)
+            whenReady(futureResult) { result =>
+              result shouldBe Right(archiveJob)
 
-                val expectedTagManifestStream = fromInputStream(
-                  zipFile.getInputStream(
-                    new ZipEntry("tagmanifest-sha256.txt"))).mkString
+              val expectedTagManifestStream = fromInputStream(
+                zipFile.getInputStream(
+                  new ZipEntry("tagmanifest-sha256.txt"))).mkString
 
-                getContentFromS3(
-                  bucket,
-                  s"archive/${archiveJob.bagLocation.bagPath}/tagmanifest-sha256.txt") shouldBe expectedTagManifestStream
-              }
+              getContentFromS3(
+                bucket,
+                s"archive/${archiveJob.bagLocation.bagPath}/tagmanifest-sha256.txt") shouldBe expectedTagManifestStream
+            }
           }
         }
       }
@@ -64,36 +63,35 @@ class ArchiveTagManifestFlowTest
   it("fails uploading the tag manifest") {
     withActorSystem { implicit actorSystem =>
       withMaterializer(actorSystem) { implicit materializer =>
-        withBagItZip(dataFileCount = 2) {
-          case (_, zipFile) =>
-            val bagIdentifier = createExternalIdentifier
+        withBagItZip(dataFileCount = 2) { zipFile =>
+          val bagIdentifier = createExternalIdentifier
 
-            val archiveJob = createArchiveJobWith(
-              zipFile = zipFile,
-              bagIdentifier = bagIdentifier,
-              bucket = Bucket("not-a-valid-bucket")
-            )
+          val archiveJob = createArchiveJobWith(
+            zipFile = zipFile,
+            bagIdentifier = bagIdentifier,
+            bucket = Bucket("not-a-valid-bucket")
+          )
 
-            val source = Source.single(archiveJob)
-            val futureResult = source via flow runWith Sink.head
+          val source = Source.single(archiveJob)
+          val futureResult = source via flow runWith Sink.head
 
-            whenReady(futureResult) { result =>
-              inside(result) {
-                case Left(ArchiveItemJobError(job, errors)) =>
-                  job shouldBe archiveJob
-                  errors should have size 1
-                  inside(errors.head) {
-                    case UploadError(location, exception, t) =>
-                      exception shouldBe a[AmazonS3Exception]
-                      exception
-                        .asInstanceOf[AmazonS3Exception]
-                        .getErrorCode shouldBe "NoSuchBucket"
-                      location shouldBe ObjectLocation(
-                        "not-a-valid-bucket",
-                        s"archive/space/$bagIdentifier/tagmanifest-sha256.txt")
-                  }
-              }
+          whenReady(futureResult) { result =>
+            inside(result) {
+              case Left(ArchiveItemJobError(job, errors)) =>
+                job shouldBe archiveJob
+                errors should have size 1
+                inside(errors.head) {
+                  case UploadError(location, exception, t) =>
+                    exception shouldBe a[AmazonS3Exception]
+                    exception
+                      .asInstanceOf[AmazonS3Exception]
+                      .getErrorCode shouldBe "NoSuchBucket"
+                    location shouldBe ObjectLocation(
+                      "not-a-valid-bucket",
+                      s"archive/space/$bagIdentifier/tagmanifest-sha256.txt")
+                }
             }
+          }
         }
       }
     }

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveTagManifestFlowTest.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveTagManifestFlowTest.scala
@@ -46,8 +46,8 @@ class ArchiveTagManifestFlowTest
             whenReady(futureResult) { result =>
               result shouldBe Right(archiveJob)
 
-              val expectedTagManifestStream = fromInputStream(
-                zipFile.getInputStream(
+              val expectedTagManifestStream =
+                fromInputStream(zipFile.getInputStream(
                   new ZipEntry("tagmanifest-sha256.txt"))).mkString
 
               getContentFromS3(

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlowTest.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlowTest.scala
@@ -74,7 +74,8 @@ class ArchiveZipFileFlowTest
                       BagLocation(
                         storageBucket.name,
                         "archive",
-                        BagPath(s"${ingestContext.storageSpace}/${bagInfo.externalIdentifier}"))
+                        BagPath(
+                          s"${ingestContext.storageSpace}/${bagInfo.externalIdentifier}"))
                     )))
 
                     assertTopicReceivesProgressEventUpdate(
@@ -116,8 +117,7 @@ class ArchiveZipFileFlowTest
                   whenReady(verification) { result =>
                     inside(result.toList) {
                       case List(Left(ArchiveJobError(_, errors))) =>
-                        all(errors) shouldBe a[
-                          ChecksumNotMatchedOnUploadError]
+                        all(errors) shouldBe a[ChecksumNotMatchedOnUploadError]
                     }
 
                     assertTopicReceivesProgressStatusUpdate(
@@ -186,8 +186,10 @@ class ArchiveZipFileFlowTest
         withMaterializer(actorSystem) { implicit materializer =>
           withLocalSnsTopic { reportingTopic =>
             val bagInfo = randomBagInfo
-            withBagItZip(bagInfo, createDataManifest = _ =>
-              Some(FileEntry("manifest-sha256.txt", "dgfssjhdfg"))) {
+            withBagItZip(
+              bagInfo,
+              createDataManifest =
+                _ => Some(FileEntry("manifest-sha256.txt", "dgfssjhdfg"))) {
               zipFile =>
                 withArchiveZipFileFlow(storageBucket, reportingTopic) {
                   uploader =>
@@ -211,7 +213,8 @@ class ArchiveZipFileFlowTest
                             .bagLocation shouldBe BagLocation(
                             storageBucket.name,
                             "archive",
-                            BagPath(s"${ingestContext.storageSpace}/${bagInfo.externalIdentifier}"))
+                            BagPath(
+                              s"${ingestContext.storageSpace}/${bagInfo.externalIdentifier}"))
                       }
 
                       assertTopicReceivesProgressStatusUpdate(

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlowTest.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlowTest.scala
@@ -55,41 +55,40 @@ class ArchiveZipFileFlowTest
         withMaterializer(actorSystem) { implicit materializer =>
           withLocalSnsTopic { reportingTopic =>
             val bagInfo = randomBagInfo
-            withBagItZip(bagInfo) {
-              case (_, zipFile) =>
-                withArchiveZipFileFlow(storageBucket, reportingTopic) {
-                  uploader =>
-                    val ingestContext = createIngestBagRequestWith()
-                    val (_, verification) =
-                      uploader.runWith(
-                        Source.single(
-                          ZipFileDownloadComplete(zipFile, ingestContext)),
-                        Sink.seq
-                      )
+            withBagItZip(bagInfo) { zipFile =>
+              withArchiveZipFileFlow(storageBucket, reportingTopic) {
+                uploader =>
+                  val ingestContext = createIngestBagRequestWith()
+                  val (_, verification) =
+                    uploader.runWith(
+                      Source.single(
+                        ZipFileDownloadComplete(zipFile, ingestContext)),
+                      Sink.seq
+                    )
 
-                    whenReady(verification) { result =>
-                      listKeysInBucket(storageBucket) should have size 5
-                      result shouldBe List(Right(ArchiveComplete(
-                        ingestContext.archiveRequestId,
-                        ingestContext.storageSpace,
-                        BagLocation(
-                          storageBucket.name,
-                          "archive",
-                          BagPath(s"${ingestContext.storageSpace}/${bagInfo.externalIdentifier}"))
-                      )))
+                  whenReady(verification) { result =>
+                    listKeysInBucket(storageBucket) should have size 5
+                    result shouldBe List(Right(ArchiveComplete(
+                      ingestContext.archiveRequestId,
+                      ingestContext.storageSpace,
+                      BagLocation(
+                        storageBucket.name,
+                        "archive",
+                        BagPath(s"${ingestContext.storageSpace}/${bagInfo.externalIdentifier}"))
+                    )))
 
-                      assertTopicReceivesProgressEventUpdate(
-                        ingestContext.archiveRequestId,
-                        reportingTopic) { events =>
-                        inside(events) {
-                          case List(event) =>
-                            event.description shouldBe "Bag uploaded and verified successfully"
-                        }
+                    assertTopicReceivesProgressEventUpdate(
+                      ingestContext.archiveRequestId,
+                      reportingTopic) { events =>
+                      inside(events) {
+                        case List(event) =>
+                          event.description shouldBe "Bag uploaded and verified successfully"
                       }
-
-                      new File(zipFile.getName).exists() shouldBe false
                     }
-                }
+
+                    new File(zipFile.getName).exists() shouldBe false
+                  }
+              }
             }
           }
         }
@@ -103,43 +102,41 @@ class ArchiveZipFileFlowTest
       withActorSystem { actorSystem =>
         withMaterializer(actorSystem) { implicit materializer =>
           withLocalSnsTopic { reportingTopic =>
-            withBagItZip(createDigest = _ => "bad_digest") {
-              case (_, zipFile) =>
-                withArchiveZipFileFlow(storageBucket, reportingTopic) {
-                  uploader =>
-                    val ingestContext = createIngestBagRequest
+            withBagItZip(createDigest = _ => "bad_digest") { zipFile =>
+              withArchiveZipFileFlow(storageBucket, reportingTopic) {
+                uploader =>
+                  val ingestContext = createIngestBagRequest
 
-                    val (_, verification) =
-                      uploader.runWith(
-                        Source.single(
-                          ZipFileDownloadComplete(zipFile, ingestContext)),
-                        Sink.seq)
+                  val (_, verification) =
+                    uploader.runWith(
+                      Source.single(
+                        ZipFileDownloadComplete(zipFile, ingestContext)),
+                      Sink.seq)
 
-                    whenReady(verification) { result =>
-                      inside(result.toList) {
-                        case List(Left(ArchiveJobError(_, errors))) =>
-                          all(errors) shouldBe a[
-                            ChecksumNotMatchedOnUploadError]
-                      }
-
-                      assertTopicReceivesProgressStatusUpdate(
-                        ingestContext.archiveRequestId,
-                        reportingTopic,
-                        Progress.Failed) { events =>
-                        events should have size (zipFile
-                          .entries()
-                          .asScala
-                          .size - 1)
-                        all(events.map(_.description)) should include regex "Calculated checksum .+ was different from bad_digest"
-                      }
+                  whenReady(verification) { result =>
+                    inside(result.toList) {
+                      case List(Left(ArchiveJobError(_, errors))) =>
+                        all(errors) shouldBe a[
+                          ChecksumNotMatchedOnUploadError]
                     }
-                }
+
+                    assertTopicReceivesProgressStatusUpdate(
+                      ingestContext.archiveRequestId,
+                      reportingTopic,
+                      Progress.Failed) { events =>
+                      events should have size (zipFile
+                        .entries()
+                        .asScala
+                        .size - 1)
+                      all(events.map(_.description)) should include regex "Calculated checksum .+ was different from bad_digest"
+                    }
+                  }
+              }
             }
           }
         }
       }
     }
-
   }
 
   it(
@@ -148,33 +145,32 @@ class ArchiveZipFileFlowTest
       withActorSystem { actorSystem =>
         withMaterializer(actorSystem) { implicit materializer =>
           withLocalSnsTopic { reportingTopic =>
-            withBagItZip(createBagInfoFile = _ => None) {
-              case (_, zipFile) =>
-                withArchiveZipFileFlow(storageBucket, reportingTopic) {
-                  uploader =>
-                    val ingestContext = createIngestBagRequest
+            withBagItZip(createBagInfoFile = _ => None) { zipFile =>
+              withArchiveZipFileFlow(storageBucket, reportingTopic) {
+                uploader =>
+                  val ingestContext = createIngestBagRequest
 
-                    val (_, verification) =
-                      uploader.runWith(
-                        Source.single(
-                          ZipFileDownloadComplete(zipFile, ingestContext)),
-                        Sink.seq)
+                  val (_, verification) =
+                    uploader.runWith(
+                      Source.single(
+                        ZipFileDownloadComplete(zipFile, ingestContext)),
+                      Sink.seq)
 
-                    whenReady(verification) { result =>
-                      result shouldBe List(
-                        Left(FileNotFoundError("bag-info.txt", ingestContext)))
+                  whenReady(verification) { result =>
+                    result shouldBe List(
+                      Left(FileNotFoundError("bag-info.txt", ingestContext)))
 
-                      assertTopicReceivesProgressStatusUpdate(
-                        ingestContext.archiveRequestId,
-                        reportingTopic,
-                        Progress.Failed) { events =>
-                        inside(events) {
-                          case List(event) =>
-                            event.description shouldBe result.head.left.get.toString
-                        }
+                    assertTopicReceivesProgressStatusUpdate(
+                      ingestContext.archiveRequestId,
+                      reportingTopic,
+                      Progress.Failed) { events =>
+                      inside(events) {
+                        case List(event) =>
+                          event.description shouldBe result.head.left.get.toString
                       }
                     }
-                }
+                  }
+              }
             }
           }
         }
@@ -192,7 +188,7 @@ class ArchiveZipFileFlowTest
             val bagInfo = randomBagInfo
             withBagItZip(bagInfo, createDataManifest = _ =>
               Some(FileEntry("manifest-sha256.txt", "dgfssjhdfg"))) {
-              case (_, zipFile) =>
+              zipFile =>
                 withArchiveZipFileFlow(storageBucket, reportingTopic) {
                   uploader =>
                     val ingestContext = createIngestBagRequest
@@ -241,27 +237,25 @@ class ArchiveZipFileFlowTest
     withLocalS3Bucket { storageBucket =>
       withActorSystem { actorSystem =>
         withMaterializer(actorSystem) { implicit materializer =>
-          withBagItZip(createDigest = _ => "bad_digest") {
-            case (_, zipFile) =>
-              withArchiveZipFileFlow(storageBucket, Topic("bad-topic")) {
-                uploader =>
-                  val ingestContext = createIngestBagRequest
+          withBagItZip(createDigest = _ => "bad_digest") { zipFile =>
+            withArchiveZipFileFlow(storageBucket, Topic("bad-topic")) {
+              uploader =>
+                val ingestContext = createIngestBagRequest
 
-                  val (_, verification) =
-                    uploader.runWith(
-                      Source.single(
-                        ZipFileDownloadComplete(zipFile, ingestContext)),
-                      Sink.seq)
+                val (_, verification) =
+                  uploader.runWith(
+                    Source.single(
+                      ZipFileDownloadComplete(zipFile, ingestContext)),
+                    Sink.seq)
 
-                  whenReady(verification) { result =>
-                    result shouldBe empty
-                  }
-              }
+                whenReady(verification) { result =>
+                  result shouldBe empty
+                }
+            }
           }
         }
       }
     }
-
   }
 
   private def withArchiveZipFileFlow[R](bucket: Bucket, topic: Topic)(

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ZipFileDownloadFlowTest.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ZipFileDownloadFlowTest.scala
@@ -56,7 +56,7 @@ class ZipFileDownloadFlowTest
               createIngestBagRequestWith(ingestBagLocation = objectLocation)
 
             val download: Future[Either[ArchiveError[IngestBagRequest],
-              ZipFileDownloadComplete]] =
+                                        ZipFileDownloadComplete]] =
               downloadZipFlow
                 .runWith(Source.single(ingestBagRequest), Sink.head)
                 ._2

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ZipFileDownloadFlowTest.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ZipFileDownloadFlowTest.scala
@@ -42,9 +42,10 @@ class ZipFileDownloadFlowTest
     withLocalS3Bucket { storageBucket =>
       withLocalSnsTopic { progressTopic =>
         withZipFileDownloadFlow(progressTopic) { downloadZipFlow =>
-          withBagItZip() {
-            case (bagName, zipFile) =>
-              val uploadKey = bagName.toString
+          val bagInfo = randomBagInfo
+          withBagItZip(bagInfo) {
+            case (_, zipFile) =>
+              val uploadKey = bagInfo.externalIdentifier.toString
 
               s3Client.putObject(
                 storageBucket.name,


### PR DESCRIPTION
Rather than passing tuples around, be explicit about when we care about the Identifier, and when we don't.