### PR TITLE
Duplicated Storage VPC inside storage AWS account 

### DIFF
--- a/infrastructure/shared/terraform/outputs.tf
+++ b/infrastructure/shared/terraform/outputs.tf
@@ -128,6 +128,20 @@ output "storage_vpc_delta_id" {
   value = "${module.storage_vpc_delta.vpc_id}"
 }
 
+# TODO: Remove storage_vpc_delta
+
+output "storage_vpc_private_subnets" {
+  value = ["${module.storage_vpc.private_subnets}"]
+}
+
+output "storage_vpc_public_subnets" {
+  value = ["${module.storage_vpc.public_subnets}"]
+}
+
+output "storage_vpc_id" {
+  value = "${module.storage_vpc.vpc_id}"
+}
+
 output "storage_cidr_block_vpc" {
   value = "${local.storage_cidr_block_vpc}"
 }

--- a/infrastructure/shared/terraform/provider.tf
+++ b/infrastructure/shared/terraform/provider.tf
@@ -9,7 +9,7 @@ provider "aws" {
   version = "1.10.0"
 
   assume_role {
-    role_arn     = "arn:aws:iam::975596993436:role/developer"
+    role_arn = "arn:aws:iam::975596993436:role/developer"
   }
 }
 

--- a/infrastructure/shared/terraform/provider.tf
+++ b/infrastructure/shared/terraform/provider.tf
@@ -3,4 +3,14 @@ provider "aws" {
   version = "1.10.0"
 }
 
+provider "aws" {
+  alias   = "storage"
+  region  = "${var.aws_region}"
+  version = "1.10.0"
+
+  assume_role {
+    role_arn     = "arn:aws:iam::975596993436:role/developer"
+  }
+}
+
 data "aws_caller_identity" "current" {}

--- a/infrastructure/shared/terraform/vpcs.tf
+++ b/infrastructure/shared/terraform/vpcs.tf
@@ -44,6 +44,26 @@ module "storage_vpc_delta" {
   cidrsubnet_newbits_private = "2"
 }
 
+module "storage_vpc" {
+  source = "github.com/wellcometrust/terraform//network/prebuilt/vpc/public-private-igw?ref=v16.1.8"
+
+  name = "storage-172-30-0-0-16"
+
+  cidr_block_vpc = "${local.storage_cidr_block_vpc}"
+
+  public_az_count           = "3"
+  cidr_block_public         = "172.30.0.0/17"
+  cidrsubnet_newbits_public = "2"
+
+  private_az_count           = "3"
+  cidr_block_private         = "172.30.128.0/17"
+  cidrsubnet_newbits_private = "2"
+
+  providers = {
+    aws = "aws.storage"
+  }
+}
+
 # Used by:
 # - Grafana service
 # - Various monitoring lambdas


### PR DESCRIPTION
In order to control centrally VPC CIDR ranges, this change duplicates the storage VPC with the intention of allowing storage infra to use that VPC from the storage.

For https://github.com/wellcometrust/platform/issues/2969