### PR TITLE
MiroTransformable doesn't exist any more, so don't name classes after it

### DIFF
--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
@@ -32,7 +32,7 @@ object Main extends WellcomeTypesafeApp {
 
     new MiroTransformerWorkerService(
       vhsRecordReceiver = vhsRecordReceiver,
-      miroTransformer = new MiroTransformableTransformer,
+      miroTransformer = new MiroRecordTransformer,
       sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config)
     )
   }

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 
 import scala.util.Try
 
-class MiroTransformableTransformer
+class MiroRecordTransformer
     extends transformers.MiroContributors
     with transformers.MiroCreatedDate
     with transformers.MiroItems

--- a/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerService.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerService.scala
@@ -5,13 +5,13 @@ import uk.ac.wellcome.Runnable
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
-import uk.ac.wellcome.platform.transformer.miro.MiroTransformableTransformer
+import uk.ac.wellcome.platform.transformer.miro.MiroRecordTransformer
 
 import scala.concurrent.Future
 
 class MiroTransformerWorkerService(
   vhsRecordReceiver: MiroVHSRecordReceiver,
-  miroTransformer: MiroTransformableTransformer,
+  miroTransformer: MiroRecordTransformer,
   sqsStream: SQSStream[NotificationMessage]
 ) extends Runnable {
 

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformerFeatureTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformerFeatureTest.scala
@@ -129,7 +129,7 @@ class MiroTransformerFeatureTest
         withSQSStream[NotificationMessage, R](queue) { sqsStream =>
           val workerService = new MiroTransformerWorkerService(
             vhsRecordReceiver = recordReceiver,
-            miroTransformer = new MiroTransformableTransformer,
+            miroTransformer = new MiroRecordTransformer,
             sqsStream = sqsStream
           )
 

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerContributorsTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerContributorsTest.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.models.work.internal.{Agent, Contributor, Unidentifiable}
 import uk.ac.wellcome.platform.transformer.miro.generators.MiroRecordGenerators
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 
-class MiroTransformableTransformerContributorsTest
+class MiroRecordTransformerContributorsTest
     extends FunSpec
     with MiroRecordGenerators
     with MiroTransformableWrapper {

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerCopyrightTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerCopyrightTest.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.models.work.internal.DigitalLocation
 import uk.ac.wellcome.platform.transformer.miro.generators.MiroRecordGenerators
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 
-class MiroTransformableTransformerCopyrightTest
+class MiroRecordTransformerCopyrightTest
     extends FunSpec
     with Matchers
     with MiroRecordGenerators

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerTest.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.platform.transformer.miro.generators.MiroRecordGenerators
 import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 
-class MiroTransformableTransformerTest
+class MiroRecordTransformerTest
     extends FunSpec
     with Matchers
     with IdentifiersGenerators

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerTitleAndDescriptionTest.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerTitleAndDescriptionTest.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
   *  The rules around this heuristic are somewhat fiddly, and we need to be
   *  careful that we're extracting the right fields from the Miro metadata.
   */
-class MiroTransformableTransformerTitleAndDescriptionTest
+class MiroRecordTransformerTitleAndDescriptionTest
     extends FunSpec
     with Matchers
     with MiroRecordGenerators

--- a/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
+++ b/catalogue_pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.models.work.internal.{
   TransformedBaseWork,
   UnidentifiedWork
 }
-import uk.ac.wellcome.platform.transformer.miro.MiroTransformableTransformer
+import uk.ac.wellcome.platform.transformer.miro.MiroRecordTransformer
 import uk.ac.wellcome.platform.transformer.miro.exceptions.MiroTransformerException
 import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
@@ -13,7 +13,7 @@ import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 import scala.util.Try
 
 trait MiroTransformableWrapper extends Matchers { this: Suite =>
-  val transformer = new MiroTransformableTransformer
+  val transformer = new MiroRecordTransformer
 
   def transformWork(miroRecord: MiroRecord): UnidentifiedWork = {
     val triedWork: Try[TransformedBaseWork] =


### PR DESCRIPTION
Resolves #3348.