### PR TITLE
Get the destination BagLocation from BagStorage

### DIFF
--- a/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicator.scala
+++ b/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicator.scala
@@ -24,10 +24,7 @@ import uk.ac.wellcome.platform.archive.bagreplicator.models.errors.{
   NotificationParsingFailed
 }
 import uk.ac.wellcome.platform.archive.bagreplicator.models.messages._
-import uk.ac.wellcome.platform.archive.bagreplicator.storage.{
-  BagStorage,
-  S3Copier
-}
+import uk.ac.wellcome.platform.archive.bagreplicator.storage.BagStorage
 import uk.ac.wellcome.platform.archive.common.flows.SupervisedMaterializer
 import uk.ac.wellcome.platform.archive.common.messaging.MessageStream
 import uk.ac.wellcome.platform.archive.common.models.ArchiveComplete
@@ -54,16 +51,20 @@ class BagReplicator(
     implicit val materializer: ActorMaterializer =
       SupervisedMaterializer.resumable
 
-    implicit val s3client: AmazonS3 = s3Client
     implicit val amazonSNS: AmazonSNS = snsClient
-    implicit val ex: ExecutionContext = actorSystem.dispatcher
-    implicit val s3Copier: S3Copier = new S3Copier(s3client)
+    implicit val ec: ExecutionContext = actorSystem.dispatcher
+
+    val bagStorage = new BagStorage(s3Client = s3Client)
 
     val flow = Flow[NotificationMessage]
       .log("received notification message")
       .map(parseReplicateBagMessage)
       .mapAsync(bagReplicatorConfig.parallelism)(
-        duplicateBagItems(bagReplicatorConfig.destination))
+        duplicateBagItems(
+          bagStorage = bagStorage,
+          storageDestination = bagReplicatorConfig.destination
+        )
+      )
       .map(notifyOutgoingTopic(outgoingSnsConfig))
       .map(notifyProgress(progressSnsConfig))
       .log("completed")
