### PR TITLE
Point to the snapshots in the “too many works” error

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ElasticErrorHandler.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ElasticErrorHandler.scala
@@ -35,7 +35,9 @@ object ElasticErrorHandler extends Logging {
           case Some(s) =>
             val size = s.group(1)
             userError(
-              s"Only the first $size works are available in the API.",
+              s"Only the first $size works are available in the API. " +
+              "If you want more works, you can download a snapshot of the complete catalogue: " +
+              "https://developers.wellcomecollection.org/datasets",
               elasticError)
           case _ =>
             serverError(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
@@ -74,10 +74,14 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
     }
 
     describe("trying to get more works than ES allows") {
+      val description = "Only the first 10000 works are available in the API. " +
+        "If you want more works, you can download a snapshot of the complete catalogue: " +
+        "https://developers.wellcomecollection.org/datasets"
+
       it("a very large page") {
         assertIsBadRequest(
           s"/works?page=10000",
-          description = "Only the first 10000 works are available in the API."
+          description = description
         )
       }
 
@@ -85,14 +89,14 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
       it("so many pages that a naive (page * pageSize) would overflow") {
         assertIsBadRequest(
           s"/works?page=2000000000&pageSize=100",
-          description = "Only the first 10000 works are available in the API."
+          description = description
         )
       }
 
       it("the 101th page with 100 results per page") {
         assertIsBadRequest(
           s"/works?page=101&pageSize=100",
-          description = "Only the first 10000 works are available in the API."
+          description = description
         )
       }
     }


### PR DESCRIPTION
I realised while working on #3266 – if you’re using the Catalogue API and run into the “only 10,000 works are available in the API” error, there’s nothing to tell you what to do next, even though we (as in the platform team) all know about the snapshots we provide.

This updates the error message to point to the snapshots:

> Only the first $size works are available in the API. If you want more works, you can download a snapshot of the complete catalogue: https://developers.wellcomecollection.org/datasets

Including @jtweed for review as this is a public-facing API change.