### PR TITLE
Try to find assets the DLCS doesn't know about

### DIFF
--- a/archive/bagger/src/main.py
+++ b/archive/bagger/src/main.py
@@ -41,7 +41,9 @@ def process_message(message):
     print("processing " + identifier)
     result = bagger_processor.process_bagging_message(body)
     error = result.get("error", None)
-    if error is not None:
+    if error is None:
+        aws.remove_error(identifier)
+    else:
         print("Could not process {0}".format(identifier))
         aws.log_processing_error(result)
     time_taken = time.time() - start


### PR DESCRIPTION
### What is this PR trying to achieve?
The bagger uses the DLCS to determine the best place to collect the asset from. But the DLCS doesn't know about all assets. An asset record might be missing from the DLCS because of a problem with a sync operation, or it's a closed file that never goes to the DLCS for access purposes. They still need to be bagged...

### Who is this change for?
All