### PR TITLE
Data science application paths

### DIFF
--- a/data_science/terraform/modules/service/main.tf
+++ b/data_science/terraform/modules/service/main.tf
@@ -8,7 +8,7 @@ resource "aws_alb_listener_rule" "path_rule" {
 
   condition {
     field  = "path-pattern"
-    values = ["/${var.namespace}/*"]
+    values = ["${var.application_path}/*"]
   }
 }
 

--- a/data_science/terraform/modules/service/variables.tf
+++ b/data_science/terraform/modules/service/variables.tf
@@ -19,6 +19,10 @@ variable "container_port" {
   default = "80"
 }
 
+variable "health_check_path" {}
+
+variable "application_path" {}
+
 variable "service_discovery_namespace" {
   default = "labs"
 }
@@ -26,8 +30,6 @@ variable "service_discovery_namespace" {
 variable "aws_region" {
   default = "eu-west-1"
 }
-
-variable "health_check_path" {}
 
 variable "memory" {
   default = "2048"

--- a/data_science/terraform/stack/labs/main.tf
+++ b/data_science/terraform/stack/labs/main.tf
@@ -43,7 +43,9 @@ module "devise_search_service" {
 
   service_discovery_namespace  = "${aws_service_discovery_private_dns_namespace.namespace.id}"
   service_lb_security_group_id = "${aws_security_group.service_lb_security_group.id}"
-  health_check_path            = "/devise/index.html"
+
+  application_path  = "/devise"
+  health_check_path = "/devise/index.html"
 }
 
 module "palette_service" {
@@ -59,7 +61,9 @@ module "palette_service" {
 
   service_discovery_namespace  = "${aws_service_discovery_private_dns_namespace.namespace.id}"
   service_lb_security_group_id = "${aws_security_group.service_lb_security_group.id}"
-  health_check_path            = "/palette/index.html"
+
+  application_path  = "/palette"
+  health_check_path = "/palette/index.html"
 }
 
 module "image_similarity_service" {
@@ -75,5 +79,7 @@ module "image_similarity_service" {
 
   service_discovery_namespace  = "${aws_service_discovery_private_dns_namespace.namespace.id}"
   service_lb_security_group_id = "${aws_security_group.service_lb_security_group.id}"
-  health_check_path            = "/image_similarity/health_check"
+
+  application_path  = "/image_similarity"
+  health_check_path = "/image_similarity/health_check"
 }


### PR DESCRIPTION
To keep the existing paths for the labs applications pass paths explicitly rather than inferring from the namespace.
