### PR TITLE
Use more types from elastic4s 6

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
@@ -23,7 +23,7 @@ class V1WorksController @Inject()(
       V1SingleWorkRequest,
       V1WorksIncludes](
       apiConfig = apiConfig,
-      indexName = elasticConfig.indexV1name,
+      indexName = elasticConfig.indexNameV1,
       documentType = elasticConfig.documentType,
       worksService = worksService
     ) {

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
@@ -23,7 +23,7 @@ class V1WorksController @Inject()(
       V1SingleWorkRequest,
       V1WorksIncludes](
       apiConfig = apiConfig,
-      indexName = elasticConfig.indexNameV1,
+      indexName = elasticConfig.indexV1,
       documentType = elasticConfig.documentType,
       worksService = worksService
     ) {

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1WorksController.scala
@@ -23,7 +23,7 @@ class V1WorksController @Inject()(
       V1SingleWorkRequest,
       V1WorksIncludes](
       apiConfig = apiConfig,
-      indexName = elasticConfig.indexV1,
+      index = elasticConfig.indexV1,
       documentType = elasticConfig.documentType,
       worksService = worksService
     ) {

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
@@ -25,7 +25,7 @@ class V2WorksController @Inject()(
       V2SingleWorkRequest,
       V2WorksIncludes](
       apiConfig = apiConfig,
-      indexName = elasticConfig.indexV2,
+      index = elasticConfig.indexV2,
       documentType = elasticConfig.documentType,
       worksService = worksService
     ) {

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
@@ -25,7 +25,7 @@ class V2WorksController @Inject()(
       V2SingleWorkRequest,
       V2WorksIncludes](
       apiConfig = apiConfig,
-      indexName = elasticConfig.indexNameV2,
+      indexName = elasticConfig.indexV2,
       documentType = elasticConfig.documentType,
       worksService = worksService
     ) {

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
@@ -25,7 +25,7 @@ class V2WorksController @Inject()(
       V2SingleWorkRequest,
       V2WorksIncludes](
       apiConfig = apiConfig,
-      indexName = elasticConfig.indexV2name,
+      indexName = elasticConfig.indexNameV2,
       documentType = elasticConfig.documentType,
       worksService = worksService
     ) {

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.api.controllers
 
 import com.jakehschwartz.finatra.swagger.SwaggerController
+import com.sksamuel.elastic4s.Index
 import com.twitter.finatra.http.Controller
 import io.swagger.models.parameters.QueryParameter
 import io.swagger.models.properties.StringProperty
@@ -86,7 +87,7 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
       val includes = request.include.getOrElse(emptyWorksIncludes)
 
       val documentOptions = ElasticsearchDocumentOptions(
-        indexName = request._index.getOrElse(indexName),
+        index = Index(request._index.getOrElse(indexName)),
         documentType = documentType
       )
 
@@ -112,7 +113,7 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
 
   private def getWorkList(request: M, pageSize: Int): Future[ResultList] = {
     val documentOptions = ElasticsearchDocumentOptions(
-      indexName = request._index.getOrElse(indexName),
+      index = Index(request._index.getOrElse(indexName)),
       documentType = documentType
     )
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
@@ -11,6 +11,7 @@ import uk.ac.wellcome.display.models.{
 
 sealed trait ApiRequest {
   val request: Request
+  val _index: Option[String]
 }
 
 trait MultipleResultsRequest[W <: WorksIncludes] extends ApiRequest {
@@ -18,7 +19,6 @@ trait MultipleResultsRequest[W <: WorksIncludes] extends ApiRequest {
   val pageSize: Option[Int]
   val include: Option[W]
   val query: Option[String]
-  val _index: Option[String]
   val request: Request
 }
 
@@ -44,7 +44,7 @@ case class V2MultipleResultsRequest(
   request: Request
 ) extends MultipleResultsRequest[V2WorksIncludes]
 
-trait SingleWorkRequest[W <: WorksIncludes] {
+trait SingleWorkRequest[W <: WorksIncludes] extends ApiRequest {
   val id: String
   val include: Option[W]
   val _index: Option[String]

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.api.services
 
 import com.google.inject.{Inject, Singleton}
+import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.http.ElasticClient
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.get.GetResponse
@@ -17,8 +18,9 @@ import uk.ac.wellcome.platform.api.models.{
 
 import scala.concurrent.Future
 
+// TODO: This is just IndexAndType
 case class ElasticsearchDocumentOptions(
-  indexName: String,
+  index: Index,
   documentType: String
 )
 
@@ -36,7 +38,7 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient) {
     elasticClient
       .execute {
         get(canonicalId).from(
-          s"${documentOptions.indexName}/${documentOptions.documentType}")
+          documentOptions.index.name / documentOptions.documentType)
       }
       .map { _.result }
 
@@ -71,7 +73,7 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient) {
     )
 
     val searchRequest: SearchRequest =
-      search(s"${documentOptions.indexName}/${documentOptions.documentType}")
+      search(documentOptions.index.name / documentOptions.documentType)
         .searchType(SearchType.DFS_QUERY_THEN_FETCH)
         .query(queryDefinition)
         .sortBy(sortDefinitions)

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.api.services
 
 import com.google.inject.{Inject, Singleton}
-import com.sksamuel.elastic4s.Index
+import com.sksamuel.elastic4s.{Index, IndexAndType}
 import com.sksamuel.elastic4s.http.ElasticClient
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.get.GetResponse
@@ -34,11 +34,10 @@ case class ElasticsearchQueryOptions(
 class ElasticsearchService @Inject()(elasticClient: ElasticClient) {
 
   def findResultById(canonicalId: String)(
-    documentOptions: ElasticsearchDocumentOptions): Future[GetResponse] =
+    indexAndType: IndexAndType): Future[GetResponse] =
     elasticClient
       .execute {
-        get(canonicalId).from(
-          documentOptions.index.name / documentOptions.documentType)
+        get(canonicalId).from(indexAndType)
       }
       .map { _.result }
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -41,7 +41,7 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient) {
       }
       .map { _.result }
 
-  def listResults: (ElasticsearchDocumentOptions,
+  def listResults: (Index,
                     ElasticsearchQueryOptions) => Future[SearchResponse] =
     executeSearch(
       maybeQueryString = None,
@@ -49,7 +49,7 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient) {
     )
 
   def simpleStringQueryResults(queryString: String)
-    : (ElasticsearchDocumentOptions,
+    : (Index,
        ElasticsearchQueryOptions) => Future[SearchResponse] =
     executeSearch(
       maybeQueryString = Some(queryString),
@@ -64,7 +64,7 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient) {
   private def executeSearch(
     maybeQueryString: Option[String],
     sortDefinitions: List[FieldSort]
-  )(documentOptions: ElasticsearchDocumentOptions,
+  )(index: Index,
     queryOptions: ElasticsearchQueryOptions): Future[SearchResponse] = {
     val queryDefinition: BoolQuery = buildQuery(
       maybeQueryString = maybeQueryString,
@@ -72,7 +72,7 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient) {
     )
 
     val searchRequest: SearchRequest =
-      search(documentOptions.index.name / documentOptions.documentType)
+      search(index)
         .searchType(SearchType.DFS_QUERY_THEN_FETCH)
         .query(queryDefinition)
         .sortBy(sortDefinitions)

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.api.services
 
 import com.google.inject.{Inject, Singleton}
+import com.sksamuel.elastic4s.IndexAndType
 import com.sksamuel.elastic4s.http.search.{SearchHit, SearchResponse}
 import io.circe.Decoder
 import uk.ac.wellcome.json.JsonUtil._
@@ -24,7 +25,12 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
     documentOptions: ElasticsearchDocumentOptions)
     : Future[Option[IdentifiedBaseWork]] =
     searchService
-      .findResultById(canonicalId)(documentOptions)
+      .findResultById(canonicalId)(
+        IndexAndType(
+          index = documentOptions.index.name,
+          `type` = documentOptions.documentType
+        )
+      )
       .map { result =>
         if (result.exists)
           Some(jsonTo[IdentifiedBaseWork](result.sourceAsString))

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -41,7 +41,7 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
                 worksSearchOptions: WorksSearchOptions): Future[ResultList] =
     searchService
       .listResults(
-        documentOptions,
+        documentOptions.index,
         toElasticsearchQueryOptions(worksSearchOptions))
       .map { createResultList }
 
@@ -50,7 +50,7 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
     worksSearchOptions: WorksSearchOptions): Future[ResultList] =
     searchService
       .simpleStringQueryResults(query)(
-        documentOptions,
+        documentOptions.index,
         toElasticsearchQueryOptions(worksSearchOptions))
       .map { createResultList }
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
@@ -12,10 +12,6 @@ trait SearchOptionsGenerators {
   val documentType: String
 
   def createElasticsearchDocumentOptionsWith(
-    indexName: String): ElasticsearchDocumentOptions =
-    createElasticsearchDocumentOptionsWith(index = Index(indexName))
-
-  def createElasticsearchDocumentOptionsWith(
     index: Index): ElasticsearchDocumentOptions =
     ElasticsearchDocumentOptions(
       index = index,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.api.generators
 
-import com.sksamuel.elastic4s.Index
+import com.sksamuel.elastic4s.{Index, IndexAndType}
 import uk.ac.wellcome.platform.api.models.WorkFilter
 import uk.ac.wellcome.platform.api.services.{
   ElasticsearchDocumentOptions,
@@ -10,6 +10,12 @@ import uk.ac.wellcome.platform.api.services.{
 
 trait SearchOptionsGenerators {
   val documentType: String
+
+  def createIndexAndType(index: Index): IndexAndType =
+    IndexAndType(
+      index = index.name,
+      `type` = documentType
+    )
 
   def createElasticsearchDocumentOptionsWith(
     index: Index): ElasticsearchDocumentOptions =

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.api.generators
 import com.sksamuel.elastic4s.{Index, IndexAndType}
 import uk.ac.wellcome.platform.api.models.WorkFilter
 import uk.ac.wellcome.platform.api.services.{
-  ElasticsearchDocumentOptions,
   ElasticsearchQueryOptions,
   WorksSearchOptions
 }
@@ -15,13 +14,6 @@ trait SearchOptionsGenerators {
     IndexAndType(
       index = index.name,
       `type` = documentType
-    )
-
-  def createElasticsearchDocumentOptionsWith(
-    index: Index): ElasticsearchDocumentOptions =
-    ElasticsearchDocumentOptions(
-      index = index,
-      documentType = documentType
     )
 
   def createElasticsearchQueryOptionsWith(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.api.generators
 
+import com.sksamuel.elastic4s.Index
 import uk.ac.wellcome.platform.api.models.WorkFilter
 import uk.ac.wellcome.platform.api.services.{
   ElasticsearchDocumentOptions,
@@ -12,8 +13,12 @@ trait SearchOptionsGenerators {
 
   def createElasticsearchDocumentOptionsWith(
     indexName: String): ElasticsearchDocumentOptions =
+    createElasticsearchDocumentOptionsWith(index = Index(indexName))
+
+  def createElasticsearchDocumentOptionsWith(
+    index: Index): ElasticsearchDocumentOptions =
     ElasticsearchDocumentOptions(
-      indexName = indexName,
+      index = index,
       documentType = documentType
     )
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -216,12 +216,11 @@ class ElasticsearchServiceTest
         insertIntoElasticsearch(index, work)
 
         withElasticsearchService { searchService =>
-          val documentOptions =
-            createElasticsearchDocumentOptionsWith(index)
+          val indexAndType = createIndexAndType(index)
 
           val searchResultFuture: Future[GetResponse] =
             searchService.findResultById(canonicalId = work.canonicalId)(
-              documentOptions)
+              indexAndType)
 
           whenReady(searchResultFuture) { result =>
             val returnedWork = jsonToIdentifiedBaseWork(result.sourceAsString)

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -44,7 +44,7 @@ class ElasticsearchServiceTest
     }
 
     it("filters search results by workType") {
-      withLocalWorksIndex { indexName =>
+      withLocalWorksIndex2 { index: Index =>
         val workWithCorrectWorkType = createIdentifiedWorkWith(
           title = "Animated artichokes",
           workType = Some(WorkType(id = "b", label = "Books"))
@@ -59,13 +59,13 @@ class ElasticsearchServiceTest
         )
 
         insertIntoElasticsearch(
-          indexName,
+          index,
           workWithCorrectWorkType,
           workWithWrongTitle,
           workWithWrongWorkType)
 
         assertSearchResultsAreCorrect(
-          index = indexName,
+          index = index,
           queryString = "artichokes",
           queryOptions = createElasticsearchQueryOptionsWith(
             filters = List(WorkTypeFilter(workTypeId = "b"))
@@ -76,7 +76,7 @@ class ElasticsearchServiceTest
     }
 
     it("filters search results with multiple workTypes") {
-      withLocalWorksIndex { indexName =>
+      withLocalWorksIndex2 { index: Index =>
         val work1 = createIdentifiedWorkWith(
           title = "Animated artichokes",
           workType = Some(WorkType(id = "b", label = "Books"))
@@ -95,14 +95,14 @@ class ElasticsearchServiceTest
         )
 
         insertIntoElasticsearch(
-          indexName,
+          index,
           work1,
           workWithWrongTitle,
           work2,
           workWithWrongType)
 
         assertSearchResultsAreCorrect(
-          index = indexName,
+          index = index,
           queryString = "artichokes",
           queryOptions = createElasticsearchQueryOptionsWith(
             filters = List(WorkTypeFilter(List("b", "m")))

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -28,7 +28,7 @@ class ElasticsearchServiceTest
 
   describe("simpleStringQueryResults") {
     it("finds results for a simpleStringQuery search") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val work1 = createIdentifiedWorkWith(title = "Amid an Aegean")
         val work2 = createIdentifiedWorkWith(title = "Before a Bengal")
         val work3 = createIdentifiedWorkWith(title = "Circling a Cheetah")
@@ -44,7 +44,7 @@ class ElasticsearchServiceTest
     }
 
     it("filters search results by workType") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val workWithCorrectWorkType = createIdentifiedWorkWith(
           title = "Animated artichokes",
           workType = Some(WorkType(id = "b", label = "Books"))
@@ -76,7 +76,7 @@ class ElasticsearchServiceTest
     }
 
     it("filters search results with multiple workTypes") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val work1 = createIdentifiedWorkWith(
           title = "Animated artichokes",
           workType = Some(WorkType(id = "b", label = "Books"))
@@ -113,7 +113,7 @@ class ElasticsearchServiceTest
     }
 
     it("filters results by item locationType") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val work = createIdentifiedWorkWith(
           title = "Tumbling tangerines",
           items = List(
@@ -144,7 +144,7 @@ class ElasticsearchServiceTest
     }
 
     it("filters results by multiple item locationTypes") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val work = createIdentifiedWorkWith(
           title = "Tumbling tangerines",
           items = List(
@@ -183,7 +183,7 @@ class ElasticsearchServiceTest
     }
 
     it("returns results in consistent order") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val works = (1 to 5)
           .map { _ =>
             createIdentifiedWorkWith(title =
@@ -210,7 +210,7 @@ class ElasticsearchServiceTest
 
   describe("findResultById") {
     it("finds a result by ID") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val work = createIdentifiedWork
 
         insertIntoElasticsearch(index, work)
@@ -234,7 +234,7 @@ class ElasticsearchServiceTest
 
   describe("listResults") {
     it("sorts results from Elasticsearch in the correct order") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val work1 = createIdentifiedWorkWith(canonicalId = "000Z")
         val work2 = createIdentifiedWorkWith(canonicalId = "000Y")
         val work3 = createIdentifiedWorkWith(canonicalId = "000X")
@@ -253,7 +253,7 @@ class ElasticsearchServiceTest
     }
 
     it("returns everything if we ask for a limit > result size") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val works = populateElasticsearch(index)
 
         val queryOptions = createElasticsearchQueryOptionsWith(
@@ -269,7 +269,7 @@ class ElasticsearchServiceTest
     }
 
     it("returns a page from the beginning of the result set") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val works = populateElasticsearch(index)
 
         val queryOptions = createElasticsearchQueryOptionsWith(limit = 4)
@@ -283,7 +283,7 @@ class ElasticsearchServiceTest
     }
 
     it("returns a page from halfway through the result set") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val works = populateElasticsearch(index)
 
         val queryOptions = createElasticsearchQueryOptionsWith(
@@ -300,7 +300,7 @@ class ElasticsearchServiceTest
     }
 
     it("returns a page from the end of the result set") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val works = populateElasticsearch(index)
 
         val queryOptions = createElasticsearchQueryOptionsWith(
@@ -317,7 +317,7 @@ class ElasticsearchServiceTest
     }
 
     it("returns an empty page if asked for a limit > result size") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val works = populateElasticsearch(index)
 
         val queryOptions = createElasticsearchQueryOptionsWith(
@@ -333,7 +333,7 @@ class ElasticsearchServiceTest
     }
 
     it("does not list works that have visible=false") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val visibleWorks = createIdentifiedWorks(count = 8)
         val invisibleWorks = createIdentifiedInvisibleWorks(count = 2)
 
@@ -348,7 +348,7 @@ class ElasticsearchServiceTest
     }
 
     it("filters list results by workType") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val work1 = createIdentifiedWorkWith(
           workType = Some(WorkType(id = "b", label = "Books"))
         )
@@ -374,7 +374,7 @@ class ElasticsearchServiceTest
     }
 
     it("filters list results with multiple workTypes") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val work1 = createIdentifiedWorkWith(
           workType = Some(WorkType(id = "b", label = "Books"))
         )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -196,7 +196,7 @@ class ElasticsearchServiceTest
           (1 to 10).foreach { _ =>
             val searchResponseFuture = searchService
               .simpleStringQueryResults("A")(
-                createElasticsearchDocumentOptionsWith(index),
+                index,
                 createElasticsearchQueryOptions)
 
             whenReady(searchResponseFuture) { response =>
@@ -438,10 +438,8 @@ class ElasticsearchServiceTest
     expectedWorks: List[IdentifiedWork]
   ): Assertion =
     withElasticsearchService { searchService =>
-      val documentOptions = createElasticsearchDocumentOptionsWith(index)
-
       val searchResponseFuture = searchService
-        .simpleStringQueryResults(queryString)(documentOptions, queryOptions)
+        .simpleStringQueryResults(queryString)(index, queryOptions)
 
       whenReady(searchResponseFuture) { response =>
         searchResponseToWorks(response) should contain theSameElementsAs expectedWorks
@@ -454,10 +452,8 @@ class ElasticsearchServiceTest
     expectedWorks: Seq[IdentifiedWork]
   ): Assertion =
     withElasticsearchService { searchService =>
-      val documentOptions = createElasticsearchDocumentOptionsWith(index)
-
       val listResponseFuture = searchService
-        .listResults(documentOptions, queryOptions)
+        .listResults(index, queryOptions)
 
       whenReady(listResponseFuture) { response =>
         searchResponseToWorks(response) should contain theSameElementsAs expectedWorks

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -106,11 +106,10 @@ class WorksServiceTest
 
             insertIntoElasticsearch(index, work)
 
-            val documentOptions =
-              createElasticsearchDocumentOptionsWith(index = index)
+            val indexAndType = createIndexAndType(index = index)
 
             val recordsFuture = worksService.findWorkById(
-              canonicalId = work.canonicalId)(documentOptions)
+              canonicalId = work.canonicalId)(indexAndType)
 
             whenReady(recordsFuture) { records =>
               records.isDefined shouldBe true
@@ -125,11 +124,10 @@ class WorksServiceTest
       withLocalWorksIndex { index: Index =>
         withElasticsearchService { searchService =>
           withWorksService(searchService) { worksService =>
-            val documentOptions =
-              createElasticsearchDocumentOptionsWith(index = index)
+            val indexAndType = createIndexAndType(index = index)
 
             val recordsFuture =
-              worksService.findWorkById(canonicalId = "1234")(documentOptions)
+              worksService.findWorkById(canonicalId = "1234")(indexAndType)
 
             whenReady(recordsFuture) { record =>
               record shouldBe None
@@ -260,7 +258,7 @@ class WorksServiceTest
 
   private def assertResultIsCorrect(
     partialSearchFunction: WorksService => (
-      ElasticsearchDocumentOptions,
+      Index,
       WorksSearchOptions) => Future[ResultList]
   )(
     allWorks: Seq[IdentifiedBaseWork],
@@ -275,12 +273,8 @@ class WorksServiceTest
             insertIntoElasticsearch(index, allWorks: _*)
           }
 
-          val documentOptions = createElasticsearchDocumentOptionsWith(
-            index: Index
-          )
-
           val future = partialSearchFunction(worksService)(
-            documentOptions,
+            index,
             worksSearchOptions)
 
           whenReady(future) { works =>

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.api.services
 
+import com.sksamuel.elastic4s.Index
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
@@ -98,15 +99,15 @@ class WorksServiceTest
 
   describe("findWorkById") {
     it("gets a DisplayWork by id") {
-      withLocalWorksIndex { indexName =>
+      withLocalWorksIndex2 { index: Index =>
         withElasticsearchService { searchService =>
           withWorksService(searchService) { worksService =>
             val work = createIdentifiedWork
 
-            insertIntoElasticsearch(indexName, work)
+            insertIntoElasticsearch(index, work)
 
             val documentOptions =
-              createElasticsearchDocumentOptionsWith(indexName = indexName)
+              createElasticsearchDocumentOptionsWith(index = index)
 
             val recordsFuture = worksService.findWorkById(
               canonicalId = work.canonicalId)(documentOptions)
@@ -121,11 +122,11 @@ class WorksServiceTest
     }
 
     it("returns a future of None if it cannot get a record by id") {
-      withLocalWorksIndex { indexName =>
+      withLocalWorksIndex2 { index: Index =>
         withElasticsearchService { searchService =>
           withWorksService(searchService) { worksService =>
             val documentOptions =
-              createElasticsearchDocumentOptionsWith(indexName = indexName)
+              createElasticsearchDocumentOptionsWith(index = index)
 
             val recordsFuture =
               worksService.findWorkById(canonicalId = "1234")(documentOptions)
@@ -267,15 +268,15 @@ class WorksServiceTest
     expectedTotalResults: Int,
     worksSearchOptions: WorksSearchOptions
   ): Assertion =
-    withLocalWorksIndex { indexName =>
+    withLocalWorksIndex2 { index: Index =>
       withElasticsearchService { searchService =>
         withWorksService(searchService) { worksService =>
-          if (!allWorks.isEmpty) {
-            insertIntoElasticsearch(indexName, allWorks: _*)
+          if (allWorks.nonEmpty) {
+            insertIntoElasticsearch(index, allWorks: _*)
           }
 
           val documentOptions = createElasticsearchDocumentOptionsWith(
-            indexName = indexName
+            index: Index
           )
 
           val future = partialSearchFunction(worksService)(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -99,7 +99,7 @@ class WorksServiceTest
 
   describe("findWorkById") {
     it("gets a DisplayWork by id") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         withElasticsearchService { searchService =>
           withWorksService(searchService) { worksService =>
             val work = createIdentifiedWork
@@ -122,7 +122,7 @@ class WorksServiceTest
     }
 
     it("returns a future of None if it cannot get a record by id") {
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         withElasticsearchService { searchService =>
           withWorksService(searchService) { worksService =>
             val documentOptions =
@@ -268,7 +268,7 @@ class WorksServiceTest
     expectedTotalResults: Int,
     worksSearchOptions: WorksSearchOptions
   ): Assertion =
-    withLocalWorksIndex2 { index: Index =>
+    withLocalWorksIndex { index: Index =>
       withElasticsearchService { searchService =>
         withWorksService(searchService) { worksService =>
           if (allWorks.nonEmpty) {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.api.works
 
+import com.sksamuel.elastic4s.Index
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.display.models.ApiVersions
@@ -32,7 +33,7 @@ class ApiErrorsTest extends ApiWorksTestBase {
   }
 
   private def withServer[R](testWith: TestWith[EmbeddedHttpServer, R]): R =
-    withServer(indexNameV1 = "index-v1", indexNameV2 = "index-v2") { server =>
+    withServer(indexV1 = Index("index-v1"), indexV2 = Index("index-v2")) { server =>
       testWith(server)
     }
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.api.works
 
-import com.sksamuel.elastic4s.Index
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.display.models.ApiVersions
@@ -9,7 +8,7 @@ import uk.ac.wellcome.test.fixtures.TestWith
 class ApiErrorsTest extends ApiWorksTestBase {
 
   it("returns a Not Found error if you try to get an API version") {
-    withServer { server =>
+    withServer() { server =>
       server.httpGet(
         path = "/catalogue/v567/works",
         andExpect = Status.NotFound,
@@ -21,7 +20,7 @@ class ApiErrorsTest extends ApiWorksTestBase {
   }
 
   it("returns a Not Found error if you try to get an unrecognised path") {
-    withServer { server =>
+    withServer() { server =>
       server.httpGet(
         path = "/foo/bar",
         andExpect = Status.NotFound,
@@ -31,9 +30,4 @@ class ApiErrorsTest extends ApiWorksTestBase {
       )
     }
   }
-
-  private def withServer[R](testWith: TestWith[EmbeddedHttpServer, R]): R =
-    withServer(indexV1 = Index("index-v1"), indexV2 = Index("index-v2")) { server =>
-      testWith(server)
-    }
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.api.works
 
-import com.sksamuel.elastic4s.Indexable
+import com.sksamuel.elastic4s.{Index, Indexable}
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.models.ApiVersions
@@ -21,14 +21,14 @@ trait ApiWorksTestBase
       toJson(t).get
   }
 
-  def withServer[R](indexNameV1: String, indexNameV2: String)(
+  def withServer[R](indexV1: Index, indexV2: Index)(
     testWith: TestWith[EmbeddedHttpServer, R]): R = {
 
     val server: EmbeddedHttpServer = new EmbeddedHttpServer(
       new Server,
       flags = displayEsLocalFlags(
-        indexNameV1 = indexNameV1,
-        indexNameV2 = indexNameV2
+        indexV1 = indexV1,
+        indexV2 = indexV2
       )
     )
 
@@ -44,10 +44,10 @@ trait ApiWorksTestBase
   def withApiFixtures[R](apiVersion: ApiVersions.Value,
                          apiName: String = "catalogue/")(
     testWith: TestWith[(String, String, String, EmbeddedHttpServer), R]): R =
-    withLocalWorksIndex { indexV1 =>
-      withLocalWorksIndex { indexV2 =>
+    withLocalWorksIndex2 { indexV1 =>
+      withLocalWorksIndex2 { indexV2 =>
         withServer(indexV1, indexV2) { server =>
-          testWith((apiName + apiVersion, indexV1, indexV2, server))
+          testWith((apiName + apiVersion, indexV1.name, indexV2.name, server))
         }
       }
     }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -44,8 +44,8 @@ trait ApiWorksTestBase
   def withApiFixtures[R](apiVersion: ApiVersions.Value,
                          apiName: String = "catalogue/")(
     testWith: TestWith[(String, String, String, EmbeddedHttpServer), R]): R =
-    withLocalWorksIndex2 { indexV1 =>
-      withLocalWorksIndex2 { indexV2 =>
+    withLocalWorksIndex { indexV1 =>
+      withLocalWorksIndex { indexV2 =>
         withServer(indexV1, indexV2) { server =>
           testWith((apiName + apiVersion, indexV1.name, indexV2.name, server))
         }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -21,7 +21,7 @@ trait ApiWorksTestBase
       toJson(t).get
   }
 
-  def withServer[R](indexV1: Index, indexV2: Index)(
+  def withServer[R](indexV1: Index = createIndex, indexV2: Index = createIndex)(
     testWith: TestWith[EmbeddedHttpServer, R]): R = {
 
     val server: EmbeddedHttpServer = new EmbeddedHttpServer(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -43,11 +43,11 @@ trait ApiWorksTestBase
 
   def withApiFixtures[R](apiVersion: ApiVersions.Value,
                          apiName: String = "catalogue/")(
-    testWith: TestWith[(String, String, String, EmbeddedHttpServer), R]): R =
+    testWith: TestWith[(String, Index, Index, EmbeddedHttpServer), R]): R =
     withLocalWorksIndex { indexV1 =>
       withLocalWorksIndex { indexV2 =>
         withServer(indexV1, indexV2) { server =>
-          testWith((apiName + apiVersion, indexV1.name, indexV2.name, server))
+          testWith((apiName + apiVersion, indexV1, indexV2, server))
         }
       }
     }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
@@ -8,8 +8,8 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
     val redirectedWork = createIdentifiedRedirectedWork
 
     withV1Api {
-      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
-        insertIntoElasticsearch(indexNameV1, redirectedWork)
+      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+        insertIntoElasticsearch(indexV1, redirectedWork)
         server.httpGet(
           path = s"/$apiPrefix/works/${redirectedWork.canonicalId}",
           andExpect = Status.Found,
@@ -24,8 +24,8 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
     val redirectedWork = createIdentifiedRedirectedWork
 
     withV1Api {
-      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
-        insertIntoElasticsearch(indexNameV1, redirectedWork)
+      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+        insertIntoElasticsearch(indexV1, redirectedWork)
         server.httpGet(
           path =
             s"/$apiPrefix/works/${redirectedWork.canonicalId}?includes=identifiers",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -9,10 +9,10 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("returns a list of works") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
-        insertIntoElasticsearch(indexNameV1, works: _*)
+        insertIntoElasticsearch(indexV1, works: _*)
 
         eventually {
           server.httpGet(
@@ -62,10 +62,10 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("returns a single work when requested with id") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWork
 
-        insertIntoElasticsearch(indexNameV1, work)
+        insertIntoElasticsearch(indexV1, work)
 
         eventually {
           server.httpGet(
@@ -91,12 +91,12 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("renders the items if the items include is present") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           itemsV1 = createIdentifiedItems(count = 1)
         )
 
-        insertIntoElasticsearch(indexNameV1, work)
+        insertIntoElasticsearch(indexV1, work)
 
         eventually {
           server.httpGet(
@@ -124,10 +124,10 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it(
     "returns the requested page of results when requested with page & pageSize") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
-        insertIntoElasticsearch(indexNameV1, works: _*)
+        insertIntoElasticsearch(indexV1, works: _*)
 
         eventually {
           server.httpGet(
@@ -231,14 +231,14 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("returns matching results if doing a full-text search") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "A drawing of a dodo"
         )
         val work2 = createIdentifiedWorkWith(
           title = "A mezzotint of a mouse"
         )
-        insertIntoElasticsearch(indexNameV1, work1, work2)
+        insertIntoElasticsearch(indexV1, work1, work2)
 
         eventually {
           server.httpGet(
@@ -276,7 +276,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it(
     "includes a list of identifiers on a list endpoint if we pass ?includes=identifiers") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val identifier0 = createSourceIdentifier
@@ -285,7 +285,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
         val work0 = works(0).copy(otherIdentifiers = List(identifier0))
         val work1 = works(1).copy(otherIdentifiers = List(identifier1))
 
-        insertIntoElasticsearch(indexNameV1, work0, work1)
+        insertIntoElasticsearch(indexV1, work0, work1)
 
         eventually {
           server.httpGet(
@@ -330,12 +330,12 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it(
     "includes a list of identifiers on a single work endpoint if we pass ?includes=identifiers") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
         val otherIdentifier = createSourceIdentifier
         val work = createIdentifiedWorkWith(
           otherIdentifiers = List(otherIdentifier)
         )
-        insertIntoElasticsearch(indexNameV1, work)
+        insertIntoElasticsearch(indexV1, work)
 
         eventually {
           server.httpGet(
@@ -363,10 +363,10 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("searches different indices with the ?_index query parameter") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
         withLocalWorksIndex { altIndex: Index =>
           val work = createIdentifiedWork
-          insertIntoElasticsearch(indexNameV1, work)
+          insertIntoElasticsearch(indexV1, work)
 
           val altWork = createIdentifiedWork
           insertIntoElasticsearch(index = altIndex, altWork)
@@ -417,12 +417,12 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("looks up works in different indices with the ?_index query parameter") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
         withLocalWorksIndex { altIndex: Index =>
           val work = createIdentifiedWorkWith(
             title = "Wombles of Wimbledon"
           )
-          insertIntoElasticsearch(indexNameV1, work)
+          insertIntoElasticsearch(indexV1, work)
 
           val altWork = createIdentifiedWorkWith(
             title = work.title
@@ -483,7 +483,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it(
     "includes the thumbnail field if available and we use the thumbnail include") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           thumbnail = Some(
             DigitalLocation(
@@ -492,7 +492,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
               license = Some(License_CCBY)
             ))
         )
-        insertIntoElasticsearch(indexNameV1, work)
+        insertIntoElasticsearch(indexV1, work)
 
         eventually {
           server.httpGet(
@@ -524,14 +524,14 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("only returns works from the v1 index") {
     withV1Api {
-      case (apiPrefix, indexNameV1, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexV1, indexV2, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "One orange ocelot"
         )
-        insertIntoElasticsearch(indexNameV1, work1)
+        insertIntoElasticsearch(indexV1, work1)
 
         val work2 = createIdentifiedWorkWith(title = work1.title)
-        insertIntoElasticsearch(indexNameV2, work2)
+        insertIntoElasticsearch(indexV2, work2)
 
         eventually {
           server.httpGet(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -364,7 +364,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it("searches different indices with the ?_index query parameter") {
     withV1Api {
       case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
-        withLocalWorksIndex2 { altIndex: Index =>
+        withLocalWorksIndex { altIndex: Index =>
           val work = createIdentifiedWork
           insertIntoElasticsearch(indexNameV1, work)
 
@@ -418,7 +418,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it("looks up works in different indices with the ?_index query parameter") {
     withV1Api {
       case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
-        withLocalWorksIndex2 { altIndex: Index =>
+        withLocalWorksIndex { altIndex: Index =>
           val work = createIdentifiedWorkWith(
             title = "Wombles of Wimbledon"
           )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
@@ -8,10 +8,10 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
 
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
         val work = createIdentifiedInvisibleWork
 
-        insertIntoElasticsearch(indexNameV1, work)
+        insertIntoElasticsearch(indexV1, work)
 
         eventually {
           server.httpGet(
@@ -25,12 +25,12 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
 
   it("excludes works with visible=false from list results") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
         val deletedWork = createIdentifiedInvisibleWork
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val worksToIndex = Seq[IdentifiedBaseWork](deletedWork) ++ works
-        insertIntoElasticsearch(indexNameV1, worksToIndex: _*)
+        insertIntoElasticsearch(indexV1, worksToIndex: _*)
 
         eventually {
           server.httpGet(
@@ -70,12 +70,12 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
 
   it("excludes works with visible=false from search results") {
     withV1Api {
-      case (apiPrefix, indexNameV1, _, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           title = "An upside-down umbrella"
         )
         val deletedWork = createIdentifiedInvisibleWork
-        insertIntoElasticsearch(indexNameV1, work, deletedWork)
+        insertIntoElasticsearch(indexV1, work, deletedWork)
 
         eventually {
           server.httpGet(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
@@ -279,7 +279,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
   // TODO figure out what the correct behaviour should be in this case
   ignore(
     "returns a Not Found error if you try to get a version that doesn't exist") {
-    withServer(indexV1 = Index("index-v1"), indexV2 = Index("index-v2")) {
+    withServer() {
       server =>
         server.httpGet(
           path = "/catalogue/v567/works?pageSize=100&page=101",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.api.works.v2
 
+import com.sksamuel.elastic4s.Index
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.display.models.ApiVersions
@@ -278,7 +279,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase {
   // TODO figure out what the correct behaviour should be in this case
   ignore(
     "returns a Not Found error if you try to get a version that doesn't exist") {
-    withServer(indexNameV1 = "not-important", indexNameV2 = "not-important") {
+    withServer(indexV1 = Index("index-v1"), indexV2 = Index("index-v2")) {
       server =>
         server.httpGet(
           path = "/catalogue/v567/works?pageSize=100&page=101",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
@@ -11,7 +11,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
   describe("listing works") {
     it("ignores works with no workType") {
       withV2Api {
-        case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
           val noWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(workType = None)
           }
@@ -19,7 +19,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             workType = Some(WorkType(id = "b", label = "Books")))
 
           val works = noWorkTypeWorks :+ matchingWork
-          insertIntoElasticsearch(indexNameV2, works: _*)
+          insertIntoElasticsearch(indexV2, works: _*)
 
           eventually {
             server.httpGet(
@@ -45,7 +45,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("filters out works with a different workType") {
       withV2Api {
-        case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               workType = Some(WorkType(id = "m", label = "Manuscripts")))
@@ -54,7 +54,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             workType = Some(WorkType(id = "b", label = "Books")))
 
           val works = wrongWorkTypeWorks :+ matchingWork
-          insertIntoElasticsearch(indexNameV2, works: _*)
+          insertIntoElasticsearch(indexV2, works: _*)
 
           eventually {
             server.httpGet(
@@ -80,7 +80,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("can filter by multiple workTypes") {
       withV2Api {
-        case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               workType = Some(WorkType(id = "m", label = "Manuscripts")))
@@ -93,7 +93,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             workType = Some(WorkType(id = "a", label = "Archives")))
 
           val works = wrongWorkTypeWorks :+ matchingWork1 :+ matchingWork2
-          insertIntoElasticsearch(indexNameV2, works: _*)
+          insertIntoElasticsearch(indexV2, works: _*)
 
           eventually {
             server.httpGet(
@@ -127,7 +127,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("filters by item LocationType") {
       withV2Api {
-        case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
           val noItemWorks = createIdentifiedWorks(count = 3)
           val matchingWork1 = createIdentifiedWorkWith(
             canonicalId = "001",
@@ -149,7 +149,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           )
 
           val works = noItemWorks :+ matchingWork1 :+ matchingWork2 :+ wrongLocationTypeWork
-          insertIntoElasticsearch(indexNameV2, works: _*)
+          insertIntoElasticsearch(indexV2, works: _*)
 
           eventually {
             server.httpGet(
@@ -184,7 +184,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
   describe("searching works") {
     it("ignores works with no workType") {
       withV2Api {
-        case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
           val noWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               title = "Amazing aubergines",
@@ -195,7 +195,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             workType = Some(WorkType(id = "b", label = "Books")))
 
           val works = noWorkTypeWorks :+ matchingWork
-          insertIntoElasticsearch(indexNameV2, works: _*)
+          insertIntoElasticsearch(indexV2, works: _*)
 
           eventually {
             server.httpGet(
@@ -221,7 +221,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("filters out works with a different workType") {
       withV2Api {
-        case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               title = "Bouncing bananas",
@@ -232,7 +232,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             workType = Some(WorkType(id = "b", label = "Books")))
 
           val works = wrongWorkTypeWorks :+ matchingWork
-          insertIntoElasticsearch(indexNameV2, works: _*)
+          insertIntoElasticsearch(indexV2, works: _*)
 
           eventually {
             server.httpGet(
@@ -258,7 +258,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("can filter by multiple workTypes") {
       withV2Api {
-        case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               title = "Bouncing bananas",
@@ -274,7 +274,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             workType = Some(WorkType(id = "a", label = "Archives")))
 
           val works = wrongWorkTypeWorks :+ matchingWork1 :+ matchingWork2
-          insertIntoElasticsearch(indexNameV2, works: _*)
+          insertIntoElasticsearch(indexV2, works: _*)
 
           eventually {
             server.httpGet(
@@ -308,7 +308,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("filters by item LocationType") {
       withV2Api {
-        case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+        case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
           val noItemWorks = createIdentifiedWorks(count = 3)
           val matchingWork1 = createIdentifiedWorkWith(
             canonicalId = "001",
@@ -332,7 +332,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           )
 
           val works = noItemWorks :+ matchingWork1 :+ matchingWork2 :+ wrongLocationTypeWork
-          insertIntoElasticsearch(indexNameV2, works: _*)
+          insertIntoElasticsearch(indexV2, works: _*)
 
           eventually {
             server.httpGet(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
@@ -8,8 +8,8 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
     val redirectedWork = createIdentifiedRedirectedWork
 
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
-        insertIntoElasticsearch(indexNameV2, redirectedWork)
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+        insertIntoElasticsearch(indexV2, redirectedWork)
         server.httpGet(
           path = s"/$apiPrefix/works/${redirectedWork.canonicalId}",
           andExpect = Status.Found,
@@ -24,8 +24,8 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
     val redirectedWork = createIdentifiedRedirectedWork
 
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
-        insertIntoElasticsearch(indexNameV2, redirectedWork)
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+        insertIntoElasticsearch(indexV2, redirectedWork)
         server.httpGet(
           path =
             s"/$apiPrefix/works/${redirectedWork.canonicalId}?include=identifiers",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
@@ -8,7 +8,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of identifiers on a list endpoint if we pass ?include=identifiers") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val identifier0 = createSourceIdentifier
@@ -17,7 +17,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
         val work0 = works(0).copy(otherIdentifiers = List(identifier0))
         val work1 = works(1).copy(otherIdentifiers = List(identifier1))
 
-        insertIntoElasticsearch(indexNameV2, work0, work1)
+        insertIntoElasticsearch(indexV2, work0, work1)
 
         eventually {
           server.httpGet(
@@ -53,12 +53,12 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of identifiers on a single work endpoint if we pass ?include=identifiers") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val otherIdentifier = createSourceIdentifier
         val work = createIdentifiedWorkWith(
           otherIdentifiers = List(otherIdentifier)
         )
-        insertIntoElasticsearch(indexNameV2, work)
+        insertIntoElasticsearch(indexV2, work)
 
         eventually {
           server.httpGet(
@@ -82,12 +82,12 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
 
   it("renders the items if the items include is present") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           items = createIdentifiedItems(count = 1) :+ createUnidentifiableItemWith()
         )
 
-        insertIntoElasticsearch(indexNameV2, work)
+        insertIntoElasticsearch(indexV2, work)
 
         eventually {
           server.httpGet(
@@ -110,7 +110,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of subjects on a list endpoint if we pass ?include=subjects") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val subjects1 = List(
@@ -120,7 +120,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
         val work0 = works(0).copy(subjects = subjects1)
         val work1 = works(1).copy(subjects = subjects2)
 
-        insertIntoElasticsearch(indexNameV2, work0, work1)
+        insertIntoElasticsearch(indexV2, work0, work1)
 
         eventually {
           server.httpGet(
@@ -153,12 +153,12 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of subjects on a single work endpoint if we pass ?include=subjects") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val subject = List(
           Subject("ornithology", List(Unidentifiable(Concept("ornithology")))))
         val work = createIdentifiedWork.copy(subjects = subject)
 
-        insertIntoElasticsearch(indexNameV2, work)
+        insertIntoElasticsearch(indexV2, work)
 
         eventually {
           server.httpGet(
@@ -180,7 +180,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
 
   it("includes a list of genres on a list endpoint if we pass ?include=genres") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val genres1 = List(
@@ -190,7 +190,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
         val work0 = works(0).copy(genres = genres1)
         val work1 = works(1).copy(genres = genres2)
 
-        insertIntoElasticsearch(indexNameV2, work0, work1)
+        insertIntoElasticsearch(indexV2, work0, work1)
 
         eventually {
           server.httpGet(
@@ -223,12 +223,12 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of genres on a single work endpoint if we pass ?include=genres") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val genre = List(
           Genre("ornithology", List(Unidentifiable(Concept("ornithology")))))
         val work = createIdentifiedWork.copy(genres = genre)
 
-        insertIntoElasticsearch(indexNameV2, work)
+        insertIntoElasticsearch(indexV2, work)
 
         eventually {
           server.httpGet(
@@ -251,7 +251,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of contributors on a list endpoint if we pass ?include=contributors") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val contributors1 =
@@ -261,7 +261,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
         val work0 = works(0).copy(contributors = contributors1)
         val work1 = works(1).copy(contributors = contributors2)
 
-        insertIntoElasticsearch(indexNameV2, work0, work1)
+        insertIntoElasticsearch(indexV2, work0, work1)
 
         eventually {
           server.httpGet(
@@ -294,12 +294,12 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of contributors on a single work endpoint if we pass ?include=contributors") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val contributor =
           List(Contributor(Unidentifiable(Person("Ginger Rogers"))))
         val work = createIdentifiedWork.copy(contributors = contributor)
 
-        insertIntoElasticsearch(indexNameV2, work)
+        insertIntoElasticsearch(indexV2, work)
 
         eventually {
           server.httpGet(
@@ -322,7 +322,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of production events on a list endpoint if we pass ?include=production") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val productionEvents1 = List(
@@ -340,7 +340,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
         val work0 = works(0).copy(production = productionEvents1)
         val work1 = works(1).copy(production = productionEvents2)
 
-        insertIntoElasticsearch(indexNameV2, work0, work1)
+        insertIntoElasticsearch(indexV2, work0, work1)
 
         eventually {
           server.httpGet(
@@ -373,7 +373,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
   it(
     "includes a list of production on a single work endpoint if we pass ?include=production") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val productionEvent = List(
           ProductionEvent(
             List(Place("London")),
@@ -382,7 +382,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
             None))
         val work = createIdentifiedWork.copy(production = productionEvent)
 
-        insertIntoElasticsearch(indexNameV2, work)
+        insertIntoElasticsearch(indexV2, work)
 
         eventually {
           server.httpGet(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -8,10 +8,10 @@ import uk.ac.wellcome.models.work.internal._
 class ApiV2WorksTest extends ApiV2WorksTestBase {
   it("returns a list of works") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
-        insertIntoElasticsearch(indexNameV2, works: _*)
+        insertIntoElasticsearch(indexV2, works: _*)
 
         eventually {
           server.httpGet(
@@ -46,10 +46,10 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("returns a single work when requested with id") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWork
 
-        insertIntoElasticsearch(indexNameV2, work)
+        insertIntoElasticsearch(indexV2, work)
 
         eventually {
           server.httpGet(
@@ -71,10 +71,10 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   it(
     "returns the requested page of results when requested with page & pageSize") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
-        insertIntoElasticsearch(indexNameV2, works: _*)
+        insertIntoElasticsearch(indexV2, works: _*)
 
         eventually {
           server.httpGet(
@@ -163,14 +163,14 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("returns matching results if doing a full-text search") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "A drawing of a dodo"
         )
         val work2 = createIdentifiedWorkWith(
           title = "A mezzotint of a mouse"
         )
-        insertIntoElasticsearch(indexNameV2, work1, work2)
+        insertIntoElasticsearch(indexV2, work1, work2)
 
         eventually {
           server.httpGet(
@@ -202,10 +202,10 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("searches different indices with the ?_index query parameter") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         withLocalWorksIndex { altIndex: Index =>
           val work = createIdentifiedWork
-          insertIntoElasticsearch(indexNameV2, work)
+          insertIntoElasticsearch(indexV2, work)
 
           val altWork = createIdentifiedWork
           insertIntoElasticsearch(index = altIndex, altWork)
@@ -246,12 +246,12 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("looks up works in different indices with the ?_index query parameter") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         withLocalWorksIndex { altIndex: Index =>
           val work = createIdentifiedWorkWith(
             title = "Playing with pangolins"
           )
-          insertIntoElasticsearch(indexNameV2, work)
+          insertIntoElasticsearch(indexV2, work)
 
           val altWork = createIdentifiedWorkWith(
             title = "Playing with pangolins"
@@ -301,7 +301,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("shows the thumbnail field if available") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           thumbnail = Some(
             DigitalLocation(
@@ -310,7 +310,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
               license = Some(License_CCBY)
             ))
         )
-        insertIntoElasticsearch(indexNameV2, work)
+        insertIntoElasticsearch(indexV2, work)
 
         eventually {
           server.httpGet(
@@ -337,16 +337,16 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("only returns works from the v2 index") {
     withV2Api {
-      case (apiPrefix, indexNameV1, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, indexV1, indexV2, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "Working with wombats"
         )
-        insertIntoElasticsearch(indexNameV1, work1)
+        insertIntoElasticsearch(indexV1, work1)
 
         val work2 = createIdentifiedWorkWith(
           title = work1.title
         )
-        insertIntoElasticsearch(indexNameV2, work2)
+        insertIntoElasticsearch(indexV2, work2)
 
         eventually {
           server.httpGet(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -203,7 +203,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   it("searches different indices with the ?_index query parameter") {
     withV2Api {
       case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
-        withLocalWorksIndex2 { altIndex: Index =>
+        withLocalWorksIndex { altIndex: Index =>
           val work = createIdentifiedWork
           insertIntoElasticsearch(indexNameV2, work)
 
@@ -247,7 +247,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   it("looks up works in different indices with the ?_index query parameter") {
     withV2Api {
       case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
-        withLocalWorksIndex2 { altIndex: Index =>
+        withLocalWorksIndex { altIndex: Index =>
           val work = createIdentifiedWorkWith(
             title = "Playing with pangolins"
           )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
@@ -7,10 +7,10 @@ import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedInvisibleWork
 
-        insertIntoElasticsearch(indexNameV2, work)
+        insertIntoElasticsearch(indexV2, work)
 
         eventually {
           server.httpGet(
@@ -24,12 +24,12 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
 
   it("excludes works with visible=false from list results") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val deletedWork = createIdentifiedInvisibleWork
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val worksToIndex = Seq[IdentifiedBaseWork](deletedWork) ++ works
-        insertIntoElasticsearch(indexNameV2, worksToIndex: _*)
+        insertIntoElasticsearch(indexV2, worksToIndex: _*)
 
         eventually {
           server.httpGet(
@@ -59,12 +59,12 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
 
   it("excludes works with visible=false from search results") {
     withV2Api {
-      case (apiPrefix, _, indexNameV2, server: EmbeddedHttpServer) =>
+      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           title = "This shouldn't be deleted!"
         )
         val deletedWork = createIdentifiedInvisibleWork
-        insertIntoElasticsearch(indexNameV2, work, deletedWork)
+        insertIntoElasticsearch(indexV2, work, deletedWork)
 
         eventually {
           server.httpGet(

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/config/builders/IngestorConfigBuilder.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/config/builders/IngestorConfigBuilder.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.ingestor.config.builders
 
+import com.sksamuel.elastic4s.Index
 import com.typesafe.config.Config
 import uk.ac.wellcome.config.core.builders.EnrichConfig._
 import uk.ac.wellcome.platform.ingestor.config.models.{
@@ -32,7 +33,7 @@ object IngestorConfigBuilder {
 
     IngestElasticConfig(
       documentType = documentType,
-      indexName = indexName
+      index = Index(indexName)
     )
   }
 }

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/config/models/IngestorConfig.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/config/models/IngestorConfig.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.ingestor.config.models
 
+import com.sksamuel.elastic4s.Index
+
 import scala.concurrent.duration.FiniteDuration
 
 case class IngestorConfig(
@@ -10,5 +12,5 @@ case class IngestorConfig(
 
 case class IngestElasticConfig(
   documentType: String,
-  indexName: String
+  index: Index
 )

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.ingestor.services
 
 import akka.Done
 import com.amazonaws.services.sqs.model.Message
-import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.http.ElasticClient
 import uk.ac.wellcome.elasticsearch.{ElasticsearchIndexCreator, WorksIndex}
 import uk.ac.wellcome.json.JsonUtil._
@@ -28,7 +27,7 @@ class IngestorWorkerService(elasticClient: ElasticClient,
   )
 
   elasticsearchIndexCreator.create(
-    index = Index(ingestorConfig.elasticConfig.indexName),
+    index = ingestorConfig.elasticConfig.index,
     mappingDefinition = WorksIndex.buildMappingDefinition(
       rootIndexType = ingestorConfig.elasticConfig.documentType
     )
@@ -58,7 +57,7 @@ class IngestorWorkerService(elasticClient: ElasticClient,
       works <- Future.successful(messageBundles.map(m => m.work))
       either <- identifiedWorkIndexer.indexWorks(
         works = works,
-        indexName = ingestorConfig.elasticConfig.indexName,
+        index = ingestorConfig.elasticConfig.index,
         documentType = ingestorConfig.elasticConfig.documentType
       )
     } yield {

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.ingestor.services
 
 import akka.Done
 import com.amazonaws.services.sqs.model.Message
+import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.http.ElasticClient
 import uk.ac.wellcome.elasticsearch.{ElasticsearchIndexCreator, WorksIndex}
 import uk.ac.wellcome.json.JsonUtil._
@@ -27,7 +28,7 @@ class IngestorWorkerService(elasticClient: ElasticClient,
   )
 
   elasticsearchIndexCreator.create(
-    indexName = ingestorConfig.elasticConfig.indexName,
+    index = Index(ingestorConfig.elasticConfig.indexName),
     mappingDefinition = WorksIndex.buildMappingDefinition(
       rootIndexType = ingestorConfig.elasticConfig.documentType
     )

--- a/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
+++ b/catalogue_pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexer.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.ingestor.services
 
-import com.sksamuel.elastic4s.Indexable
+import com.sksamuel.elastic4s.{Index, Indexable}
 import com.sksamuel.elastic4s.VersionType.ExternalGte
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.bulk.{BulkResponse, BulkResponseItem}
@@ -29,14 +29,14 @@ class WorkIndexer(
   }
 
   def indexWorks(works: Seq[IdentifiedBaseWork],
-                 indexName: String,
+                 index: Index,
                  documentType: String)
     : Future[Either[Seq[IdentifiedBaseWork], Seq[IdentifiedBaseWork]]] = {
 
     debug(s"Indexing work ${works.map(_.canonicalId).mkString(", ")}")
 
     val inserts = works.map { work =>
-      indexInto(indexName / documentType)
+      indexInto(index.name / documentType)
         .version(calculateEsVersion(work))
         .versionType(ExternalGte)
         .id(work.canonicalId)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -26,7 +26,7 @@ class IngestorFeatureTest
 
     withLocalSqsQueue { queue =>
       sendMessage[IdentifiedBaseWork](queue = queue, obj = work)
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         withWorkerService(queue, index) { _ =>
           assertElasticsearchEventuallyHasWork2(index, work)
         }
@@ -41,7 +41,7 @@ class IngestorFeatureTest
 
     withLocalSqsQueue { queue =>
       sendMessage[IdentifiedBaseWork](queue = queue, obj = work)
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         withWorkerService(queue, index) { _ =>
           assertElasticsearchEventuallyHasWork2(index, work)
         }
@@ -51,7 +51,7 @@ class IngestorFeatureTest
 
   it("does not delete a message from the queue if it fails processing") {
     withLocalSqsQueue { queue =>
-      withLocalWorksIndex2 { index =>
+      withLocalWorksIndex { index =>
         withWorkerService(queue, index) { _ =>
           sendNotificationToSQS(
             queue = queue,

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -28,7 +28,7 @@ class IngestorFeatureTest
       sendMessage[IdentifiedBaseWork](queue = queue, obj = work)
       withLocalWorksIndex { index: Index =>
         withWorkerService(queue, index) { _ =>
-          assertElasticsearchEventuallyHasWork2(index, work)
+          assertElasticsearchEventuallyHasWork(index, work)
         }
       }
     }
@@ -43,7 +43,7 @@ class IngestorFeatureTest
       sendMessage[IdentifiedBaseWork](queue = queue, obj = work)
       withLocalWorksIndex { index: Index =>
         withWorkerService(queue, index) { _ =>
-          assertElasticsearchEventuallyHasWork2(index, work)
+          assertElasticsearchEventuallyHasWork(index, work)
         }
       }
     }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.ingestor
 
+import com.sksamuel.elastic4s.Index
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
@@ -25,9 +26,9 @@ class IngestorFeatureTest
 
     withLocalSqsQueue { queue =>
       sendMessage[IdentifiedBaseWork](queue = queue, obj = work)
-      withLocalWorksIndex { indexName =>
-        withWorkerService(queue, indexName) { _ =>
-          assertElasticsearchEventuallyHasWork(indexName, work)
+      withLocalWorksIndex2 { index: Index =>
+        withWorkerService(queue, index) { _ =>
+          assertElasticsearchEventuallyHasWork2(index, work)
         }
       }
     }
@@ -40,9 +41,9 @@ class IngestorFeatureTest
 
     withLocalSqsQueue { queue =>
       sendMessage[IdentifiedBaseWork](queue = queue, obj = work)
-      withLocalWorksIndex { indexName =>
-        withWorkerService(queue, indexName) { _ =>
-          assertElasticsearchEventuallyHasWork(indexName, work)
+      withLocalWorksIndex2 { index: Index =>
+        withWorkerService(queue, index) { _ =>
+          assertElasticsearchEventuallyHasWork2(index, work)
         }
       }
     }
@@ -50,8 +51,8 @@ class IngestorFeatureTest
 
   it("does not delete a message from the queue if it fails processing") {
     withLocalSqsQueue { queue =>
-      withLocalWorksIndex { indexName =>
-        withWorkerService(queue, indexName) { _ =>
+      withLocalWorksIndex2 { index =>
+        withWorkerService(queue, index) { _ =>
           sendNotificationToSQS(
             queue = queue,
             body = "not a json string -- this will fail parsing"

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
@@ -23,7 +23,7 @@ class IngestorIndexTest
 
     withLocalSqsQueue { queue =>
       withWorkerService(queue, index) { _ =>
-        eventuallyIndexExists2(index)
+        eventuallyIndexExists(index)
       }
     }
   }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.ingestor
 
-import com.sksamuel.elastic4s.Index
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
@@ -17,7 +16,7 @@ class IngestorIndexTest
     with WorkerServiceFixture {
 
   it("creates the index at startup if it doesn't already exist") {
-    val index = Index("works")
+    val index = createIndex
 
     eventuallyDeleteIndex(index)
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.ingestor
 
+import com.sksamuel.elastic4s.Index
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
@@ -16,13 +17,13 @@ class IngestorIndexTest
     with WorkerServiceFixture {
 
   it("creates the index at startup if it doesn't already exist") {
-    val indexName = "works"
+    val index = Index("works")
 
-    eventuallyDeleteIndex(indexName)
+    eventuallyDeleteIndex(index)
 
     withLocalSqsQueue { queue =>
-      withWorkerService(queue, indexName) { _ =>
-        eventuallyIndexExists(indexName)
+      withWorkerService(queue, index) { _ =>
+        eventuallyIndexExists2(index)
       }
     }
   }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkerServiceFixture.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkerServiceFixture.scala
@@ -21,7 +21,7 @@ import scala.concurrent.duration._
 trait WorkerServiceFixture extends ElasticsearchFixtures with Messaging {
   this: Suite =>
   def withWorkerService[R](queue: Queue,
-                           index: Index,
+                           index: Index = createIndex,
                            elasticClient: ElasticClient = elasticClient)(
     testWith: TestWith[IngestorWorkerService, R]): R =
     withActorSystem { implicit actorSystem =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkerServiceFixture.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkerServiceFixture.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.ingestor.fixtures
 
+import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.http.ElasticClient
 import org.scalatest.Suite
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
@@ -20,7 +21,7 @@ import scala.concurrent.duration._
 trait WorkerServiceFixture extends ElasticsearchFixtures with Messaging {
   this: Suite =>
   def withWorkerService[R](queue: Queue,
-                           indexName: String,
+                           index: Index,
                            elasticClient: ElasticClient = elasticClient)(
     testWith: TestWith[IngestorWorkerService, R]): R =
     withActorSystem { implicit actorSystem =>
@@ -33,7 +34,7 @@ trait WorkerServiceFixture extends ElasticsearchFixtures with Messaging {
             flushInterval = 5 seconds,
             elasticConfig = IngestElasticConfig(
               documentType = documentType,
-              indexName = indexName
+              index = index
             )
           )
 

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -132,14 +132,14 @@ class IngestorWorkerServiceTest
 
     val work = createIdentifiedWork
 
-    withLocalWorksIndex { indexName =>
+    withLocalWorksIndex { index: Index =>
       withLocalSqsQueueAndDlq {
         case QueuePair(queue, dlq) =>
-          withWorkerService(queue, indexName) { _ =>
+          withWorkerService(queue, index) { _ =>
             sendMessage[IdentifiedBaseWork](queue = queue, obj = work)
             sendMessage(queue = queue, obj = square)
 
-            assertElasticsearchEventuallyHasWork(indexName = indexName, work)
+            assertElasticsearchEventuallyHasWork2(index = index, work)
 
             assertQueueEmpty(queue)
             assertQueueHasSize(dlq, 1)
@@ -178,7 +178,7 @@ class IngestorWorkerServiceTest
 
   private def assertWorksIndexedCorrectly(
     works: IdentifiedBaseWork*): Assertion =
-    withLocalWorksIndex2 { index: Index =>
+    withLocalWorksIndex { index: Index =>
       withLocalSqsQueueAndDlqAndTimeout(visibilityTimeout = 10) {
         case QueuePair(queue, dlq) =>
           withWorkerService(queue, index) { _ =>

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -139,7 +139,7 @@ class IngestorWorkerServiceTest
             sendMessage[IdentifiedBaseWork](queue = queue, obj = work)
             sendMessage(queue = queue, obj = square)
 
-            assertElasticsearchEventuallyHasWork2(index = index, work)
+            assertElasticsearchEventuallyHasWork(index = index, work)
 
             assertQueueEmpty(queue)
             assertQueueHasSize(dlq, 1)
@@ -186,7 +186,7 @@ class IngestorWorkerServiceTest
               sendMessage[IdentifiedBaseWork](queue = queue, obj = work)
             }
 
-            assertElasticsearchEventuallyHasWork2(index = index, works: _*)
+            assertElasticsearchEventuallyHasWork(index = index, works: _*)
 
             assertQueueEmpty(queue)
             assertQueueEmpty(dlq)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -160,10 +160,7 @@ class IngestorWorkerServiceTest
         val brokenElasticClient: ElasticClient =
           ElasticClient.fromRestClient(brokenRestClient)
 
-        withWorkerService(
-          queue,
-          index = Index("works-v1"),
-          elasticClient = brokenElasticClient) { _ =>
+        withWorkerService(queue, elasticClient = brokenElasticClient) { _ =>
           val work = createIdentifiedWork
 
           sendMessage[IdentifiedBaseWork](queue = queue, obj = work)

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -28,7 +28,7 @@ class WorkIndexerTest
 
       whenReady(future) { result =>
         result.right.get should contain(work)
-        assertElasticsearchEventuallyHasWork2(index = index, work)
+        assertElasticsearchEventuallyHasWork(index = index, work)
       }
     }
   }
@@ -42,7 +42,7 @@ class WorkIndexerTest
       )
 
       whenReady(future) { _ =>
-        assertElasticsearchEventuallyHasWork2(index = index, work)
+        assertElasticsearchEventuallyHasWork(index = index, work)
       }
     }
   }
@@ -78,7 +78,7 @@ class WorkIndexerTest
 
       whenReady(future) { result =>
         result.right.get should contain(updatedWork)
-        assertElasticsearchEventuallyHasWork2(
+        assertElasticsearchEventuallyHasWork(
           index = index,
           updatedWork)
       }
@@ -197,7 +197,7 @@ class WorkIndexerTest
       )
 
       whenReady(future) { successfullyInserted =>
-        assertElasticsearchEventuallyHasWork2(index = index, works: _*)
+        assertElasticsearchEventuallyHasWork(index = index, works: _*)
         successfullyInserted.right.get should contain theSameElementsAs works
       }
     }
@@ -211,7 +211,7 @@ class WorkIndexerTest
 
     val works = validWorks :+ notMatchingMappingWork
 
-    withLocalElasticsearchIndex2(OnlyInvisibleWorksIndex) { index: Index =>
+    withLocalElasticsearchIndex(OnlyInvisibleWorksIndex) { index: Index =>
       val future = workIndexer.indexWorks(
         works = works,
         index = index,
@@ -219,10 +219,10 @@ class WorkIndexerTest
       )
 
       whenReady(future) { result =>
-        assertElasticsearchEventuallyHasWork2(
+        assertElasticsearchEventuallyHasWork(
           index = index,
           validWorks: _*)
-        assertElasticsearchNeverHasWork2(
+        assertElasticsearchNeverHasWork(
           index = index,
           notMatchingMappingWork)
         result.left.get should contain(notMatchingMappingWork)
@@ -252,6 +252,6 @@ class WorkIndexerTest
     ingestedWork: IdentifiedBaseWork,
     index: Index) = {
     result.isRight shouldBe true
-    assertElasticsearchEventuallyHasWork2(index = index, ingestedWork)
+    assertElasticsearchEventuallyHasWork(index = index, ingestedWork)
   }
 }

--- a/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
+++ b/catalogue_pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/WorkIndexerTest.scala
@@ -23,7 +23,7 @@ class WorkIndexerTest
   it("inserts an identified Work into Elasticsearch") {
     val work = createIdentifiedWork
 
-    withLocalWorksIndex2 { index: Index =>
+    withLocalWorksIndex { index: Index =>
       val future = indexWork(work, index, workIndexer)
 
       whenReady(future) { result =>
@@ -36,7 +36,7 @@ class WorkIndexerTest
   it("only adds one record when the same ID is ingested multiple times") {
     val work = createIdentifiedWork
 
-    withLocalWorksIndex2 { index: Index =>
+    withLocalWorksIndex { index: Index =>
       val future = Future.sequence(
         (1 to 2).map(_ => indexWork(work, index, workIndexer))
       )
@@ -51,7 +51,7 @@ class WorkIndexerTest
     val work = createIdentifiedWorkWith(version = 3)
     val olderWork = work.copy(version = 1)
 
-    withLocalWorksIndex2 { index: Index =>
+    withLocalWorksIndex { index: Index =>
       val future = ingestWorkPairInOrder(
         firstWork = work,
         secondWork = olderWork,
@@ -70,7 +70,7 @@ class WorkIndexerTest
     val work = createIdentifiedWorkWith(version = 3)
     val updatedWork = work.copy(title = "a different title")
 
-    withLocalWorksIndex2 { index: Index =>
+    withLocalWorksIndex { index: Index =>
       val future = ingestWorkPairInOrder(
         firstWork = work,
         secondWork = updatedWork,
@@ -91,7 +91,7 @@ class WorkIndexerTest
       val mergedWork = createIdentifiedWorkWith(version = 3, merged = true)
       val unmergedWork = mergedWork.copy(merged = false)
 
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val unmergedWorkInsertFuture = ingestWorkPairInOrder(
           firstWork = mergedWork,
           secondWork = unmergedWork,
@@ -110,7 +110,7 @@ class WorkIndexerTest
       val unmergedNewWork = createIdentifiedWorkWith(version = 4)
       val mergedOldWork = unmergedNewWork.copy(version = 3, merged = true)
 
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val mergedWorkInsertFuture = ingestWorkPairInOrder(
           firstWork = unmergedNewWork,
           secondWork = mergedOldWork,
@@ -131,7 +131,7 @@ class WorkIndexerTest
         canonicalId = identifiedNewWork.canonicalId,
         version = 3)
 
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val redirectedWorkInsertFuture = ingestWorkPairInOrder(
           firstWork = identifiedNewWork,
           secondWork = redirectedOldWork,
@@ -151,7 +151,7 @@ class WorkIndexerTest
         canonicalId = redirectedWork.canonicalId,
         version = 3)
 
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val identifiedWorkInsertFuture = ingestWorkPairInOrder(
           firstWork = redirectedWork,
           secondWork = identifiedWork,
@@ -171,7 +171,7 @@ class WorkIndexerTest
         canonicalId = work.canonicalId,
         version = 4)
 
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val invisibleWorkInsertFuture = ingestWorkPairInOrder(
           firstWork = work,
           secondWork = invisibleWork,
@@ -189,7 +189,7 @@ class WorkIndexerTest
   it("inserts a list of works into elasticsearch and returns them") {
     val works = createIdentifiedWorks(count = 5)
 
-    withLocalWorksIndex2 { index: Index =>
+    withLocalWorksIndex { index: Index =>
       val future = workIndexer.indexWorks(
         works = works,
         index = index,

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
@@ -54,14 +54,14 @@ class SnapshotService @Inject()(akkaS3Client: S3Client,
         runStream(
           publicBucketName = publicBucketName,
           publicObjectKey = publicObjectKey,
-          indexName = elasticConfig.indexNameV1,
+          indexName = elasticConfig.indexV1,
           toDisplayWork = DisplayWorkV1.apply(_, V1WorksIncludes.includeAll())
         )
       case ApiVersions.v2 =>
         runStream(
           publicBucketName = publicBucketName,
           publicObjectKey = publicObjectKey,
-          indexName = elasticConfig.indexNameV2,
+          indexName = elasticConfig.indexV2,
           toDisplayWork = DisplayWorkV2.apply(_, V2WorksIncludes.includeAll())
         )
     }

--- a/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
+++ b/data_api/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
@@ -54,14 +54,14 @@ class SnapshotService @Inject()(akkaS3Client: S3Client,
         runStream(
           publicBucketName = publicBucketName,
           publicObjectKey = publicObjectKey,
-          indexName = elasticConfig.indexV1name,
+          indexName = elasticConfig.indexNameV1,
           toDisplayWork = DisplayWorkV1.apply(_, V1WorksIncludes.includeAll())
         )
       case ApiVersions.v2 =>
         runStream(
           publicBucketName = publicBucketName,
           publicObjectKey = publicObjectKey,
-          indexName = elasticConfig.indexV2name,
+          indexName = elasticConfig.indexNameV2,
           toDisplayWork = DisplayWorkV2.apply(_, V2WorksIncludes.includeAll())
         )
     }

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/ServerTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/ServerTest.scala
@@ -30,11 +30,11 @@ class ServerTest
   private def withFixtures[R](testWith: TestWith[EmbeddedHttpServer, R]) =
     withLocalSqsQueue { queue =>
       withLocalSnsTopic { topic =>
-        withLocalWorksIndex { indexNameV1 =>
-          withLocalWorksIndex { indexNameV2 =>
+        withLocalWorksIndex2 { indexV1 =>
+          withLocalWorksIndex2 { indexV2 =>
             val flags = snsLocalFlags(topic) ++ sqsLocalFlags(queue) ++ displayEsLocalFlags(
-              indexNameV1,
-              indexNameV2)
+              indexV1,
+              indexV2)
             withServer(flags) { server =>
               testWith(server)
             }

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/ServerTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/ServerTest.scala
@@ -30,8 +30,8 @@ class ServerTest
   private def withFixtures[R](testWith: TestWith[EmbeddedHttpServer, R]) =
     withLocalSqsQueue { queue =>
       withLocalSnsTopic { topic =>
-        withLocalWorksIndex2 { indexV1 =>
-          withLocalWorksIndex2 { indexV2 =>
+        withLocalWorksIndex { indexV1 =>
+          withLocalWorksIndex { indexV2 =>
             val flags = snsLocalFlags(topic) ++ sqsLocalFlags(queue) ++ displayEsLocalFlags(
               indexV1,
               indexV2)

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -46,10 +46,10 @@ class SnapshotGeneratorFeatureTest
 
   it("completes a snapshot generation") {
     withFixtures {
-      case (queue, topic, indexNameV1, _, publicBucket: Bucket) =>
+      case (queue, topic, indexV1, _, publicBucket: Bucket) =>
         val works = createIdentifiedWorks(count = 3)
 
-        insertIntoElasticsearch(indexNameV1, works: _*)
+        insertIntoElasticsearch(indexV1, works: _*)
 
         val publicObjectKey = "target.txt.gz"
 

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.snapshot_generator
 import java.io.File
 
 import com.amazonaws.services.s3.model.GetObjectRequest
+import com.sksamuel.elastic4s.Index
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models.ApiVersions
@@ -108,17 +109,17 @@ class SnapshotGeneratorFeatureTest
   }
 
   def withFixtures[R](
-    testWith: TestWith[(Queue, Topic, String, String, Bucket), R]) =
+    testWith: TestWith[(Queue, Topic, Index, Index, Bucket), R]): R =
     withLocalSqsQueue { queue =>
       withLocalSnsTopic { topic =>
-        withLocalWorksIndex { indexNameV1 =>
-          withLocalWorksIndex { indexNameV2 =>
+        withLocalWorksIndex2 { indexV1 =>
+          withLocalWorksIndex2 { indexV2 =>
             withLocalS3Bucket { bucket =>
               val flags = snsLocalFlags(topic) ++ sqsLocalFlags(queue) ++ displayEsLocalFlags(
-                indexNameV1,
-                indexNameV2) ++ s3ClientLocalFlags
+                indexV1,
+                indexV2) ++ s3ClientLocalFlags
               withServer(flags) { _ =>
-                testWith((queue, topic, indexNameV1, indexNameV2, bucket))
+                testWith((queue, topic, indexV1, indexV2, bucket))
               }
             }
           }

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -112,8 +112,8 @@ class SnapshotGeneratorFeatureTest
     testWith: TestWith[(Queue, Topic, Index, Index, Bucket), R]): R =
     withLocalSqsQueue { queue =>
       withLocalSnsTopic { topic =>
-        withLocalWorksIndex2 { indexV1 =>
-          withLocalWorksIndex2 { indexV2 =>
+        withLocalWorksIndex { indexV1 =>
+          withLocalWorksIndex { indexV2 =>
             withLocalS3Bucket { bucket =>
               val flags = snsLocalFlags(topic) ++ sqsLocalFlags(queue) ++ displayEsLocalFlags(
                 indexV1,

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -73,8 +73,8 @@ class SnapshotServiceTest
     withActorSystem { implicit actorSystem =>
       withMaterializer(actorSystem) { implicit materializer =>
         withS3AkkaClient { s3Client =>
-          withLocalWorksIndex2 { indexV1 =>
-            withLocalWorksIndex2 { indexV2 =>
+          withLocalWorksIndex { indexV1 =>
+            withLocalWorksIndex { indexV2 =>
               withLocalS3Bucket { bucket =>
                 withSnapshotService(s3Client, indexV1, indexV2) {
                   snapshotService =>

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -50,8 +50,8 @@ class SnapshotServiceTest
 
   private def withSnapshotService[R](
     s3AkkaClient: S3Client,
-    indexV1: Index,
-    indexV2: Index)(testWith: TestWith[SnapshotService, R])(
+    indexV1: Index = createIndex,
+    indexV2: Index = createIndex)(testWith: TestWith[SnapshotService, R])(
     implicit actorSystem: ActorSystem): R = {
     val elasticConfig = createDisplayElasticConfigWith(
       indexV1 = indexV1,
@@ -262,8 +262,8 @@ class SnapshotServiceTest
         withS3AkkaClient { s3Client =>
           withSnapshotService(
             s3Client,
-            indexV1 = Index("wrong-index"),
-            indexV2 = Index("wrong-index")) { brokenSnapshotService =>
+            indexV1 = createIndex,
+            indexV2 = createIndex) { brokenSnapshotService =>
             val snapshotJob = SnapshotJob(
               publicBucketName = "bukkit",
               publicObjectKey = "target.json.gz",
@@ -296,10 +296,7 @@ class SnapshotServiceTest
       withActorSystem { implicit actorSystem =>
         withMaterializer(actorSystem) { implicit materializer =>
           withS3AkkaClient(endpoint = "") { s3Client =>
-            withSnapshotService(
-              s3Client,
-              indexV1 = Index("indexv1"),
-              indexV2 = Index("indexv2")) { snapshotService =>
+            withSnapshotService(s3Client) { snapshotService =>
               snapshotService.buildLocation(
                 bucketName = "bukkit",
                 objectKey = "snapshot.json.gz"

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -53,8 +53,8 @@ class SnapshotServiceTest
     indexNameV2: String)(testWith: TestWith[SnapshotService, R])(
     implicit actorSystem: ActorSystem): R = {
     val elasticConfig = createDisplayElasticConfigWith(
-      indexV1name = indexNameV1,
-      indexV2name = indexNameV2
+      indexNameV1 = indexNameV1,
+      indexNameV2 = indexNameV2
     )
 
     val snapshotService = new SnapshotService(

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
@@ -23,7 +23,7 @@ class ElasticsearchSourceTest
   it("outputs the entire content of the index") {
     withActorSystem { implicit actorSystem =>
       withMaterializer(actorSystem) { implicit materializer =>
-        withLocalWorksIndex2 { index: Index =>
+        withLocalWorksIndex { index: Index =>
           val works = createIdentifiedWorks(count = 10)
           insertIntoElasticsearch(index, works: _*)
 
@@ -42,7 +42,7 @@ class ElasticsearchSourceTest
   it("filters non visible works") {
     withActorSystem { implicit actorSystem =>
       withMaterializer(actorSystem) { implicit materializer =>
-        withLocalWorksIndex2 { index: Index =>
+        withLocalWorksIndex { index: Index =>
           val visibleWorks = createIdentifiedWorks(count = 10)
           val invisibleWorks = createIdentifiedInvisibleWorks(count = 3)
 

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.snapshot_generator.source
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Sink, Source}
+import com.sksamuel.elastic4s.Index
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
@@ -65,8 +66,8 @@ class ElasticsearchSourceTest
     implicit actorSystem: ActorSystem): R = {
     val source = ElasticsearchWorksSource(
       elasticClient = elasticClient,
-      indexName = indexName,
-      documentType = documentType)
+      index = Index(indexName)
+    )
     testWith(source)
   }
 }

--- a/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
+++ b/data_api/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
@@ -23,11 +23,11 @@ class ElasticsearchSourceTest
   it("outputs the entire content of the index") {
     withActorSystem { implicit actorSystem =>
       withMaterializer(actorSystem) { implicit materializer =>
-        withLocalWorksIndex { indexName =>
+        withLocalWorksIndex2 { index: Index =>
           val works = createIdentifiedWorks(count = 10)
-          insertIntoElasticsearch(indexName, works: _*)
+          insertIntoElasticsearch(index, works: _*)
 
-          withSource(indexName) { source =>
+          withSource(index) { source =>
             val future = source.runWith(Sink.seq)
 
             whenReady(future) { result =>
@@ -42,14 +42,14 @@ class ElasticsearchSourceTest
   it("filters non visible works") {
     withActorSystem { implicit actorSystem =>
       withMaterializer(actorSystem) { implicit materializer =>
-        withLocalWorksIndex { indexName =>
+        withLocalWorksIndex2 { index: Index =>
           val visibleWorks = createIdentifiedWorks(count = 10)
           val invisibleWorks = createIdentifiedInvisibleWorks(count = 3)
 
           val works = visibleWorks ++ invisibleWorks
-          insertIntoElasticsearch(indexName, works: _*)
+          insertIntoElasticsearch(index, works: _*)
 
-          withSource(indexName) { source =>
+          withSource(index) { source =>
             val future = source.runWith(Sink.seq)
 
             whenReady(future) { result =>
@@ -61,12 +61,12 @@ class ElasticsearchSourceTest
     }
   }
 
-  private def withSource[R](indexName: String)(
+  private def withSource[R](index: Index)(
     testWith: TestWith[Source[IdentifiedWork, NotUsed], R])(
     implicit actorSystem: ActorSystem): R = {
     val source = ElasticsearchWorksSource(
       elasticClient = elasticClient,
-      index = Index(indexName)
+      index = index
     )
     testWith(source)
   }

--- a/sbt_common/config/elasticsearch/src/main/scala/uk/ac/wellcome/config/elasticsearch/builders/ElasticBuilder.scala
+++ b/sbt_common/config/elasticsearch/src/main/scala/uk/ac/wellcome/config/elasticsearch/builders/ElasticBuilder.scala
@@ -25,7 +25,7 @@ object ElasticBuilder {
   def buildElasticConfig(config: Config): DisplayElasticConfig =
     DisplayElasticConfig(
       documentType = config.getOrElse[String]("es.type")(default = "item"),
-      indexV1name = config.required[String]("es.index.v1"),
-      indexV2name = config.required[String]("es.index.v2")
+      indexNameV1 = config.required[String]("es.index.v1"),
+      indexNameV2 = config.required[String]("es.index.v2")
     )
 }

--- a/sbt_common/config/elasticsearch/src/main/scala/uk/ac/wellcome/config/elasticsearch/builders/ElasticBuilder.scala
+++ b/sbt_common/config/elasticsearch/src/main/scala/uk/ac/wellcome/config/elasticsearch/builders/ElasticBuilder.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.config.elasticsearch.builders
 
+import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.http.ElasticClient
 import com.typesafe.config.Config
 import uk.ac.wellcome.config.core.builders.EnrichConfig._
@@ -25,7 +26,7 @@ object ElasticBuilder {
   def buildElasticConfig(config: Config): DisplayElasticConfig =
     DisplayElasticConfig(
       documentType = config.getOrElse[String]("es.type")(default = "item"),
-      indexNameV1 = config.required[String]("es.index.v1"),
-      indexNameV2 = config.required[String]("es.index.v2")
+      indexV1 = Index(name = config.required[String]("es.index.v1")),
+      indexV2 = Index(name = config.required[String]("es.index.v2"))
     )
 }

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/DisplayElasticConfig.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/DisplayElasticConfig.scala
@@ -2,6 +2,6 @@ package uk.ac.wellcome.elasticsearch
 
 case class DisplayElasticConfig(
   documentType: String,
-  indexV1name: String,
-  indexV2name: String
+  indexNameV1: String,
+  indexNameV2: String
 )

--- a/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/DisplayElasticConfig.scala
+++ b/sbt_common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/DisplayElasticConfig.scala
@@ -1,7 +1,9 @@
 package uk.ac.wellcome.elasticsearch
 
+import com.sksamuel.elastic4s.Index
+
 case class DisplayElasticConfig(
   documentType: String,
-  indexNameV1: String,
-  indexNameV2: String
+  indexV1: Index,
+  indexV2: Index
 )

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndexTest.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndexTest.scala
@@ -71,7 +71,7 @@ class ElasticsearchIndexTest
   }
 
   it("creates an index into which doc of the expected type can be put") {
-    withLocalElasticsearchIndex2(TestIndex) { index: Index =>
+    withLocalElasticsearchIndex(TestIndex) { index: Index =>
       val testObject = TestObject(
         id = "id",
         description = "description",
@@ -101,7 +101,7 @@ class ElasticsearchIndexTest
   }
 
   it("create an index where inserting a doc of an unexpected type fails") {
-    withLocalElasticsearchIndex2(TestIndex) { index: Index =>
+    withLocalElasticsearchIndex(TestIndex) { index: Index =>
       val badTestObject = BadTestObject(id = "id", weight = 5)
       val badTestObjectJson = toJson(badTestObject).get
 
@@ -120,8 +120,8 @@ class ElasticsearchIndexTest
   }
 
   it("updates an already existing index with a compatible mapping") {
-    withLocalElasticsearchIndex2(TestIndex) { index: Index =>
-      withLocalElasticsearchIndex2(CompatibleTestIndex, index = index) {
+    withLocalElasticsearchIndex(TestIndex) { index: Index =>
+      withLocalElasticsearchIndex(CompatibleTestIndex, index = index) {
         _ =>
           val compatibleTestObject = CompatibleTestObject(
             id = "id",

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexTest.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexTest.scala
@@ -39,7 +39,7 @@ class WorksIndexTest
 
   it("puts a valid work") {
     forAll { sampleWork: IdentifiedBaseWork =>
-      withLocalWorksIndex2 { index: Index =>
+      withLocalWorksIndex { index: Index =>
         val sampleWorkJson = toJson(sampleWork).get
 
         val futureIndexResponse = elasticClient.execute(
@@ -56,7 +56,7 @@ class WorksIndexTest
   // a bug in the mapping related to person subjects wasn't caught by the above test.
   // So let's add a specific one
   it("puts a work with a person subject") {
-    withLocalWorksIndex2 { index: Index =>
+    withLocalWorksIndex { index: Index =>
       val sampleWorkJson = toJson(
         createIdentifiedWorkWith(
           subjects = List(
@@ -83,7 +83,7 @@ class WorksIndexTest
   }
 
   it("does not put an invalid work") {
-    withLocalWorksIndex2 { index: Index =>
+    withLocalWorksIndex { index: Index =>
       val badTestObject = BadTestObject("id", 5)
       val badTestObjectJson = toJson(badTestObject).get
 

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -70,6 +70,11 @@ trait ElasticsearchFixtures
       testWith(indexName)
     }
 
+  def withLocalWorksIndex2[R](testWith: TestWith[Index, R]): R =
+    withLocalElasticsearchIndex[R](WorksIndex) { indexName =>
+      testWith(Index(name = indexName))
+    }
+
   private val elasticsearchIndexCreator = new ElasticsearchIndexCreator(
     elasticClient = elasticClient
   )
@@ -179,14 +184,13 @@ trait ElasticsearchFixtures
     }
   }
 
-  // TODO: This method can use Index as a parameter
   def createDisplayElasticConfigWith(
-    indexNameV1: String,
-    indexNameV2: String): DisplayElasticConfig =
+    indexV1: Index,
+    indexV2: Index): DisplayElasticConfig =
     DisplayElasticConfig(
       documentType = documentType,
-      indexV1 = Index(name = indexNameV1),
-      indexV2 = Index(name = indexNameV2)
+      indexV1 = indexV1,
+      indexV2 = indexV2
     )
 
   private def createIndexName: String =

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -120,13 +120,13 @@ trait ElasticsearchFixtures
       response.result.isExists shouldBe true
     }
 
-  def eventuallyDeleteIndex(indexName: String): Assertion = {
-    elasticClient.execute(deleteIndex(indexName))
+  def eventuallyDeleteIndex(index: Index): Assertion = {
+    elasticClient.execute(deleteIndex(index.name))
 
     eventually {
       val response: Response[IndexExistsResponse] =
         elasticClient
-          .execute(indexExists(indexName))
+          .execute(indexExists(index.name))
           .await
 
       response.result.isExists shouldBe false

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -188,6 +188,6 @@ trait ElasticsearchFixtures
       indexV2 = indexV2
     )
 
-  private def createIndex: Index =
+  def createIndex: Index =
     Index(name = (Random.alphanumeric take 10 mkString) toLowerCase)
 }

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.elasticsearch.test.fixtures
 
+import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.VersionType.ExternalGte
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.cluster.ClusterHealthResponse
@@ -178,13 +179,14 @@ trait ElasticsearchFixtures
     }
   }
 
+  // TODO: This method can use Index as a parameter
   def createDisplayElasticConfigWith(
     indexNameV1: String,
     indexNameV2: String): DisplayElasticConfig =
     DisplayElasticConfig(
       documentType = documentType,
-      indexNameV1 = indexNameV1,
-      indexNameV2 = indexNameV2
+      indexV1 = Index(name = indexNameV1),
+      indexV2 = Index(name = indexNameV2)
     )
 
   private def createIndexName: String =

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -84,7 +84,7 @@ trait ElasticsearchFixtures
     indexName: String = createIndexName)(testWith: TestWith[String, R]): R = {
     elasticsearchIndexCreator
       .create(
-        indexName = indexName,
+        index = Index(name = indexName),
         mappingDefinition = index.buildMappingDefinition(documentType)
       )
       .await

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -152,10 +152,6 @@ trait ElasticsearchFixtures
     }
   }
 
-  def insertIntoElasticsearch(indexName: String,
-                              works: IdentifiedBaseWork*): Assertion =
-    insertIntoElasticsearch(Index(name), works: _*)
-
   def insertIntoElasticsearch(index: Index,
                               works: IdentifiedBaseWork*): Assertion = {
     val result = elasticClient.execute(

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -98,7 +98,7 @@ trait ElasticsearchFixtures
 
     // Elasticsearch is eventually consistent, so the future
     // completing doesn't actually mean that the index exists yet
-    eventuallyIndexExists2(index)
+    eventuallyIndexExists(index)
 
     try {
       testWith(index)
@@ -107,10 +107,7 @@ trait ElasticsearchFixtures
     }
   }
 
-  def eventuallyIndexExists(indexName: String): Assertion =
-    eventuallyIndexExists2(Index(indexName))
-
-  def eventuallyIndexExists2(index: Index): Assertion =
+  def eventuallyIndexExists(index: Index): Assertion =
     eventually {
       val response: Response[IndexExistsResponse] =
         elasticClient

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -66,8 +66,8 @@ trait ElasticsearchFixtures
     implicitly[Position])
 
   def withLocalWorksIndex[R](testWith: TestWith[Index, R]): R =
-    withLocalElasticsearchIndex[R](WorksIndex) { indexName =>
-      testWith(Index(name = indexName))
+    withLocalElasticsearchIndex[R](WorksIndex) { index: Index =>
+      testWith(index)
     }
 
   private val elasticsearchIndexCreator = new ElasticsearchIndexCreator(
@@ -75,13 +75,6 @@ trait ElasticsearchFixtures
   )
 
   def withLocalElasticsearchIndex[R](
-    index: MappingDefinitionBuilder,
-    indexName: String = createIndexName)(testWith: TestWith[String, R]): R =
-    withLocalElasticsearchIndex2(index, Index(indexName)) { idx =>
-      testWith(idx.name)
-    }
-
-  def withLocalElasticsearchIndex2[R](
     mappingDefinition: MappingDefinitionBuilder,
     index: Index = createIndexName)(testWith: TestWith[Index, R]): R = {
     elasticsearchIndexCreator
@@ -126,11 +119,6 @@ trait ElasticsearchFixtures
   }
 
   def assertElasticsearchEventuallyHasWork(
-    indexName: String,
-    works: IdentifiedBaseWork*): Seq[Assertion] =
-    assertElasticsearchEventuallyHasWork2(Index(indexName), works: _*)
-
-  def assertElasticsearchEventuallyHasWork2(
     index: Index,
     works: IdentifiedBaseWork*): Seq[Assertion] =
     works.map { work =>
@@ -149,12 +137,8 @@ trait ElasticsearchFixtures
       }
     }
 
-  def assertElasticsearchNeverHasWork(indexName: String,
-                                      works: IdentifiedBaseWork*): Unit =
-    assertElasticsearchNeverHasWork2(Index(indexName), works: _*)
-
-  def assertElasticsearchNeverHasWork2(index: Index,
-                                       works: IdentifiedBaseWork*): Unit = {
+  def assertElasticsearchNeverHasWork(index: Index,
+                                      works: IdentifiedBaseWork*): Unit = {
     // Let enough time pass to account for elasticsearch
     // eventual consistency before asserting
     Thread.sleep(500)

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -76,7 +76,7 @@ trait ElasticsearchFixtures
 
   def withLocalElasticsearchIndex[R](
     mappingDefinition: MappingDefinitionBuilder,
-    index: Index = createIndexName)(testWith: TestWith[Index, R]): R = {
+    index: Index = createIndex)(testWith: TestWith[Index, R]): R = {
     elasticsearchIndexCreator
       .create(
         index = index,
@@ -188,6 +188,6 @@ trait ElasticsearchFixtures
       indexV2 = indexV2
     )
 
-  private def createIndexName: String =
-    (Random.alphanumeric take 10 mkString) toLowerCase
+  private def createIndex: Index =
+    Index(name = (Random.alphanumeric take 10 mkString) toLowerCase)
 }

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -33,12 +33,6 @@ trait ElasticsearchFixtures
 
   val documentType = "work"
 
-  def displayEsLocalFlags(indexNameV1: String, indexNameV2: String) =
-    displayEsLocalFlags(
-      indexV1 = Index(indexNameV1),
-      indexV2 = Index(indexNameV2)
-    )
-
   def displayEsLocalFlags(indexV1: Index, indexV2: Index): Map[String, String] =
     Map(
       "es.host" -> esHost,

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -179,12 +179,12 @@ trait ElasticsearchFixtures
   }
 
   def createDisplayElasticConfigWith(
-    indexV1name: String,
-    indexV2name: String): DisplayElasticConfig =
+    indexNameV1: String,
+    indexNameV2: String): DisplayElasticConfig =
     DisplayElasticConfig(
       documentType = documentType,
-      indexV1name = indexV1name,
-      indexV2name = indexV2name
+      indexNameV1 = indexNameV1,
+      indexNameV2 = indexNameV2
     )
 
   private def createIndexName: String =

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -65,12 +65,7 @@ trait ElasticsearchFixtures
     ),
     implicitly[Position])
 
-  def withLocalWorksIndex[R](testWith: TestWith[String, R]): R =
-    withLocalElasticsearchIndex[R](WorksIndex) { indexName =>
-      testWith(indexName)
-    }
-
-  def withLocalWorksIndex2[R](testWith: TestWith[Index, R]): R =
+  def withLocalWorksIndex[R](testWith: TestWith[Index, R]): R =
     withLocalElasticsearchIndex[R](WorksIndex) { indexName =>
       testWith(Index(name = indexName))
     }

--- a/sbt_common/finatra_elasticsearch/src/main/scala/uk/ac/wellcome/finatra/elasticsearch/ElasticConfigModule.scala
+++ b/sbt_common/finatra_elasticsearch/src/main/scala/uk/ac/wellcome/finatra/elasticsearch/ElasticConfigModule.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.finatra.elasticsearch
 
 import com.google.inject.{Provides, Singleton}
+import com.sksamuel.elastic4s.Index
 import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
 
@@ -16,7 +17,7 @@ object ElasticConfigModule extends TwitterModule {
   def providesElasticConfig(): DisplayElasticConfig =
     DisplayElasticConfig(
       documentType = documentType(),
-      indexNameV1 = indexNameV1(),
-      indexNameV2 = indexNameV2()
+      indexV1 = Index(name = indexNameV1()),
+      indexV2 = Index(name = indexNameV2())
     )
 }

--- a/sbt_common/finatra_elasticsearch/src/main/scala/uk/ac/wellcome/finatra/elasticsearch/ElasticConfigModule.scala
+++ b/sbt_common/finatra_elasticsearch/src/main/scala/uk/ac/wellcome/finatra/elasticsearch/ElasticConfigModule.scala
@@ -8,15 +8,15 @@ object ElasticConfigModule extends TwitterModule {
   private val documentType =
     flag[String]("es.type", "item", "document type in Elasticsearch")
 
-  private val indexV1name = flag[String]("es.index.v1", "V1 ES index name")
-  private val indexV2name = flag[String]("es.index.v2", "V2 ES index name")
+  private val indexNameV1 = flag[String]("es.index.v1", "V1 ES index name")
+  private val indexNameV2 = flag[String]("es.index.v2", "V2 ES index name")
 
   @Singleton
   @Provides
   def providesElasticConfig(): DisplayElasticConfig =
     DisplayElasticConfig(
       documentType = documentType(),
-      indexV1name = indexV1name(),
-      indexV2name = indexV2name()
+      indexNameV1 = indexNameV1(),
+      indexNameV2 = indexNameV2()
     )
 }


### PR DESCRIPTION
Elasticsearch 6 is deprecating the idea of separate document types and indexes, and Elasticsearch 7 will remove the separate document type entirely.

To prepare for that migration, elastic4s has:

* Recommended we switch to the index-only APIs
* Introduced some nice new case classes to pass that info around

Let's use those sweet treats, because who doesn't love some extra types?