### PR TITLE
Use the latest version of scala-json

### DIFF
--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/NotificationMessageFlow.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/NotificationMessageFlow.scala
@@ -24,8 +24,6 @@ import uk.ac.wellcome.platform.archive.common.progress.models.{
   *
   */
 object NotificationMessageFlow extends Logging {
-  import IngestBagRequest._
-
   def apply(parallelism: Int,
             snsClient: AmazonSNS,
             progressSnsConfig: SNSConfig)

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/ArchivistFeatureTest.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/ArchivistFeatureTest.scala
@@ -24,8 +24,6 @@ class ArchivistFeatureTest
     with IntegrationPatience
     with ProgressUpdateAssertions {
 
-  import IngestBagRequest._
-
   it("downloads, uploads and verifies a BagIt bag") {
     withArchivist {
       case (

--- a/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ArchivistFixtures.scala
+++ b/archive/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ArchivistFixtures.scala
@@ -28,8 +28,6 @@ trait ArchivistFixtures
     with BagUploaderConfigGenerators
     with IngestBagRequestGenerators {
 
-  import IngestBagRequest._
-
   def sendBag[R](zipFile: ZipFile, ingestBucket: Bucket, queuePair: QueuePair)(
     testWith: TestWith[IngestBagRequest, R]): R = {
 

--- a/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/json/URIConverters.scala
+++ b/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/json/URIConverters.scala
@@ -1,10 +1,9 @@
 package uk.ac.wellcome.platform.archive.common.json
 
-import java.net.{URI, URISyntaxException}
+import java.net.URI
 
 import com.gu.scanamo.DynamoFormat
-import io.circe.{Decoder, DecodingFailure, Encoder}
-import uk.ac.wellcome.json.JsonUtil.{fromJson, toJson}
+import uk.ac.wellcome.json.JsonUtil._
 
 trait URIConverters {
   implicit val fmtUri =
@@ -13,18 +12,4 @@ trait URIConverters {
     )(
       toJson[URI](_).get
     )
-
-  implicit val uriEncoder: Encoder[URI] =
-    Encoder.encodeString.contramap[URI](_.toString)
-  implicit val uriDecoder: Decoder[URI] = Decoder.instance { cursor =>
-    cursor.as[String] match {
-      case Right(str) =>
-        try Right(new URI(str))
-        catch {
-          case _: URISyntaxException =>
-            Left(DecodingFailure("URI", cursor.history))
-        }
-      case l @ Left(_) => l.asInstanceOf[Decoder.Result[URI]]
-    }
-  }
 }

--- a/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/json/UUIDConverters.scala
+++ b/archive/common/src/main/scala/uk/ac/wellcome/platform/archive/common/json/UUIDConverters.scala
@@ -3,8 +3,7 @@ package uk.ac.wellcome.platform.archive.common.json
 import java.util.UUID
 
 import com.gu.scanamo.DynamoFormat
-import io.circe.{Decoder, DecodingFailure, Encoder}
-import uk.ac.wellcome.json.JsonUtil.{fromJson, toJson}
+import uk.ac.wellcome.json.JsonUtil._
 
 trait UUIDConverters {
   implicit val fmtUuid =
@@ -13,18 +12,4 @@ trait UUIDConverters {
     )(
       toJson[UUID](_).get
     )
-
-  implicit val uuidEncoder: Encoder[UUID] =
-    Encoder.encodeString.contramap[UUID](_.toString)
-  implicit val uuidDecoder: Decoder[UUID] = Decoder.instance { cursor =>
-    cursor.as[String] match {
-      case Right(str) =>
-        try Right(UUID.fromString(str))
-        catch {
-          case _: IllegalArgumentException =>
-            Left(DecodingFailure("UUID", cursor.history))
-        }
-      case l @ Left(_) => l.asInstanceOf[Decoder.Result[UUID]]
-    }
-  }
 }

--- a/archive/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/Notifier.scala
+++ b/archive/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/Notifier.scala
@@ -19,7 +19,6 @@ import uk.ac.wellcome.platform.archive.common.models.{
   NotificationMessage
 }
 import uk.ac.wellcome.platform.archive.notifier.flows.NotificationFlow
-import uk.ac.wellcome.platform.archive.common.models.CallbackNotification._
 
 import scala.concurrent.Future
 

--- a/archive/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/archive/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -45,8 +45,6 @@ class NotifierFeatureTest
     with ProgressGenerators
     with TimeTestFixture {
 
-  import uk.ac.wellcome.platform.archive.common.progress.models.Progress._
-
   implicit val system: ActorSystem = ActorSystem("test")
   implicit val materializer: ActorMaterializer = ActorMaterializer()
 

--- a/archive/progress_async/src/main/scala/uk/ac/wellcome/platform/archive/progress_async/flows/CallbackNotificationFlow.scala
+++ b/archive/progress_async/src/main/scala/uk/ac/wellcome/platform/archive/progress_async/flows/CallbackNotificationFlow.scala
@@ -19,8 +19,6 @@ import uk.ac.wellcome.platform.archive.common.progress.models.Progress.{
 }
 
 object CallbackNotificationFlow extends Logging {
-  import CallbackNotification._
-
   type Publication = Flow[Progress, Unit, NotUsed]
 
   def apply(snsClient: AmazonSNS, snsConfig: SNSConfig): Publication = {

--- a/archive/progress_async/src/test/scala/uk/ac/wellcome/platform/archive/progress_async/ProgressAsyncFeatureTest.scala
+++ b/archive/progress_async/src/test/scala/uk/ac/wellcome/platform/archive/progress_async/ProgressAsyncFeatureTest.scala
@@ -20,8 +20,6 @@ class ProgressAsyncFeatureTest
     with ProgressFixture
     with IntegrationPatience {
 
-  import CallbackNotification._
-
   it("updates an existing progress status to Completed") {
     withConfiguredApp {
       case (qPair, topic, table, app) => {

--- a/archive/progress_http/src/main/scala/uk/ac/wellcome/platform/archive/progress_http/ProgressStarter.scala
+++ b/archive/progress_http/src/main/scala/uk/ac/wellcome/platform/archive/progress_http/ProgressStarter.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.platform.archive.progress_http
+
 import com.google.inject.Inject
 import uk.ac.wellcome.messaging.sns.SNSWriter
 import uk.ac.wellcome.platform.archive.common.models.{
   IngestBagRequest,
   StorageSpace
 }
-import uk.ac.wellcome.platform.archive.common.models.IngestBagRequest._
 import uk.ac.wellcome.platform.archive.common.progress.models.Progress
 import uk.ac.wellcome.platform.archive.common.progress.monitor.ProgressTracker
 import uk.ac.wellcome.json.JsonUtil._

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 
 object WellcomeDependencies {
   private lazy val versions = new {
-    val json = "1.0.0"
+    val json = "1.1.1"
     val monitoring = "1.1.0"
     val storage = "2.6.0"
   }


### PR DESCRIPTION
The new version of scala-json has built-in support for URI and UUID decoders/encoders (well, URIs – apparently Circe already handles UUIDs).

See https://github.com/wellcometrust/scala-json/pull/5

Plus some better error messages from JsonAssertions when a test fails.