@@ -84,16 +85,15 @@ class BagReplicator(
   }
 
   private def duplicateBagItems(
+    bagStorage: BagStorage,
     storageDestination: ReplicatorDestinationConfig)(
     in: Either[BagReplicationError, BagReplicationRequest])(
-    implicit s3Client: AmazonS3,
-    s3Copier: S3Copier,
-    ex: ExecutionContext)
+    implicit ec: ExecutionContext)
     : Future[Either[BagReplicationError, CompletedBagReplication]] = {
     in.fold(
       left => Future(Left(left)),
       bagReplicationRequest =>
-        BagStorage
+        bagStorage
           .duplicateBag(
             bagReplicationRequest.sourceBagLocation,
             storageDestination)

--- a/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicator.scala
+++ b/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicator.scala
@@ -57,7 +57,7 @@ class BagReplicator(
     implicit val s3client: AmazonS3 = s3Client
     implicit val amazonSNS: AmazonSNS = snsClient
     implicit val ex: ExecutionContext = actorSystem.dispatcher
-    implicit val s3Copier: S3Copier = new S3Copier()
+    implicit val s3Copier: S3Copier = new S3Copier(s3client)
 
     val flow = Flow[NotificationMessage]
       .log("received notification message")

--- a/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
+++ b/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
@@ -105,12 +105,12 @@ class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends Logg
     val destinationBagLocation = sourceBagItemLocation.bagLocation.copy(
       storagePrefix = storageDestination.rootPath
     )
-    val destinationBagItem = sourceBagItemLocation.copy(
+    val destinationBagItemLocation = sourceBagItemLocation.copy(
       bagLocation = destinationBagLocation
     )
 
     val destinationNamespace = storageDestination.namespace
-    val destinationItemKey = destinationBagItem.completePath
+    val destinationItemKey = destinationBagItemLocation.completePath
 
     debug(
       List(
@@ -121,10 +121,8 @@ class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends Logg
     )
 
     s3Copier.copy(
-      sourceNamespace,
-      sourceItemKey,
-      destinationNamespace,
-      destinationItemKey
+      src = sourceBagItemLocation.objectLocation,
+      dst = destinationBagItemLocation.objectLocation
     )
   }
 }

--- a/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
+++ b/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
@@ -14,15 +14,14 @@ import uk.ac.wellcome.platform.archive.common.models.bagit.{
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
-object BagStorage extends Logging {
+class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends Logging {
+
+  val s3Copier = new S3Copier(s3Client)
 
   def duplicateBag(
     sourceBagLocation: BagLocation,
     storageDestination: ReplicatorDestinationConfig
-  )(implicit
-    s3Client: AmazonS3,
-    s3Copier: S3Copier,
-    ctx: ExecutionContext): Future[List[CopyResult]] = {
+  ): Future[List[CopyResult]] = {
     debug(
       List(
         s"duplicating bag from",
@@ -43,12 +42,7 @@ object BagStorage extends Logging {
     } yield copyResults
   }
 
-  private def listObjects(
-    s3Client: AmazonS3,
-    bagLocation: BagLocation
-  )(implicit
-    ctx: ExecutionContext): Future[ObjectListing] = Future {
-
+  private def listObjects(bagLocation: BagLocation): Future[ObjectListing] = Future {
     val absolutePathInStorage = bagLocation.completePath
       .replaceAll("(.*[^/]+)/*", "$1/")
 
@@ -61,15 +55,14 @@ object BagStorage extends Logging {
   private def getItemInPath(
     summary: S3ObjectSummary,
     prefix: String
-  ) =
+  ): String =
     summary.getKey
       .stripPrefix(prefix)
 
   private def getObjectSummaries(
     listing: ObjectListing,
     bagLocation: BagLocation
-  )(implicit
-    ctx: ExecutionContext): Future[List[BagItemLocation]] = Future {
+  ): Future[List[BagItemLocation]] = Future {
     val prefix = s"${bagLocation.completePath}/"
 
     listing.getObjectSummaries.asScala
@@ -85,16 +78,14 @@ object BagStorage extends Logging {
 
   private def listBagItems(
     location: BagLocation
-  )(implicit
-    s3Client: AmazonS3,
-    ctx: ExecutionContext): Future[List[BagItemLocation]] = {
+  ): Future[List[BagItemLocation]] = {
     // TODO: limit size of the returned List
     // use Marker to paginate(?)
     // needs care if bag contents can change during copy.
     debug(s"listing items in $location")
 
     for {
-      listing <- listObjects(s3Client, location)
+      listing <- listObjects(location)
       summaries <- getObjectSummaries(listing, location)
     } yield summaries
   }
@@ -102,9 +93,7 @@ object BagStorage extends Logging {
   private def duplicateBagItems(
     sourceBagItems: List[BagItemLocation],
     storageDestination: ReplicatorDestinationConfig
-  )(implicit
-    s3Copier: S3Copier,
-    ctx: ExecutionContext): Future[List[CopyResult]] = {
+  ): Future[List[CopyResult]] = {
     debug(s"duplicating bag items: $sourceBagItems")
 
     Future.sequence(
@@ -117,9 +106,7 @@ object BagStorage extends Logging {
   private def duplicateBagItem(
     sourceBagItemLocation: BagItemLocation,
     storageDestination: ReplicatorDestinationConfig
-  )(implicit
-    s3Copier: S3Copier,
-    ctx: ExecutionContext): Future[CopyResult] = {
+  ): Future[CopyResult] = {
 
     val sourceNamespace = sourceBagItemLocation.bagLocation.storageNamespace
     val sourceItemKey = sourceBagItemLocation.completePath

--- a/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
+++ b/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
@@ -22,19 +22,10 @@ class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends Logg
     sourceBagLocation: BagLocation,
     storageDestination: ReplicatorDestinationConfig
   ): Future[List[CopyResult]] = {
-    debug(
-      List(
-        s"duplicating bag from",
-        sourceBagLocation.toString,
-        s"to $storageDestination"
-      ).mkString(" ")
-    )
+    debug(s"duplicating bag from $sourceBagLocation to $storageDestination")
 
     for {
-      sourceBagItems <- listBagItems(
-        sourceBagLocation
-      )
-
+      sourceBagItems <- listBagItems(sourceBagLocation)
       copyResults <- duplicateBagItems(
         sourceBagItems,
         storageDestination

--- a/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
+++ b/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
@@ -25,6 +25,7 @@ class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends Logg
     debug(s"duplicating bag from $sourceBagLocation to $storageDestination")
 
     val dstBagLocation = sourceBagLocation.copy(
+      storageNamespace = storageDestination.namespace,
       storagePrefix = storageDestination.rootPath
     )
 

--- a/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
+++ b/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
@@ -20,7 +20,7 @@ class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends Logg
   def duplicateBag(
     sourceBagLocation: BagLocation,
     storageDestination: ReplicatorDestinationConfig
-  ): Future[List[BagItemLocation]] = {
+  ): Future[BagLocation] = {
     debug(s"duplicating bag from $sourceBagLocation to $storageDestination")
 
     val dstBagLocation = sourceBagLocation.copy(
@@ -34,7 +34,7 @@ class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends Logg
         sourceBagItems = sourceBagItems,
         dstBagLocation = dstBagLocation
       )
-    } yield copyResults
+    } yield dstBagLocation
   }
 
   private def listObjects(bagLocation: BagLocation): Future[ObjectListing] = Future {

--- a/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
+++ b/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
@@ -13,7 +13,8 @@ import uk.ac.wellcome.platform.archive.common.models.bagit.{
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
-class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends Logging {
+class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext)
+    extends Logging {
 
   val s3Copier = new S3Copier(s3Client)
 
@@ -37,15 +38,16 @@ class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends Logg
     } yield dstBagLocation
   }
 
-  private def listObjects(bagLocation: BagLocation): Future[ObjectListing] = Future {
-    val absolutePathInStorage = bagLocation.completePath
-      .replaceAll("(.*[^/]+)/*", "$1/")
+  private def listObjects(bagLocation: BagLocation): Future[ObjectListing] =
+    Future {
+      val absolutePathInStorage = bagLocation.completePath
+        .replaceAll("(.*[^/]+)/*", "$1/")
 
-    s3Client.listObjects(
-      bagLocation.storageNamespace,
-      absolutePathInStorage
-    )
-  }
+      s3Client.listObjects(
+        bagLocation.storageNamespace,
+        absolutePathInStorage
+      )
+    }
 
   private def getItemInPath(
     summary: S3ObjectSummary,
@@ -102,7 +104,9 @@ class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends Logg
           dst = dstBagItemLocation.objectLocation
         )
 
-        future.map { _ => dstBagItemLocation }
+        future.map { _ =>
+          dstBagItemLocation
+        }
       }
     )
   }

--- a/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
+++ b/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
@@ -98,26 +98,11 @@ class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends Logg
     sourceBagItemLocation: BagItemLocation,
     storageDestination: ReplicatorDestinationConfig
   ): Future[CopyResult] = {
-
-    val sourceNamespace = sourceBagItemLocation.bagLocation.storageNamespace
-    val sourceItemKey = sourceBagItemLocation.completePath
-
     val destinationBagLocation = sourceBagItemLocation.bagLocation.copy(
       storagePrefix = storageDestination.rootPath
     )
     val destinationBagItemLocation = sourceBagItemLocation.copy(
       bagLocation = destinationBagLocation
-    )
-
-    val destinationNamespace = storageDestination.namespace
-    val destinationItemKey = destinationBagItemLocation.completePath
-
-    debug(
-      List(
-        "duplicating bag item",
-        s"$sourceNamespace/$sourceItemKey",
-        s"-> $destinationNamespace/$destinationItemKey"
-      ).mkString(" ")
     )
 
     s3Copier.copy(

--- a/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3Copier.scala
+++ b/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3Copier.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.archive.bagreplicator.storage
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.transfer.model.CopyResult
 import grizzled.slf4j.Logging
+import uk.ac.wellcome.storage.ObjectLocation
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -15,18 +16,16 @@ class S3Copier(s3Client: AmazonS3) extends Logging {
     .build // Fixed thread pool
 
   def copy(
-    sourceNamespace: String,
-    sourceItemKey: String,
-    destinationNamespace: String,
-    destinationItemKey: String
+    src: ObjectLocation,
+    dst: ObjectLocation
   )(implicit
-    ctx: ExecutionContext): Future[CopyResult] = Future {
+    ec: ExecutionContext): Future[CopyResult] = Future {
 
     val copyTransfer = transferManager.copy(
-      sourceNamespace,
-      sourceItemKey,
-      destinationNamespace,
-      destinationItemKey
+      src.namespace,
+      src.key,
+      dst.namespace,
+      dst.key
     )
 
     copyTransfer.waitForCopyResult()

--- a/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3Copier.scala
+++ b/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3Copier.scala
@@ -20,6 +20,7 @@ class S3Copier(s3Client: AmazonS3) extends Logging {
     dst: ObjectLocation
   )(implicit
     ec: ExecutionContext): Future[CopyResult] = Future {
+    debug(s"Copying ${s3Uri(src)} -> ${s3Uri(dst)}")
 
     val copyTransfer = transferManager.copy(
       src.namespace,
@@ -30,4 +31,7 @@ class S3Copier(s3Client: AmazonS3) extends Logging {
 
     copyTransfer.waitForCopyResult()
   }
+
+  private def s3Uri(objectLocation: ObjectLocation): String =
+    s"s3://${objectLocation.namespace}/${objectLocation.key}"
 }

--- a/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3Copier.scala
+++ b/storage/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3Copier.scala
@@ -6,7 +6,7 @@ import grizzled.slf4j.Logging
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class S3Copier(implicit s3Client: AmazonS3) extends Logging {
+class S3Copier(s3Client: AmazonS3) extends Logging {
 
   import com.amazonaws.services.s3.transfer.TransferManagerBuilder
 
@@ -30,11 +30,5 @@ class S3Copier(implicit s3Client: AmazonS3) extends Logging {
     )
 
     copyTransfer.waitForCopyResult()
-  }
-}
-
-object S3Copier {
-  def apply()(implicit s3Client: AmazonS3) = {
-    new S3Copier()
   }
 }

--- a/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagStorageTest.scala
+++ b/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagStorageTest.scala
@@ -5,15 +5,13 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
 import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.BagReplicatorFixtures
-import uk.ac.wellcome.platform.archive.bagreplicator.storage.{
-  BagStorage,
-  S3Copier
-}
+import uk.ac.wellcome.platform.archive.bagreplicator.storage.BagStorage
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
 import uk.ac.wellcome.platform.archive.common.models.bagit.{
   BagLocation,
   ExternalIdentifier
 }
+import uk.ac.wellcome.test.fixtures.TestWith
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -27,33 +25,30 @@ class BagStorageTest
     with BagReplicatorFixtures {
 
   it("should duplicate a bag into a given location") {
-
     withLocalS3Bucket { sourceBucket =>
       withLocalS3Bucket { destinationBucket =>
         withBag(
           storageBucket = sourceBucket,
           bagInfo = randomBagInfo
         ) { bagLocation: BagLocation =>
-          // TODO: Move these implicits to the top level
-          implicit val _s3Client = s3Client
-          implicit val _s3Copier = new S3Copier(s3Client)
-
-          val destinationLocation = ReplicatorDestinationConfig(
-            namespace = destinationBucket.name,
-            rootPath = randomAlphanumeric()
-          )
-
-          val result: Future[List[CopyResult]] =
-            BagStorage.duplicateBag(
-              sourceBagLocation = bagLocation,
-              storageDestination = destinationLocation
+          withBagStorage { bagStorage =>
+            val destinationLocation = ReplicatorDestinationConfig(
+              namespace = destinationBucket.name,
+              rootPath = randomAlphanumeric()
             )
 
-          whenReady(result) { _ =>
-            verifyBagCopied(
-              sourceLocation = bagLocation,
-              storageDestination = destinationLocation
-            )
+            val result: Future[List[CopyResult]] =
+              bagStorage.duplicateBag(
+                sourceBagLocation = bagLocation,
+                storageDestination = destinationLocation
+              )
+
+            whenReady(result) { _ =>
+              verifyBagCopied(
+                sourceLocation = bagLocation,
+                storageDestination = destinationLocation
+              )
+            }
           }
         }
       }
@@ -76,30 +71,34 @@ class BagStorageTest
                 externalIdentifier = ExternalIdentifier("prefix_suffix")
               )
             ) { _ =>
-              implicit val _s3Client = s3Client
-              implicit val _s3Copier = new S3Copier(s3Client)
-
-              val destinationLocation = ReplicatorDestinationConfig(
-                namespace = destinationBucket.name,
-                rootPath = randomAlphanumeric()
-              )
-
-              val result: Future[List[CopyResult]] =
-                BagStorage.duplicateBag(
-                  sourceBagLocation = bagLocation,
-                  storageDestination = destinationLocation
+              withBagStorage { bagStorage =>
+                val destinationLocation = ReplicatorDestinationConfig(
+                  namespace = destinationBucket.name,
+                  rootPath = randomAlphanumeric()
                 )
 
-              whenReady(result) { _ =>
-                verifyBagCopied(
-                  sourceLocation = bagLocation,
-                  storageDestination = destinationLocation
-                )
+                val result: Future[List[CopyResult]] =
+                  bagStorage.duplicateBag(
+                    sourceBagLocation = bagLocation,
+                    storageDestination = destinationLocation
+                  )
+
+                whenReady(result) { _ =>
+                  verifyBagCopied(
+                    sourceLocation = bagLocation,
+                    storageDestination = destinationLocation
+                  )
+                }
               }
             }
           }
         }
       }
     }
+  }
+
+  private def withBagStorage[R](testWith: TestWith[BagStorage, R]): R = {
+    val bagStorage = new BagStorage(s3Client = s3Client)
+    testWith(bagStorage)
   }
 }

--- a/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagStorageTest.scala
+++ b/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagStorageTest.scala
@@ -123,7 +123,8 @@ class BagStorageTest
     destinationKeyEtags should contain theSameElementsAs sourceKeyEtags
   }
 
-  private def getObjectSummaries(bagLocation: BagLocation): List[S3ObjectSummary] =
+  private def getObjectSummaries(
+    bagLocation: BagLocation): List[S3ObjectSummary] =
     s3Client
       .listObjects(bagLocation.storageNamespace, bagLocation.completePath)
       .getObjectSummaries

--- a/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagStorageTest.scala
+++ b/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagStorageTest.scala
@@ -36,7 +36,7 @@ class BagStorageTest
         ) { bagLocation: BagLocation =>
           // TODO: Move these implicits to the top level
           implicit val _s3Client = s3Client
-          implicit val _s3Copier = S3Copier()
+          implicit val _s3Copier = new S3Copier(s3Client)
 
           val destinationLocation = ReplicatorDestinationConfig(
             namespace = destinationBucket.name,
@@ -62,7 +62,6 @@ class BagStorageTest
 
   describe("when other bags have the same prefix") {
     it("should duplicate a bag into a given location") {
-
       withLocalS3Bucket { sourceBucket =>
         withLocalS3Bucket { destinationBucket =>
           withBag(
@@ -78,7 +77,7 @@ class BagStorageTest
               )
             ) { _ =>
               implicit val _s3Client = s3Client
-              implicit val _s3Copier = S3Copier()
+              implicit val _s3Copier = new S3Copier(s3Client)
 
               val destinationLocation = ReplicatorDestinationConfig(
                 namespace = destinationBucket.name,

--- a/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagStorageTest.scala
+++ b/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagStorageTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
 import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.BagReplicatorFixtures
 import uk.ac.wellcome.platform.archive.bagreplicator.storage.BagStorage
-import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
+import uk.ac.wellcome.platform.archive.common.generators.BagInfoGenerators
 import uk.ac.wellcome.platform.archive.common.models.bagit.{
   BagLocation,
   ExternalIdentifier
@@ -20,8 +20,8 @@ class BagStorageTest
     extends FunSpec
     with Matchers
     with ScalaFutures
-    with RandomThings
     with IntegrationPatience
+    with BagInfoGenerators
     with BagReplicatorFixtures {
 
   val bagStorage = new BagStorage(s3Client = s3Client)
@@ -77,11 +77,11 @@ class BagStorageTest
 
   describe("when other bags have the same prefix") {
     it("should duplicate a bag into a given location") {
-      val bagInfo1 = randomBagInfo.copy(
+      val bagInfo1 = createBagInfoWith(
         externalIdentifier = ExternalIdentifier("prefix")
       )
 
-      val bagInfo2 = randomBagInfo.copy(
+      val bagInfo2 = createBagInfoWith(
         externalIdentifier = ExternalIdentifier("prefix_suffix")
       )
 

--- a/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagStorageTest.scala
+++ b/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagStorageTest.scala
@@ -1,17 +1,19 @@
 package uk.ac.wellcome.platform.archive.bagreplicator
 
-import com.amazonaws.services.s3.transfer.model.CopyResult
+import com.amazonaws.services.s3.model.S3ObjectSummary
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
 import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.BagReplicatorFixtures
 import uk.ac.wellcome.platform.archive.bagreplicator.storage.BagStorage
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
 import uk.ac.wellcome.platform.archive.common.models.bagit.{
+  BagItemLocation,
   BagLocation,
   ExternalIdentifier
 }
 
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -33,15 +35,16 @@ class BagStorageTest
           rootPath = randomAlphanumeric()
         )
 
-        val result = bagStorage.duplicateBag(
+        val result: Future[List[BagItemLocation]] = bagStorage.duplicateBag(
           sourceBagLocation = bagLocation,
           storageDestination = destinationConfig
         )
 
-        whenReady(result) { _ =>
+        whenReady(result) { itemLocations =>
           verifyBagCopied(
             sourceLocation = bagLocation,
-            storageDestination = destinationConfig
+            storageDestination = destinationConfig,
+            expectedItemLocations = itemLocations
           )
         }
       }
@@ -52,21 +55,22 @@ class BagStorageTest
     withLocalS3Bucket { sourceBucket =>
       withLocalS3Bucket { destinationBucket =>
         withBag(sourceBucket) { bagLocation =>
-          val destinationLocation = ReplicatorDestinationConfig(
+          val destinationConfig = ReplicatorDestinationConfig(
             namespace = destinationBucket.name,
             rootPath = randomAlphanumeric()
           )
 
-          val result: Future[List[CopyResult]] =
+          val result: Future[List[BagItemLocation]] =
             bagStorage.duplicateBag(
               sourceBagLocation = bagLocation,
-              storageDestination = destinationLocation
+              storageDestination = destinationConfig
             )
 
-          whenReady(result) { _ =>
+          whenReady(result) { itemLocations =>
             verifyBagCopied(
               sourceLocation = bagLocation,
-              storageDestination = destinationLocation
+              storageDestination = destinationConfig,
+              expectedItemLocations = itemLocations
             )
           }
         }
@@ -90,21 +94,22 @@ class BagStorageTest
                 externalIdentifier = ExternalIdentifier("prefix_suffix")
               )
             ) { _ =>
-              val destinationLocation = ReplicatorDestinationConfig(
+              val destinationConfig = ReplicatorDestinationConfig(
                 namespace = destinationBucket.name,
                 rootPath = randomAlphanumeric()
               )
 
-              val result: Future[List[CopyResult]] =
+              val result: Future[List[BagItemLocation]] =
                 bagStorage.duplicateBag(
                   sourceBagLocation = bagLocation,
-                  storageDestination = destinationLocation
+                  storageDestination = destinationConfig
                 )
 
-              whenReady(result) { _ =>
+              whenReady(result) { itemLocations =>
                 verifyBagCopied(
                   sourceLocation = bagLocation,
-                  storageDestination = destinationLocation
+                  storageDestination = destinationConfig,
+                  expectedItemLocations = itemLocations
                 )
               }
             }
@@ -113,4 +118,34 @@ class BagStorageTest
       }
     }
   }
+
+  def verifyBagCopied(
+    sourceLocation: BagLocation,
+    storageDestination: ReplicatorDestinationConfig,
+    expectedItemLocations: List[BagItemLocation]
+  ): Assertion = {
+    val sourceItems = getObjectSummaries(
+      namespace = sourceLocation.storageNamespace,
+      prefix = sourceLocation.completePath
+    )
+
+    val sourceKeyEtags = sourceItems.map { _.getETag }
+
+    val destinationItems = getObjectSummaries(
+      namespace = storageDestination.namespace,
+      prefix = storageDestination.rootPath
+    )
+
+    destinationItems.map { _.getKey } shouldBe expectedItemLocations.map { _.completePath }
+
+    val destinationKeyEtags = destinationItems.map { _.getETag }
+    destinationKeyEtags should contain theSameElementsAs sourceKeyEtags
+  }
+
+  private def getObjectSummaries(namespace: String, prefix: String): List[S3ObjectSummary] =
+    s3Client
+      .listObjects(namespace, prefix)
+      .getObjectSummaries
+      .asScala
+      .toList
 }

--- a/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.archive.bagreplicator.fixtures
 
 import java.util.UUID
 
-import org.scalatest.Assertion
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.Messaging
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
@@ -27,8 +26,6 @@ import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import uk.ac.wellcome.test.fixtures.{Akka, TestWith}
 
-import scala.collection.JavaConverters._
-
 trait BagReplicatorFixtures
     extends S3
     with RandomThings
@@ -36,33 +33,6 @@ trait BagReplicatorFixtures
     with Akka
     with BagLocationFixtures
     with ArchiveMessaging {
-
-  def verifyBagCopied(
-    sourceLocation: BagLocation,
-    storageDestination: ReplicatorDestinationConfig
-  ): Assertion = {
-    val sourceItems = s3Client.listObjects(
-      sourceLocation.storageNamespace,
-      sourceLocation.completePath)
-
-    val sourceKeyEtags =
-      sourceItems.getObjectSummaries.asScala.toList.map(_.getETag)
-
-//    val bagPath = List(
-//      storageDestination.rootPath,
-//      sourceLocation.bagPath
-//    ).mkString("/")
-
-    val destinationItems = s3Client.listObjects(
-      storageDestination.namespace,
-      storageDestination.rootPath
-    )
-
-    val destinationKeyEtags =
-      destinationItems.getObjectSummaries.asScala.toList.map(_.getETag)
-
-    destinationKeyEtags should contain theSameElementsAs sourceKeyEtags
-  }
 
   def withBagNotification[R](
     queuePair: QueuePair,

--- a/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -54,7 +54,8 @@ trait BagReplicatorFixtures
 //    ).mkString("/")
 
     val destinationItems = s3Client.listObjects(
-      storageDestination.namespace
+      storageDestination.namespace,
+      storageDestination.rootPath
     )
 
     val destinationKeyEtags =

--- a/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3CopierTest.scala
+++ b/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3CopierTest.scala
@@ -1,0 +1,84 @@
+package uk.ac.wellcome.platform.archive.bagreplicator.storage
+
+import com.amazonaws.services.s3.model.PutObjectResult
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{Assertion, FunSpec, Matchers}
+import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
+import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.fixtures.S3
+import uk.ac.wellcome.test.fixtures.TestWith
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class S3CopierTest extends FunSpec with Matchers with ScalaFutures with RandomThings with S3 {
+  it("copies a file inside a bucket") {
+    withLocalS3Bucket { bucket =>
+      val src = ObjectLocation(
+        namespace = bucket.name,
+        key = "123.txt"
+      )
+
+      val dst = ObjectLocation(
+        namespace = bucket.name,
+        key = "456.txt"
+      )
+
+      createObject(src)
+      listKeysInBucket(bucket) shouldBe List(src.key)
+
+      withS3Copier { s3Copier =>
+        val future = s3Copier.copy(src = src, dst = dst)
+
+        whenReady(future) { _ =>
+          listKeysInBucket(bucket) shouldBe List(src.key, dst.key)
+          assertEqualObjects(src, dst)
+        }
+      }
+    }
+  }
+
+  it("copies a file across different buckets") {
+    withLocalS3Bucket { srcBucket =>
+      val src = ObjectLocation(
+        namespace = srcBucket.name,
+        key = "123.txt"
+      )
+
+      withLocalS3Bucket { dstBucket =>
+        val dst = ObjectLocation(
+          namespace = dstBucket.name,
+          key = "456.txt"
+        )
+
+        createObject(src)
+        listKeysInBucket(srcBucket) shouldBe List(src.key)
+        listKeysInBucket(dstBucket) shouldBe List()
+
+        withS3Copier { s3Copier =>
+          val future = s3Copier.copy(src = src, dst = dst)
+
+          whenReady(future) { _ =>
+            listKeysInBucket(srcBucket) shouldBe List(src.key)
+            listKeysInBucket(dstBucket) shouldBe List(dst.key)
+            assertEqualObjects(src, dst)
+          }
+        }
+      }
+    }
+  }
+
+  private def withS3Copier[R](testWith: TestWith[S3Copier, R]): R = {
+    val s3Copier = new S3Copier(s3Client)
+    testWith(s3Copier)
+  }
+
+  private def createObject(location: ObjectLocation): PutObjectResult =
+    s3Client.putObject(
+      location.namespace,
+      location.key,
+      randomAlphanumeric()
+    )
+
+  private def assertEqualObjects(x: ObjectLocation, y: ObjectLocation): Assertion =
+    getContentFromS3(x) shouldBe getContentFromS3(y)
+}

--- a/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3CopierTest.scala
+++ b/storage/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3CopierTest.scala
@@ -10,7 +10,12 @@ import uk.ac.wellcome.test.fixtures.TestWith
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class S3CopierTest extends FunSpec with Matchers with ScalaFutures with RandomThings with S3 {
+class S3CopierTest
+    extends FunSpec
+    with Matchers
+    with ScalaFutures
+    with RandomThings
+    with S3 {
   it("copies a file inside a bucket") {
     withLocalS3Bucket { bucket =>
       val src = ObjectLocation(
@@ -79,6 +84,7 @@ class S3CopierTest extends FunSpec with Matchers with ScalaFutures with RandomTh
       randomAlphanumeric()
     )
 
-  private def assertEqualObjects(x: ObjectLocation, y: ObjectLocation): Assertion =
+  private def assertEqualObjects(x: ObjectLocation,
+                                 y: ObjectLocation): Assertion =
     getContentFromS3(x) shouldBe getContentFromS3(y)
 }

--- a/storage/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagLocationFixtures.scala
+++ b/storage/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagLocationFixtures.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.test.fixtures.TestWith
 
 trait BagLocationFixtures extends S3 with BagIt {
   def withBag[R](
-    storageBucket: Bucket,
+    bucket: Bucket,
     dataFileCount: Int = 1,
     bagInfo: BagInfo = randomBagInfo,
     storageSpace: StorageSpace = randomStorageSpace,
@@ -32,7 +32,7 @@ trait BagLocationFixtures extends S3 with BagIt {
     val storagePrefix = "archive"
 
     val bagLocation = BagLocation(
-      storageNamespace = storageBucket.name,
+      storageNamespace = bucket.name,
       storagePrefix = storagePrefix,
       storageSpace = storageSpace,
       bagPath = BagPath(bagIdentifier.toString)

--- a/storage/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/BagInfoGenerators.scala
+++ b/storage/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/BagInfoGenerators.scala
@@ -3,11 +3,13 @@ package uk.ac.wellcome.platform.archive.common.generators
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
 import uk.ac.wellcome.platform.archive.common.models.bagit.{
   BagInfo,
-  ExternalDescription
+  ExternalDescription,
+  ExternalIdentifier
 }
 
 trait BagInfoGenerators extends RandomThings {
   def createBagInfoWith(
+    externalIdentifier: ExternalIdentifier = randomExternalIdentifier,
     externalDescription: Option[ExternalDescription] = Some(
       randomExternalDescription)
   ): BagInfo =


### PR DESCRIPTION
Some more refactoring for #3285. This modifies the BagStorage class to return a list of the BagLocation of the copied bag, not an S3 CopyResult.

I ended up doing quite a bit of refactoring in BagStorage (and adding a couple of extra tests!), so this is a standalone patch that can be merged separately.