### PR TITLE
Debug the Elasticsearch query in the API; remove unused Logging imports/extends from

### DIFF
--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/bag/ArchiveItemJobCreator.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/bag/ArchiveItemJobCreator.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.archive.archivist.bag
 import java.io.InputStream
 
 import cats.implicits._
-import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.archivist.models.errors.FileNotFoundError
 import uk.ac.wellcome.platform.archive.archivist.models.{
   ArchiveDigestItemJob,
@@ -14,7 +13,7 @@ import uk.ac.wellcome.platform.archive.archivist.zipfile.ZipFileReader
 import uk.ac.wellcome.platform.archive.common.bag.BagDigestFileCreator
 import uk.ac.wellcome.platform.archive.common.models.error.ArchiveError
 
-object ArchiveItemJobCreator extends Logging {
+object ArchiveItemJobCreator {
 
   /** Returns a list of all the items inside a bag that the manifest(s)
     * refer to.

--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveChecksumFlow.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveChecksumFlow.scala
@@ -5,7 +5,6 @@ import java.security.MessageDigest
 import akka.stream._
 import akka.stream.stage._
 import akka.util.ByteString
-import grizzled.slf4j.Logging
 
 /** This is a custom graph stage that receives a single stream of bytes in,
   * and emits two streams: the bytes for uploading to another service, and
@@ -20,8 +19,7 @@ import grizzled.slf4j.Logging
   *
   */
 class ArchiveChecksumFlow(algorithm: String)
-    extends GraphStage[FanOutShape2[ByteString, ByteString, String]]
-    with Logging {
+    extends GraphStage[FanOutShape2[ByteString, ByteString, String]] {
 
   val in = Inlet[ByteString]("DigestCalculator.in")
   val out = Outlet[ByteString]("DigestCalculator.out")

--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/NotificationMessageFlow.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/NotificationMessageFlow.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.archive.archivist.flow
+
 import akka.NotUsed
 import akka.stream.scaladsl.{Flow, Source}
 import com.amazonaws.services.sns.AmazonSNS
-import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.platform.archive.common.messaging.{
@@ -24,7 +24,7 @@ import uk.ac.wellcome.platform.archive.common.progress.models.{
   * progress service that it's done so, and emits the bag request.
   *
   */
-object NotificationMessageFlow extends Logging {
+object NotificationMessageFlow {
   def apply(progressSnsConfig: SNSConfig)(
     implicit snsClient: AmazonSNS,
     parallelism: Parallelism

--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/UploadDigestItemFlow.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/UploadDigestItemFlow.scala
@@ -5,7 +5,6 @@ import java.io.InputStream
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import com.amazonaws.services.s3.AmazonS3
-import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.archivist.models.errors.FileNotFoundError
 import uk.ac.wellcome.platform.archive.archivist.models.{
   ArchiveDigestItemJob,
@@ -29,7 +28,7 @@ import uk.ac.wellcome.platform.archive.common.models.error.ArchiveError
   *   - The checksums don't match
   *
   */
-object UploadDigestItemFlow extends Logging {
+object UploadDigestItemFlow {
   def apply(parallelism: Int)(
     implicit s3Client: AmazonS3
   ): Flow[ArchiveDigestItemJob,

--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/UploadItemFlow.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/UploadItemFlow.scala
@@ -5,7 +5,6 @@ import java.io.InputStream
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import com.amazonaws.services.s3.AmazonS3
-import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.archivist.models.errors.FileNotFoundError
 import uk.ac.wellcome.platform.archive.archivist.models.{
   ArchiveItemJob,
@@ -27,7 +26,7 @@ import uk.ac.wellcome.platform.archive.common.models.error.ArchiveError
   *   - The upload to S3 fails
   *
   */
-object UploadItemFlow extends Logging {
+object UploadItemFlow {
   def apply(parallelism: Int)(
     implicit s3Client: AmazonS3
   ): Flow[ArchiveItemJob,

--- a/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ZipFileDownloadFlow.scala
+++ b/archive/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ZipFileDownloadFlow.scala
@@ -4,7 +4,6 @@ import akka.NotUsed
 import akka.stream.scaladsl.{Flow, Source}
 import com.amazonaws.services.s3.transfer.TransferManager
 import com.amazonaws.services.sns.AmazonSNS
-import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.platform.archive.archivist.models.TypeAliases._
@@ -24,7 +23,7 @@ import scala.concurrent.ExecutionContext
   * original request on the Right.
   *
   */
-object ZipFileDownloadFlow extends Logging {
+object ZipFileDownloadFlow {
 
   def apply(snsConfig: SNSConfig)(
     implicit transferManager: TransferManager,

--- a/archive/progress_async/src/main/scala/uk/ac/wellcome/platform/archive/progress_async/flows/CallbackNotificationFlow.scala
+++ b/archive/progress_async/src/main/scala/uk/ac/wellcome/platform/archive/progress_async/flows/CallbackNotificationFlow.scala
@@ -6,7 +6,6 @@ import java.util.UUID
 import akka.NotUsed
 import akka.stream.scaladsl.{Flow, Source}
 import com.amazonaws.services.sns.AmazonSNS
-import grizzled.slf4j.Logging
 import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.platform.archive.common.messaging.SnsPublishFlow
 import uk.ac.wellcome.platform.archive.common.models.CallbackNotification
@@ -18,7 +17,7 @@ import uk.ac.wellcome.platform.archive.common.progress.models.Progress.{
   Failed
 }
 
-object CallbackNotificationFlow extends Logging {
+object CallbackNotificationFlow {
   type Publication = Flow[Progress, Unit, NotUsed]
 
   def apply(snsClient: AmazonSNS, snsConfig: SNSConfig): Publication = {

--- a/archive/registrar_async/src/main/scala/uk/ac/wellcome/platform/archive/registrar/async/factories/StorageManifestFactory.scala
+++ b/archive/registrar_async/src/main/scala/uk/ac/wellcome/platform/archive/registrar/async/factories/StorageManifestFactory.scala
@@ -5,7 +5,6 @@ import java.time.Instant
 
 import cats.implicits._
 import com.amazonaws.services.s3.AmazonS3
-import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.bag.{
   BagDigestFileCreator,
   BagInfoParser
@@ -26,7 +25,7 @@ import uk.ac.wellcome.platform.archive.common.progress.models.{
 import uk.ac.wellcome.platform.archive.registrar.common.models._
 import uk.ac.wellcome.storage.ObjectLocation
 
-object StorageManifestFactory extends Logging {
+object StorageManifestFactory {
   def create(archiveComplete: ArchiveComplete)(implicit s3Client: AmazonS3)
     : Either[ArchiveError[ArchiveComplete], StorageManifest] = {
 

--- a/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/catalogue_api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -10,6 +10,7 @@ import com.sksamuel.elastic4s.searches.queries.term.TermsQuery
 import com.sksamuel.elastic4s.searches.queries.{BoolQuery, Query}
 import com.sksamuel.elastic4s.searches.sort.{FieldSort, SortOrder}
 import com.sksamuel.elastic4s.searches.SearchRequest
+import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.api.models.{
   ItemLocationTypeFilter,
   WorkFilter,
@@ -27,7 +28,7 @@ case class ElasticsearchQueryOptions(
 @Singleton
 class ElasticsearchService @Inject()(elasticClient: ElasticClient)(
   implicit ec: ExecutionContext
-) {
+) extends Logging {
 
   def findResultById(canonicalId: String)(
     index: Index): Future[Either[ElasticError, GetResponse]] =
@@ -73,6 +74,8 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient)(
         .sortBy(sortDefinitions)
         .limit(queryOptions.limit)
         .from(queryOptions.from)
+
+    debug(s"Sending ES request: $searchRequest")
 
     elasticClient
       .execute { searchRequest }

--- a/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
+++ b/catalogue_pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.idminter.steps
 
-import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.work.internal.SourceIdentifier
 import uk.ac.wellcome.platform.idminter.database.IdentifiersDao
 import uk.ac.wellcome.platform.idminter.models.Identifier
@@ -8,7 +7,7 @@ import uk.ac.wellcome.platform.idminter.utils.Identifiable
 
 import scala.util.Try
 
-class IdentifierGenerator(identifiersDao: IdentifiersDao) extends Logging {
+class IdentifierGenerator(identifiersDao: IdentifiersDao) {
 
   def retrieveOrGenerateCanonicalId(
     identifier: SourceIdentifier

--- a/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
+++ b/catalogue_pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
@@ -1,14 +1,12 @@
 package uk.ac.wellcome.platform.matcher.storage
 
 import com.gu.scanamo.error.DynamoReadError
-import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.matcher.WorkNode
 import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkUpdate}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class WorkGraphStore(workNodeDao: WorkNodeDao)(implicit ec: ExecutionContext)
-    extends Logging {
+class WorkGraphStore(workNodeDao: WorkNodeDao)(implicit ec: ExecutionContext) {
 
   def findAffectedWorks(workUpdate: WorkUpdate): Future[WorkGraph] = {
     val directlyAffectedWorkIds = workUpdate.referencedWorkIds + workUpdate.workId

--- a/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
+++ b/catalogue_pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.merger.services
 
 import akka.Done
-import grizzled.slf4j.Logging
 import uk.ac.wellcome.Runnable
 import uk.ac.wellcome.messaging.message.MessageWriter
 import uk.ac.wellcome.messaging.sns.NotificationMessage
@@ -18,8 +17,7 @@ class MergerWorkerService(
   mergerManager: MergerManager,
   messageWriter: MessageWriter[BaseWork]
 )(implicit ec: ExecutionContext)
-    extends Logging
-    with Runnable {
+    extends Runnable {
 
   def run(): Future[Done] =
     sqsStream.foreach(this.getClass.getSimpleName, processMessage)

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.sierra_bib_merger.services
 
-import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraBibRecord
 import uk.ac.wellcome.platform.sierra_bib_merger.merger.BibMerger
@@ -18,7 +17,7 @@ class SierraBibMergerUpdaterService(
   versionedHybridStore: VersionedHybridStore[SierraTransformable,
                                              EmptyMetadata,
                                              ObjectStore[SierraTransformable]]
-) extends Logging {
+) {
 
   def update(bibRecord: SierraBibRecord): Future[VHSIndexEntry[EmptyMetadata]] =
     versionedHybridStore

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.sierra_item_merger.services
 
-import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
 import uk.ac.wellcome.platform.sierra_item_merger.exceptions.SierraItemMergerException
@@ -20,8 +19,7 @@ class SierraItemMergerUpdaterService(
   versionedHybridStore: VersionedHybridStore[SierraTransformable,
                                              EmptyMetadata,
                                              ObjectStore[SierraTransformable]]
-)(implicit ec: ExecutionContext)
-    extends Logging {
+)(implicit ec: ExecutionContext) {
 
   def update(itemRecord: SierraItemRecord)
     : Future[List[VHSIndexEntry[EmptyMetadata]]] = {

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
@@ -5,12 +5,11 @@ import java.time.{Instant, LocalDate, ZoneOffset}
 
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
-import grizzled.slf4j.Logging
 import io.circe.Json
 import io.circe.optics.JsonPath.root
 import uk.ac.wellcome.models.transformable.sierra.AbstractSierraRecord
 
-object SierraRecordWrapperFlow extends Logging {
+object SierraRecordWrapperFlow {
   def apply[T <: AbstractSierraRecord](
     createRecord: (String, String, Instant) => T): Flow[Json, T, NotUsed] =
     Flow.fromFunction({ json =>


### PR DESCRIPTION
This would have made it much easier to spot the bug in 
https://github.com/wellcometrust/platform/issues/3233 – the debug log would show we were sending a negative `"from"` parameter.

Plus removing a bunch of `extends Logging` from classes/objects that never actually log.