### PR TITLE
Correct the capitalisation of “Digital Images” as the work type on Miro records

### DIFF
--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroWorkType.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroWorkType.scala
@@ -13,6 +13,6 @@ trait MiroWorkType {
     Some(
       WorkType(
         id = "q",
-        label = "Digital images"
+        label = "Digital Images"
       ))
 }

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableTransformerTest.scala
@@ -291,10 +291,10 @@ class MiroTransformableTransformerTest
     work.items shouldBe List(Unidentifiable(Item(List(expectedLocation))))
   }
 
-  it("sets the WorkType as 'Digital images'") {
+  it("sets the WorkType as 'Digital Images'") {
     val work = transformWork(createMiroRecord)
     work.workType.isDefined shouldBe true
-    work.workType.get.label shouldBe "Digital images"
+    work.workType.get.label shouldBe "Digital Images"
   }
 
   it("sets the thumbnail with the IIIF Image URL") {

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroWorkTypeTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroWorkTypeTest.scala
@@ -3,9 +3,9 @@ package uk.ac.wellcome.platform.transformer.miro.transformers
 import org.scalatest.{FunSpec, Matchers}
 
 class MiroWorkTypeTest extends FunSpec with Matchers {
-  it("sets a WorkType of 'Digital images'") {
+  it("sets a WorkType of 'Digital Images'") {
     transformer.getWorkType.isDefined shouldBe true
-    transformer.getWorkType.get.label shouldBe "Digital images"
+    transformer.getWorkType.get.label shouldBe "Digital Images"
   }
 
   val transformer = new MiroWorkType {}


### PR DESCRIPTION
Code fix for #3287.