### PR TITLE
Update remaining services to latest typesafe config docker image

### DIFF
--- a/archive/notifier/Dockerfile
+++ b/archive/notifier/Dockerfile
@@ -1,4 +1,4 @@
-FROM wellcome/typesafe_config_base:2
+FROM wellcome/typesafe_config_base:27
 
 ADD target/universal/stage /opt/docker
 

--- a/archive/notifier/src/main/resources/application.conf
+++ b/archive/notifier/src/main/resources/application.conf
@@ -1,0 +1,4 @@
+aws.sqs.queue.url=${?notifier_queue_url}
+aws.sns.topic.arn=${?progress_topic_arn}
+contextURL=${?context_url}
+metrics.namespace=notifier

--- a/archive/notifier/src/universal/conf/application.conf.template
+++ b/archive/notifier/src/universal/conf/application.conf.template
@@ -1,4 +1,0 @@
-aws.sqs.queue.url="${notifier_queue_url}"
-aws.sns.topic.arn="${progress_topic_arn}"
-contextURL="${context_url}"
-metrics.namespace=notifier

--- a/archive/progress_async/Dockerfile
+++ b/archive/progress_async/Dockerfile
@@ -1,4 +1,4 @@
-FROM wellcome/typesafe_config_base:2
+FROM wellcome/typesafe_config_base:27
 
 ADD target/universal/stage /opt/docker
 

--- a/archive/progress_async/src/main/resources/application.conf
+++ b/archive/progress_async/src/main/resources/application.conf
@@ -1,0 +1,4 @@
+aws.sqs.queue.url=${?queue_url}
+aws.sns.topic.arn=${?topic_arn}
+aws.dynamo.tableName=${?archive_progress_table_name}
+metrics.namespace=progress_async

--- a/archive/progress_async/src/universal/conf/application.conf.template
+++ b/archive/progress_async/src/universal/conf/application.conf.template
@@ -1,4 +1,0 @@
-aws.sqs.queue.url="${queue_url}"
-aws.sns.topic.arn="${topic_arn}"
-aws.dynamo.tableName="${archive_progress_table_name}"
-metrics.namespace=progress_async

--- a/archive/progress_http/Dockerfile
+++ b/archive/progress_http/Dockerfile
@@ -1,4 +1,4 @@
-FROM wellcome/typesafe_config_base:2
+FROM wellcome/typesafe_config_base:27
 
 ADD target/universal/stage /opt/docker
 

--- a/archive/progress_http/src/main/resources/application.conf
+++ b/archive/progress_http/src/main/resources/application.conf
@@ -1,0 +1,8 @@
+aws.dynamo.tableName=${?archive_progress_table_name}
+aws.dynamo.tableIndex=${?archive_bag_progress_index_name}
+metrics.namespace=progress_http
+http.externalBaseURL=${?app_base_url}
+http.host="0.0.0.0"
+http.port=9001
+contextURL=${?context_url}
+aws.sns.topic.arn=${?topic_arn}

--- a/archive/progress_http/src/universal/conf/application.conf.template
+++ b/archive/progress_http/src/universal/conf/application.conf.template
@@ -1,8 +1,0 @@
-aws.dynamo.tableName="${archive_progress_table_name}"
-aws.dynamo.tableIndex="${archive_bag_progress_index_name}"
-metrics.namespace=progress_http
-http.externalBaseURL="${app_base_url}"
-http.host="0.0.0.0"
-http.port=9001
-contextURL="${context_url}"
-aws.sns.topic.arn="${topic_arn}"

--- a/archive/registrar_async/Dockerfile
+++ b/archive/registrar_async/Dockerfile
@@ -1,4 +1,4 @@
-FROM wellcome/typesafe_config_base:2
+FROM wellcome/typesafe_config_base:27
 
 ADD target/universal/stage /opt/docker
 

--- a/archive/registrar_async/src/main/resources/application.conf
+++ b/archive/registrar_async/src/main/resources/application.conf
@@ -1,0 +1,6 @@
+aws.sqs.queue.url=${?queue_url}
+aws.sns.topic.arn=${?progress_topic_arn}
+aws.vhs.dynamo.tableName=${?vhs_table_name}
+aws.vhs.s3.bucketName=${?vhs_bucket_name}
+aws.vhs.s3.globalPrefix=archive
+metrics.namespace=registrar_async

--- a/archive/registrar_async/src/universal/conf/application.conf.template
+++ b/archive/registrar_async/src/universal/conf/application.conf.template
@@ -1,6 +1,0 @@
-aws.sqs.queue.url="${queue_url}"
-aws.sns.topic.arn="${progress_topic_arn}"
-aws.vhs.dynamo.tableName="${vhs_table_name}"
-aws.vhs.s3.bucketName="${vhs_bucket_name}"
-aws.vhs.s3.globalPrefix=archive
-metrics.namespace=registrar_async

--- a/archive/registrar_http/Dockerfile
+++ b/archive/registrar_http/Dockerfile
@@ -1,4 +1,4 @@
-FROM wellcome/typesafe_config_base:2
+FROM wellcome/typesafe_config_base:27
 
 ADD target/universal/stage /opt/docker
 

--- a/archive/registrar_http/src/main/resources/application.conf
+++ b/archive/registrar_http/src/main/resources/application.conf
@@ -1,0 +1,7 @@
+aws.vhs.dynamo.tableName=${?vhs_table_name}
+aws.vhs.s3.bucketName=${?vhs_bucket_name}
+aws.vhs.s3.globalPrefix=archive
+http.externalBaseURL=${?app_base_url}
+http.host="0.0.0.0"
+http.port=9001
+contextURL=${?context_url}

--- a/archive/registrar_http/src/universal/conf/application.conf.template
+++ b/archive/registrar_http/src/universal/conf/application.conf.template
@@ -1,7 +1,0 @@
-aws.vhs.dynamo.tableName="${vhs_table_name}"
-aws.vhs.s3.bucketName="${vhs_bucket_name}"
-aws.vhs.s3.globalPrefix=archive
-http.externalBaseURL="${app_base_url}"
-http.host="0.0.0.0"
-http.port=9001
-contextURL="${context_url}"


### PR DESCRIPTION
### What is this PR trying to achieve?

As the move to `wellcome/typesafe_config_base` seems to be good for the archivist, move all remaining archive services to use the same image.
