### PR TITLE
Append subfield t to MARC tags 600 and 700

### DIFF
--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAgents.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAgents.scala
@@ -101,7 +101,7 @@ trait SierraAgents {
     }
   }
 
-  private def getLabel(subfields: List[MarcSubfield]): Option[String] =
+  def getLabel(subfields: List[MarcSubfield]): Option[String] =
     // Extract the label from subfield $a.  This is a non-repeatable
     // field in the MARC spec, but we have seen records where it
     // doesn't appear.  In that case, we discard the entire agent.

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributors.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributors.scala
@@ -59,8 +59,8 @@ trait SierraContributors extends MarcUtils with SierraAgents {
       }
   }
 
-  private def getMarcTag700Contributors(
-    bibData: SierraBibData): List[Contributor[MaybeDisplayable[AbstractAgent]]] = {
+  private def getMarcTag700Contributors(bibData: SierraBibData)
+    : List[Contributor[MaybeDisplayable[AbstractAgent]]] = {
     val agents = getMatchingSubfields(
       bibData,
       marcTag = "700",
@@ -72,14 +72,19 @@ trait SierraContributors extends MarcUtils with SierraAgents {
         val roles = getContributionRoles(subfields)
         val hasSubfieldT = subfields.exists { _.tag == "t" }
 
-        val maybeAgent: Option[MaybeDisplayable[AbstractAgent]] = if (hasSubfieldT) {
-          getLabel(subfields)
-            .map { Agent(_) }
-            .map { agent => identify(subfields, agent, "Agent") }
-        } else {
-          getPerson(subfields, normalisePerson = true)
-            .map { person => identify(subfields, person, "Person") }
-        }
+        val maybeAgent: Option[MaybeDisplayable[AbstractAgent]] =
+          if (hasSubfieldT) {
+            getLabel(subfields)
+              .map { Agent(_) }
+              .map { agent =>
+                identify(subfields, agent, "Agent")
+              }
+          } else {
+            getPerson(subfields, normalisePerson = true)
+              .map { person =>
+                identify(subfields, person, "Person")
+              }
+          }
 
         maybeAgent.map { agent =>
           Contributor(

--- a/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjects.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjects.scala
@@ -17,8 +17,11 @@ trait SierraPersonSubjects extends MarcUtils with SierraAgents {
   //
   // Use MARC field "600" where the second indicator is not 7.
   //
-  // Within this MARC tag we have one concept (the Person), and we also use
-  // the contents of subfield $x (general subdivision) as other Concepts.
+  // The concepts come from:
+  //
+  //    - The person
+  //    - The contents of subfields $t and $x (title and general subdivision),
+  //      both as Concepts
   //
   // The label is constructed concatenating subfields $a, $b, $c, $d, $e,
   // where $d and $e represent the person's dates and roles respectively.
@@ -57,10 +60,9 @@ trait SierraPersonSubjects extends MarcUtils with SierraAgents {
 
   private def getPersonSubjectLabel(person: Person,
                                     roles: List[String],
-                                    dates: Option[String]) = {
+                                    dates: Option[String]): String =
     (List(person.label) ++ person.numeration ++ person.prefix ++ dates ++ roles)
       .mkString(" ")
-  }
 
   private def getConcepts(
     person: Person,
@@ -69,7 +71,10 @@ trait SierraPersonSubjects extends MarcUtils with SierraAgents {
 
     val generalSubdivisionConcepts =
       varField.subfields
-        .collect { case MarcSubfield("x", content) => content }
+        .collect {
+          case MarcSubfield("t", content) => content
+          case MarcSubfield("x", content) => content
+        }
         .map { label =>
           Unidentifiable(Concept(label))
         }

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributorsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributorsTest.scala
@@ -414,6 +414,29 @@ class SierraContributorsTest
         varFields = varFields,
         expectedContributors = expectedContributors)
     }
+
+    it("returns an Agent if MARC tag 700 has a subfield t") {
+      val name = "William Shakespeare"
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "700",
+          subfields = List(
+            MarcSubfield(tag = "a", content = name),
+            MarcSubfield(tag = "t", content = "Hamlet")
+          )
+        )
+      )
+
+      val expectedContributors = List(
+        Contributor(
+          agent = Unidentifiable(Agent(label = name))
+        )
+      )
+
+      transformAndCheckContributors(
+        varFields = varFields,
+        expectedContributors = expectedContributors)
+    }
   }
 
   describe("Organisation") {

--- a/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
@@ -249,4 +249,27 @@ class SierraPersonSubjectsTest
       Unidentifiable(Concept("Hamlet"))
     )
   }
+
+  it("includes the contents of subfield t in the concepts") {
+    // Based on https://search.wellcomelibrary.org/iii/encore/record/C__Rb1190271?marcData=Y
+    // as retrieved 22 January 2019.
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "600",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "Aristophanes"),
+            MarcSubfield(tag = "t", content = "Birds")
+          )
+        )
+      )
+    )
+
+    val subjects = transformer.getSubjectsWithPerson(bibData)
+    subjects should have size 1
+    subjects.head.concepts shouldBe List(
+      Unidentifiable(Person("Aristophanes")),
+      Unidentifiable(Concept("Birds"))
+    )
+  }
 }


### PR DESCRIPTION
Strictly:

- MARC 600: Add the contents of subfield t as a new `Concept` to the subject on our Work
- MARC 700: If subfield t is present, create an `Agent` instead of a `Person`

Tagging @jtweed to double-check I got 700 right.

For #3262.