### PR TITLE
refactor into a single all-powerful b number generator

### DIFF
--- a/storage/bagger/src/local_bag_all.py
+++ b/storage/bagger/src/local_bag_all.py
@@ -24,7 +24,7 @@ import time
 import logging
 import bagger_processor
 import aws
-from mets_filesource import b_numbers_from_s3
+from mets_filesource import bnumber_generator
 
 
 def main():
@@ -47,13 +47,6 @@ def main():
         time_taken = time.time() - start
         print("----------------")
         print("{0} items in {1} seconds.".format(counter, time_taken))
-
-
-def bnumber_generator(filter_expression):
-    if filter_expression.startswith("b"):
-        return (b for b in [filter_expression])
-    else:
-        return b_numbers_from_s3(filter_expression)
 
 
 if __name__ == "__main__":

--- a/storage/bagger/src/local_enqueue.py
+++ b/storage/bagger/src/local_enqueue.py
@@ -24,7 +24,7 @@ import sys
 import time
 import logging
 import aws
-from mets_filesource import b_numbers_from_s3
+from mets_filesource import bnumber_generator
 
 
 def main():
@@ -40,12 +40,8 @@ def main():
             info = "METS only"
         start = time.time()
         counter = 0
-        if to_process.startswith("b"):
-            generator = (b for b in [to_process])
-        else:
-            generator = b_numbers_from_s3(to_process)
 
-        for b_number in generator:
+        for b_number in bnumber_generator(to_process):
             counter = counter + 1
             logging.info("processing " + b_number)
             message = {"identifier": b_number, "do_not_bag": skip}

--- a/storage/bagger/src/mets_filesource.py
+++ b/storage/bagger/src/mets_filesource.py
@@ -1,6 +1,7 @@
 import os
 import re
 import settings
+from pathlib import Path
 from s3_keys import get_matching_s3_keys
 
 # Unlike the DDS implementation of this, only get b numbers that are correctly arranged
@@ -45,3 +46,15 @@ def b_numbers_from_s3(filter=""):
         m = b_number_pattern.match(key)
         if m:
             yield m.group(1)
+
+
+def bnumber_generator(filter_expression):
+    source_list = Path(filter_expression)
+    if source_list.is_file():
+        with open(filter_expression) as f:
+            bnumbers = f.readlines()
+        return [b.strip() for b in bnumbers if not b.strip() == ""]
+    elif filter_expression.startswith("b"):
+        return (b for b in [filter_expression])
+    else:
+        return b_numbers_from_s3(filter_expression)

--- a/storage/bagger/src/mets_publish.py
+++ b/storage/bagger/src/mets_publish.py
@@ -26,7 +26,7 @@ import time
 import boto3
 import os
 import json
-from mets_filesource import b_numbers_from_fileshare, b_numbers_from_s3
+from mets_filesource import b_numbers_from_fileshare, bnumber_generator
 
 
 def main():
@@ -54,16 +54,10 @@ def main():
         publish_from_s3(filter)
 
 
-def process_filter(filter):
-    if filter[0] == "b":
-        yield filter
-    return b_numbers_from_s3(filter)
-
-
 def publish_from_s3(filter):
     start = time.time()
     counter = 1
-    for b in process_filter(filter):
+    for b in bnumber_generator(filter):
         print("{0: <6} | {1}".format(counter, b))
         counter = counter + 1
         publish(b)

--- a/storage/bagger/src/mets_queuer.py
+++ b/storage/bagger/src/mets_queuer.py
@@ -23,7 +23,7 @@ The spread of b numbers is fairly even:
 
 import sys
 import time
-from mets_filesource import b_numbers_from_fileshare, b_numbers_from_s3
+from mets_filesource import b_numbers_from_fileshare, bnumber_generator
 
 
 def main():
@@ -39,7 +39,7 @@ def main():
 def print_from_s3(filter):
     start = time.time()
     counter = 1
-    for b in b_numbers_from_s3(filter):
+    for b in bnumber_generator(filter):
         print("{0: <6} | {1}".format(counter, b))
         counter = counter + 1
     end = time.time()

--- a/storage/bagger/src/migration_tools.py
+++ b/storage/bagger/src/migration_tools.py
@@ -8,8 +8,7 @@ import requests
 import json
 import storage_api
 import dds
-from pathlib import Path
-from mets_filesource import b_numbers_from_s3
+from mets_filesource import bnumber_generator
 from status_table import get_table
 
 
