### PR TITLE
Refactor the API error tests to share common test cases

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -93,7 +93,7 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
     //
     val willOverflow =
       (worksSearchOptions.pageNumber > Int.MaxValue) ||
-      (worksSearchOptions.pageSize > Int.MaxValue / worksSearchOptions.pageNumber)
+        (worksSearchOptions.pageSize > Int.MaxValue / worksSearchOptions.pageNumber)
 
     val from = if (willOverflow) {
       Int.MaxValue

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -55,12 +55,63 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
       }
 
   private def toElasticsearchQueryOptions(
-    worksSearchOptions: WorksSearchOptions): ElasticsearchQueryOptions =
+    worksSearchOptions: WorksSearchOptions): ElasticsearchQueryOptions = {
+
+    // Because we use Int for the pageSize and pageNumber, computing
+    //
+    //     from = (pageNumber - 1) * pageSize
+    //
+    // can potentially overflow and be negative or even wrap around.
+    // For example, pageNumber=2018634700 and pageSize=100 would return
+    // results if you don't handle this!
+    //
+    // If we are about to overflow, we pass the max possible int
+    // into the Elasticsearch query and let it bubble up from there.
+    // We could skip the query and throw here, because the user is almost
+    // certainly doing something wrong, but that would mean simulating an
+    // ES error or modifying our exception handling, and that seems more
+    // disruptive than just clamping the overflow.
+    //
+    // Note: the checks on "pageSize" mean we know it must be
+    // at most 100.
+
+    // How this check works:
+    //
+    //    1.  If pageNumber > MaxValue, then (pageNumber - 1) * pageSize is
+    //        probably bigger, as pageSize >= 1.
+    //
+    //    2.  Alternatively, we care about whether
+    //
+    //            pageSize * pageNumber > MaxValue
+    //
+    //        Since pageNumber is known positive, this is equivalent to
+    //
+    //            pageSize > MaxValue / pageNumber
+    //
+    //        And we know the division won't overflow because we have
+    //        pageValue < MaxValue by the first check.
+    //
+    val willOverflow =
+      (worksSearchOptions.pageNumber > Int.MaxValue) ||
+      (worksSearchOptions.pageSize > Int.MaxValue / worksSearchOptions.pageNumber)
+
+    val from = if (willOverflow) {
+      Int.MaxValue
+    } else {
+      (worksSearchOptions.pageNumber - 1) * worksSearchOptions.pageSize
+    }
+
+    assert(
+      from >= 0,
+      message = s"from = $from < 0, which is daft.  Has something overflowed?"
+    )
+
     ElasticsearchQueryOptions(
       filters = worksSearchOptions.filters,
       limit = worksSearchOptions.pageSize,
-      from = (worksSearchOptions.pageNumber - 1) * worksSearchOptions.pageSize
+      from = from
     )
+  }
 
   private def createResultList(searchResponse: SearchResponse): ResultList =
     ResultList(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
@@ -22,7 +22,8 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
         val pageSize = 101
         assertIsBadRequest(
           s"/works?pageSize=$pageSize",
-          description = s"pageSize: [$pageSize] is not less than or equal to 100"
+          description =
+            s"pageSize: [$pageSize] is not less than or equal to 100"
         )
       }
 
@@ -30,7 +31,8 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
         val pageSize = 0
         assertIsBadRequest(
           s"/works?pageSize=$pageSize",
-          description = s"pageSize: [$pageSize] is not greater than or equal to 1"
+          description =
+            s"pageSize: [$pageSize] is not greater than or equal to 1"
         )
       }
 
@@ -38,7 +40,8 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
         val pageSize = 100000
         assertIsBadRequest(
           s"/works?pageSize=$pageSize",
-          description = s"pageSize: [$pageSize] is not less than or equal to 100"
+          description =
+            s"pageSize: [$pageSize] is not less than or equal to 100"
         )
       }
 
@@ -46,7 +49,8 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
         val pageSize = -50
         assertIsBadRequest(
           s"/works?pageSize=$pageSize",
-          description = s"pageSize: [$pageSize] is not greater than or equal to 1"
+          description =
+            s"pageSize: [$pageSize] is not greater than or equal to 1"
         )
       }
     }
