### PR TITLE
Use moar generators for Subject and Production

### DIFF
--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
@@ -2,9 +2,10 @@ package uk.ac.wellcome.platform.api.works.v2
 
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
+import uk.ac.wellcome.models.work.generators.ProductionEventGenerators
 import uk.ac.wellcome.models.work.internal._
 
-class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
+class ApiV2WorksIncludesTest extends ApiV2WorksTestBase with ProductionEventGenerators {
   it(
     "includes a list of identifiers on a list endpoint if we pass ?include=identifiers") {
     withV2Api {
@@ -325,18 +326,8 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
       case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
-        val productionEvents1 = List(
-          ProductionEvent(
-            List(Place("London")),
-            List(Unidentifiable(Person("Bumblebee"))),
-            List(Period("1984")),
-            None))
-        val productionEvents2 = List(
-          ProductionEvent(
-            List(Place("Madrid")),
-            List(Unidentifiable(Person("Bumblebee"))),
-            List(Period("1984")),
-            None))
+        val productionEvents1 = createProductionEventList(count = 1)
+        val productionEvents2 = createProductionEventList(count = 2)
         val work0 = works(0).copy(production = productionEvents1)
         val work1 = works(1).copy(production = productionEvents2)
 
@@ -374,13 +365,9 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase {
     "includes a list of production on a single work endpoint if we pass ?include=production") {
     withV2Api {
       case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
-        val productionEvent = List(
-          ProductionEvent(
-            List(Place("London")),
-            List(Unidentifiable(Person("Bumblebee"))),
-            List(Period("1984")),
-            None))
-        val work = createIdentifiedWork.copy(production = productionEvent)
+        val work = createIdentifiedWorkWith(
+          production = createProductionEventList(count = 1)
+        )
 
         insertIntoElasticsearch(indexV2, work)
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
@@ -2,10 +2,13 @@ package uk.ac.wellcome.platform.api.works.v2
 
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
-import uk.ac.wellcome.models.work.generators.ProductionEventGenerators
+import uk.ac.wellcome.models.work.generators.{
+  ProductionEventGenerators,
+  SubjectGenerators
+}
 import uk.ac.wellcome.models.work.internal._
 
-class ApiV2WorksIncludesTest extends ApiV2WorksTestBase with ProductionEventGenerators {
+class ApiV2WorksIncludesTest extends ApiV2WorksTestBase with ProductionEventGenerators with SubjectGenerators {
   it(
     "includes a list of identifiers on a list endpoint if we pass ?include=identifiers") {
     withV2Api {
@@ -114,10 +117,8 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase with ProductionEventGene
       case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
-        val subjects1 = List(
-          Subject("ornithology", List(Unidentifiable(Concept("ornithology")))))
-        val subjects2 = List(
-          Subject("flying cars", List(Unidentifiable(Concept("flying cars")))))
+        val subjects1 = List(createSubject)
+        val subjects2 = List(createSubject)
         val work0 = works(0).copy(subjects = subjects1)
         val work1 = works(1).copy(subjects = subjects2)
 
@@ -155,8 +156,7 @@ class ApiV2WorksIncludesTest extends ApiV2WorksTestBase with ProductionEventGene
     "includes a list of subjects on a single work endpoint if we pass ?include=subjects") {
     withV2Api {
       case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
-        val subject = List(
-          Subject("ornithology", List(Unidentifiable(Concept("ornithology")))))
+        val subject = List(createSubject)
         val work = createIdentifiedWork.copy(subjects = subject)
 
         insertIntoElasticsearch(indexV2, work)

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1SerialisationTest.scala
@@ -148,8 +148,8 @@ class DisplayWorkV1SerialisationTest
 
     val workWithSubjects = createIdentifiedWorkWith(
       subjects = List(
-        Subject("label", List(concept0)),
-        Subject("label", List(concept1))
+        createSubjectWith(concepts = List(concept0)),
+        createSubjectWith(concepts = List(concept1)),
       )
     )
 

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -2,10 +2,10 @@ package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models._
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.{ProductionEventGenerators, WorksGenerators}
 import uk.ac.wellcome.models.work.internal._
 
-class DisplayWorkV1Test extends FunSpec with Matchers with WorksGenerators {
+class DisplayWorkV1Test extends FunSpec with Matchers with ProductionEventGenerators with WorksGenerators {
 
   it("parses a Work without any items") {
     val work = createIdentifiedWorkWith(
@@ -198,14 +198,7 @@ class DisplayWorkV1Test extends FunSpec with Matchers with WorksGenerators {
 
   it("errors if you try to convert a work with non-empty production field") {
     val work = createIdentifiedWorkWith(
-      production = List(
-        ProductionEvent(
-          places = List(),
-          agents = List(),
-          dates = List(),
-          function = Some(Concept("Manufacture"))
-        )
-      )
+      production = createProductionEventList()
     )
 
     val caught = intercept[IllegalArgumentException] {

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v1/DisplayWorkV1Test.scala
@@ -2,10 +2,19 @@ package uk.ac.wellcome.display.models.v1
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.display.models._
-import uk.ac.wellcome.models.work.generators.{ProductionEventGenerators, WorksGenerators}
+import uk.ac.wellcome.models.work.generators.{
+  ProductionEventGenerators,
+  SubjectGenerators,
+  WorksGenerators
+}
 import uk.ac.wellcome.models.work.internal._
 
-class DisplayWorkV1Test extends FunSpec with Matchers with ProductionEventGenerators with WorksGenerators {
+class DisplayWorkV1Test
+  extends FunSpec
+    with Matchers
+    with ProductionEventGenerators
+    with SubjectGenerators
+    with WorksGenerators {
 
   it("parses a Work without any items") {
     val work = createIdentifiedWorkWith(
@@ -167,17 +176,15 @@ class DisplayWorkV1Test extends FunSpec with Matchers with ProductionEventGenera
       Concept("a second generic concept")
     )
 
-    val subjects = List[Subject[Displayable[AbstractConcept]]](
-      Subject(
-        label = "a subject created by DisplayWorkV1Test",
+    val subjects = List(
+      createSubjectWith(
         concepts = List(
           Unidentifiable(concepts(0)),
           Unidentifiable(concepts(1)),
           Unidentifiable(concepts(2))
         )
       ),
-      Subject(
-        label = "a second subject created for DisplayWorkV1Test",
+      createSubjectWith(
         concepts = List(
           Unidentifiable(concepts(3))
         )

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayProductionEventTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayProductionEventTest.scala
@@ -1,9 +1,10 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.generators.ProductionEventGenerators
 import uk.ac.wellcome.models.work.internal._
 
-class DisplayProductionEventTest extends FunSpec with Matchers {
+class DisplayProductionEventTest extends FunSpec with Matchers with ProductionEventGenerators {
   it("serialises a DisplayProductionEvent from a ProductionEvent") {
     val productionEvent = ProductionEvent(
       places = List(Place("London")),

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplaySubjectV2SerialisationTest.scala
@@ -3,14 +3,15 @@ package uk.ac.wellcome.display.models.v2
 import org.scalatest.FunSpec
 import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
-import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
+import uk.ac.wellcome.models.work.generators.{IdentifiersGenerators, SubjectGenerators}
 import uk.ac.wellcome.models.work.internal._
 
 class DisplaySubjectV2SerialisationTest
     extends FunSpec
     with DisplayV2SerialisationTestBase
     with JsonMapperTestUtil
-    with IdentifiersGenerators {
+    with IdentifiersGenerators
+    with SubjectGenerators {
 
   it("serialises a DisplaySubject constructed from a Subject") {
     val concept0 = Unidentifiable(Concept("conceptLabel"))
@@ -23,8 +24,7 @@ class DisplaySubjectV2SerialisationTest
       agent = Place("placeLabel")
     )
 
-    val subject = Subject(
-      label = "subjectLabel",
+    val subject = createSubjectWith(
       concepts = List(concept0, concept1, concept2)
     )
 
@@ -57,8 +57,7 @@ class DisplaySubjectV2SerialisationTest
 
   it("serialises a DisplaySubject from a Subject with a Person concept") {
     val person = Person("Dolly Parton")
-    val subject = Subject(
-      label = "subjectLabel",
+    val subject = createSubjectWith(
       concepts = List(Unidentifiable(person))
     )
     assertObjectMapsToJson(
@@ -79,8 +78,7 @@ class DisplaySubjectV2SerialisationTest
 
   it("serialises a DisplaySubject from a Subject with a Agent concept") {
     val agent = Agent("Dolly Parton")
-    val subject = Subject(
-      label = "subjectLabel",
+    val subject = createSubjectWith(
       concepts = List(Unidentifiable(agent))
     )
     assertObjectMapsToJson(
@@ -101,8 +99,7 @@ class DisplaySubjectV2SerialisationTest
 
   it("serialises a DisplaySubject from a Subject with a Organisation concept") {
     val organisation = Organisation("Dolly Parton")
-    val subject = Subject(
-      label = "subjectLabel",
+    val subject = createSubjectWith(
       concepts = List(Unidentifiable(organisation))
     )
     assertObjectMapsToJson(

--- a/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/sbt_common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -4,13 +4,14 @@ import org.scalatest.FunSpec
 import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.display.models.V2WorksIncludes
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.{SubjectGenerators, WorksGenerators}
 import uk.ac.wellcome.models.work.internal._
 
 class DisplayWorkV2SerialisationTest
     extends FunSpec
     with DisplayV2SerialisationTestBase
     with JsonMapperTestUtil
+    with SubjectGenerators
     with WorksGenerators {
 
   it("serialises a DisplayWorkV2") {
@@ -124,10 +125,7 @@ class DisplayWorkV2SerialisationTest
   it(
     "includes subject information in DisplayWorkV2 serialisation with the subjects include") {
     val workWithSubjects = createIdentifiedWorkWith(
-      subjects = List(
-        Subject("label", List(Unidentifiable(Concept("fish")))),
-        Subject("label", List(Unidentifiable(Concept("gardening"))))
-      )
+      subjects = createSubjectList()
     )
 
     val expectedJson = s"""{

--- a/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexTest.scala
+++ b/sbt_common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexTest.scala
@@ -14,13 +14,8 @@ import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.json.JsonUtil._
 import org.scalacheck.ScalacheckShapeless._
 import uk.ac.wellcome.json.utils.JsonAssertions
-import uk.ac.wellcome.models.work.generators.WorksGenerators
-import uk.ac.wellcome.models.work.internal.{
-  IdentifiedBaseWork,
-  Person,
-  Subject,
-  Unidentifiable
-}
+import uk.ac.wellcome.models.work.generators.{SubjectGenerators, WorksGenerators}
+import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, Person, Subject, Unidentifiable}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -33,6 +28,7 @@ class WorksIndexTest
     with Matchers
     with JsonAssertions
     with PropertyChecks
+    with SubjectGenerators
     with WorksGenerators {
 
   // On failure, scalacheck tries to shrink to the smallest input that causes a failure.
@@ -51,20 +47,21 @@ class WorksIndexTest
 
   // Possibly because the number of variations in the work model is too big,
   // a bug in the mapping related to person subjects wasn't caught by the above test.
-  // So let's add a specific one
+  // So let's add a specific one.
+  // https://github.com/wellcometrust/platform/pull/2544
   it("puts a work with a person subject") {
     withLocalWorksIndex { index =>
       val sampleWork = createIdentifiedWorkWith(
         subjects = List(
-          Subject(
-            label = "Daredevil",
+          createSubjectWith(
             concepts = List(
               Unidentifiable(
                 Person(
                   label = "Daredevil",
                   prefix = Some("Superhero"),
                   numeration = Some("I")
-                ))
+                )
+              )
             )
           )
         )

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/generators/RandomStrings.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/generators/RandomStrings.scala
@@ -1,0 +1,8 @@
+package uk.ac.wellcome.models.generators
+
+import scala.util.Random
+
+trait RandomStrings {
+  def randomAlphanumeric(length: Int): String =
+    (Random.alphanumeric take length mkString) toLowerCase
+}

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
@@ -1,13 +1,9 @@
 package uk.ac.wellcome.models.work.generators
 
+import uk.ac.wellcome.models.generators.RandomStrings
 import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier}
 
-import scala.util.Random
-
-trait IdentifiersGenerators {
-  def randomAlphanumeric(length: Int): String =
-    (Random.alphanumeric take length mkString) toLowerCase
-
+trait IdentifiersGenerators extends RandomStrings {
   def createCanonicalId: String = randomAlphanumeric(length = 10)
 
   def createSourceIdentifier: SourceIdentifier = createSourceIdentifierWith()

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ProductionEventGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ProductionEventGenerators.scala
@@ -1,0 +1,20 @@
+package uk.ac.wellcome.models.work.generators
+
+import uk.ac.wellcome.models.generators.RandomStrings
+import uk.ac.wellcome.models.work.internal._
+
+trait ProductionEventGenerators extends RandomStrings {
+  def createProductionEventWith(function: Option[Concept] = None): ProductionEvent[Displayable[AbstractAgent]] =
+    ProductionEvent(
+      places = List(Place(randomAlphanumeric(10))),
+      agents = List(Unidentifiable(Person(randomAlphanumeric(10)))),
+      dates = List(Period(randomAlphanumeric(5))),
+      function = function
+    )
+
+  def createProductionEvent(): ProductionEvent[Displayable[AbstractAgent]] =
+    createProductionEventWith()
+
+  def createProductionEventList(count: Int = 1): List[ProductionEvent[Displayable[AbstractAgent]]] =
+    (1 to count).map { _ => createProductionEvent() }.toList
+}

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/SubjectGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/SubjectGenerators.scala
@@ -1,0 +1,22 @@
+package uk.ac.wellcome.models.work.generators
+
+import uk.ac.wellcome.models.generators.RandomStrings
+import uk.ac.wellcome.models.work.internal._
+
+trait SubjectGenerators extends RandomStrings {
+  def createSubjectWith(
+    concepts: List[Displayable[AbstractRootConcept]] = createConcepts
+  ): Subject[Displayable[AbstractRootConcept]] =
+    Subject(
+      label = randomAlphanumeric(10),
+      concepts = concepts
+    )
+
+  def createSubject: Subject[Displayable[AbstractRootConcept]] =
+    createSubjectWith()
+
+  private def createConcepts: List[Displayable[AbstractRootConcept]] =
+    (1 to 3)
+      .map { _ => Unidentifiable(Concept(randomAlphanumeric(15))) }
+      .asInstanceOf[List[Displayable[AbstractRootConcept]]]
+}

--- a/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/SubjectGenerators.scala
+++ b/sbt_common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/SubjectGenerators.scala
@@ -15,6 +15,9 @@ trait SubjectGenerators extends RandomStrings {
   def createSubject: Subject[Displayable[AbstractRootConcept]] =
     createSubjectWith()
 
+  def createSubjectList(count: Int = 3): List[Subject[Displayable[AbstractRootConcept]]] =
+    (1 to count).map { _ => createSubject }.toList
+
   private def createConcepts: List[Displayable[AbstractRootConcept]] =
     (1 to 3)
       .map { _ => Unidentifiable(Concept(randomAlphanumeric(15))) }


### PR DESCRIPTION
A bit of refactoring in anticipation of #3264 and #3265. Nothing too different, but lays the ground for useful changes later and should help reduce the diffs on those patches.