### PR TITLE
We don't need to wrap this HttpResponse in an option

### DIFF
--- a/storage/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/flows/CallbackUrlFlow.scala
+++ b/storage/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/flows/CallbackUrlFlow.scala
@@ -34,7 +34,7 @@ object CallbackUrlFlow extends Logging {
         case (tryHttpResponse, id) =>
           CallbackFlowResult(
             id = id,
-            httpResponse = Some(tryHttpResponse)
+            httpResponse = tryHttpResponse
           )
       }
 

--- a/storage/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/flows/PrepareNotificationFlow.scala
+++ b/storage/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/flows/PrepareNotificationFlow.scala
@@ -37,7 +37,8 @@ object PrepareNotificationFlow extends Logging {
               ProgressCallbackStatusUpdate(
                 id = id,
                 callbackStatus = Failed,
-                events = List(ProgressEvent(s"Callback failed for: $id, got $status!"))
+                events =
+                  List(ProgressEvent(s"Callback failed for: $id, got $status!"))
               )
             }
           case Failure(e) =>
@@ -46,7 +47,8 @@ object PrepareNotificationFlow extends Logging {
             ProgressCallbackStatusUpdate(
               id = id,
               callbackStatus = Failed,
-              events = List(ProgressEvent(s"Callback failed for: $id (${e.getMessage})"))
+              events = List(
+                ProgressEvent(s"Callback failed for: $id (${e.getMessage})"))
             )
         }
     }

--- a/storage/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/flows/PrepareNotificationFlow.scala
+++ b/storage/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/flows/PrepareNotificationFlow.scala
@@ -18,45 +18,37 @@ import uk.ac.wellcome.platform.archive.notifier.models.CallbackFlowResult
 import scala.util.{Failure, Success}
 
 object PrepareNotificationFlow extends Logging {
-
   def apply(): Flow[CallbackFlowResult, ProgressUpdate, NotUsed] = {
     Flow[CallbackFlowResult].map {
-      case CallbackFlowResult(
-          id,
-          Some(Success(HttpResponse(status, _, _, _)))) =>
-        if (status.isSuccess()) {
-          debug(s"Callback fulfilled for: $id")
+      case CallbackFlowResult(id, response) =>
+        response match {
+          case Success(HttpResponse(status, _, _, _)) =>
+            if (status.isSuccess()) {
+              debug(s"Callback fulfilled for: $id")
 
-          ProgressCallbackStatusUpdate(
-            id,
-            Succeeded,
-            List(ProgressEvent("Callback fulfilled.")),
-          )
-        } else {
-          debug(s"Callback failed for: $id, got $status!")
+              ProgressCallbackStatusUpdate(
+                id = id,
+                callbackStatus = Succeeded,
+                events = List(ProgressEvent("Callback fulfilled."))
+              )
+            } else {
+              debug(s"Callback failed for: $id, got $status!")
 
-          ProgressCallbackStatusUpdate(
-            id,
-            Failed,
-            List(ProgressEvent(s"Callback failed for: $id, got $status!"))
-          )
+              ProgressCallbackStatusUpdate(
+                id = id,
+                callbackStatus = Failed,
+                events = List(ProgressEvent(s"Callback failed for: $id, got $status!"))
+              )
+            }
+          case Failure(e) =>
+            error(s"Callback failed for: $id", e)
+
+            ProgressCallbackStatusUpdate(
+              id = id,
+              callbackStatus = Failed,
+              events = List(ProgressEvent(s"Callback failed for: $id (${e.getMessage})"))
+            )
         }
-      case CallbackFlowResult(id, Some(Failure(e))) =>
-        error(s"Callback failed for: $id", e)
-
-        ProgressCallbackStatusUpdate(
-          id,
-          Failed,
-          List(ProgressEvent(s"Callback failed for: $id (${e.getMessage})"))
-        )
-      case CallbackFlowResult(id, result) =>
-        error(s"Unexpected callback failure for: $id got $result")
-
-        ProgressCallbackStatusUpdate(
-          id,
-          Failed,
-          List(ProgressEvent(s"Unexpected callback failure for: $id"))
-        )
     }
   }
 }

--- a/storage/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/models/CallbackFlowResult.scala
+++ b/storage/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/models/CallbackFlowResult.scala
@@ -8,5 +8,5 @@ import scala.util.Try
 
 case class CallbackFlowResult(
   id: UUID,
-  httpResponse: Option[Try[HttpResponse]]
+  httpResponse: Try[HttpResponse]
 )

--- a/storage/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/fixtures/NotifierGenerators.scala
+++ b/storage/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/fixtures/NotifierGenerators.scala
@@ -12,12 +12,9 @@ trait NotifierGenerators extends RandomThings {
 
   def createCallbackResultWith(id: UUID = randomUUID,
                                response: HttpResponse): CallbackFlowResult =
-    CallbackFlowResult(id, Some(Success(response)))
+    CallbackFlowResult(id, httpResponse = Success(response))
 
   def createFailedCallbackResultWith(id: UUID = randomUUID,
                                      exception: Throwable): CallbackFlowResult =
-    CallbackFlowResult(id, Some(Failure(exception)))
-
-  def createEmptyCallbackResultWith(id: UUID = randomUUID): CallbackFlowResult =
-    CallbackFlowResult(id, None)
+    CallbackFlowResult(id, httpResponse = Failure(exception))
 }

--- a/storage/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/flows/PrepareNotificationFlowTest.scala
+++ b/storage/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/flows/PrepareNotificationFlowTest.scala
@@ -144,31 +144,5 @@ class PrepareNotificationFlowTest
         }
       }
     }
-
-    it("returns a failed ProgressUpdate when a callback returns nothing") {
-      withMaterializer { implicit materializer =>
-        val id = UUID.fromString("12f251b8-c4a9-4afa-85de-c34ec3ed71fe")
-        val callbackResult = createEmptyCallbackResultWith(id = id)
-
-        val eventualResult =
-          Source
-            .single(callbackResult)
-            .via(PrepareNotificationFlow())
-            .runWith(Sink.seq)
-
-        whenReady(eventualResult) { result =>
-          inside(result.head) {
-            case ProgressCallbackStatusUpdate(
-                actualId,
-                callbackStatus,
-                List(progressEvent)) =>
-              actualId shouldBe id
-              progressEvent.description shouldBe "Unexpected callback failure for: 12f251b8-c4a9-4afa-85de-c34ec3ed71fe"
-              callbackStatus shouldBe Callback.Failed
-              assertRecent(progressEvent.createdDate)
-          }
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
Possibly we did once, but we never set it to anything except a Some(…) value, so we can ditch the Option entirely and simplify this bit of the code.

Spotted on a code read – I might have missed somewhere we set this to `None`, but it's a small app so I think this is okay?