### PR TITLE
Don't error in the Sierra transformer if we see an unrecognised LocationType

### DIFF
--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -1,11 +1,12 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
+import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.sierra.exceptions.SierraTransformerException
 import uk.ac.wellcome.platform.transformer.sierra.source.SierraItemData
 import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLocation
 
-trait SierraLocation {
+trait SierraLocation extends Logging {
   def getPhysicalLocation(itemData: SierraItemData): Option[PhysicalLocation] =
     itemData.location match {
       // We've seen records where the "location" field is populated in
@@ -15,14 +16,30 @@ trait SierraLocation {
       case Some(SierraSourceLocation("", ""))         => None
       case Some(SierraSourceLocation("none", "none")) => None
 
-      case Some(loc: SierraSourceLocation) =>
-        Some(
-          PhysicalLocation(
-            locationType = LocationType(loc.code),
-            label = loc.name
-          )
+      case Some(loc: SierraSourceLocation) => Some(
+        PhysicalLocation(
+          locationType = getLocationType(loc),
+          label = loc.name
         )
+      )
       case None => None
+    }
+
+  private def getLocationType(loc: SierraSourceLocation): LocationType =
+    try {
+      LocationType(loc.code)
+    } catch {
+      // Sometimes the cataloguers add new location types, which causes the pipeline
+      // to break if we don't add them to location-types.csv.
+      //
+      // Rather than playing whack-a-mole, just drop a warning and guess the label we
+      // would have put in the spreadsheet anyway.
+      case _: IllegalArgumentException =>
+        warn(s"No lookup provided for LocationType ${loc.code}, so using Sierra data")
+        LocationType(
+          id = loc.code,
+          label = loc.name
+        )
     }
 
   def getDigitalLocation(identifier: String): DigitalLocation = {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -16,12 +16,13 @@ trait SierraLocation extends Logging {
       case Some(SierraSourceLocation("", ""))         => None
       case Some(SierraSourceLocation("none", "none")) => None
 
-      case Some(loc: SierraSourceLocation) => Some(
-        PhysicalLocation(
-          locationType = getLocationType(loc),
-          label = loc.name
+      case Some(loc: SierraSourceLocation) =>
+        Some(
+          PhysicalLocation(
+            locationType = getLocationType(loc),
+            label = loc.name
+          )
         )
-      )
       case None => None
     }
 
@@ -35,7 +36,8 @@ trait SierraLocation extends Logging {
       // Rather than playing whack-a-mole, just drop a warning and guess the label we
       // would have put in the spreadsheet anyway.
       case _: IllegalArgumentException =>
-        warn(s"No lookup provided for LocationType ${loc.code}, so using Sierra data")
+        warn(
+          s"No lookup provided for LocationType ${loc.code}, so using Sierra data")
         LocationType(
           id = loc.code,
           label = loc.name

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/TroubleshootSierraTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/TroubleshootSierraTransformerTest.scala
@@ -1,0 +1,51 @@
+package uk.ac.wellcome.platform.transformer.sierra
+
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.models.transformable.SierraTransformable
+import uk.ac.wellcome.models.transformable.SierraTransformable._
+import uk.ac.wellcome.platform.transformer.sierra.transformers.SierraTransformableTestBase
+import uk.ac.wellcome.storage.vhs.HybridRecord
+
+class TroubleshootSierraTransformerTest extends FunSpec with Matchers with SierraTransformableTestBase {
+
+  ignore("transforms this message received from SQS") {
+    val queueJsonString =
+      """
+        |{
+        |  "Type" : "Notification",
+        |  "MessageId" : "5c940368-1de4-598d-9fdc-57176d33c537",
+        |  "TopicArn" : "arn:aws:sns:eu-west-1:760097843905:catalogue_sierra_reindex_topic",
+        |  "Subject" : "BulkSNSSender",
+        |  "Message" : "{\"location\":{\"namespace\":\"wellcomecollection-vhs-sourcedata-sierra\",\"key\":\"27/3076072/7dd114318a87edaf9aea0608682baa531eb91e67783064aca14e8defd9d06b02\"},\"id\":\"3076072\",\"version\":4}",
+        |  "Timestamp" : "2018-12-03T17:57:43.289Z",
+        |  "SignatureVersion" : "1",
+        |  "Signature" : "a4ARVmWuTk6UJkGkUTfWOn24Yqkp7BYCS/TAFCFKg963F/pqRwHLgu26Yl221nLubrqs78CVvizvzQG8BHWX2y8+U+Yn5bsVQHKjkydz7RH/PyRk9c/YVQavZRZ5hm/Elr6UkyLSeK/2q9tCccc6nWkNtSnPAeRRIOFUkAZbwDT1sjBUDat/Af53KGcSfxCREuXxXJk0Ww4jmM6Z0Rwh+MWWSS6wnolY/oguum1NNVDnaM2vdhDCrp34c1MxkUoPtQdQ7F6GIIU3bVdO5NY6BQihmOQBqKdKlQ0WG0zGGo/Nw/32rmLmnxCI0VetCO1u9Kdzv26djhcyaaxKiwi2bg==",
+        |  "SigningCertURL" : "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
+        |  "UnsubscribeURL" : "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:760097843905:catalogue_sierra_reindex_topic:ca9a6ac3-9d30-4b0f-8fdc-c2769399eb7d"
+        |}
+      """.stripMargin
+
+    val notification: NotificationMessage = fromJson[NotificationMessage](queueJsonString).get
+    val hybridRecord = fromJson[HybridRecord](notification.body).get
+
+    val s3client = AmazonS3ClientBuilder.standard.withRegion("eu-west-1").build()
+
+    val jsonString =
+      scala.io.Source
+        .fromInputStream(
+          s3client.getObject(hybridRecord.location.namespace, hybridRecord.location.key).getObjectContent
+        )
+        .mkString
+
+    println(s"VHS content = <<$jsonString>>")
+
+    val transformable = fromJson[SierraTransformable](jsonString).get
+
+    transformToWork(transformable)
+  }
+
+  val transformer = new SierraTransformableTransformer
+}

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/TroubleshootSierraTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/TroubleshootSierraTransformerTest.scala
@@ -9,7 +9,10 @@ import uk.ac.wellcome.models.transformable.SierraTransformable._
 import uk.ac.wellcome.platform.transformer.sierra.transformers.SierraTransformableTestBase
 import uk.ac.wellcome.storage.vhs.HybridRecord
 
-class TroubleshootSierraTransformerTest extends FunSpec with Matchers with SierraTransformableTestBase {
+class TroubleshootSierraTransformerTest
+    extends FunSpec
+    with Matchers
+    with SierraTransformableTestBase {
 
   ignore("transforms this message received from SQS") {
     val queueJsonString =
@@ -28,15 +31,21 @@ class TroubleshootSierraTransformerTest extends FunSpec with Matchers with Sierr
         |}
       """.stripMargin
 
-    val notification: NotificationMessage = fromJson[NotificationMessage](queueJsonString).get
+    val notification: NotificationMessage =
+      fromJson[NotificationMessage](queueJsonString).get
     val hybridRecord = fromJson[HybridRecord](notification.body).get
 
-    val s3client = AmazonS3ClientBuilder.standard.withRegion("eu-west-1").build()
+    val s3client =
+      AmazonS3ClientBuilder.standard.withRegion("eu-west-1").build()
 
     val jsonString =
       scala.io.Source
         .fromInputStream(
-          s3client.getObject(hybridRecord.location.namespace, hybridRecord.location.key).getObjectContent
+          s3client
+            .getObject(
+              hybridRecord.location.namespace,
+              hybridRecord.location.key)
+            .getObjectContent
         )
         .mkString
 

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
@@ -53,6 +53,19 @@ class SierraLocationTest
 
       transformer.getPhysicalLocation(itemData = itemData) shouldBe None
     }
+
+    it("tries to extract a LocationType if it can't find one") {
+      val itemData = createSierraItemDataWith(
+        location = Some(SierraSourceLocation("foo", "bar"))
+      )
+
+      transformer.getPhysicalLocation(itemData = itemData) shouldBe Some(
+        PhysicalLocation(
+          locationType = LocationType(id = "foo", label = "bar"),
+          label = "bar"
+        )
+      )
+    }
   }
 
   describe("Digital locations") {

--- a/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/LocationType.scala
+++ b/sbt_common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/LocationType.scala
@@ -40,11 +40,8 @@ case object LocationType {
     }
 
   def apply(id: String): LocationType = {
-    locationTypeMap.get(id) match {
-      case Some(id) => id
-      case None =>
-        throw new IllegalArgumentException(s"Unrecognised location type: [$id]")
-    }
+    locationTypeMap.getOrElse(id, default = {
+      throw new IllegalArgumentException(s"Unrecognised location type: [$id]")
+    })
   }
-
 }


### PR DESCRIPTION
All we'll do is edit the spreadsheet with whatever value we see, and re-run it – let's skip the manual step and the alarm spam.