### PR TITLE
Fix sqs parallelism config

### DIFF
--- a/sbt_common/config/messaging/src/main/scala/uk/ac/wellcome/config/messaging/builders/SQSBuilder.scala
+++ b/sbt_common/config/messaging/src/main/scala/uk/ac/wellcome/config/messaging/builders/SQSBuilder.scala
@@ -14,7 +14,8 @@ object SQSBuilder extends AWSClientConfigBuilder {
     val queueUrl = config
       .required[String](s"aws.$namespace.sqs.queue.url")
     val parallelism = config
-      .getOrElse[String](s"aws.$namespace.sqs.queue.parallelism")(default = "10")
+      .getOrElse[String](s"aws.$namespace.sqs.queue.parallelism")(
+        default = "10")
     // TODO: revisit to support default and config.getInt, cannot cast String to Integer here
     SQSConfig(
       queueUrl = queueUrl,

--- a/sbt_common/config/messaging/src/main/scala/uk/ac/wellcome/config/messaging/builders/SQSBuilder.scala
+++ b/sbt_common/config/messaging/src/main/scala/uk/ac/wellcome/config/messaging/builders/SQSBuilder.scala
@@ -14,11 +14,11 @@ object SQSBuilder extends AWSClientConfigBuilder {
     val queueUrl = config
       .required[String](s"aws.$namespace.sqs.queue.url")
     val parallelism = config
-      .getOrElse[Int](s"aws.$namespace.sqs.queue.parallelism")(default = 10)
-
+      .getOrElse[String](s"aws.$namespace.sqs.queue.parallelism")(default = "10")
+    // TODO: revisit to support default and config.getInt, cannot cast String to Integer here
     SQSConfig(
       queueUrl = queueUrl,
-      parallelism = parallelism
+      parallelism = Integer.parseInt(parallelism)
     )
   }
 

--- a/storage/archivist/src/main/resources/application.conf
+++ b/storage/archivist/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 aws.sqs.queue.url=${?queue_url}
-aws.next.sns.topic.arn=${?registrar_topic_arn}
+aws.next.sns.topic.arn=${?next_service_topic_arn}
 aws.sqs.queue.parallelism=${?queue_parallelism}
 aws.progress.sns.topic.arn=${?progress_topic_arn}
 upload.namespace=${?archive_bucket}


### PR DESCRIPTION
### What is this PR trying to achieve?

This is a tactical fix to get our typesafe config to parse Integers.  `EnrichConfig` complicates this a bit because it supports defaults and lenient path interpolation which are used here so we can't just drop in a native typesafe config `getInt`.

It needs fixing properly, I suggest using native typesafe config and drop defaults and lenient path parsing, but that is too large a change for now.

