### PR TITLE
Point to the snapshots in the "too many works" error

### DIFF
--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ElasticErrorHandler.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ElasticErrorHandler.scala
@@ -36,9 +36,10 @@ object ElasticErrorHandler extends Logging {
             val size = s.group(1)
             userError(
               s"Only the first $size works are available in the API. " +
-              "If you want more works, you can download a snapshot of the complete catalogue: " +
-              "https://developers.wellcomecollection.org/datasets",
-              elasticError)
+                "If you want more works, you can download a snapshot of the complete catalogue: " +
+                "https://developers.wellcomecollection.org/datasets",
+              elasticError
+            )
           case _ =>
             serverError(
               s"Unknown error in search phase execution: $reason",

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ElasticErrorHandler.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ElasticErrorHandler.scala
@@ -35,7 +35,9 @@ object ElasticErrorHandler extends Logging {
           case Some(s) =>
             val size = s.group(1)
             userError(
-              s"Only the first $size works are available in the API.",
+              s"Only the first $size works are available in the API. " +
+              "If you want more works, you can download a snapshot of the complete catalogue: " +
+              "https://developers.wellcomecollection.org/datasets",
               elasticError)
           case _ =>
             serverError(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
@@ -74,10 +74,14 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
     }
 
     describe("trying to get more works than ES allows") {
+      val description = "Only the first 10000 works are available in the API. " +
+        "If you want more works, you can download a snapshot of the complete catalogue: " +
+        "https://developers.wellcomecollection.org/datasets"
+
       it("a very large page") {
         assertIsBadRequest(
           s"/works?page=10000",
-          description = "Only the first 10000 works are available in the API."
+          description = description
         )
       }
 
@@ -85,14 +89,14 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
       it("so many pages that a naive (page * pageSize) would overflow") {
         assertIsBadRequest(
           s"/works?page=2000000000&pageSize=100",
-          description = "Only the first 10000 works are available in the API."
+          description = description
         )
       }
 
       it("the 101th page with 100 results per page") {
         assertIsBadRequest(
           s"/works?page=101&pageSize=100",
-          description = "Only the first 10000 works are available in the API."
+          description = description
         )
       }
     }


### PR DESCRIPTION
Replaces #3267.