@@ -166,26 +170,28 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
   }
 
   def assertIsBadRequest(path: String, description: String): Response =
-    withApi { case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-      server.httpGet(
-        path = s"/$apiPrefix$path",
-        andExpect = Status.BadRequest,
-        withJsonBody = badRequest(
-          apiPrefix = apiPrefix,
-          description = description
+    withApi {
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
+        server.httpGet(
+          path = s"/$apiPrefix$path",
+          andExpect = Status.BadRequest,
+          withJsonBody = badRequest(
+            apiPrefix = apiPrefix,
+            description = description
+          )
         )
-      )
     }
 
   def assertIsNotFound(path: String, description: String): Response =
-    withApi { case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-      server.httpGet(
-        path = s"/$apiPrefix$path",
-        andExpect = Status.NotFound,
-        withJsonBody = notFound(
-          apiPrefix = apiPrefix,
-          description = description
+    withApi {
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
+        server.httpGet(
+          path = s"/$apiPrefix$path",
+          andExpect = Status.NotFound,
+          withJsonBody = notFound(
+            apiPrefix = apiPrefix,
+            description = description
+          )
         )
-      )
     }
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
@@ -1,0 +1,85 @@
+package uk.ac.wellcome.platform.api.works
+
+import com.sksamuel.elastic4s.Index
+import com.twitter.finagle.http.{Response, Status}
+import com.twitter.finatra.http.EmbeddedHttpServer
+import uk.ac.wellcome.test.fixtures.TestWith
+
+trait ApiErrorsTestBase { this: ApiWorksTestBase =>
+  def withApi[R]: TestWith[(String, Index, Index, EmbeddedHttpServer), R] => R
+
+  describe("returns a 400 Bad Request for user errors") {
+    it("when it gets malformed query parameters") {
+      assertIsBadRequest(
+        "/works?pageSize=penguin",
+        description = "pageSize: 'penguin' is not a valid Integer"
+      )
+    }
+
+    // We want to cover multiple cases with the page size tests:
+    //
+    //    - Just beyond the upper limit
+    //    - Just below the lower limit
+    //    - Large, but low enoguh that Elasticsearch is still able to tell us
+    //      what went wrong.
+    //
+
+    it("when asked for a page size just over the maximum") {
+      val pageSize = 101
+      assertIsBadRequest(
+        s"/works?pageSize=$pageSize",
+        description = s"pageSize: [$pageSize] is not less than or equal to 100"
+      )
+    }
+
+    it("when asked for a zero-length page") {
+      val pageSize = 0
+      assertIsBadRequest(
+        s"/works?pageSize=$pageSize",
+        description = s"pageSize: [$pageSize] is not greater than or equal to 1"
+      )
+    }
+
+    it("when asked for a large page size") {
+      val pageSize = 100000
+      assertIsBadRequest(
+        s"/works?pageSize=$pageSize",
+        description = s"pageSize: [$pageSize] is not less than or equal to 100"
+      )
+    }
+  }
+
+  describe("returns a 404 Not Found for missing resources") {
+    it("when asked for a work that doesn't exist") {
+      val badId = "doesnotexist"
+      assertIsNotFound(
+        s"/works/$badId",
+        description = s"Work not found for identifier $badId"
+      )
+    }
+  }
+
+  private def assertIsBadRequest(path: String, description: String): Response =
+    withApi { case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
+      server.httpGet(
+        path = s"/$apiPrefix$path",
+        andExpect = Status.BadRequest,
+        withJsonBody = badRequest(
+          apiPrefix = apiPrefix,
+          description = description
+        )
+      )
+    }
+
+  private def assertIsNotFound(path: String, description: String): Response =
+    withApi { case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
+      server.httpGet(
+        path = s"/$apiPrefix$path",
+        andExpect = Status.NotFound,
+        withJsonBody = notFound(
+          apiPrefix = apiPrefix,
+          description = description
+        )
+      )
+    }
+}

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
@@ -9,57 +9,165 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
   def withApi[R]: TestWith[(String, Index, Index, EmbeddedHttpServer), R] => R
 
   describe("returns a 400 Bad Request for user errors") {
-    it("when it gets malformed query parameters") {
-      assertIsBadRequest(
-        "/works?pageSize=penguin",
-        description = "pageSize: 'penguin' is not a valid Integer"
-      )
+    describe("errors in the ?pageSize query") {
+      it("not an integer") {
+        val pageSize = "penguin"
+        assertIsBadRequest(
+          s"/works?pageSize=$pageSize",
+          description = s"pageSize: '$pageSize' is not a valid Integer"
+        )
+      }
+
+      it("just over the maximum") {
+        val pageSize = 101
+        assertIsBadRequest(
+          s"/works?pageSize=$pageSize",
+          description = s"pageSize: [$pageSize] is not less than or equal to 100"
+        )
+      }
+
+      it("just below the minimum") {
+        val pageSize = 0
+        assertIsBadRequest(
+          s"/works?pageSize=$pageSize",
+          description = s"pageSize: [$pageSize] is not greater than or equal to 1"
+        )
+      }
+
+      it("a large page size") {
+        val pageSize = 100000
+        assertIsBadRequest(
+          s"/works?pageSize=$pageSize",
+          description = s"pageSize: [$pageSize] is not less than or equal to 100"
+        )
+      }
+
+      it("a negative page size") {
+        val pageSize = -50
+        assertIsBadRequest(
+          s"/works?pageSize=$pageSize",
+          description = s"pageSize: [$pageSize] is not greater than or equal to 1"
+        )
+      }
     }
 
-    // We want to cover multiple cases with the page size tests:
-    //
-    //    - Just beyond the upper limit
-    //    - Just below the lower limit
-    //    - Large, but low enoguh that Elasticsearch is still able to tell us
-    //      what went wrong.
-    //
+    describe("errors in the ?page query") {
+      it("page 0") {
+        val page = 0
+        assertIsBadRequest(
+          s"/works?page=$page",
+          description = s"page: [$page] is not greater than or equal to 1"
+        )
+      }
 
-    it("when asked for a page size just over the maximum") {
-      val pageSize = 101
-      assertIsBadRequest(
-        s"/works?pageSize=$pageSize",
-        description = s"pageSize: [$pageSize] is not less than or equal to 100"
-      )
+      it("a negative page") {
+        val page = -50
+        assertIsBadRequest(
+          s"/works?page=$page",
+          description = s"page: [$page] is not greater than or equal to 1"
+        )
+      }
+
+
     }
 
-    it("when asked for a zero-length page") {
-      val pageSize = 0
-      assertIsBadRequest(
-        s"/works?pageSize=$pageSize",
-        description = s"pageSize: [$pageSize] is not greater than or equal to 1"
-      )
+    describe("trying to get more works than ES allows") {
+      it("a very large page") {
+        assertIsBadRequest(
+          s"/works?page=10000",
+          description = "Only the first 10000 works are available in the API."
+        )
+      }
+
+      it("the 101th page with 100 results per page") {
+        assertIsBadRequest(
+          s"/works?page=101&pageSize=100",
+          description = "Only the first 10000 works are available in the API."
+        )
+      }
     }
 
-    it("when asked for a large page size") {
-      val pageSize = 100000
+    it("returns multiple errors if there's more than one invalid parameter") {
+      val pageSize = -60
+      val page = -50
       assertIsBadRequest(
-        s"/works?pageSize=$pageSize",
-        description = s"pageSize: [$pageSize] is not less than or equal to 100"
+        s"/works?pageSize=$pageSize&page=$page",
+        description =
+          s"page: [$page] is not greater than or equal to 1, pageSize: [$pageSize] is not greater than or equal to 1"
       )
     }
   }
 
   describe("returns a 404 Not Found for missing resources") {
-    it("when asked for a work that doesn't exist") {
+    it("looking up a work that doesn't exist") {
       val badId = "doesnotexist"
       assertIsNotFound(
         s"/works/$badId",
         description = s"Work not found for identifier $badId"
       )
     }
+
+    it("looking up a work with a malformed identifier") {
+      val badId = "zd224ncv]"
+      assertIsNotFound(
+        s"/works/$badId",
+        description = s"Work not found for identifier $badId"
+      )
+    }
+
+    describe("an index that doesn't exist") {
+      val indexName = "foobarbaz"
+
+      it("listing") {
+        assertIsNotFound(
+          s"/works?_index=$indexName",
+          description = s"There is no index $indexName"
+        )
+      }
+
+      it("looking up a work") {
+        assertIsNotFound(
+          s"/works/1234?_index=$indexName",
+          description = s"There is no index $indexName"
+        )
+      }
+
+      it("searching") {
+        assertIsNotFound(
+          s"/works/1234?_index=$indexName&query=foobar",
+          description = s"There is no index $indexName"
+        )
+      }
+    }
   }
 
-  private def assertIsBadRequest(path: String, description: String): Response =
+  it("returns an Internal Server error if you try to search a malformed index") {
+    // We need to do something that reliably triggers an internal exception
+    // in the Elasticsearch handler.
+    //
+    // By creating an index without a mapping, we don't have a canonicalId field
+    // to sort on.  Trying to query this index of these will trigger one such exception!
+    withApi {
+      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
+        withEmptyIndex { index =>
+          server.httpGet(
+            path = s"/$apiPrefix/works?_index=${index.name}",
+            andExpect = Status.InternalServerError,
+            withJsonBody = s"""
+                              |{
+                              |  "@context": "https://localhost:8888/$apiPrefix/context.json",
+                              |  "type": "Error",
+                              |  "errorType": "http",
+                              |  "httpStatus": 500,
+                              |  "label": "Internal Server Error"
+                              |}
+               """.stripMargin
+          )
+        }
+    }
+  }
+
+  def assertIsBadRequest(path: String, description: String): Response =
     withApi { case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
       server.httpGet(
         path = s"/$apiPrefix$path",
@@ -71,7 +179,7 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
       )
     }
 
-  private def assertIsNotFound(path: String, description: String): Response =
+  def assertIsNotFound(path: String, description: String): Response =
     withApi { case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
       server.httpGet(
         path = s"/$apiPrefix$path",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
@@ -26,7 +26,7 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
         )
       }
 
-      it("just below the minimum") {
+      it("just below the minimum (zero)") {
         val pageSize = 0
         assertIsBadRequest(
           s"/works?pageSize=$pageSize",
@@ -67,8 +67,6 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
           description = s"page: [$page] is not greater than or equal to 1"
         )
       }
-
-
     }
 
     describe("trying to get more works than ES allows") {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
@@ -81,6 +81,14 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
         )
       }
 
+      // https://github.com/wellcometrust/platform/issues/3233
+      it("so many pages that a naive (page * pageSize) would overflow") {
+        assertIsBadRequest(
+          s"/works?page=2000000000&pageSize=100",
+          description = "Only the first 10000 works are available in the API."
+        )
+      }
+
       it("the 101th page with 100 results per page") {
         assertIsBadRequest(
           s"/works?page=101&pageSize=100",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
@@ -6,7 +6,8 @@ import uk.ac.wellcome.platform.api.works.ApiErrorsTestBase
 import uk.ac.wellcome.test.fixtures.TestWith
 
 class ApiV1ErrorsTest extends ApiV1WorksTestBase with ApiErrorsTestBase {
-  def withApi[R]: TestWith[(String, Index, Index, EmbeddedHttpServer), R] => R = withV1Api[R]
+  def withApi[R]: TestWith[(String, Index, Index, EmbeddedHttpServer), R] => R =
+    withV1Api[R]
 
   describe("returns a 400 Bad Request for errors in the ?includes parameter") {
     it("a single invalid include") {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
@@ -1,302 +1,40 @@
 package uk.ac.wellcome.platform.api.works.v1
 
-import com.twitter.finagle.http.Status
+import com.sksamuel.elastic4s.Index
 import com.twitter.finatra.http.EmbeddedHttpServer
+import uk.ac.wellcome.platform.api.works.ApiErrorsTestBase
+import uk.ac.wellcome.test.fixtures.TestWith
 
-class ApiV1ErrorsTest extends ApiV1WorksTestBase {
+class ApiV1ErrorsTest extends ApiV1WorksTestBase with ApiErrorsTestBase {
+  def withApi[R]: TestWith[(String, Index, Index, EmbeddedHttpServer), R] => R = withV1Api[R]
 
-  it("returns a BadRequest error when malformed query parameters are presented") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?pageSize=penguin",
-          andExpect = Status.BadRequest,
-          withJsonBody =
-            badRequest(apiPrefix, "pageSize: 'penguin' is not a valid Integer")
-        )
+  describe("returns a 400 Bad Request for errors in the ?includes parameter") {
+    it("a single invalid include") {
+      assertIsBadRequest(
+        "/works?includes=foo",
+        description = "includes: 'foo' is not a valid include"
+      )
     }
 
-  }
-
-  it("returns a NotFound error when requesting a work with a non-existent id") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        val badId = "non-existing-id"
-        server.httpGet(
-          path = s"/$apiPrefix/works/$badId",
-          andExpect = Status.NotFound,
-          withJsonBody =
-            notFound(apiPrefix, s"Work not found for identifier $badId")
-        )
-    }
-  }
-
-  it(
-    "returns a BadRequest error if the user asks for a page size just over the maximum") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        val pageSize = 101
-        server.httpGet(
-          path = s"/$apiPrefix/works?pageSize=$pageSize",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            s"pageSize: [$pageSize] is not less than or equal to 100")
-        )
+    it("multiple invalid includes") {
+      assertIsBadRequest(
+        "/works?includes=foo,bar",
+        description = "includes: 'foo', 'bar' are not valid includes"
+      )
     }
 
-  }
-
-  it(
-    "returns a BadRequest error if the user asks for an overly large page size") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        val pageSize = 100000
-        server.httpGet(
-          path = s"/$apiPrefix/works?pageSize=$pageSize",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            s"pageSize: [$pageSize] is not less than or equal to 100")
-        )
-
-    }
-  }
-
-  it("returns a BadRequest error if the user asks for zero-length pages") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        val pageSize = 0
-        server.httpGet(
-          path = s"/$apiPrefix/works?pageSize=$pageSize",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            s"pageSize: [$pageSize] is not greater than or equal to 1")
-        )
+    it("a mixture of valid and invalid includes") {
+      assertIsBadRequest(
+        "/works?includes=foo,identifiers,bar",
+        description = "includes: 'foo', 'bar' are not valid includes"
+      )
     }
 
-  }
-
-  it("returns a BadRequest error if the user asks for a negative page size") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        val pageSize = -50
-        server.httpGet(
-          path = s"/$apiPrefix/works?pageSize=$pageSize",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            s"pageSize: [$pageSize] is not greater than or equal to 1")
-        )
-    }
-  }
-
-  it("returns a BadRequest error if the user asks for page 0") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?page=0",
-          andExpect = Status.BadRequest,
-          withJsonBody =
-            badRequest(apiPrefix, "page: [0] is not greater than or equal to 1")
-        )
-    }
-
-  }
-
-  it("returns a BadRequest error if the user asks for a page before 0") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?page=-50",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            "page: [-50] is not greater than or equal to 1")
-        )
-    }
-
-  }
-
-  it("returns multiple errors if there's more than one invalid parameter") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?pageSize=-60&page=-50",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            "page: [-50] is not greater than or equal to 1, pageSize: [-60] is not greater than or equal to 1")
-        )
-    }
-  }
-
-  it("returns a Bad Request error if asked for an invalid include") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?includes=foo",
-          andExpect = Status.BadRequest,
-          withJsonBody =
-            badRequest(apiPrefix, "includes: 'foo' is not a valid include")
-        )
-    }
-
-  }
-
-  it("returns a Bad Request error if asked for more than one invalid include") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?includes=foo,bar",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            "includes: 'foo', 'bar' are not valid includes")
-        )
-    }
-
-  }
-
-  it(
-    "returns a Bad Request error if asked for a mixture of valid and invalid includes") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?includes=foo,identifiers,bar",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            "includes: 'foo', 'bar' are not valid includes")
-        )
-    }
-
-  }
-
-  it(
-    "returns a Bad Request error if asked for an invalid include on an individual work") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works/nfdn7wac?includes=foo",
-          andExpect = Status.BadRequest,
-          withJsonBody =
-            badRequest(apiPrefix, "includes: 'foo' is not a valid include")
-        )
-
-    }
-  }
-
-  it("returns Not Found if you list in a non-existent index") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?_index=foobarbaz",
-          andExpect = Status.NotFound,
-          withJsonBody = notFound(apiPrefix, "There is no index foobarbaz")
-        )
-    }
-  }
-
-  it("returns Not Found if you look up in a non-existent index") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works/1234?_index=foobarbaz",
-          andExpect = Status.NotFound,
-          withJsonBody = notFound(apiPrefix, "There is no index foobarbaz")
-        )
-    }
-  }
-
-  it("returns Not Found if you search in a non-existent index") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?_index=foobarbaz&query=foobar",
-          andExpect = Status.NotFound,
-          withJsonBody = notFound(apiPrefix, "There is no index foobarbaz")
-        )
-    }
-  }
-
-  it("returns Not Found if you ask for a non-existent work") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works/xhu96f9j",
-          andExpect = Status.NotFound,
-          withJsonBody =
-            notFound(apiPrefix, "Work not found for identifier xhu96f9j")
-        )
-    }
-  }
-
-  it("returns Bad Request if you ask for a malformed identifier") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works/zd224ncv]",
-          andExpect = Status.NotFound,
-          withJsonBody =
-            notFound(apiPrefix, "Work not found for identifier zd224ncv]")
-        )
-    }
-  }
-
-  it("returns an Internal Server error if you try to search a malformed index") {
-    // We need to do something that reliably triggers an internal exception
-    // in the Elasticsearch handler.
-    //
-    // By creating an index without a mapping, we don't have a canonicalId field
-    // to sort on.  Trying to query this index of these will trigger one such exception!
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        withEmptyIndex { index =>
-          server.httpGet(
-            path = s"/$apiPrefix/works?_index=${index.name}",
-            andExpect = Status.InternalServerError,
-            withJsonBody = s"""
-                 |{
-                 |  "@context": "https://localhost:8888/$apiPrefix/context.json",
-                 |  "type": "Error",
-                 |  "errorType": "http",
-                 |  "httpStatus": 500,
-                 |  "label": "Internal Server Error"
-                 |}
-               """.stripMargin
-          )
-        }
-    }
-  }
-
-  it("returns a Bad Request error if you try to access the 10000th page") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?page=10000",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            "Only the first 10000 works are available in the API.")
-        )
-
-    }
-  }
-
-  it(
-    "returns a Bad Request error if you try to get the 101th page with 100 results per page") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?pageSize=100&page=101",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            "Only the first 10000 works are available in the API.")
-        )
-
+    it("an invalid include on an individual work") {
+      assertIsBadRequest(
+        "/works/nfdn7wac?includes=foo",
+        description = "includes: 'foo' is not a valid include"
+      )
     }
   }
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
@@ -1,315 +1,39 @@
 package uk.ac.wellcome.platform.api.works.v2
 
