### PR TITLE
Ensure consistent ordering when returning results in the API

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -6,11 +6,18 @@ import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.http.get.GetResponse
 import com.sksamuel.elastic4s.http.search.SearchResponse
 import com.sksamuel.elastic4s.searches.SearchDefinition
-import com.sksamuel.elastic4s.searches.queries.{BoolQueryDefinition, QueryDefinition}
+import com.sksamuel.elastic4s.searches.queries.{
+  BoolQueryDefinition,
+  QueryDefinition
+}
 import com.sksamuel.elastic4s.searches.queries.term.TermsQueryDefinition
 import com.sksamuel.elastic4s.searches.sort.FieldSortDefinition
 import org.elasticsearch.action.search.SearchType
-import uk.ac.wellcome.platform.api.models.{ItemLocationTypeFilter, WorkFilter, WorkTypeFilter}
+import uk.ac.wellcome.platform.api.models.{
+  ItemLocationTypeFilter,
+  WorkFilter,
+  WorkTypeFilter
+}
 
 import scala.concurrent.Future
 
@@ -36,9 +43,8 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient) {
           s"${documentOptions.indexName}/${documentOptions.documentType}")
       }
 
-  def listResults
-    : (ElasticsearchDocumentOptions,
-       ElasticsearchQueryOptions) => Future[SearchResponse] =
+  def listResults: (ElasticsearchDocumentOptions,
+                    ElasticsearchQueryOptions) => Future[SearchResponse] =
     executeSearch(
       maybeQueryString = None,
       sortByFields = List("canonicalId")
@@ -65,10 +71,12 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient) {
       filters = queryOptions.filters
     )
 
-    val sortDefinitions: List[FieldSortDefinition] = sortByFields.map(fieldName => fieldSort(fieldName))
+    val sortDefinitions: List[FieldSortDefinition] =
+      sortByFields.map(fieldName => fieldSort(fieldName))
 
     val searchDefinition: SearchDefinition =
-      search(s"${documentOptions.indexName}/${documentOptions.documentType}").searchType(SearchType.DFS_QUERY_THEN_FETCH)
+      search(s"${documentOptions.indexName}/${documentOptions.documentType}")
+        .searchType(SearchType.DFS_QUERY_THEN_FETCH)
         .query(queryDefinition)
         .sortBy(sortDefinitions)
         .limit(queryOptions.limit)

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -7,11 +7,18 @@ import com.sksamuel.elastic4s.http.get.GetResponse
 import com.sksamuel.elastic4s.http.search.SearchResponse
 import com.sksamuel.elastic4s.searches.SearchDefinition
 import com.sksamuel.elastic4s.searches.queries.term.TermsQueryDefinition
-import com.sksamuel.elastic4s.searches.queries.{BoolQueryDefinition, QueryDefinition}
+import com.sksamuel.elastic4s.searches.queries.{
+  BoolQueryDefinition,
+  QueryDefinition
+}
 import com.sksamuel.elastic4s.searches.sort.FieldSortDefinition
 import org.elasticsearch.action.search.SearchType
 import org.elasticsearch.search.sort.SortOrder
-import uk.ac.wellcome.platform.api.models.{ItemLocationTypeFilter, WorkFilter, WorkTypeFilter}
+import uk.ac.wellcome.platform.api.models.{
+  ItemLocationTypeFilter,
+  WorkFilter,
+  WorkTypeFilter
+}
 
 import scala.concurrent.Future
 
