### PR TITLE
Use the latest version of scala-storage

### DIFF
--- a/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
+++ b/catalogue_pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
@@ -30,10 +30,10 @@ class RecorderFeatureTest
 
               eventually {
                 assertStored[TransformedBaseWork](
-                  bucket,
-                  table,
+                  table = table,
                   id = work.sourceIdentifier.toString,
-                  record = work)
+                  record = work
+                )
               }
             }
           }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object WellcomeDependencies {
   private lazy val versions = new {
     val json = "1.0.0"
     val monitoring = "1.1.0"
-    val storage = "2.6.0"
+    val storage = "2.7.0"
   }
 
   val jsonLibrary: Seq[ModuleID] = Seq(

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraAdapterHelpers.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraAdapterHelpers.scala
@@ -62,11 +62,8 @@ trait SierraAdapterHelpers extends LocalVersionedHybridStore with Messaging {
       record = transformable
     )
 
-  def assertStoredAndSent[T](
-    t: T,
-    id: String,
-    topic: Topic,
-    table: Table)(implicit decoder: Decoder[T]): Assertion = {
+  def assertStoredAndSent[T](t: T, id: String, topic: Topic, table: Table)(
+    implicit decoder: Decoder[T]): Assertion = {
     val hybridRecord = getHybridRecord(table, id = id)
 
     val storedTransformable = getObjectFromS3[T](

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraAdapterHelpers.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraAdapterHelpers.scala
@@ -66,13 +66,13 @@ trait SierraAdapterHelpers extends LocalVersionedHybridStore with Messaging {
     t: T,
     id: String,
     topic: Topic,
-    bucket: Bucket,
     table: Table)(implicit decoder: Decoder[T]): Assertion = {
     val hybridRecord = getHybridRecord(table, id = id)
 
     val storedTransformable = getObjectFromS3[T](
-      Bucket(hybridRecord.location.namespace),
-      hybridRecord.location.key)
+      bucket = Bucket(hybridRecord.location.namespace),
+      key = hybridRecord.location.key
+    )
     storedTransformable shouldBe t
 
     listMessagesReceivedFromSNS(topic).map { info: MessageInfo =>
@@ -80,6 +80,7 @@ trait SierraAdapterHelpers extends LocalVersionedHybridStore with Messaging {
     } should contain(hybridRecord)
   }
 
+  // TODO: Remove the bucket parameter from this method
   def assertStoredAndSent(transformable: SierraTransformable,
                           topic: Topic,
                           bucket: Bucket,
@@ -88,7 +89,6 @@ trait SierraAdapterHelpers extends LocalVersionedHybridStore with Messaging {
       transformable,
       id = transformable.sierraId.withoutCheckDigit,
       topic = topic,
-      bucket = bucket,
       table = table
     )
 }

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraAdapterHelpers.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraAdapterHelpers.scala
@@ -80,10 +80,8 @@ trait SierraAdapterHelpers extends LocalVersionedHybridStore with Messaging {
     } should contain(hybridRecord)
   }
 
-  // TODO: Remove the bucket parameter from this method
   def assertStoredAndSent(transformable: SierraTransformable,
                           topic: Topic,
-                          bucket: Bucket,
                           table: Table): Assertion =
     assertStoredAndSent[SierraTransformable](
       transformable,

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraAdapterHelpers.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraAdapterHelpers.scala
@@ -54,14 +54,15 @@ trait SierraAdapterHelpers extends LocalVersionedHybridStore with Messaging {
       }
     )
 
+  // TODO: We can drop the 'bucket' parameter from this method
   def assertStored(transformable: SierraTransformable,
                    bucket: Bucket,
                    table: Table): Assertion =
     assertStored[SierraTransformable](
-      bucket,
-      table,
+      table = table,
       id = transformable.sierraId.withoutCheckDigit,
-      record = transformable)
+      record = transformable
+    )
 
   def assertStoredAndSent[T](
     t: T,

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraAdapterHelpers.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/utils/SierraAdapterHelpers.scala
@@ -54,9 +54,7 @@ trait SierraAdapterHelpers extends LocalVersionedHybridStore with Messaging {
       }
     )
 
-  // TODO: We can drop the 'bucket' parameter from this method
   def assertStored(transformable: SierraTransformable,
-                   bucket: Bucket,
                    table: Table): Assertion =
     assertStored[SierraTransformable](
       table = table,

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -45,7 +45,6 @@ class SierraBibMergerFeatureTest
                 assertStoredAndSent(
                   transformable = expectedSierraTransformable,
                   topic = topic,
-                  bucket = bucket,
                   table = table
                 )
               }
@@ -81,13 +80,11 @@ class SierraBibMergerFeatureTest
                   assertStoredAndSent(
                     transformable = expectedTransformable1,
                     topic = topic,
-                    bucket = bucket,
                     table = table
                   )
                   assertStoredAndSent(
                     transformable = expectedTransformable2,
                     topic = topic,
-                    bucket = bucket,
                     table = table
                   )
                 }
@@ -133,7 +130,6 @@ class SierraBibMergerFeatureTest
                   assertStoredAndSent(
                     transformable = expectedTransformable,
                     topic = topic,
-                    bucket = bucket,
                     table = table
                   )
                 }
@@ -179,7 +175,6 @@ class SierraBibMergerFeatureTest
                 assertStoredAndSent(
                   transformable = expectedTransformable,
                   topic = topic,
-                  bucket = bucket,
                   table = table
                 )
               }
