### PR TITLE
Return storage API responses as the platform JSON model

### DIFF
--- a/archive/terraform/stack-041218/api/gateway_responses.tf
+++ b/archive/terraform/stack-041218/api/gateway_responses.tf
@@ -1,0 +1,38 @@
+locals {
+  context_url = "https://api.wellcomecollection.org/storage/v1/context.json"
+}
+
+resource "aws_api_gateway_gateway_response" "default_4xx" {
+  rest_api_id   = "${aws_api_gateway_rest_api.api.id}"
+  response_type = "DEFAULT_4XX"
+
+  response_templates = {
+    "application/json" = <<EOF
+{
+  "@context": "${local.context_url}",
+  "errorType": "http",
+  "httpStatus": $context.error.responseType.statusCode,
+  "label": "Client Error",
+  "description": $context.error.messageString,
+  "type": "Error"
+}
+EOF
+  }
+}
+
+resource "aws_api_gateway_gateway_response" "default_5xx" {
+  rest_api_id   = "${aws_api_gateway_rest_api.api.id}"
+  response_type = "DEFAULT_5XX"
+
+  response_templates = {
+    "application/json" = <<EOF
+{
+  "@context": "${local.context_url}",
+  "errorType": "http",
+  "httpStatus": 500,
+  "label": "Internal Server Error",
+  "type": "Error"
+}
+EOF
+  }
+}

--- a/archive/terraform/stack-041218/api/gateway_responses.tf
+++ b/archive/terraform/stack-041218/api/gateway_responses.tf
@@ -11,7 +11,6 @@ module "response_default_5xx" {
   context_url = "${local.context_url}"
 }
 
