### PR TITLE
Ensure all b numbers are in migration table

### DIFF
--- a/storage/bagger/src/migration_tools.py
+++ b/storage/bagger/src/migration_tools.py
@@ -28,6 +28,23 @@ class MigrationTool(object):
     def simulate_goobi_call(self, delay, filter=""):
         call_dds(delay, filter)
 
+    def ensure_population(self, filter=""):
+        populate_table(filter)
+
+
+def populate_table(filter):
+    # no dynamo batch upsert, unforch...
+    counter = 0
+    start = time.time()
+    for bnumber in bnumber_generator(filter):
+        counter = counter + 1
+        if counter % 100 == 0:
+            t = int(round(time.time() - start))
+            print("...{0} b numbers registered after {1} seconds..".format(counter, t))
+        status_table.record_activity(bnumber, "registered")
+    t = int(round(time.time() - start))
+    print("Registered {0} b numbers for filter {1} in {2} s".format(counter, filter, t))
+
 
 def get_min_bag_date():
     min_bag_date = datetime.datetime(2018, 12, 1)

--- a/storage/bagger/src/status_table.py
+++ b/storage/bagger/src/status_table.py
@@ -14,7 +14,7 @@ def record_activity(bnumber, field):
 
 
 def activity_timestamp():
-    datetime.datetime.now().isoformat()
+    return datetime.datetime.now().isoformat()
 
 
 def record_data(bnumber, data):

--- a/storage/bagger/src/storage_api.py
+++ b/storage/bagger/src/storage_api.py
@@ -48,13 +48,18 @@ def get_oauthed_json(url, scope, method="GET", data=None):
     return resp.json()
 
 
+def get_ingest_scope():
+    return settings.WELLCOME_API_SCOPE or settings.STORAGE_API_INGESTS
+
+
 def get_ingest_for_identifier(bnumber):
-    scope = settings.STORAGE_API_INGESTS
-    url = "{0}/find-by-bag-id/digitised:{1}".format(scope, bnumber)
+    base_url = settings.STORAGE_API_INGESTS
+    scope = get_ingest_scope()
+    url = "{0}/find-by-bag-id/digitised:{1}".format(base_url, bnumber)
     ingests = get_oauthed_json(url, scope)
     by_date = sorted(ingests, key=lambda ingest: ingest["createdDate"])
     if len(by_date) > 0:
-        url = "{0}/{1}".format(scope, by_date[-1]["id"])
+        url = "{0}/{1}".format(base_url, by_date[-1]["id"])
         return get_oauthed_json(url, scope)
     return None
 
@@ -64,5 +69,5 @@ def ingest(bnumber):
     body = deepcopy(ingest_template)
     body["sourceLocation"]["path"] = bnumber + ".zip"
     url = settings.STORAGE_API_INGESTS
-    scope = settings.WELLCOME_API_SCOPE
-    return get_oauthed_json(url or scope, scope, method="POST", data=json.dumps(body))
+    scope = get_ingest_scope()
+    return get_oauthed_json(url, scope, method="POST", data=json.dumps(body))

--- a/travistooling/tests/test_decisionmaker.py
+++ b/travistooling/tests/test_decisionmaker.py
@@ -260,13 +260,13 @@ test_cases = [
         "storage/archivist/src/main/resources/application.conf",
         "api-test",
         InsignificantFile,
-        False
+        False,
     ),
     (
         "storage/archivist/src/main/resources/application.conf",
         "archivist-test",
         SignificantFile,
-        True
+        True,
     ),
 ]
 


### PR DESCRIPTION
### What is this PR trying to achieve?
Gives the migration report the full scale of the task ahead, by registering a Dynamo item for all b numbers (without overwriting existing ones)

### Who is this change for?
Migration report viewers
