### PR TITLE
Don’t throw a 500 error on high page numbers

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -101,6 +101,11 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
       (worksSearchOptions.pageNumber - 1) * worksSearchOptions.pageSize
     }
 
+    assert(
+      from >= 0,
+      message = s"from = $from < 0, which is daft.  Has something overflowed?"
+    )
+
     ElasticsearchQueryOptions(
       filters = worksSearchOptions.filters,
       limit = worksSearchOptions.pageSize,

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -55,12 +55,58 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
       }
 
   private def toElasticsearchQueryOptions(
-    worksSearchOptions: WorksSearchOptions): ElasticsearchQueryOptions =
+    worksSearchOptions: WorksSearchOptions): ElasticsearchQueryOptions = {
+
+    // Because we use Int for the pageSize and pageNumber, computing
+    //
+    //     from = (pageNumber - 1) * pageSize
+    //
+    // can potentially overflow and be negative or even wrap around.
+    // For example, pageNumber=2018634700 and pageSize=100 would return
+    // results if you don't handle this!
+    //
+    // If we are about to overflow, we pass the max possible int
+    // into the Elasticsearch query and let it bubble up from there.
+    // We could skip the query and throw here, because the user is almost
+    // certainly doing something wrong, but that would mean simulating an
+    // ES error or modifying our exception handling, and that seems more
+    // disruptive than just clamping the overflow.
+    //
+    // Note: the checks on "pageSize" mean we know it must be
+    // at most 100.
+
+    // How this check works:
+    //
+    //    1.  If pageNumber > MaxValue, then (pageNumber - 1) * pageSize is
+    //        probably bigger, as pageSize >= 1.
+    //
+    //    2.  Alternatively, we care about whether
+    //
+    //            pageSize * pageNumber > MaxValue
+    //
+    //        Since pageNumber is known positive, this is equivalent to
+    //
+    //            pageSize > MaxValue / pageNumber
+    //
+    //        And we know the division won't overflow because we have
+    //        pageValue < MaxValue by the first check.
+    //
+    val willOverflow =
+      (worksSearchOptions.pageNumber > Int.MaxValue) ||
+      (worksSearchOptions.pageSize > Int.MaxValue / worksSearchOptions.pageNumber)
+
+    val from = if (willOverflow) {
+      Int.MaxValue
+    } else {
+      (worksSearchOptions.pageNumber - 1) * worksSearchOptions.pageSize
+    }
+
     ElasticsearchQueryOptions(
       filters = worksSearchOptions.filters,
       limit = worksSearchOptions.pageSize,
-      from = (worksSearchOptions.pageNumber - 1) * worksSearchOptions.pageSize
+      from = from
     )
+  }
 
   private def createResultList(searchResponse: SearchResponse): ResultList =
     ResultList(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
@@ -82,7 +82,7 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
       }
 
       // https://github.com/wellcometrust/platform/issues/3233
-      it("so many pages that Elasticsearch errors out") {
+      it("so many pages that a naive (page * pageSize) would overflow") {
         assertIsBadRequest(
           s"/works?page=2000000000&pageSize=100",
           description = "Only the first 10000 works are available in the API."

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
@@ -81,6 +81,14 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
         )
       }
 
+      // https://github.com/wellcometrust/platform/issues/3233
+      it("so many pages that Elasticsearch errors out") {
+        assertIsBadRequest(
+          s"/works?page=2000000000&pageSize=100",
+          description = "Only the first 10000 works are available in the API."
+        )
+      }
+
       it("the 101th page with 100 results per page") {
         assertIsBadRequest(
           s"/works?page=101&pageSize=100",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,7 +41,7 @@ object Dependencies {
     val mockito = "1.9.5"
     val scalatest = "3.0.1"
     val junitInterface = "0.11"
-    val elastic4s = "6.4.0"
+    val elastic4s = "6.5.0"
     val circeVersion = "0.9.0"
     val scalaCheckVersion = "1.13.4"
     val scalaCheckShapelessVersion = "1.1.6"


### PR DESCRIPTION
Resolves #3233. This turned out to be two problems, with one hiding behind the other:

* Elasticsearch 6.5 (which we run in production and in our test containers) can respond with errors that our version of elastic4s can't parse as JSON. Bumping our version of elastic4s fixes that.

* We were getting an unusual error type because our (pageSize * pageNumber) calculation was overflowing, and sending a negative `"from"` parameter to Elasticsearch. This is daft – the overflow is now capped when we do this computation, with a chunky comment to explain why and an assertion to spot it if it happens again.