-
 module "response_default_4xx" {
   source = "./response_4xx"
 

--- a/archive/terraform/stack-041218/api/gateway_responses.tf
+++ b/archive/terraform/stack-041218/api/gateway_responses.tf
@@ -2,27 +2,10 @@ locals {
   context_url = "https://api.wellcomecollection.org/storage/v1/context.json"
 }
 
-resource "aws_api_gateway_gateway_response" "default_4xx" {
-  rest_api_id   = "${aws_api_gateway_rest_api.api.id}"
-  response_type = "DEFAULT_4XX"
-
-  response_templates = {
-    "application/json" = <<EOF
-{
-  "@context": "${local.context_url}",
-  "errorType": "http",
-  "httpStatus": $context.error.responseType.statusCode,
-  "label": "Client Error",
-  "description": $context.error.messageString,
-  "type": "Error"
-}
-EOF
-  }
-}
-
 resource "aws_api_gateway_gateway_response" "default_5xx" {
   rest_api_id   = "${aws_api_gateway_rest_api.api.id}"
   response_type = "DEFAULT_5XX"
+  status_code   = 500
 
   response_templates = {
     "application/json" = <<EOF
@@ -35,4 +18,156 @@ resource "aws_api_gateway_gateway_response" "default_5xx" {
 }
 EOF
   }
+}
+
+module "response_default_4xx" {
+  source = "./response_4xx"
+
+  response_type = "DEFAULT_4XX"
+  label         = "Client Error"
+
+  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  context_url = "${local.context_url}"
+}
+
+module "response_access_denied" {
+  source = "./response_4xx"
+
+  response_type = "ACCESS_DENIED"
+  label         = "Access Denied"
+  status_code   = 401
+
+  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  context_url = "${local.context_url}"
+}
+
+module "response_bad_request_parameters" {
+  source = "./response_4xx"
+
+  response_type = "BAD_REQUEST_PARAMETERS"
+  label         = "Bad Request Parameters"
+
+  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  context_url = "${local.context_url}"
+}
+
+module "response_bad_request_body" {
+  source = "./response_4xx"
+
+  response_type = "BAD_REQUEST_BODY"
+  label         = "Bad Request Body"
+  status_code   = 401
+
+  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  context_url = "${local.context_url}"
+}
+
+module "response_expired_token" {
+  source = "./response_4xx"
+
+  response_type = "EXPIRED_TOKEN"
+  label         = "Expired Token"
+  status_code   = 401
+
+  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  context_url = "${local.context_url}"
+}
+
+module "response_invalid_api_key" {
+  source = "./response_4xx"
+
+  response_type = "INVALID_API_KEY"
+  label         = "Invalid API key"
+  status_code   = 403
+
+  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  context_url = "${local.context_url}"
+}
+
+module "response_invalid_signature" {
+  source = "./response_4xx"
+
+  response_type = "INVALID_SIGNATURE"
+  label         = "Invalid Signature"
+  status_code   = 403
+
+  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  context_url = "${local.context_url}"
+}
+
+module "response_missing_authentication_token" {
+  source = "./response_4xx"
+
+  response_type = "MISSING_AUTHENTICATION_TOKEN"
+  label         = "Missing Authentication Token"
+  status_code   = 403
+
+  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  context_url = "${local.context_url}"
+}
+
+module "response_quota_exceeded" {
+  source = "./response_4xx"
+
+  response_type = "QUOTA_EXCEEDED"
+  label         = "Quota Exceeded"
+  status_code   = 429
+
+  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  context_url = "${local.context_url}"
+}
+
+module "response_request_too_large" {
+  source = "./response_4xx"
+
+  response_type = "REQUEST_TOO_LARGE"
+  label         = "Request Too Large"
+  status_code   = 413
+
+  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  context_url = "${local.context_url}"
+}
+
+module "response_not_found" {
+  source = "./response_4xx"
+
+  response_type = "RESOURCE_NOT_FOUND"
+  label         = "Not Found"
+  status_code   = 404
+
+  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  context_url = "${local.context_url}"
+}
+
+module "response_throttled" {
+  source = "./response_4xx"
+
+  response_type = "THROTTLED"
+  label         = "Throttled"
+  status_code   = 429
+
+  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  context_url = "${local.context_url}"
+}
+
+module "response_unauthorized" {
+  source = "./response_4xx"
+
+  response_type = "UNAUTHORIZED"
+  label         = "Unauthorized"
+  status_code   = 401
+
+  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  context_url = "${local.context_url}"
+}
+
+module "response_unsupported_media_type" {
+  source = "./response_4xx"
+
+  response_type = "UNSUPPORTED_MEDIA_TYPE"
+  label         = "Unsupported Media Type"
+  status_code   = 415
+
+  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  context_url = "${local.context_url}"
 }

--- a/archive/terraform/stack-041218/api/gateway_responses.tf
+++ b/archive/terraform/stack-041218/api/gateway_responses.tf
@@ -2,23 +2,15 @@ locals {
   context_url = "https://api.wellcomecollection.org/storage/v1/context.json"
 }
 
-resource "aws_api_gateway_gateway_response" "default_5xx" {
-  rest_api_id   = "${aws_api_gateway_rest_api.api.id}"
-  response_type = "DEFAULT_5XX"
-  status_code   = 500
+module "response_default_5xx" {
+  source = "./response_5xx"
 
-  response_templates = {
-    "application/json" = <<EOF
-{
-  "@context": "${local.context_url}",
-  "errorType": "http",
-  "httpStatus": 500,
-  "label": "Internal Server Error",
-  "type": "Error"
+  response_type = "DEFAULT_5XX"
+
+  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  context_url = "${local.context_url}"
 }
-EOF
-  }
-}
+
 
 module "response_default_4xx" {
   source = "./response_4xx"

--- a/archive/terraform/stack-041218/api/response_4xx/main.tf
+++ b/archive/terraform/stack-041218/api/response_4xx/main.tf
@@ -1,0 +1,26 @@
+variable "rest_api_id" {}
+variable "response_type" {}
+variable "status_code" {
+  default = 400
+}
+variable "label" {}
+variable "context_url" {}
+
+resource "aws_api_gateway_gateway_response" "response" {
+  rest_api_id   = "${var.rest_api_id}"
+  response_type = "${var.response_type}"
+  status_code   = "${var.status_code}"
+
+  response_templates = {
+    "application/json" = <<EOF
+{
+  "@context": "${var.context_url}",
+  "errorType": "http",
+  "httpStatus": "${var.status_code}",
+  "label": "${var.label}",
+  "description": $context.error.messageString,
+  "type": "Error"
+}
+EOF
+  }
+}

--- a/archive/terraform/stack-041218/api/response_4xx/main.tf
+++ b/archive/terraform/stack-041218/api/response_4xx/main.tf
@@ -1,8 +1,10 @@
 variable "rest_api_id" {}
 variable "response_type" {}
+
 variable "status_code" {
   default = 400
 }
+
 variable "label" {}
 variable "context_url" {}
 

--- a/archive/terraform/stack-041218/api/response_5xx/main.tf
+++ b/archive/terraform/stack-041218/api/response_5xx/main.tf
@@ -1,9 +1,8 @@
 variable "rest_api_id" {}
 variable "response_type" {}
 variable "status_code" {
-  default = 400
+  default = 500
 }
-variable "label" {}
 variable "context_url" {}
 
 data "template_file" "error" {
@@ -12,8 +11,7 @@ data "template_file" "error" {
 "@context":"${var.context_url}",
 "errorType":"http",
 "httpStatus":"${var.status_code}",
-"label":"${var.label}",
-"description":$context.error.messageString,
+"label":"Server Error",
 "type":"Error"
 }
 EOF

--- a/archive/terraform/stack-041218/api/response_5xx/main.tf
+++ b/archive/terraform/stack-041218/api/response_5xx/main.tf
@@ -1,8 +1,10 @@
 variable "rest_api_id" {}
 variable "response_type" {}
+
 variable "status_code" {
   default = 500
 }
+
 variable "context_url" {}
 
 data "template_file" "error" {


### PR DESCRIPTION
A first pass at some of #3078.

The error descriptions from API Gateway aren't very detailed, and we may want to drop the `description` field in those cases.