### PR TITLE
Storage stack typos

### DIFF
--- a/archive/archivist/src/universal/conf/application.conf.template
+++ b/archive/archivist/src/universal/conf/application.conf.template
@@ -1,5 +1,5 @@
 aws.sqs.queue.url="${queue_url}"
-aws.sns.registrar.topic.arn="${registrar_topic_arn}"
-aws.sns.progress.topic.arn="${progress_topic_arn}"
+aws.registrar.sns.topic.arn="${registrar_topic_arn}"
+aws.progress.sns.topic.arn="${progress_topic_arn}"
 upload.namespace="${archive_bucket}"
 metrics.namespace=archivist

--- a/archive/terraform/stack/main.tf
+++ b/archive/terraform/stack/main.tf
@@ -154,7 +154,7 @@ module "api" {
   bags_env_vars = {
     context_url     = "https://api.wellcomecollection.org/storage/v1/context.json"
     vhs_bucket_name = "${var.vhs_archive_manifest_bucket_name}"
-    vhs_table_name  = "${var.vhs_archive_manifest_bucket_name}"
+    vhs_table_name  = "${var.vhs_archive_manifest_table_name}"
     app_base_url    = "https://api.wellcomecollection.org/storage/v1/bags"
   }
   bags_env_vars_length       = 4


### PR DESCRIPTION
Fix a couple of typos in the storage stack deployment
 - SNS has a namespace, but this is at a fixed position within the config strong, so match that.
 - Correct VHS table name variable.