### PR TITLE
Make the Sierra reader happy again

### DIFF
--- a/sierra_adapter/build_missing_windows.py
+++ b/sierra_adapter/build_missing_windows.py
@@ -9,11 +9,14 @@ import sys
 
 import boto3
 
-from build_windows import generate_windows
-
 sys.path.append(
     os.path.join(os.path.dirname(__file__), "sierra_progress_reporter", "src")
 )
+sys.path.append(
+    os.path.join(os.path.dirname(__file__), "sierra_window_generator", "src")
+)
+
+from build_windows import generate_windows  # noqa
 from sierra_progress_reporter import build_report  # noqa
 
 
@@ -44,7 +47,7 @@ def get_missing_windows(report):
         missing_start = window_1.end - dt.timedelta(seconds=1)
         missing_end = window_2.start + dt.timedelta(seconds=1)
 
-        yield from generate_windows(start=missing_start, end=missing_end, minutes=5)
+        yield from generate_windows(start=missing_start, end=missing_end, minutes=2)
 
 
 if __name__ == "__main__":

--- a/sierra_adapter/sierra_progress_reporter/src/sierra_progress_reporter.py
+++ b/sierra_adapter/sierra_progress_reporter/src/sierra_progress_reporter.py
@@ -197,4 +197,3 @@ if __name__ == "__main__":
 
     for resource_type in ("bibs", "items"):
         print_report(s3_client=s3_client, bucket=bucket, resource_type=resource_type)
-

--- a/sierra_adapter/sierra_progress_reporter/src/sierra_progress_reporter.py
+++ b/sierra_adapter/sierra_progress_reporter/src/sierra_progress_reporter.py
@@ -5,6 +5,7 @@ a report in Slack
 """
 
 import datetime as dt
+import itertools
 import json
 import os
 
@@ -83,18 +84,56 @@ def process_report(s3_client, bucket, resource_type):
             raise IncompleteReportError(resource_type)
 
 
-def prepare_report(s3_client, bucket, resource_type):
-    lines = ["", f"*{resource_type} windows*"]
+def prepare_present_report(s3_client, bucket, resource_type):
+    """
+    Generate a report for windows that are present.
+    """
+    yield ""
+    yield f"*{resource_type} windows*"
 
     for iv in get_consolidated_report(s3_client, bucket, resource_type):
-        lines.append(f"{iv.start.isoformat()} – {iv.end.isoformat()}")
+        yield f"{iv.start.isoformat()} – {iv.end.isoformat()}"
 
-    lines.append("")
-    return lines
+    yield ""
+
+
+# https://stackoverflow.com/q/6822725/1558022
+def window(seq, n=2):
+    """
+    Returns a sliding window (of width n) over data from the iterable
+
+        s -> (s0,s1,...s[n-1]), (s1,s2,...,sn),
+
+    """
+    it = iter(seq)
+    result = tuple(itertools.islice(it, n))
+    if len(result) == n:
+        yield result
+    for elem in it:
+        result = result[1:] + (elem,)
+        yield result
+
+
+def prepare_missing_report(s3_client, bucket, resource_type):
+    """
+    Generate a report for windows that are missing.
+    """
+    yield ""
+    yield f"*missing {resource_type} windows*"
+
+    for iv1, iv2 in window(get_consolidated_report(s3_client, bucket, resource_type)):
+        missing_start = iv1.end
+        missing_end = iv2.start
+        if missing_start.date() == missing_end.date():
+            yield f"{missing_start.date()}: {missing_start.strftime('%H:%M:%S')} — {missing_end.strftime('%H:%M:%S')}"
+        else:
+            yield f"{missing_start.strftime('%Y-%m-%d %H:%M:%S')} — {missing_end.strftime('%Y-%m-%d %H:%M:%S')}"
+
+    yield ""
 
 
 def print_report(s3_client, bucket, resource_type):
-    print("\n".join(prepare_report(s3_client, bucket, resource_type)))
+    print("\n".join(prepare_present_report(s3_client, bucket, resource_type)))
 
 
 def main(event=None, _ctxt=None):
@@ -112,7 +151,7 @@ def main(event=None, _ctxt=None):
             )
         except IncompleteReportError:
             error_lines.extend(
-                prepare_report(
+                prepare_missing_report(
                     s3_client=s3_client, bucket=bucket, resource_type=resource_type
                 )
             )
@@ -158,3 +197,4 @@ if __name__ == "__main__":
 
     for resource_type in ("bibs", "items"):
         print_report(s3_client=s3_client, bucket=bucket, resource_type=resource_type)
+

--- a/sierra_adapter/sierra_window_generator/src/build_windows.py
+++ b/sierra_adapter/sierra_window_generator/src/build_windows.py
@@ -42,14 +42,12 @@ import json
 import math
 
 import boto3
-import docopt
-import maya
-import tqdm
+import pytz
 
 
 def generate_windows(start, end, minutes):
-    current = start
-    end = end
+    current = pytz.utc.localize(start)
+    end = pytz.utc.localize(end)
     while current <= end:
         yield {
             "start": current.isoformat(),
@@ -59,6 +57,10 @@ def generate_windows(start, end, minutes):
 
 
 if __name__ == "__main__":
+    import docopt
+    import maya
+    import tqdm
+
     args = docopt.docopt(__doc__)
 
     start = maya.parse(args["--start"]).datetime()

--- a/sierra_adapter/sierra_window_generator/src/sierra_window_generator.py
+++ b/sierra_adapter/sierra_window_generator/src/sierra_window_generator.py
@@ -7,19 +7,20 @@ import datetime as dt
 import os
 
 import boto3
-import pytz
 from wellcome_aws_utils.lambda_utils import log_on_error
 from wellcome_aws_utils.sns_utils import publish_sns_message
+
+from build_windows import generate_windows
 
 
 def build_window(minutes):
     """Construct the Sierra update window."""
     seconds = minutes * 60
 
-    end = pytz.utc.localize(dt.datetime.utcnow())
+    end = dt.datetime.now()
     start = end - dt.timedelta(seconds=seconds)
 
-    return {"start": start.isoformat(), "end": end.isoformat()}
+    return next(generate_windows(start=start, end=end, minutes=minutes))
 
 
 @log_on_error

--- a/sierra_adapter/sierra_window_generator/src/test_sierra_window_generator.py
+++ b/sierra_adapter/sierra_window_generator/src/test_sierra_window_generator.py
@@ -10,7 +10,7 @@ from sierra_window_generator import build_window, main
 
 class patched_datetime(dt.datetime):
     @classmethod
-    def utcnow(cls):
+    def now(cls):
         return dt.datetime(2011, 6, 21, 0, 0, 0, 0)
 
 


### PR DESCRIPTION
Resolves #3224.

The problem is that the `build_missing_windows.py` script wasn't localising timestamps as UTC, so the reader couldn't parse them. Localising as UTC fixes that.

I've also improved the error reporting from the Slack bot.