@@ -22,8 +21,8 @@ class MigrationTool(object):
     def populate_initial(self, filter=""):
         populate_initial(filter)
 
-    def update_status(self, delay, filter=""):
-        update_bag_and_ingest_status(delay, filter)
+    def update_status(self, delay, filter="", check_package=False, check_alto=False):
+        update_bag_and_ingest_status(delay, filter, check_package, check_alto)
 
     def ingest(self, delay, filter=""):
         do_ingest(delay, filter)
@@ -55,7 +54,7 @@ def get_min_bag_date():
     return min_bag_date
 
 
-def update_bag_and_ingest_status(delay, filter):
+def update_bag_and_ingest_status(delay, filter, check_package, check_alto):
     table = get_table()
     no_ingest = {
         "id": "-",
@@ -67,7 +66,7 @@ def update_bag_and_ingest_status(delay, filter):
 
     for bnumber in bnumber_generator(filter):
         try:
-            output = update_bag_and_ingest_status_bnumber(bnumber, table, no_ingest)
+            output = update_bag_and_ingest_status_bnumber(bnumber, table, no_ingest, check_package, check_alto)
         except Exception as e:
             err_obj = {"ERROR": bnumber, "error": e}
             print(err_obj)
@@ -80,11 +79,12 @@ def update_bag_and_ingest_status(delay, filter):
     print("]")
 
 
-def update_bag_and_ingest_status_bnumber(bnumber, table, no_ingest):
+def update_bag_and_ingest_status_bnumber(bnumber, table, no_ingest, check_package, check_alto):
     bag_date = "-"
     bag_size = 0
     bag_error = "-"
     package_date = "-"
+    dds_package_date = None
 
     # check for bag
     bag_zip = aws.get_dropped_bag_info(bnumber)
@@ -102,9 +102,10 @@ def update_bag_and_ingest_status_bnumber(bnumber, table, no_ingest):
     if ingest is None:
         ingest = no_ingest
 
-    dds_package_date = dds.get_package_file_modified(bnumber)
-    if dds_package_date is not None:
-        package_date = dds_package_date
+    if check_package:
+        dds_package_date = dds.get_package_file_modified(bnumber)
+        if dds_package_date is not None:
+            package_date = dds_package_date
 
     table.update_item(
         Key={"bnumber": bnumber},
@@ -127,18 +128,6 @@ def update_bag_and_ingest_status_bnumber(bnumber, table, no_ingest):
         "ingest": ingest,
         "dds_package_date": dds_package_date,
     }
-
-
-def bnumber_generator(filter_expression):
-    source_list = Path(filter_expression)
-    if source_list.is_file():
-        with open(filter_expression) as f:
-            bnumbers = f.readlines()
-        return [b.strip() for b in bnumbers if not b.strip() == ""]
-    elif filter_expression.startswith("b"):
-        return (b for b in [filter_expression])
-    else:
-        return b_numbers_from_s3(filter_expression)
 
 
 def batch(bnumbers):

--- a/storage/bagger/src/migration_tools.py
+++ b/storage/bagger/src/migration_tools.py
@@ -66,7 +66,9 @@ def update_bag_and_ingest_status(delay, filter, check_package, check_alto):
 
     for bnumber in bnumber_generator(filter):
         try:
-            output = update_bag_and_ingest_status_bnumber(bnumber, table, no_ingest, check_package, check_alto)
+            output = update_bag_and_ingest_status_bnumber(
+                bnumber, table, no_ingest, check_package, check_alto
+            )
         except Exception as e:
             err_obj = {"ERROR": bnumber, "error": e}
             print(err_obj)
@@ -79,7 +81,9 @@ def update_bag_and_ingest_status(delay, filter, check_package, check_alto):
     print("]")
 
 
-def update_bag_and_ingest_status_bnumber(bnumber, table, no_ingest, check_package, check_alto):
+def update_bag_and_ingest_status_bnumber(
+    bnumber, table, no_ingest, check_package, check_alto
+):
     bag_date = "-"
     bag_size = 0
     bag_error = "-"


### PR DESCRIPTION
### What is this PR trying to achieve?

Minor refactoring to avoid duplicate code
All migration python tools can now take a filter expression which is either:
 - a b number
 - a filter of b numbers (e.g., 1/2/3)
 - a path to a file containing a list of b numbers (one per line)

### Who is this change for?

Migrators