### PR TITLE
[WIP] Upgrade the pipeline and API to use Elasticsearch 6

### DIFF
--- a/catalogue_api/api/docker-compose.yml
+++ b/catalogue_api/api/docker-compose.yml
@@ -1,5 +1,5 @@
 elasticsearch:
-  image: docker.elastic.co/elasticsearch/elasticsearch:5.6.6
+  image: docker.elastic.co/elasticsearch/elasticsearch:6.4.0
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/ManagementController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/ManagementController.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.api.controllers
 
 import com.google.inject.{Inject, Singleton}
-import com.sksamuel.elastic4s.http.HttpClient
+import com.sksamuel.elastic4s.http.ElasticClient
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
@@ -10,7 +10,7 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class ManagementController @Inject()(
-  elasticClient: HttpClient
+  elasticClient: ElasticClient
 )(implicit ec: ExecutionContext)
     extends Controller {
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
@@ -24,7 +24,6 @@ class V1WorksController @Inject()(
       V1WorksIncludes](
       apiConfig = apiConfig,
       indexName = elasticConfig.indexV1name,
-      documentType = elasticConfig.documentType,
       worksService = worksService
     ) {
   implicit protected val swagger = ApiV1Swagger

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
@@ -26,7 +26,6 @@ class V2WorksController @Inject()(
       V2WorksIncludes](
       apiConfig = apiConfig,
       indexName = elasticConfig.indexV2name,
-      documentType = elasticConfig.documentType,
       worksService = worksService
     ) {
   implicit protected val swagger = ApiV2Swagger

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -28,7 +28,6 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
                                S <: SingleWorkRequest[W],
                                W <: WorksIncludes](
   apiConfig: ApiConfig,
-  documentType: String,
   indexName: String,
   worksService: WorksService)(implicit ec: ExecutionContext)
     extends Controller
@@ -86,8 +85,7 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
       val includes = request.include.getOrElse(emptyWorksIncludes)
 
       val documentOptions = ElasticsearchDocumentOptions(
-        indexName = request._index.getOrElse(indexName),
-        documentType = documentType
+        indexName = request._index.getOrElse(indexName)
       )
 
       val contextUri =
@@ -112,8 +110,7 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
 
   private def getWorkList(request: M, pageSize: Int): Future[ResultList] = {
     val documentOptions = ElasticsearchDocumentOptions(
-      indexName = request._index.getOrElse(indexName),
-      documentType = documentType
+      indexName = request._index.getOrElse(indexName)
     )
 
     val worksSearchOptions = WorksSearchOptions(

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -13,8 +13,7 @@ import uk.ac.wellcome.platform.api.models.{ItemLocationTypeFilter, WorkFilter, W
 import scala.concurrent.Future
 
 case class ElasticsearchDocumentOptions(
-  indexName: String,
-  documentType: String
+  indexName: String
 )
 
 case class ElasticsearchQueryOptions(
@@ -30,8 +29,8 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient) {
     documentOptions: ElasticsearchDocumentOptions): Future[Response[GetResponse]] =
     elasticClient
       .execute {
-        get(canonicalId).from(
-          s"${documentOptions.indexName}/${documentOptions.documentType}")
+        get(canonicalId)
+          .from(documentOptions.indexName)
       }
 
   def listResults(sortByField: String)
@@ -70,7 +69,7 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient) {
       }
 
     val searchDefinition =
-      search(s"${documentOptions.indexName}/${documentOptions.documentType}")
+      search(documentOptions.indexName)
         .query(queryDefinition)
         .sortBy(sortDefinitions)
         .limit(queryOptions.limit)

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -24,7 +24,6 @@ case class ElasticsearchQueryOptions(
 
 @Singleton
 class ElasticsearchService @Inject()(elasticClient: ElasticClient) {
-
   def findResultById(canonicalId: String)(
     documentOptions: ElasticsearchDocumentOptions): Future[Response[GetResponse]] =
     elasticClient

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -8,7 +8,11 @@ import com.sksamuel.elastic4s.http.search.SearchResponse
 import com.sksamuel.elastic4s.searches.queries.{BoolQuery, Query}
 import com.sksamuel.elastic4s.searches.queries.term.TermsQuery
 import com.sksamuel.elastic4s.searches.sort.FieldSort
-import uk.ac.wellcome.platform.api.models.{ItemLocationTypeFilter, WorkFilter, WorkTypeFilter}
+import uk.ac.wellcome.platform.api.models.{
+  ItemLocationTypeFilter,
+  WorkFilter,
+  WorkTypeFilter
+}
 
 import scala.concurrent.Future
 
@@ -25,7 +29,8 @@ case class ElasticsearchQueryOptions(
 @Singleton
 class ElasticsearchService @Inject()(elasticClient: ElasticClient) {
   def findResultById(canonicalId: String)(
-    documentOptions: ElasticsearchDocumentOptions): Future[Response[GetResponse]] =
+    documentOptions: ElasticsearchDocumentOptions)
+    : Future[Response[GetResponse]] =
     elasticClient
       .execute {
         get(canonicalId)
@@ -55,7 +60,8 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient) {
     maybeQueryString: Option[String],
     sortByField: Option[String]
   )(documentOptions: ElasticsearchDocumentOptions,
-    queryOptions: ElasticsearchQueryOptions): Future[Response[SearchResponse]] = {
+    queryOptions: ElasticsearchQueryOptions)
+    : Future[Response[SearchResponse]] = {
     val queryDefinition = buildQuery(
       maybeQueryString = maybeQueryString,
       filters = queryOptions.filters
@@ -78,8 +84,7 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient) {
       .execute { searchDefinition }
   }
 
-  private def toTermQuery(
-    workFilter: WorkFilter): TermsQuery[String] =
+  private def toTermQuery(workFilter: WorkFilter): TermsQuery[String] =
     workFilter match {
       case ItemLocationTypeFilter(itemLocationTypeIds) =>
         termsQuery(
@@ -95,7 +100,8 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient) {
       maybeQueryString.map { simpleStringQuery }
     ).flatten
 
-    val filterDefinitions: List[Query] = filters.map { toTermQuery } :+ termQuery(
+    val filterDefinitions
+      : List[Query] = filters.map { toTermQuery } :+ termQuery(
       "type",
       "IdentifiedWork")
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -27,7 +27,9 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
     : Future[Option[IdentifiedBaseWork]] =
     searchService
       .findResultById(canonicalId)(documentOptions)
-      .map { response: Response[GetResponse] => response.result }
+      .map { response: Response[GetResponse] =>
+        response.result
+      }
       .map { result: GetResponse =>
         if (result.exists)
           Some(jsonTo[IdentifiedBaseWork](result.sourceAsString))
@@ -59,7 +61,8 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
       from = (worksSearchOptions.pageNumber - 1) * worksSearchOptions.pageSize
     )
 
-  private def createResultList(searchResponse: Response[SearchResponse]): ResultList =
+  private def createResultList(
+    searchResponse: Response[SearchResponse]): ResultList =
     ResultList(
       results = searchResponseToWorks(searchResponse.result),
       totalResults = searchResponse.result.totalHits.toInt

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
@@ -8,13 +8,10 @@ import uk.ac.wellcome.platform.api.services.{
 }
 
 trait SearchOptionsGenerators {
-  val documentType: String
-
   def createElasticsearchDocumentOptionsWith(
     indexName: String): ElasticsearchDocumentOptions =
     ElasticsearchDocumentOptions(
-      indexName = indexName,
-      documentType = documentType
+      indexName = indexName
     )
 
   def createElasticsearchQueryOptionsWith(

--- a/catalogue_api/api/src/universal/conf/application.ini.template
+++ b/catalogue_api/api/src/universal/conf/application.ini.template
@@ -3,7 +3,6 @@
 -es.port=${es_port}
 -es.index.v1=${es_index_v1}
 -es.index.v2=${es_index_v2}
--es.type=${es_doc_type}
 -es.username=${es_username}
 -es.password=${es_password}
 -es.protocol=${es_protocol}

--- a/catalogue_api/terraform/data_api/service_snapshot_generator.tf
+++ b/catalogue_api/terraform/data_api/service_snapshot_generator.tf
@@ -25,11 +25,10 @@ module "snapshot_generator" {
     es_protocol       = "${var.es_cluster_credentials["protocol"]}"
     es_index_v1       = "${var.es_config_snapshot["index_v1"]}"
     es_index_v2       = "${var.es_config_snapshot["index_v2"]}"
-    es_doc_type       = "${var.es_config_snapshot["doc_type"]}"
     metrics_namespace = "snapshot_generator"
   }
 
-  env_vars_length = 11
+  env_vars_length = 10
 
   memory = 4096
   cpu    = 2048

--- a/catalogue_pipeline/ingestor/docker-compose.yml
+++ b/catalogue_pipeline/ingestor/docker-compose.yml
@@ -3,7 +3,7 @@ sqs:
   ports:
     - "9324:9324"
 elasticsearch:
-  image: docker.elastic.co/elasticsearch/elasticsearch:5.6.6
+  image: "docker.elastic.co/elasticsearch/elasticsearch:6.4.0"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/Main.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/Main.scala
@@ -23,7 +23,7 @@ object Main extends App with Logging {
     AkkaBuilder.buildExecutionContext()
 
   val workerService = new IngestorWorkerService(
-    elasticClient = ElasticBuilder.buildHttpClient(config),
+    elasticClient = ElasticBuilder.buildElasticClient(config),
     ingestorConfig = IngestorConfigBuilder.buildIngestorConfig(config),
     messageStream =
       MessagingBuilder.buildMessageStream[IdentifiedBaseWork](config)

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/config/builders/IngestorConfigBuilder.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/config/builders/IngestorConfigBuilder.scala
@@ -27,11 +27,9 @@ object IngestorConfigBuilder {
   }
 
   def buildElasticConfig(config: Config): IngestElasticConfig = {
-    val documentType = config.getOrElse[String]("es.type")(default = "item")
     val indexName = config.required[String]("es.index")
 
     IngestElasticConfig(
-      documentType = documentType,
       indexName = indexName
     )
   }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/config/models/IngestorConfig.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/config/models/IngestorConfig.scala
@@ -9,6 +9,5 @@ case class IngestorConfig(
 )
 
 case class IngestElasticConfig(
-  documentType: String,
   indexName: String
 )

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -55,8 +55,7 @@ class IngestorWorkerService(elasticClient: ElasticClient,
       works <- Future.successful(messageBundles.map(m => m.work))
       either <- identifiedWorkIndexer.indexWorks(
         works = works,
-        indexName = ingestorConfig.elasticConfig.indexName,
-        documentType = ingestorConfig.elasticConfig.documentType
+        indexName = ingestorConfig.elasticConfig.indexName
       )
     } yield {
       val failedWorks = either.left.getOrElse(Nil)

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -24,7 +24,7 @@ class IngestorWorkerService(elasticClient: ElasticClient,
 
   val worksIndex = new WorksIndex(
     client = elasticClient,
-    rootIndexType = ingestorConfig.elasticConfig.documentType
+    indexName = ingestorConfig.elasticConfig.indexName
   )
 
   worksIndex.create(

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.ingestor.services
 
 import akka.Done
 import com.amazonaws.services.sqs.model.Message
-import com.sksamuel.elastic4s.http.HttpClient
+import com.sksamuel.elastic4s.http.ElasticClient
 import uk.ac.wellcome.elasticsearch.WorksIndex
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.message.MessageStream
@@ -11,7 +11,7 @@ import uk.ac.wellcome.platform.ingestor.config.models.IngestorConfig
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class IngestorWorkerService(elasticClient: HttpClient,
+class IngestorWorkerService(elasticClient: ElasticClient,
                             ingestorConfig: IngestorConfig,
                             messageStream: MessageStream[IdentifiedBaseWork])(
   implicit ec: ExecutionContext) {

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -26,14 +26,12 @@ class WorkIndexer(
   }
 
   def indexWorks(works: Seq[IdentifiedBaseWork],
-                 indexName: String,
-                 documentType: String)
+                 indexName: String)
     : Future[Either[Seq[IdentifiedBaseWork], Seq[IdentifiedBaseWork]]] = {
-
     debug(s"Indexing work ${works.map(_.canonicalId).mkString(", ")}")
 
     val inserts = works.map { work =>
-      indexInto(indexName / documentType)
+      indexInto(indexName)
         .version(calculateEsVersion(work))
         .versionType(ExternalGte)
         .id(work.canonicalId)

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -7,7 +7,12 @@ import com.sksamuel.elastic4s.http.{ElasticClient, Response}
 import com.sksamuel.elastic4s.http.bulk.{BulkResponse, BulkResponseItem}
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.elasticsearch.ElasticsearchExceptionManager
-import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, IdentifiedInvisibleWork, IdentifiedRedirectedWork, IdentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  IdentifiedBaseWork,
+  IdentifiedInvisibleWork,
+  IdentifiedRedirectedWork,
+  IdentifiedWork
+}
 import uk.ac.wellcome.json.JsonUtil._
 
 import scala.language.implicitConversions
@@ -25,8 +30,7 @@ class WorkIndexer(
       toJson(t).get
   }
 
-  def indexWorks(works: Seq[IdentifiedBaseWork],
-                 indexName: String)
+  def indexWorks(works: Seq[IdentifiedBaseWork], indexName: String)
     : Future[Either[Seq[IdentifiedBaseWork], Seq[IdentifiedBaseWork]]] = {
     debug(s"Indexing work ${works.map(_.canonicalId).mkString(", ")}")
 

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -1,25 +1,20 @@
 package uk.ac.wellcome.platform.ingestor.services
 
 import com.sksamuel.elastic4s.Indexable
+import com.sksamuel.elastic4s.VersionType.ExternalGte
 import com.sksamuel.elastic4s.http.ElasticDsl._
-import com.sksamuel.elastic4s.http.HttpClient
+import com.sksamuel.elastic4s.http.{ElasticClient, Response}
 import com.sksamuel.elastic4s.http.bulk.{BulkResponse, BulkResponseItem}
 import grizzled.slf4j.Logging
-import org.elasticsearch.index.VersionType
 import uk.ac.wellcome.elasticsearch.ElasticsearchExceptionManager
-import uk.ac.wellcome.models.work.internal.{
-  IdentifiedBaseWork,
-  IdentifiedInvisibleWork,
-  IdentifiedRedirectedWork,
-  IdentifiedWork
-}
+import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, IdentifiedInvisibleWork, IdentifiedRedirectedWork, IdentifiedWork}
 import uk.ac.wellcome.json.JsonUtil._
-import scala.language.implicitConversions
 
+import scala.language.implicitConversions
 import scala.concurrent.{ExecutionContext, Future}
 
 class WorkIndexer(
-  elasticClient: HttpClient
+  elasticClient: ElasticClient
 )(implicit ec: ExecutionContext)
     extends Logging
     with ElasticsearchExceptionManager {
@@ -40,7 +35,7 @@ class WorkIndexer(
     val inserts = works.map { work =>
       indexInto(indexName / documentType)
         .version(calculateEsVersion(work))
-        .versionType(VersionType.EXTERNAL_GTE)
+        .versionType(ExternalGte)
         .id(work.canonicalId)
         .doc(work)
     }
@@ -49,7 +44,8 @@ class WorkIndexer(
       .execute {
         bulk(inserts)
       }
-      .map { bulkResponse: BulkResponse =>
+      .map { response: Response[BulkResponse] =>
+        val bulkResponse = response.result
         val actualFailures = bulkResponse.failures.filterNot {
           isVersionConflictException
         }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
@@ -1,9 +1,7 @@
 package uk.ac.wellcome.platform.ingestor
 
-import com.sksamuel.elastic4s.ElasticDsl.{deleteIndex, index}
-import com.sksamuel.elastic4s.http.ElasticDsl._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{Assertion, FunSpec, Matchers}
+import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.messaging.test.fixtures.{Messaging, SQS}
 import uk.ac.wellcome.platform.ingestor.fixtures.WorkerServiceFixture
@@ -25,25 +23,6 @@ class IngestorIndexTest
     withLocalSqsQueue { queue =>
       withWorkerService(queue, indexName) { _ =>
         eventuallyIndexExists(indexName)
-      }
-    }
-  }
-
-  private def eventuallyIndexExists(indexName: String): Assertion =
-    eventually {
-      val future = elasticClient.execute(index exists indexName)
-      whenReady(future) { result =>
-        result.isExists should be(true)
-      }
-    }
-
-  private def deleteIndexIfExists(indexName: String): Assertion = {
-    elasticClient.execute(deleteIndex(indexName))
-
-    eventually {
-      val future = elasticClient.execute(index exists indexName)
-      whenReady(future) { result =>
-        result.isExists should be(false)
       }
     }
   }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkerServiceFixture.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkerServiceFixture.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.ingestor.fixtures
 
-import com.sksamuel.elastic4s.http.{ElasticClient, HttpClient}
+import com.sksamuel.elastic4s.http.ElasticClient
 import org.scalatest.Suite
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.json.JsonUtil._

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkerServiceFixture.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkerServiceFixture.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.ingestor.fixtures
 
-import com.sksamuel.elastic4s.http.HttpClient
+import com.sksamuel.elastic4s.http.{ElasticClient, HttpClient}
 import org.scalatest.Suite
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.json.JsonUtil._
@@ -21,7 +21,7 @@ trait WorkerServiceFixture extends ElasticsearchFixtures with Messaging {
   this: Suite =>
   def withWorkerService[R](queue: Queue,
                            indexName: String,
-                           elasticClient: HttpClient = elasticClient)(
+                           elasticClient: ElasticClient = elasticClient)(
     testWith: TestWith[IngestorWorkerService, R]): R =
     withActorSystem { implicit actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>
@@ -32,7 +32,6 @@ trait WorkerServiceFixture extends ElasticsearchFixtures with Messaging {
             batchSize = 100,
             flushInterval = 5 seconds,
             elasticConfig = IngestElasticConfig(
-              documentType = documentType,
               indexName = indexName
             )
           )

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/CustomElasticsearchMapping.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/CustomElasticsearchMapping.scala
@@ -1,12 +1,7 @@
 package uk.ac.wellcome.platform.ingestor.services
 
-import com.sksamuel.elastic4s.http.ElasticDsl.{
-  intField,
-  keywordField,
-  mapping,
-  objectField
-}
-import com.sksamuel.elastic4s.http.HttpClient
+import com.sksamuel.elastic4s.http.ElasticDsl.{intField, keywordField, mapping, objectField}
+import com.sksamuel.elastic4s.http.{ElasticClient, HttpClient}
 import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicMapping
 import com.sksamuel.elastic4s.mappings.{FieldDefinition, MappingDefinition}
 import uk.ac.wellcome.elasticsearch.ElasticsearchIndex
@@ -15,11 +10,9 @@ import scala.concurrent.ExecutionContext
 
 trait CustomElasticsearchMapping {
 
-  class OnlyInvisibleWorksIndex(elasticClient: HttpClient, documentType: String)(
+  class OnlyInvisibleWorksIndex(val elasticClient: ElasticClient, documentType: String)(
     implicit val ec: ExecutionContext)
       extends ElasticsearchIndex {
-    val httpClient: HttpClient = elasticClient
-
     def sourceIdentifierFields = Seq(
       keywordField("ontologyType"),
       objectField("identifierType").fields(

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/CustomElasticsearchMapping.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/CustomElasticsearchMapping.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.ingestor.services
 
 import com.sksamuel.elastic4s.http.ElasticDsl.{intField, keywordField, mapping, objectField}
-import com.sksamuel.elastic4s.http.{ElasticClient, HttpClient}
+import com.sksamuel.elastic4s.http.ElasticClient
 import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicMapping
 import com.sksamuel.elastic4s.mappings.{FieldDefinition, MappingDefinition}
 import uk.ac.wellcome.elasticsearch.ElasticsearchIndex
@@ -10,7 +10,7 @@ import scala.concurrent.ExecutionContext
 
 trait CustomElasticsearchMapping {
 
-  class OnlyInvisibleWorksIndex(val elasticClient: ElasticClient, documentType: String)(
+  class OnlyInvisibleWorksIndex(val elasticClient: ElasticClient, indexName: String)(
     implicit val ec: ExecutionContext)
       extends ElasticsearchIndex {
     def sourceIdentifierFields = Seq(
@@ -32,7 +32,7 @@ trait CustomElasticsearchMapping {
         keywordField("type")
       )
 
-    override val mappingDefinition: MappingDefinition = mapping(documentType)
+    override val mappingDefinition: MappingDefinition = mapping(indexName)
       .dynamic(DynamicMapping.Strict)
       .as(rootIndexFields)
   }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/CustomElasticsearchMapping.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/CustomElasticsearchMapping.scala
@@ -1,6 +1,11 @@
 package uk.ac.wellcome.platform.ingestor.services
 
-import com.sksamuel.elastic4s.http.ElasticDsl.{intField, keywordField, mapping, objectField}
+import com.sksamuel.elastic4s.http.ElasticDsl.{
+  intField,
+  keywordField,
+  mapping,
+  objectField
+}
 import com.sksamuel.elastic4s.http.ElasticClient
 import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicMapping
 import com.sksamuel.elastic4s.mappings.{FieldDefinition, MappingDefinition}
@@ -10,8 +15,9 @@ import scala.concurrent.ExecutionContext
 
 trait CustomElasticsearchMapping {
 
-  class OnlyInvisibleWorksIndex(val elasticClient: ElasticClient, indexName: String)(
-    implicit val ec: ExecutionContext)
+  class OnlyInvisibleWorksIndex(
+    val elasticClient: ElasticClient,
+    indexName: String)(implicit val ec: ExecutionContext)
       extends ElasticsearchIndex {
     def sourceIdentifierFields = Seq(
       keywordField("ontologyType"),

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.ingestor.services
 
-import com.sksamuel.elastic4s.http.HttpClient
+import com.sksamuel.elastic4s.http.ElasticClient
 import org.apache.http.HttpHost
 import org.elasticsearch.client.RestClient
 import org.scalatest.concurrent.ScalaFutures
@@ -157,8 +157,8 @@ class IngestorWorkerServiceTest
             new ElasticCredentials("elastic", "changeme"))
           .build()
 
-        val brokenElasticClient: HttpClient =
-          HttpClient.fromRestClient(brokenRestClient)
+        val brokenElasticClient: ElasticClient =
+          ElasticClient.fromRestClient(brokenRestClient)
 
         withWorkerService(
           queue,

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -228,7 +228,7 @@ class WorkIndexerTest
   it("returns a list of Works that weren't indexed correctly") {
     val subsetOfFieldsIndex = new OnlyInvisibleWorksIndex(
       elasticClient = elasticClient,
-      indexName = randomAlphanumeric()
+      indexName = randomAlphanumeric(length = 10)
     )
 
     val validWorks = createIdentifiedInvisibleWorks(count = 5)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -228,7 +228,7 @@ class WorkIndexerTest
   it("returns a list of Works that weren't indexed correctly") {
     val subsetOfFieldsIndex = new OnlyInvisibleWorksIndex(
       elasticClient = elasticClient,
-      documentType = documentType
+      indexName = randomAlphanumeric()
     )
 
     val validWorks = createIdentifiedInvisibleWorks(count = 5)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -214,8 +214,7 @@ class WorkIndexerTest
       withWorkIndexer { workIndexer =>
         val future = workIndexer.indexWorks(
           works = works,
-          indexName = indexName,
-          documentType = documentType
+          indexName = indexName
         )
 
         whenReady(future) { successfullyInserted =>
@@ -243,8 +242,7 @@ class WorkIndexerTest
       withWorkIndexer { workIndexer =>
         val future = workIndexer.indexWorks(
           works = works,
-          indexName = indexName,
-          documentType = documentType
+          indexName = indexName
         )
 
         whenReady(future) { result =>
@@ -277,11 +275,11 @@ class WorkIndexerTest
 
   private def indexWork(work: IdentifiedBaseWork,
                         indexName: String,
-                        workIndexer: WorkIndexer) = workIndexer.indexWorks(
-    works = List(work),
-    indexName = indexName,
-    documentType = documentType
-  )
+                        workIndexer: WorkIndexer) =
+    workIndexer.indexWorks(
+      works = List(work),
+      indexName = indexName
+    )
 
   private def assertIngestedWorkIs(
     result: Either[Seq[IdentifiedBaseWork], Seq[IdentifiedBaseWork]],

--- a/catalogue_pipeline/ingestor/src/universal/conf/application.conf.template
+++ b/catalogue_pipeline/ingestor/src/universal/conf/application.conf.template
@@ -1,7 +1,6 @@
 es.host="${es_host}"
 es.port=${es_port}
 es.index="${es_index}"
-es.type="${es_doc_type}"
 aws.metrics.namespace="${metrics_namespace}"
 es.username="${es_username}"
 es.password="${es_password}"

--- a/catalogue_pipeline/terraform/pipelines.tf
+++ b/catalogue_pipeline/terraform/pipelines.tf
@@ -1,7 +1,7 @@
-module "catalogue_pipelines" {
+module "catalogue_pipeline_v6" {
   source = "pipelines"
 
-  namespace = "catalogue_291118"
+  namespace = "catalogue_20181203"
 
   miro_adapter_topic_names = [
     "${local.miro_reindexer_topic_name}",
@@ -17,8 +17,8 @@ module "catalogue_pipelines" {
 
   sierra_adapter_topic_count = 3
 
-  index_v1 = "v1-2018-11-29-merge-versioning"
-  index_v2 = "v2-2018-11-29-merge-versioning"
+  index_v1 = "v1-2018-12-03-elasticsearch6"
+  index_v2 = "v2-2018-12-03-elasticsearch6"
 
   transformer_miro_container_image   = "${local.transformer_miro_container_image}"
   transformer_sierra_container_image = "${local.transformer_sierra_container_image}"
@@ -49,7 +49,7 @@ module "catalogue_pipelines" {
   identifiers_rds_cluster_port     = "${local.identifiers_rds_cluster_port}"
   identifiers_rds_cluster_host     = "${local.identifiers_rds_cluster_host}"
 
-  es_cluster_credentials = "${var.es_cluster_credentials}"
+  es_cluster_credentials = "${var.es_cluster_credentials_v6}"
   dlq_alarm_arn          = "${local.dlq_alarm_arn}"
   lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
 

--- a/catalogue_pipeline/terraform/pipelines/v1_pipeline/services.tf
+++ b/catalogue_pipeline/terraform/pipelines/v1_pipeline/services.tf
@@ -66,11 +66,10 @@ module "ingestor" {
     es_password         = "${var.es_cluster_credentials["password"]}"
     es_protocol         = "${var.es_cluster_credentials["protocol"]}"
     es_index            = "${var.index}"
-    es_doc_type         = "work"
     ingest_queue_id     = "${module.es_ingest_queue.id}"
   }
 
-  env_vars_length   = 10
+  env_vars_length   = 9
   container_image   = "${var.ingestor_container_image}"
   source_queue_name = "${module.es_ingest_queue.name}"
   source_queue_arn  = "${module.es_ingest_queue.arn}"

--- a/catalogue_pipeline/terraform/pipelines/v2_pipeline/services.tf
+++ b/catalogue_pipeline/terraform/pipelines/v2_pipeline/services.tf
@@ -153,11 +153,10 @@ module "ingestor" {
     es_password         = "${var.es_cluster_credentials["password"]}"
     es_protocol         = "${var.es_cluster_credentials["protocol"]}"
     es_index            = "${var.index}"
-    es_doc_type         = "work"
     ingest_queue_id     = "${module.es_ingest_queue.id}"
   }
 
-  env_vars_length   = 10
+  env_vars_length   = 9
   container_image   = "${var.ingestor_container_image}"
   source_queue_name = "${module.es_ingest_queue.name}"
   source_queue_arn  = "${module.es_ingest_queue.arn}"

--- a/catalogue_pipeline/terraform/variables.tf
+++ b/catalogue_pipeline/terraform/variables.tf
@@ -21,7 +21,9 @@ variable "es_cluster_credentials" {
   type        = "map"
 }
 
-variable "es_cluster_credentials_v6" { type = "map" }
+variable "es_cluster_credentials_v6" {
+  type = "map"
+}
 
 variable "matcher_graph_table_index" {
   description = "Name of the GSI in the matcher graph table"

--- a/catalogue_pipeline/terraform/variables.tf
+++ b/catalogue_pipeline/terraform/variables.tf
@@ -21,6 +21,8 @@ variable "es_cluster_credentials" {
   type        = "map"
 }
 
+variable "es_cluster_credentials_v6" { type = "map" }
+
 variable "matcher_graph_table_index" {
   description = "Name of the GSI in the matcher graph table"
   default     = "work-sets-index"

--- a/data_api/snapshot_generator/docker-compose.yml
+++ b/data_api/snapshot_generator/docker-compose.yml
@@ -11,7 +11,7 @@ s3:
   ports:
     - "33333:8000"
 elasticsearch:
-  image: docker.elastic.co/elasticsearch/elasticsearch:5.6.6
+  image: "docker.elastic.co/elasticsearch/elasticsearch:6.4.0"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
@@ -88,9 +88,8 @@ class SnapshotService @Inject()(akkaS3Client: S3Client,
     // This source outputs DisplayWorks in the elasticsearch index.
     val displayWorks: Source[DisplayWork, Any] =
       ElasticsearchWorksSource(
-        elasticClient,
-        indexName,
-        elasticConfig.documentType)
+        elasticClient = elasticClient,
+        indexName = indexName)
         .via(IdentifiedWorkToVisibleDisplayWork(toDisplayWork))
 
     // This source generates JSON strings of DisplayWork instances, which

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
@@ -8,28 +8,21 @@ import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.inject.Inject
-import com.sksamuel.elastic4s.http.HttpClient
+import com.sksamuel.elastic4s.http.ElasticClient
 import com.twitter.inject.Logging
 import uk.ac.wellcome.display.models.v1.DisplayWorkV1
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
-import uk.ac.wellcome.platform.snapshot_generator.flow.{
-  DisplayWorkToJsonStringFlow,
-  IdentifiedWorkToVisibleDisplayWork,
-  StringToGzipFlow
-}
-import uk.ac.wellcome.platform.snapshot_generator.models.{
-  CompletedSnapshotJob,
-  SnapshotJob
-}
+import uk.ac.wellcome.platform.snapshot_generator.flow.{DisplayWorkToJsonStringFlow, IdentifiedWorkToVisibleDisplayWork, StringToGzipFlow}
+import uk.ac.wellcome.platform.snapshot_generator.models.{CompletedSnapshotJob, SnapshotJob}
 import uk.ac.wellcome.platform.snapshot_generator.source.ElasticsearchWorksSource
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class SnapshotService @Inject()(akkaS3Client: S3Client,
-                                elasticClient: HttpClient,
+                                elasticClient: ElasticClient,
                                 elasticConfig: DisplayElasticConfig,
                                 objectMapper: ObjectMapper)(
   implicit actorSystem: ActorSystem,

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
@@ -15,8 +15,15 @@ import uk.ac.wellcome.display.models.v2.DisplayWorkV2
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
-import uk.ac.wellcome.platform.snapshot_generator.flow.{DisplayWorkToJsonStringFlow, IdentifiedWorkToVisibleDisplayWork, StringToGzipFlow}
-import uk.ac.wellcome.platform.snapshot_generator.models.{CompletedSnapshotJob, SnapshotJob}
+import uk.ac.wellcome.platform.snapshot_generator.flow.{
+  DisplayWorkToJsonStringFlow,
+  IdentifiedWorkToVisibleDisplayWork,
+  StringToGzipFlow
+}
+import uk.ac.wellcome.platform.snapshot_generator.models.{
+  CompletedSnapshotJob,
+  SnapshotJob
+}
 import uk.ac.wellcome.platform.snapshot_generator.source.ElasticsearchWorksSource
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchWorksSource.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchWorksSource.scala
@@ -3,16 +3,16 @@ package uk.ac.wellcome.platform.snapshot_generator.source
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Flow, Sink, Source}
+import com.sksamuel.elastic4s.http.ElasticClient
 import com.sksamuel.elastic4s.http.ElasticDsl.{search, termQuery}
-import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.http.search.SearchHit
 import com.sksamuel.elastic4s.streams.ReactiveElastic._
 import com.twitter.inject.Logging
-import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.models.work.internal.IdentifiedWork
 
 object ElasticsearchWorksSource extends Logging {
-  def apply(elasticClient: HttpClient, indexName: String)(
+  def apply(elasticClient: ElasticClient, indexName: String)(
     implicit actorSystem: ActorSystem): Source[IdentifiedWork, NotUsed] = {
     val loggingSink = Flow[IdentifiedWork]
       .grouped(10000)

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchWorksSource.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchWorksSource.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.json.JsonUtil._
 
 object ElasticsearchWorksSource extends Logging {
-  def apply(elasticClient: HttpClient, indexName: String, documentType: String)(
+  def apply(elasticClient: HttpClient, indexName: String)(
     implicit actorSystem: ActorSystem): Source[IdentifiedWork, NotUsed] = {
     val loggingSink = Flow[IdentifiedWork]
       .grouped(10000)
@@ -24,7 +24,7 @@ object ElasticsearchWorksSource extends Logging {
     Source
       .fromPublisher(
         elasticClient.publisher(
-          search(s"$indexName/$documentType")
+          search(indexName)
             .query(termQuery("type", "IdentifiedWork"))
             .scroll(keepAlive = "2m")
             // Increasing the size of each request from the

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
@@ -65,8 +65,7 @@ class ElasticsearchSourceTest
     implicit actorSystem: ActorSystem): R = {
     val source = ElasticsearchWorksSource(
       elasticClient = elasticClient,
-      indexName = indexName,
-      documentType = documentType)
+      indexName = indexName)
     testWith(source)
   }
 }

--- a/data_api/snapshot_generator/src/universal/conf/application.ini.template
+++ b/data_api/snapshot_generator/src/universal/conf/application.ini.template
@@ -5,7 +5,6 @@
 -es.port=${es_port}
 -es.index.v1=${es_index_v1}
 -es.index.v2=${es_index_v2}
--es.type=${es_doc_type}
 -es.username=${es_username}
 -es.password=${es_password}
 -es.protocol=${es_protocol}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
     val mockito = "1.9.5"
     val scalatest = "3.0.1"
     val junitInterface = "0.11"
-    val elastic4s = "5.6.5"
+    val elastic4s = "6.4.0"
     val circeVersion = "0.9.0"
     val scalaCheckVersion = "1.13.4"
     val scalaCheckShapelessVersion = "1.1.6"

--- a/sbt_common/config/elasticsearch/src/main/scala/uk/ac/wellcome/config/elasticsearch/builders/ElasticBuilder.scala
+++ b/sbt_common/config/elasticsearch/src/main/scala/uk/ac/wellcome/config/elasticsearch/builders/ElasticBuilder.scala
@@ -24,7 +24,6 @@ object ElasticBuilder {
 
   def buildElasticConfig(config: Config): DisplayElasticConfig =
     DisplayElasticConfig(
-      documentType = config.getOrElse[String]("es.type")(default = "item"),
       indexV1name = config.required[String]("es.index.v1"),
       indexV2name = config.required[String]("es.index.v2")
     )

--- a/sbt_common/config/elasticsearch/src/main/scala/uk/ac/wellcome/config/elasticsearch/builders/ElasticBuilder.scala
+++ b/sbt_common/config/elasticsearch/src/main/scala/uk/ac/wellcome/config/elasticsearch/builders/ElasticBuilder.scala
@@ -1,12 +1,12 @@
 package uk.ac.wellcome.config.elasticsearch.builders
 
-import com.sksamuel.elastic4s.http.HttpClient
+import com.sksamuel.elastic4s.http.ElasticClient
 import com.typesafe.config.Config
 import uk.ac.wellcome.config.core.builders.EnrichConfig._
 import uk.ac.wellcome.elasticsearch.{DisplayElasticConfig, ElasticClientBuilder}
 
 object ElasticBuilder {
-  def buildHttpClient(config: Config): HttpClient = {
+  def buildElasticClient(config: Config): ElasticClient = {
     val hostname = config.getOrElse[String]("es.host")(default = "localhost")
     val port = config.getOrElse[Int]("es.port")(default = 9200)
     val protocol = config.getOrElse[String]("es.protocol")(default = "http")

--- a/sbt_common/elasticsearch/docker-compose.yml
+++ b/sbt_common/elasticsearch/docker-compose.yml
@@ -1,5 +1,5 @@
 elasticsearch:
-  image: docker.elastic.co/elasticsearch/elasticsearch:5.6.6
+  image: "docker.elastic.co/elasticsearch/elasticsearch:6.4.0"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/DisplayElasticConfig.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/DisplayElasticConfig.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.elasticsearch
 
 case class DisplayElasticConfig(
-  documentType: String,
   indexV1name: String,
   indexV2name: String
 )

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticClientBuilder.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticClientBuilder.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.elasticsearch
 
-import com.sksamuel.elastic4s.http.HttpClient
+import com.sksamuel.elastic4s.http.ElasticClient
 import org.apache.http.HttpHost
 import org.apache.http.auth.{AuthScope, UsernamePasswordCredentials}
 import org.apache.http.impl.client.BasicCredentialsProvider
@@ -25,7 +25,7 @@ object ElasticClientBuilder {
              port: Int,
              protocol: String,
              username: String,
-             password: String): HttpClient = {
+             password: String): ElasticClient = {
     val restClient = RestClient
       .builder(new HttpHost(hostname, port, protocol))
       .setHttpClientConfigCallback(new ElasticCredentials(username, password))
@@ -34,6 +34,6 @@ object ElasticClientBuilder {
       .setMaxRetryTimeoutMillis(2000)
       .build()
 
-    HttpClient.fromRestClient(restClient)
+    ElasticClient.fromRestClient(restClient)
   }
 }

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndex.scala
@@ -11,12 +11,12 @@ import org.elasticsearch.client.ResponseException
 import scala.concurrent.{ExecutionContext, Future}
 
 trait ElasticsearchIndex extends Logging {
-  val httpClient: ElasticClient
+  val elasticClient: ElasticClient
   val mappingDefinition: MappingDefinition
   implicit val ec: ExecutionContext
 
   def create(indexName: String): Future[Unit] =
-    httpClient
+    elasticClient
       .execute(createIndex(indexName).mappings {
         mappingDefinition
       })
@@ -34,7 +34,7 @@ trait ElasticsearchIndex extends Logging {
       }
 
   private def update(indexName: String): Future[Response[PutMappingResponse]] =
-    httpClient
+    elasticClient
       .execute {
         putMapping(indexName / mappingDefinition.`type`)
           .dynamic(mappingDefinition.dynamic.getOrElse(DynamicMapping.Strict))

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndex.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.elasticsearch
 
 import com.sksamuel.elastic4s.http.ElasticDsl.{createIndex, _}
-import com.sksamuel.elastic4s.http.HttpClient
+import com.sksamuel.elastic4s.http.{ElasticClient, Response}
 import com.sksamuel.elastic4s.http.index.mappings.PutMappingResponse
 import com.sksamuel.elastic4s.mappings.MappingDefinition
 import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicMapping
@@ -11,7 +11,7 @@ import org.elasticsearch.client.ResponseException
 import scala.concurrent.{ExecutionContext, Future}
 
 trait ElasticsearchIndex extends Logging {
-  val httpClient: HttpClient
+  val httpClient: ElasticClient
   val mappingDefinition: MappingDefinition
   implicit val ec: ExecutionContext
 
@@ -33,7 +33,7 @@ trait ElasticsearchIndex extends Logging {
         info("Index updated successfully")
       }
 
-  private def update(indexName: String): Future[PutMappingResponse] =
+  private def update(indexName: String): Future[Response[PutMappingResponse]] =
     httpClient
       .execute {
         putMapping(indexName / mappingDefinition.`type`)

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -2,19 +2,19 @@ package uk.ac.wellcome.elasticsearch
 
 import com.sksamuel.elastic4s.analyzers._
 import com.sksamuel.elastic4s.http.ElasticDsl._
-import com.sksamuel.elastic4s.http.HttpClient
+import com.sksamuel.elastic4s.http.ElasticClient
 import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicMapping
 import com.sksamuel.elastic4s.mappings.{FieldDefinition, MappingDefinition}
 import grizzled.slf4j.Logging
 
 import scala.concurrent.ExecutionContext
 
-class WorksIndex(client: HttpClient, rootIndexType: String)(
+class WorksIndex(client: ElasticClient, rootIndexType: String)(
   implicit val ec: ExecutionContext)
     extends ElasticsearchIndex
     with Logging {
 
-  val httpClient: HttpClient = client
+  val httpClient: ElasticClient = client
 
   val license = objectField("license").fields(
     keywordField("id")

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -14,7 +14,7 @@ class WorksIndex(client: ElasticClient, indexName: String)(
     extends ElasticsearchIndex
     with Logging {
 
-  val httpClient: ElasticClient = client
+  val elasticClient: ElasticClient = client
 
   val license = objectField("license").fields(
     keywordField("id")

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -9,7 +9,7 @@ import grizzled.slf4j.Logging
 
 import scala.concurrent.ExecutionContext
 
-class WorksIndex(client: ElasticClient, rootIndexType: String)(
+class WorksIndex(client: ElasticClient, indexName: String)(
   implicit val ec: ExecutionContext)
     extends ElasticsearchIndex
     with Logging {
@@ -177,7 +177,7 @@ class WorksIndex(client: ElasticClient, rootIndexType: String)(
       booleanField("merged")
     )
 
-  val mappingDefinition: MappingDefinition = mapping(rootIndexType)
+  val mappingDefinition: MappingDefinition = mapping(indexName)
     .dynamic(DynamicMapping.Strict)
     .as(rootIndexFields)
 }

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndexTest.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndexTest.scala
@@ -44,7 +44,7 @@ class ElasticsearchIndexTest
   val testType = "thing"
 
   object TestIndex extends ElasticsearchIndex {
-    val httpClient: HttpClient = elasticClient
+    val elasticClient: HttpClient = elasticClient
     val mappingDefinition: MappingDefinition = mapping(testType)
       .dynamic(DynamicMapping.Strict)
       .as(
@@ -57,7 +57,7 @@ class ElasticsearchIndexTest
   }
 
   object CompatibleTestIndex extends ElasticsearchIndex {
-    val httpClient: HttpClient = elasticClient
+    val elasticClient: HttpClient = elasticClient
     val mappingDefinition: MappingDefinition = mapping(testType)
       .dynamic(DynamicMapping.Strict)
       .as(

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndexTest.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndexTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.elasticsearch
 
 import com.sksamuel.elastic4s.http.ElasticDsl._
-import com.sksamuel.elastic4s.http.HttpClient
+import com.sksamuel.elastic4s.http.ElasticClient
 import com.sksamuel.elastic4s.mappings.MappingDefinition
 import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicMapping
 import org.elasticsearch.client.ResponseException
@@ -44,7 +44,7 @@ class ElasticsearchIndexTest
   val testType = "thing"
 
   object TestIndex extends ElasticsearchIndex {
-    val elasticClient: HttpClient = elasticClient
+    val elasticClient: ElasticClient = elasticClient
     val mappingDefinition: MappingDefinition = mapping(testType)
       .dynamic(DynamicMapping.Strict)
       .as(
@@ -57,7 +57,7 @@ class ElasticsearchIndexTest
   }
 
   object CompatibleTestIndex extends ElasticsearchIndex {
-    val elasticClient: HttpClient = elasticClient
+    val elasticClient: ElasticClient = elasticClient
     val mappingDefinition: MappingDefinition = mapping(testType)
       .dynamic(DynamicMapping.Strict)
       .as(
@@ -81,7 +81,7 @@ class ElasticsearchIndexTest
             indexInto(indexName / testType).doc(testObjectJson))
           hits <- elasticClient
             .execute(search(s"$indexName/$testType").matchAllQuery())
-            .map { _.hits.hits }
+            .map { _.result.hits.hits }
         } yield {
           hits should have size 1
 
@@ -123,7 +123,7 @@ class ElasticsearchIndexTest
             eventually {
               val hits = elasticClient
                 .execute(search(s"$testIndexName/$testType").matchAllQuery())
-                .map { _.hits.hits }
+                .map { _.result.hits.hits }
                 .await
 
               hits should have size 1

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -9,7 +9,12 @@ import org.scalactic.source.Position
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{Assertion, Matchers, Suite}
-import uk.ac.wellcome.elasticsearch.{DisplayElasticConfig, ElasticClientBuilder, ElasticsearchIndex, WorksIndex}
+import uk.ac.wellcome.elasticsearch.{
+  DisplayElasticConfig,
+  ElasticClientBuilder,
+  ElasticsearchIndex,
+  WorksIndex
+}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
@@ -156,11 +161,9 @@ trait ElasticsearchFixtures
 
     whenReady(result) { _ =>
       eventually {
-        val response: Response[SearchResponse] = elasticClient
-          .execute {
-            search(indexName).matchAllQuery()
-          }
-          .await
+        val response: Response[SearchResponse] = elasticClient.execute {
+          search(indexName).matchAllQuery()
+        }.await
         response.result.hits.total shouldBe works.size
       }
     }

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -1,18 +1,13 @@
 package uk.ac.wellcome.elasticsearch.test.fixtures
 
 import com.sksamuel.elastic4s.http.ElasticDsl._
-import com.sksamuel.elastic4s.http.HttpClient
+import com.sksamuel.elastic4s.http.ElasticClient
 import org.elasticsearch.index.VersionType
 import org.scalactic.source.Position
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{Assertion, Matchers, Suite}
-import uk.ac.wellcome.elasticsearch.{
-  DisplayElasticConfig,
-  ElasticClientBuilder,
-  ElasticsearchIndex,
-  WorksIndex
-}
+import uk.ac.wellcome.elasticsearch.{DisplayElasticConfig, ElasticClientBuilder, ElasticsearchIndex, WorksIndex}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
@@ -42,7 +37,7 @@ trait ElasticsearchFixtures
       "es.type" -> documentType
     )
 
-  val elasticClient: HttpClient = ElasticClientBuilder.create(
+  val elasticClient: ElasticClient = ElasticClientBuilder.create(
     hostname = esHost,
     port = esPort,
     protocol = "http",

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -28,15 +28,12 @@ trait ElasticsearchFixtures
   private val esHost = "localhost"
   private val esPort = 9200
 
-  val documentType = "work"
-
   def displayEsLocalFlags(indexNameV1: String, indexNameV2: String) =
     Map(
       "es.host" -> esHost,
       "es.port" -> esPort.toString,
       "es.index.v1" -> indexNameV1,
-      "es.index.v2" -> indexNameV2,
-      "es.type" -> documentType
+      "es.index.v2" -> indexNameV2
     )
 
   val elasticClient: ElasticClient = ElasticClientBuilder.create(
@@ -107,7 +104,7 @@ trait ElasticsearchFixtures
 
       eventually {
         val response: Response[GetResponse] = elasticClient
-          .execute(get(work.canonicalId).from(s"$indexName/$documentType"))
+          .execute(get(work.canonicalId).from(indexName))
           .await
 
         response.result.exists shouldBe true
@@ -124,7 +121,7 @@ trait ElasticsearchFixtures
 
     works.foreach { work =>
       val response: Response[GetResponse] = elasticClient
-        .execute(get(work.canonicalId).from(s"$indexName/$documentType"))
+        .execute(get(work.canonicalId).from(indexName))
         .await
 
       response.result.found shouldBe false
@@ -138,7 +135,7 @@ trait ElasticsearchFixtures
         works.map { work =>
           val jsonDoc = toJson(work).get
 
-          indexInto(indexName / documentType)
+          indexInto(indexName)
             .version(work.version)
             .versionType(ExternalGte)
             .id(work.canonicalId)

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -66,7 +66,7 @@ trait ElasticsearchFixtures
 
     val index = new WorksIndex(
       client = elasticClient,
-      rootIndexType = elasticConfig.documentType
+      indexName = indexName
     )
 
     withLocalElasticsearchIndex(index, indexName) { indexName =>
@@ -161,7 +161,6 @@ trait ElasticsearchFixtures
     indexV1name: String,
     indexV2name: String): DisplayElasticConfig =
     DisplayElasticConfig(
-      documentType = documentType,
       indexV1name = indexV1name,
       indexV2name = indexV2name
     )

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -58,11 +58,6 @@ trait ElasticsearchFixtures
   def withLocalElasticsearchIndex[R](testWith: TestWith[String, R]): R = {
     val indexName = createIndexName
 
-    val elasticConfig = createDisplayElasticConfigWith(
-      indexV1name = indexName,
-      indexV2name = s"$indexName-v2"
-    )
-
     val index = new WorksIndex(
       client = elasticClient,
       indexName = indexName

--- a/sbt_common/finatra_elasticsearch/src/main/scala/uk/ac/wellcome/finatra/elasticsearch/ElasticClientModule.scala
+++ b/sbt_common/finatra_elasticsearch/src/main/scala/uk/ac/wellcome/finatra/elasticsearch/ElasticClientModule.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.finatra.elasticsearch
 
 import com.google.inject.{Provides, Singleton}
-import com.sksamuel.elastic4s.http.HttpClient
+import com.sksamuel.elastic4s.http.ElasticClient
 import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.elasticsearch.ElasticClientBuilder
 
@@ -16,7 +16,7 @@ object ElasticClientModule extends TwitterModule {
 
   @Singleton
   @Provides
-  def providesElasticClient(): HttpClient =
+  def providesElasticClient(): ElasticClient =
     ElasticClientBuilder.create(
       hostname = hostname(),
       port = hostPort(),

--- a/sbt_common/finatra_elasticsearch/src/main/scala/uk/ac/wellcome/finatra/elasticsearch/ElasticConfigModule.scala
+++ b/sbt_common/finatra_elasticsearch/src/main/scala/uk/ac/wellcome/finatra/elasticsearch/ElasticConfigModule.scala
@@ -5,9 +5,6 @@ import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
 
 object ElasticConfigModule extends TwitterModule {
-  private val documentType =
-    flag[String]("es.type", "item", "document type in Elasticsearch")
-
   private val indexV1name = flag[String]("es.index.v1", "V1 ES index name")
   private val indexV2name = flag[String]("es.index.v2", "V2 ES index name")
 
@@ -15,7 +12,6 @@ object ElasticConfigModule extends TwitterModule {
   @Provides
   def providesElasticConfig(): DisplayElasticConfig =
     DisplayElasticConfig(
-      documentType = documentType(),
       indexV1name = indexV1name(),
       indexV2name = indexV2name()
     )


### PR DESCRIPTION
Which should unblock us using a fixed version of elastic4s.

I'm deploying this into a new catalogue pipeline and indexing into a new cluster.