-import com.twitter.finagle.http.Status
+import com.sksamuel.elastic4s.Index
 import com.twitter.finatra.http.EmbeddedHttpServer
-import uk.ac.wellcome.display.models.ApiVersions
+import uk.ac.wellcome.platform.api.works.ApiErrorsTestBase
+import uk.ac.wellcome.test.fixtures.TestWith
 
-class ApiV2ErrorsTest extends ApiV2WorksTestBase {
+class ApiV2ErrorsTest extends ApiV2WorksTestBase with ApiErrorsTestBase {
+  def withApi[R]: TestWith[(String, Index, Index, EmbeddedHttpServer), R] => R = withV2Api[R]
 
-  it("returns a BadRequest error when malformed query parameters are presented") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?pageSize=penguin",
-          andExpect = Status.BadRequest,
-          withJsonBody =
-            badRequest(apiPrefix, "pageSize: 'penguin' is not a valid Integer")
-        )
-    }
-  }
-
-  it("returns a NotFound error when requesting a work with a non-existent id") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        val badId = "non-existing-id"
-        server.httpGet(
-          path = s"/$apiPrefix/works/$badId",
-          andExpect = Status.NotFound,
-          withJsonBody =
-            notFound(apiPrefix, s"Work not found for identifier $badId")
-        )
-    }
-  }
-
-  it(
-    "returns a BadRequest error if the user asks for a page size just over the maximum") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        val pageSize = 101
-        server.httpGet(
-          path = s"/$apiPrefix/works?pageSize=$pageSize",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            s"pageSize: [$pageSize] is not less than or equal to 100")
-        )
+  describe("returns a 400 Bad Request for errors in the ?include parameter") {
+    it("a single invalid include") {
+      assertIsBadRequest(
+        "/works?include=foo",
+        description = "include: 'foo' is not a valid include"
+      )
     }
 
-  }
-
-  it(
-    "returns a BadRequest error if the user asks for an overly large page size") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        val pageSize = 100000
-        server.httpGet(
-          path = s"/$apiPrefix/works?pageSize=$pageSize",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            s"pageSize: [$pageSize] is not less than or equal to 100")
-        )
+    it("multiple invalid includes") {
+      assertIsBadRequest(
+        "/works?include=foo,bar",
+        description = "include: 'foo', 'bar' are not valid includes"
+      )
     }
 