@@ -49,7 +56,9 @@ class ElasticsearchService @Inject()(elasticClient: HttpClient) {
        ElasticsearchQueryOptions) => Future[SearchResponse] =
     executeSearch(
       maybeQueryString = Some(queryString),
-      sortDefinitions = List(fieldSort("_score").order(SortOrder.DESC),fieldSort("canonicalId").order(SortOrder.ASC))
+      sortDefinitions = List(
+        fieldSort("_score").order(SortOrder.DESC),
+        fieldSort("canonicalId").order(SortOrder.ASC))
     )
 
   /** Given a set of query options, build a SearchDefinition for Elasticsearch

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -34,7 +34,7 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
   def listWorks(documentOptions: ElasticsearchDocumentOptions,
                 worksSearchOptions: WorksSearchOptions): Future[ResultList] =
     searchService
-      .listResults(sortByField = "canonicalId")(
+      .listResults(
         documentOptions,
         toElasticsearchQueryOptions(worksSearchOptions))
       .map { createResultList }
@@ -59,7 +59,7 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
   private def createResultList(searchResponse: SearchResponse): ResultList =
     ResultList(
       results = searchResponseToWorks(searchResponse),
-      totalResults = searchResponse.totalHits
+      totalResults = searchResponse.totalHits.toInt
     )
 
   private def searchResponseToWorks(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -23,7 +23,7 @@ class ElasticsearchServiceTest
     with Matchers
     with ScalaFutures
     with SearchOptionsGenerators
-    with WorksGenerators {
+    with WorksGenerators  {
 
   describe("simpleStringQueryResults") {
     it("finds results for a simpleStringQuery search") {
@@ -180,7 +180,27 @@ class ElasticsearchServiceTest
         )
       }
     }
-  }
+
+    it("returns results in consistent order") {
+      withLocalElasticsearchIndex { indexName =>
+        val works = (1 to 5).map { _ => createIdentifiedWorkWith(title = s"A ${Random.alphanumeric.filterNot(_.equals('A')) take 10 mkString}") }.sortBy(_.canonicalId)
+
+        insertIntoElasticsearch(indexName, works: _*)
+        withElasticsearchService { searchService =>
+          (1 to 10).foreach { _ =>
+
+            val searchResponseFuture = searchService
+              .simpleStringQueryResults("A")(createElasticsearchDocumentOptionsWith(indexName), createElasticsearchQueryOptions)
+
+            whenReady(searchResponseFuture) { response =>
+              searchResponseToWorks(response) shouldBe works
+            }
+          }
+        }
+        }
+      }
+    }
+
 
   describe("findResultById") {
     it("finds a result by ID") {
@@ -432,7 +452,7 @@ class ElasticsearchServiceTest
       val documentOptions = createElasticsearchDocumentOptionsWith(indexName)
 
       val listResponseFuture = searchService
-        .listResults(sortByField = "canonicalId")(documentOptions, queryOptions)
+        .listResults(documentOptions, queryOptions)
 
       whenReady(listResponseFuture) { response =>
         searchResponseToWorks(response) should contain theSameElementsAs expectedWorks

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -23,7 +23,7 @@ class ElasticsearchServiceTest
     with Matchers
     with ScalaFutures
     with SearchOptionsGenerators
-    with WorksGenerators  {
+    with WorksGenerators {
 
   describe("simpleStringQueryResults") {
     it("finds results for a simpleStringQuery search") {
@@ -183,24 +183,29 @@ class ElasticsearchServiceTest
 
     it("returns results in consistent order") {
       withLocalElasticsearchIndex { indexName =>
-        val works = (1 to 5).map { _ => createIdentifiedWorkWith(title = s"A ${Random.alphanumeric.filterNot(_.equals('A')) take 10 mkString}") }.sortBy(_.canonicalId)
+        val works = (1 to 5)
+          .map { _ =>
+            createIdentifiedWorkWith(title =
+              s"A ${Random.alphanumeric.filterNot(_.equals('A')) take 10 mkString}")
+          }
+          .sortBy(_.canonicalId)
 
         insertIntoElasticsearch(indexName, works: _*)
         withElasticsearchService { searchService =>
           (1 to 10).foreach { _ =>
-
             val searchResponseFuture = searchService
-              .simpleStringQueryResults("A")(createElasticsearchDocumentOptionsWith(indexName), createElasticsearchQueryOptions)
+              .simpleStringQueryResults("A")(
+                createElasticsearchDocumentOptionsWith(indexName),
+                createElasticsearchQueryOptions)
 
             whenReady(searchResponseFuture) { response =>
               searchResponseToWorks(response) shouldBe works
             }
           }
         }
-        }
       }
     }
-
+  }
 
   describe("findResultById") {
     it("finds a result by ID") {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,7 +38,14 @@ object Dependencies {
     val mockito = "1.9.5"
     val scalatest = "3.0.1"
     val junitInterface = "0.11"
-    val elastic4s = "5.6.5"
+    
+    // This is our own published version of elastic4s. The reason 
+    // for patching the library is that 5.6.x versions of elastic4s 
+    // have a bug where search_type parameter is not passed in correctly.
+    // TODO set this to an official release of elastic4s once 
+    // (if) https://github.com/sksamuel/elastic4s/pull/1572 gets accepted
+    val elastic4s = "5.6.8.1"
+    
     val circeVersion = "0.9.0"
     val scalaCheckVersion = "1.13.4"
     val scalaCheckShapelessVersion = "1.1.6"
@@ -111,10 +118,10 @@ object Dependencies {
   val elasticsearchDependencies = Seq(
     "org.apache.logging.log4j" % "log4j-core" % versions.apacheLogging,
     "org.apache.logging.log4j" % "log4j-api" % versions.apacheLogging,
-    "com.sksamuel.elastic4s" %% "elastic4s-core" % versions.elastic4s,
-    "com.sksamuel.elastic4s" %% "elastic4s-http" % versions.elastic4s,
-    "com.sksamuel.elastic4s" %% "elastic4s-http-streams" % versions.elastic4s,
-    "com.sksamuel.elastic4s" %% "elastic4s-testkit" % versions.elastic4s % "test"
+    "uk.ac.wellcome" %% "elastic4s-core" % versions.elastic4s,
+    "uk.ac.wellcome" %% "elastic4s-http" % versions.elastic4s,
+    "uk.ac.wellcome" %% "elastic4s-http-streams" % versions.elastic4s,
+    "uk.ac.wellcome" %% "elastic4s-testkit" % versions.elastic4s % "test"
   )
 
   val scalaGraphDependencies = Seq(


### PR DESCRIPTION
For #3082 