@@ -219,7 +214,6 @@ class SierraBibMergerFeatureTest
                   assertStoredAndSent(
                     transformable = expectedTransformable,
                     topic = topic,
-                    bucket = bucket,
                     table = table
                   )
                 }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/SierraItemMergerFeatureTest.scala
@@ -56,7 +56,6 @@ class SierraItemMergerFeatureTest
                     assertStoredAndSent(
                       transformable = expectedSierraTransformable,
                       topic = topic,
-                      bucket = sierraDataBucket,
                       table = table
                     )
                   }
@@ -122,13 +121,11 @@ class SierraItemMergerFeatureTest
                     assertStoredAndSent(
                       transformable = expectedSierraTransformable1,
                       topic = topic,
-                      bucket = sierraDataBucket,
                       table = table
                     )
                     assertStoredAndSent(
                       transformable = expectedSierraTransformable2,
                       topic = topic,
-                      bucket = sierraDataBucket,
                       table = table
                     )
                   }
@@ -176,7 +173,6 @@ class SierraItemMergerFeatureTest
                       assertStoredAndSent(
                         transformable = tranformable,
                         topic = topic,
-                        bucket = sierraDataBucket,
                         table = table
                       )
                     }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -39,7 +39,6 @@ class SierraItemMergerUpdaterServiceTest
 
               assertStored(
                 transformable = expectedSierraTransformable,
-                bucket = bucket,
                 table = table
               )
             }
@@ -111,17 +110,14 @@ class SierraItemMergerUpdaterServiceTest
               whenReady(sierraUpdaterService.update(itemRecord)) { _ =>
                 assertStored(
                   transformable = expectedNewSierraTransformable,
-                  bucket = bucket,
                   table = table
                 )
                 assertStored(
                   transformable = expectedUpdatedSierraTransformable,
-                  bucket = bucket,
                   table = table
                 )
                 assertStored(
                   transformable = newTransformable,
-                  bucket = bucket,
                   table = table
                 )
               }
@@ -168,7 +164,6 @@ class SierraItemMergerUpdaterServiceTest
 
                 assertStored(
                   transformable = expectedTransformable,
-                  bucket = bucket,
                   table = table
                 )
               }
@@ -232,12 +227,10 @@ class SierraItemMergerUpdaterServiceTest
               whenReady(sierraUpdaterService.update(unlinkItemRecord)) { _ =>
                 assertStored(
                   transformable = expectedTransformable1,
-                  bucket = bucket,
                   table = table
                 )
                 assertStored(
                   transformable = expectedTransformable2,
-                  bucket = bucket,
                   table = table
                 )
               }
@@ -301,12 +294,10 @@ class SierraItemMergerUpdaterServiceTest
               whenReady(sierraUpdaterService.update(unlinkItemRecord)) { _ =>
                 assertStored(
                   transformable = expectedTransformable1,
-                  bucket = bucket,
                   table = table
                 )
                 assertStored(
                   transformable = expectedTransformable2,
-                  bucket = bucket,
                   table = table
                 )
               }
@@ -371,12 +362,10 @@ class SierraItemMergerUpdaterServiceTest
               whenReady(sierraUpdaterService.update(unlinkItemRecord)) { _ =>
                 assertStored(
                   transformable = expectedTransformable1,
-                  bucket = bucket,
                   table = table
                 )
                 assertStored(
                   transformable = expectedTransformable2,
-                  bucket = bucket,
                   table = table
                 )
               }