-  }
-
-  it("returns a BadRequest error if the user asks for zero-length pages") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        val pageSize = 0
-        server.httpGet(
-          path = s"/$apiPrefix/works?pageSize=$pageSize",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            s"pageSize: [$pageSize] is not greater than or equal to 1")
-        )
+    it("a mixture of valid and invalid includes") {
+      assertIsBadRequest(
+        "/works?include=foo,identifiers,bar",
+        description = "include: 'foo', 'bar' are not valid includes"
+      )
     }
 
-  }
-
-  it("returns a BadRequest error if the user asks for a negative page size") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        val pageSize = -50
-        server.httpGet(
-          path = s"/$apiPrefix/works?pageSize=$pageSize",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            s"pageSize: [$pageSize] is not greater than or equal to 1")
-        )
-    }
-
-  }
-
-  it("returns a BadRequest error if the user asks for page 0") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?page=0",
-          andExpect = Status.BadRequest,
-          withJsonBody =
-            badRequest(apiPrefix, "page: [0] is not greater than or equal to 1")
-        )
-
-    }
-  }
-
-  it("returns a BadRequest error if the user asks for a page before 0") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?page=-50",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            "page: [-50] is not greater than or equal to 1")
-        )
-    }
-
-  }
-
-  it("returns multiple errors if there's more than one invalid parameter") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?pageSize=-60&page=-50",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            "page: [-50] is not greater than or equal to 1, pageSize: [-60] is not greater than or equal to 1")
-        )
-    }
-  }
-
-  it("returns a Bad Request error if asked for an invalid include") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?include=foo",
-          andExpect = Status.BadRequest,
-          withJsonBody =
-            badRequest(apiPrefix, "include: 'foo' is not a valid include")
-        )
-    }
-  }
-
-  it("returns a Bad Request error if asked for more than one invalid include") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?include=foo,bar",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            "include: 'foo', 'bar' are not valid includes")
-        )
-
-    }
-  }
-
-  it(
-    "returns a Bad Request error if asked for a mixture of valid and invalid includes") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?include=foo,identifiers,bar",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            "include: 'foo', 'bar' are not valid includes")
-        )
-    }
-  }
-
-  it(
-    "returns a Bad Request error if asked for an invalid include on an individual work") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works/nfdn7wac?include=foo",
-          andExpect = Status.BadRequest,
-          withJsonBody =
-            badRequest(apiPrefix, "include: 'foo' is not a valid include")
-        )
-    }
-  }
-
-  it("returns Not Found if you list in a non-existent index") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?_index=foobarbaz",
-          andExpect = Status.NotFound,
-          withJsonBody = notFound(apiPrefix, "There is no index foobarbaz")
-        )
-    }
-  }
-
-  it("returns Not Found if you look up in a non-existent index") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works/1234?_index=foobarbaz",
-          andExpect = Status.NotFound,
-          withJsonBody = notFound(apiPrefix, "There is no index foobarbaz")
-        )
-    }
-  }
-
-  it("returns Not Found if you search in a non-existent index") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?_index=foobarbaz&query=foobar",
-          andExpect = Status.NotFound,
-          withJsonBody = notFound(apiPrefix, "There is no index foobarbaz")
-        )
-    }
-  }
-
-  it("returns Not Found if you ask for a non-existent work") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works/xhu96f9j",
-          andExpect = Status.NotFound,
-          withJsonBody =
-            notFound(apiPrefix, "Work not found for identifier xhu96f9j")
-        )
-    }
-
-  }
-
-  it("returns Bad Request if you ask for a malformed identifier") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works/zd224ncv]",
-          andExpect = Status.NotFound,
-          withJsonBody =
-            notFound(apiPrefix, "Work not found for identifier zd224ncv]")
-        )
-    }
-
-  }
-
-  it("returns an Internal Server error if you try to search a malformed index") {
-    // We need to do something that reliably triggers an internal exception
-    // in the Elasticsearch handler.
-    //
-    // By creating an index without a mapping, we don't have a canonicalId field
-    // to sort on.  Trying to query this index of these will trigger one such exception!
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        withEmptyIndex { index =>
-          server.httpGet(
-            path = s"/$apiPrefix/works?_index=${index.name}",
-            andExpect = Status.InternalServerError,
-            withJsonBody = s"""
-                 |{
-                 |  "@context": "https://localhost:8888/$apiPrefix/context.json",
-                 |  "type": "Error",
-                 |  "errorType": "http",
-                 |  "httpStatus": 500,
-                 |  "label": "Internal Server Error"
-                 |}
-               """.stripMargin
-          )
-        }
-    }
-  }
-
-  it("returns a Bad Request error if you try to access the 10000th page") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?page=10000",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            "Only the first 10000 works are available in the API.")
-        )
-    }
-
-  }
-
-  it(
-    "returns a Bad Request error if you try to get the 101th page with 100 results per page") {
-    withV2Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?pageSize=100&page=101",
-          andExpect = Status.BadRequest,
-          withJsonBody = badRequest(
-            apiPrefix,
-            "Only the first 10000 works are available in the API.")
-        )
-    }
-
-  }
-
-  // TODO figure out what the correct behaviour should be in this case
-  ignore(
-    "returns a Not Found error if you try to get a version that doesn't exist") {
-    withServer(indexV1 = "not-important", indexV2 = "not-important") { server =>
-      server.httpGet(
-        path = "/catalogue/v567/works?pageSize=100&page=101",
-        andExpect = Status.NotFound,
-        withJsonBody = badRequest(
-          s"catalogue/${ApiVersions.default.toString}",
-          "v567 is not a valid API version")
+    it("an invalid include on an individual work") {
+      assertIsBadRequest(
+        "/works/nfdn7wac?include=foo",
+        description = "include: 'foo' is not a valid include"
       )
     }
   }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
@@ -6,7 +6,8 @@ import uk.ac.wellcome.platform.api.works.ApiErrorsTestBase
 import uk.ac.wellcome.test.fixtures.TestWith
 
 class ApiV2ErrorsTest extends ApiV2WorksTestBase with ApiErrorsTestBase {
-  def withApi[R]: TestWith[(String, Index, Index, EmbeddedHttpServer), R] => R = withV2Api[R]
+  def withApi[R]: TestWith[(String, Index, Index, EmbeddedHttpServer), R] => R =
+    withV2Api[R]
 
   describe("returns a 400 Bad Request for errors in the ?include parameter") {
     it("a single invalid include") {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,7 +41,7 @@ object Dependencies {
     val mockito = "1.9.5"
     val scalatest = "3.0.1"
     val junitInterface = "0.11"
-    val elastic4s = "6.4.0"
+    val elastic4s = "6.5.0"
     val circeVersion = "0.9.0"
     val scalaCheckVersion = "1.13.4"
     val scalaCheckShapelessVersion = "1.1.6"


### PR DESCRIPTION
Most of the error test cases are the same for V1 and V2, so we can put them in an abstract class and then subclass it and get all those tests in both versions.

This is a bit of refactoring for #3233.