### PR TITLE
Push our shared build tooling into a separate repo, away from Make

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build-tooling"]
+	path = build-tooling
+	url = git@github.com:wellcometrust/platform-build-tooling.git

--- a/README.md
+++ b/README.md
@@ -56,3 +56,13 @@ To reduce build times in the main repo, we've pushed out some of our libraries i
 [monitoring]: https://github.com/wellcometrust/scala-monitoring
 [storage]: https://github.com/wellcometrust/scala-storage
 [sierra]: https://techdocs.iii.com/sierraapi/Default.htm
+
+## Getting started
+
+Some of our shared code is brought into the project using Git submodules.
+Once you have a clone of the repo, you can set up the submodules as follows:
+
+```console
+$ git submodule init
+$ git submodule update
+```

--- a/makefiles/terraform.Makefile
+++ b/makefiles/terraform.Makefile
@@ -43,15 +43,7 @@ endif
 #
 define terraform_plan
 	make uptodate-git
-	$(ROOT)/docker_run.py --aws -- \
-		--volume $(ROOT):$(ROOT) \
-		--workdir $(ROOT)/$(1) \
-		--env OP=plan \
-		--env GET_TFVARS=true \
-		--env BUCKET_NAME=$(TFVARS_BUCKET) \
-		--env OBJECT_KEY=$(TFVARS_KEY) \
-		--env IS_PUBLIC_FACING=$(2) \
-		$(TERRAFORM_WRAPPER_IMAGE)
+	python $(ROOT)/build-tooling/terraform_plan.py $(1) --profile=platform-admin
 endef
 
 


### PR DESCRIPTION
I've pushed a script into a new repo: https://github.com/wellcometrust/platform-build-tooling

And then included it in the main repo as a Git submodule. I think this should give us an easier way to share code (or at least consolidate it; we have different versions split over our repos now).

It also means we can get away from Make for our build tooling, which is really starting to creak under the size of the project.

Thoughts?