@@ -418,7 +407,6 @@ class SierraItemMergerUpdaterServiceTest
               whenReady(sierraUpdaterService.update(oldItemRecord)) { _ =>
                 assertStored(
                   transformable = transformable,
-                  bucket = bucket,
                   table = table
                 )
               }
@@ -459,7 +447,6 @@ class SierraItemMergerUpdaterServiceTest
               whenReady(sierraUpdaterService.update(itemRecord)) { _ =>
                 assertStored(
                   transformable = expectedTransformable,
-                  bucket = bucket,
                   table = table
                 )
               }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
@@ -39,7 +39,6 @@ class SierraItemsToDynamoFeatureTest
                 assertStoredAndSent(
                   itemRecord = itemRecord,
                   topic = topic,
-                  bucket = bucket,
                   table = table
                 )
               }
@@ -50,10 +49,8 @@ class SierraItemsToDynamoFeatureTest
     }
   }
 
-  // TODO: Remove the bucket parameter from this method.
   private def assertStoredAndSent(itemRecord: SierraItemRecord,
                                   topic: Topic,
-                                  bucket: Bucket,
                                   table: Table): Assertion =
     assertStoredAndSent[SierraItemRecord](
       itemRecord,

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
@@ -9,7 +9,6 @@ import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.sierra_adapter.utils.SierraAdapterHelpers
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
-import uk.ac.wellcome.storage.fixtures.S3.Bucket
 
 class SierraItemsToDynamoFeatureTest
     extends FunSpec

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/SierraItemsToDynamoFeatureTest.scala
@@ -50,6 +50,7 @@ class SierraItemsToDynamoFeatureTest
     }
   }
 
+  // TODO: Remove the bucket parameter from this method.
   private def assertStoredAndSent(itemRecord: SierraItemRecord,
                                   topic: Topic,
                                   bucket: Bucket,
@@ -58,7 +59,6 @@ class SierraItemsToDynamoFeatureTest
       itemRecord,
       id = itemRecord.id.withoutCheckDigit,
       topic = topic,
-      bucket = bucket,
       table = table
     )
 }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
@@ -32,7 +32,6 @@ class DynamoInserterTest
 
           whenReady(futureUnit) { _ =>
             assertStored[SierraItemRecord](
-              bucket = bucket,
               table = table,
               id = record.id.withoutCheckDigit,
               record = record
@@ -66,7 +65,6 @@ class DynamoInserterTest
           val futureUnit = dynamoInserter.insertIntoDynamo(oldRecord)
           whenReady(futureUnit) { _ =>
             assertStored[SierraItemRecord](
-              bucket = bucket,
               table = table,
               id = oldRecord.id.withoutCheckDigit,
               record = newRecord
@@ -101,7 +99,6 @@ class DynamoInserterTest
 
           whenReady(futureUnit) { _ =>
             assertStored[SierraItemRecord](
-              bucket = bucket,
               table = table,
               id = oldRecord.id.withoutCheckDigit,
               record = newRecord
@@ -137,7 +134,6 @@ class DynamoInserterTest
 
           whenReady(futureUnit) { _ =>
             assertStored[SierraItemRecord](
-              bucket = bucket,
               table = table,
               id = oldRecord.id.withoutCheckDigit,
               record = newRecord.copy(unlinkedBibIds = List(bibIds(2)))
@@ -173,7 +169,6 @@ class DynamoInserterTest
 
           whenReady(futureUnit) { _ =>
             assertStored[SierraItemRecord](
-              bucket = bucket,
               table = table,
               id = oldRecord.id.withoutCheckDigit,
               record = newRecord.copy(unlinkedBibIds = List(bibIds(0)))

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -67,7 +67,6 @@ class SierraItemsToDynamoWorkerServiceTest
 
                 eventually {
                   assertStored[SierraItemRecord](
-                    bucket = bucket,
                     table = table,
                     id = record1.id.withoutCheckDigit,
                     record = expectedRecord


### PR DESCRIPTION
There's been a new version of scala-storage for a while that tidies up a few of the VHS helpers – specifically, since `HybridRecord` includes the bucket name, there's no need to pass the bucket name when retrieving a record. Lets us shed a few lines.