### PR TITLE
Don't create as many Elasticsearch indexes/start as many servers in the API tests

### DIFF
--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
@@ -8,8 +8,8 @@ import uk.ac.wellcome.display.models.ApiVersions
 class ApiContextTest extends ApiWorksTestBase {
   it("returns a context for all versions") {
     ApiVersions.values.toList.foreach { version: ApiVersions.Value =>
-      withApi(apiVersion = version) {
-        case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
+      withHttpServer(version) {
+        case (apiPrefix, server: EmbeddedHttpServer) =>
           server.httpGet(
             path = s"/$apiPrefix/context.json",
             andExpect = Status.Ok,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
@@ -7,14 +7,13 @@ import uk.ac.wellcome.display.models.ApiVersions
 
 class ApiContextTest extends ApiWorksTestBase {
   it("returns a context for all versions") {
-    ApiVersions.values.toList.foreach { version: ApiVersions.Value =>
-      withHttpServer(version) {
-        case (apiPrefix, server: EmbeddedHttpServer) =>
-          server.httpGet(
-            path = s"/$apiPrefix/context.json",
-            andExpect = Status.Ok,
-            withJsonBody = IOUtils
-              .toString(getClass.getResourceAsStream("/context.json"), "UTF-8"))
+    withHttpServer { server: EmbeddedHttpServer =>
+      ApiVersions.values.toList.foreach { apiVersion: ApiVersions.Value =>
+        server.httpGet(
+          path = s"/${getApiPrefix(apiVersion)}/context.json",
+          andExpect = Status.Ok,
+          withJsonBody = IOUtils
+            .toString(getClass.getResourceAsStream("/context.json"), "UTF-8"))
       }
     }
   }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.display.models.ApiVersions
 class ApiContextTest extends ApiWorksTestBase {
   it("returns a context for all versions") {
     ApiVersions.values.toList.foreach { version: ApiVersions.Value =>
-      withApiFixtures(apiVersion = version) {
+      withApi(apiVersion = version) {
         case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
           server.httpGet(
             path = s"/$apiPrefix/context.json",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiContextTest.scala
@@ -13,7 +13,8 @@ class ApiContextTest extends ApiWorksTestBase {
           path = s"/${getApiPrefix(apiVersion)}/context.json",
           andExpect = Status.Ok,
           withJsonBody = IOUtils
-            .toString(getClass.getResourceAsStream("/context.json"), "UTF-8"))
+            .toString(getClass.getResourceAsStream("/context.json"), "UTF-8")
+        )
       }
     }
   }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
@@ -22,9 +22,8 @@ class ApiErrorsTest extends ApiWorksTestBase {
       server.httpGet(
         path = "/foo/bar",
         andExpect = Status.NotFound,
-        withJsonBody = notFound(
-          getApiPrefix(),
-          "Page not found for URL /foo/bar")
+        withJsonBody =
+          notFound(getApiPrefix(), "Page not found for URL /foo/bar")
       )
     }
   }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
@@ -2,33 +2,30 @@ package uk.ac.wellcome.platform.api.works
 
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
-import uk.ac.wellcome.display.models.ApiVersions
 
 class ApiErrorsTest extends ApiWorksTestBase {
 
   it("returns a Not Found error if you try to get an API version") {
-    withHttpServer(ApiVersions.default) {
-      case (apiPrefix, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = "/catalogue/v567/works",
-          andExpect = Status.NotFound,
-          withJsonBody = notFound(
-            apiPrefix,
-            "Page not found for URL /catalogue/v567/works")
-        )
+    withHttpServer { server: EmbeddedHttpServer =>
+      server.httpGet(
+        path = "/catalogue/v567/works",
+        andExpect = Status.NotFound,
+        withJsonBody = notFound(
+          getApiPrefix(),
+          "Page not found for URL /catalogue/v567/works")
+      )
     }
   }
 
   it("returns a Not Found error if you try to get an unrecognised path") {
-    withHttpServer(ApiVersions.default) {
-      case (apiPrefix, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = "/foo/bar",
-          andExpect = Status.NotFound,
-          withJsonBody = notFound(
-            apiPrefix,
-            "Page not found for URL /foo/bar")
-        )
+    withHttpServer { server: EmbeddedHttpServer =>
+      server.httpGet(
+        path = "/foo/bar",
+        andExpect = Status.NotFound,
+        withJsonBody = notFound(
+          getApiPrefix(),
+          "Page not found for URL /foo/bar")
+      )
     }
   }
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTest.scala
@@ -1,40 +1,34 @@
 package uk.ac.wellcome.platform.api.works
 
-import com.sksamuel.elastic4s.Index
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.display.models.ApiVersions
-import uk.ac.wellcome.test.fixtures.TestWith
 
 class ApiErrorsTest extends ApiWorksTestBase {
 
   it("returns a Not Found error if you try to get an API version") {
-    withServer { server =>
-      server.httpGet(
-        path = "/catalogue/v567/works",
-        andExpect = Status.NotFound,
-        withJsonBody = notFound(
-          s"catalogue/${ApiVersions.default.toString}",
-          "Page not found for URL /catalogue/v567/works")
-      )
+    withHttpServer(ApiVersions.default) {
+      case (apiPrefix, server: EmbeddedHttpServer) =>
+        server.httpGet(
+          path = "/catalogue/v567/works",
+          andExpect = Status.NotFound,
+          withJsonBody = notFound(
+            apiPrefix,
+            "Page not found for URL /catalogue/v567/works")
+        )
     }
   }
 
   it("returns a Not Found error if you try to get an unrecognised path") {
-    withServer { server =>
-      server.httpGet(
-        path = "/foo/bar",
-        andExpect = Status.NotFound,
-        withJsonBody = notFound(
-          s"catalogue/${ApiVersions.default.toString}",
-          "Page not found for URL /foo/bar")
-      )
+    withHttpServer(ApiVersions.default) {
+      case (apiPrefix, server: EmbeddedHttpServer) =>
+        server.httpGet(
+          path = "/foo/bar",
+          andExpect = Status.NotFound,
+          withJsonBody = notFound(
+            apiPrefix,
+            "Page not found for URL /foo/bar")
+        )
     }
   }
-
-  private def withServer[R](testWith: TestWith[EmbeddedHttpServer, R]): R =
-    withServer(indexV1 = Index("index-v1"), indexV2 = Index("index-v2")) {
-      server =>
-        testWith(server)
-    }
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
@@ -167,8 +167,7 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
         server.httpGet(
           path = s"/${getApiPrefix()}/works?_index=${index.name}",
           andExpect = Status.InternalServerError,
-          withJsonBody =
-            s"""
+          withJsonBody = s"""
                |{
                |  "@context": "https://localhost:8888/${getApiPrefix()}/context.json",
                |  "type": "Error",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
@@ -1,10 +1,8 @@
 package uk.ac.wellcome.platform.api.works
 
-import com.sksamuel.elastic4s.Index
 import com.twitter.finagle.http.{Response, Status}
 import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.display.models.ApiVersions
-import uk.ac.wellcome.test.fixtures.TestWith
 
 trait ApiErrorsTestBase { this: ApiWorksTestBase =>
   val apiVersion: ApiVersions.Value
@@ -162,8 +160,8 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
     //
     // By creating an index without a mapping, we don't have a canonicalId field
     // to sort on.  Trying to query this index of these will trigger one such exception!
-    withApi {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
+    withHttpServer() {
+      case (apiPrefix, server: EmbeddedHttpServer) =>
         withEmptyIndex { index =>
           server.httpGet(
             path = s"/$apiPrefix/works?_index=${index.name}",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
@@ -3,10 +3,11 @@ package uk.ac.wellcome.platform.api.works
 import com.sksamuel.elastic4s.Index
 import com.twitter.finagle.http.{Response, Status}
 import com.twitter.finatra.http.EmbeddedHttpServer
+import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.test.fixtures.TestWith
 
 trait ApiErrorsTestBase { this: ApiWorksTestBase =>
-  def withApi[R]: TestWith[(String, Index, Index, EmbeddedHttpServer), R] => R
+  val apiVersion: ApiVersions.Value
 
   describe("returns a 400 Bad Request for user errors") {
     describe("errors in the ?pageSize query") {
@@ -182,8 +183,8 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
   }
 
   def assertIsBadRequest(path: String, description: String): Response =
-    withApi {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
+    withHttpServer(apiVersion) {
+      case (apiPrefix, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix$path",
           andExpect = Status.BadRequest,
@@ -195,8 +196,8 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
     }
 
   def assertIsNotFound(path: String, description: String): Response =
-    withApi {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
+    withHttpServer(apiVersion) {
+      case (apiPrefix, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix$path",
           andExpect = Status.NotFound,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
@@ -2,9 +2,12 @@ package uk.ac.wellcome.platform.api.works
 
 import com.twitter.finagle.http.{Response, Status}
 import com.twitter.finatra.http.EmbeddedHttpServer
+import uk.ac.wellcome.test.fixtures.TestWith
 
 trait ApiErrorsTestBase { this: ApiWorksTestBase =>
   val apiPrefix: String
+
+  def withServer[R](testWith: TestWith[EmbeddedHttpServer, R]): R
 
   describe("returns a 400 Bad Request for user errors") {
     describe("errors in the ?pageSize query") {
@@ -180,7 +183,7 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
   }
 
   def assertIsBadRequest(path: String, description: String): Response =
-    withHttpServer { server: EmbeddedHttpServer =>
+    withServer { server: EmbeddedHttpServer =>
       server.httpGet(
         path = s"/$apiPrefix$path",
         andExpect = Status.BadRequest,
@@ -192,7 +195,7 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
     }
 
   def assertIsNotFound(path: String, description: String): Response =
-    withHttpServer { server: EmbeddedHttpServer =>
+    withServer { server: EmbeddedHttpServer =>
       server.httpGet(
         path = s"/$apiPrefix$path",
         andExpect = Status.NotFound,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -46,11 +46,11 @@ trait ApiWorksTestBase
 
   val apiName = "catalogue/"
 
-  def getApiPrefix(apiVersion: ApiVersions.Value = ApiVersions.default): String =
+  def getApiPrefix(
+    apiVersion: ApiVersions.Value = ApiVersions.default): String =
     apiName + apiVersion
 
-  def withApi[R](
-    testWith: TestWith[(Index, Index, EmbeddedHttpServer), R]): R =
+  def withApi[R](testWith: TestWith[(Index, Index, EmbeddedHttpServer), R]): R =
     withLocalWorksIndex { indexV1 =>
       withLocalWorksIndex { indexV2 =>
         withServer(indexV1, indexV2) { server =>

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -46,12 +46,15 @@ trait ApiWorksTestBase
 
   val apiName = "catalogue/"
 
+  def getApiPrefix(apiVersion: ApiVersions.Value = ApiVersions.default): String =
+    apiName + apiVersion
+
   def withApi[R](apiVersion: ApiVersions.Value)(
     testWith: TestWith[(String, Index, Index, EmbeddedHttpServer), R]): R =
     withLocalWorksIndex { indexV1 =>
       withLocalWorksIndex { indexV2 =>
         withServer(indexV1, indexV2) { server =>
-          testWith((apiName + apiVersion, indexV1, indexV2, server))
+          testWith((getApiPrefix(apiVersion), indexV1, indexV2, server))
         }
       }
     }
@@ -60,7 +63,7 @@ trait ApiWorksTestBase
     testWith: TestWith[(String, Index, EmbeddedHttpServer), R]): R =
     withLocalWorksIndex { indexV1 =>
       withServer(indexV1, Index("index-v2")) { server =>
-        testWith((apiName + ApiVersions.v1, indexV1, server))
+        testWith((getApiPrefix(ApiVersions.v1), indexV1, server))
       }
     }
 
@@ -68,14 +71,13 @@ trait ApiWorksTestBase
     testWith: TestWith[(String, Index, EmbeddedHttpServer), R]): R =
     withLocalWorksIndex { indexV2 =>
       withServer(Index("index-v1"), indexV2) { server =>
-        testWith((apiName + ApiVersions.v2, indexV2, server))
+        testWith((getApiPrefix(ApiVersions.v2), indexV2, server))
       }
     }
 
-  def withHttpServer[R](apiVersion: ApiVersions.Value = ApiVersions.default)(
-    testWith: TestWith[(String, EmbeddedHttpServer), R]): R =
+  def withHttpServer[R](testWith: TestWith[EmbeddedHttpServer, R]): R =
     withServer(Index("index-v1"), Index("index-v2")) { server =>
-      testWith((apiName + apiVersion, server))
+      testWith(server)
     }
 
   def emptyJsonResult(apiPrefix: String): String = s"""

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -44,8 +44,9 @@ trait ApiWorksTestBase
     }
   }
 
-  def withApiFixtures[R](apiVersion: ApiVersions.Value,
-                         apiName: String = "catalogue/")(
+  val apiName = "catalogue/"
+
+  def withApiFixtures[R](apiVersion: ApiVersions.Value)(
     testWith: TestWith[(String, Index, Index, EmbeddedHttpServer), R]): R =
     withLocalWorksIndex { indexV1 =>
       withLocalWorksIndex { indexV2 =>
@@ -53,6 +54,28 @@ trait ApiWorksTestBase
           testWith((apiName + apiVersion, indexV1, indexV2, server))
         }
       }
+    }
+
+  def withV1ApiFixtures[R](
+    testWith: TestWith[(String, Index, EmbeddedHttpServer), R]): R =
+    withLocalWorksIndex { indexV1 =>
+      withServer(indexV1, Index("index-v2")) { server =>
+        testWith((apiName + ApiVersions.v1, indexV1, server))
+      }
+    }
+
+  def withV2ApiFixtures[R](
+    testWith: TestWith[(String, Index, EmbeddedHttpServer), R]): R =
+    withLocalWorksIndex { indexV2 =>
+      withServer(Index("index-v1"), indexV2) { server =>
+        testWith((apiName + ApiVersions.v2, indexV2, server))
+      }
+    }
+
+  def withHttpServer[R](apiVersion: ApiVersions.Value)(
+    testWith: TestWith[(String, EmbeddedHttpServer), R]): R =
+    withServer(Index("index-v1"), Index("index-v2")) { server =>
+      testWith((apiName + apiVersion, server))
     }
 
   def emptyJsonResult(apiPrefix: String): String = s"""

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -24,7 +24,7 @@ trait ApiWorksTestBase
       toJson(t).get
   }
 
-  def withServer[R](indexV1: Index, indexV2: Index)(
+  private def withServer[R](indexV1: Index, indexV2: Index)(
     testWith: TestWith[EmbeddedHttpServer, R]): R = {
 
     val server: EmbeddedHttpServer = new EmbeddedHttpServer(
@@ -46,7 +46,7 @@ trait ApiWorksTestBase
 
   val apiName = "catalogue/"
 
-  def withApiFixtures[R](apiVersion: ApiVersions.Value)(
+  def withApi[R](apiVersion: ApiVersions.Value)(
     testWith: TestWith[(String, Index, Index, EmbeddedHttpServer), R]): R =
     withLocalWorksIndex { indexV1 =>
       withLocalWorksIndex { indexV2 =>
@@ -56,7 +56,7 @@ trait ApiWorksTestBase
       }
     }
 
-  def withV1ApiFixtures[R](
+  def withV1Api[R](
     testWith: TestWith[(String, Index, EmbeddedHttpServer), R]): R =
     withLocalWorksIndex { indexV1 =>
       withServer(indexV1, Index("index-v2")) { server =>
@@ -64,7 +64,7 @@ trait ApiWorksTestBase
       }
     }
 
-  def withV2ApiFixtures[R](
+  def withV2Api[R](
     testWith: TestWith[(String, Index, EmbeddedHttpServer), R]): R =
     withLocalWorksIndex { indexV2 =>
       withServer(Index("index-v1"), indexV2) { server =>
@@ -72,7 +72,7 @@ trait ApiWorksTestBase
       }
     }
 
-  def withHttpServer[R](apiVersion: ApiVersions.Value)(
+  def withHttpServer[R](apiVersion: ApiVersions.Value = ApiVersions.default)(
     testWith: TestWith[(String, EmbeddedHttpServer), R]): R =
     withServer(Index("index-v1"), Index("index-v2")) { server =>
       testWith((apiName + apiVersion, server))

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -24,7 +24,7 @@ trait ApiWorksTestBase
       toJson(t).get
   }
 
-  private def withServer[R](indexV1: Index, indexV2: Index)(
+  def withServer[R](indexV1: Index, indexV2: Index)(
     testWith: TestWith[EmbeddedHttpServer, R]): R = {
 
     val server: EmbeddedHttpServer = new EmbeddedHttpServer(
@@ -49,29 +49,13 @@ trait ApiWorksTestBase
   def getApiPrefix(apiVersion: ApiVersions.Value = ApiVersions.default): String =
     apiName + apiVersion
 
-  def withApi[R](apiVersion: ApiVersions.Value)(
-    testWith: TestWith[(String, Index, Index, EmbeddedHttpServer), R]): R =
+  def withApi[R](
+    testWith: TestWith[(Index, Index, EmbeddedHttpServer), R]): R =
     withLocalWorksIndex { indexV1 =>
       withLocalWorksIndex { indexV2 =>
         withServer(indexV1, indexV2) { server =>
-          testWith((getApiPrefix(apiVersion), indexV1, indexV2, server))
+          testWith((indexV1, indexV2, server))
         }
-      }
-    }
-
-  def withV1Api[R](
-    testWith: TestWith[(String, Index, EmbeddedHttpServer), R]): R =
-    withLocalWorksIndex { indexV1 =>
-      withServer(indexV1, Index("index-v2")) { server =>
-        testWith((getApiPrefix(ApiVersions.v1), indexV1, server))
-      }
-    }
-
-  def withV2Api[R](
-    testWith: TestWith[(String, Index, EmbeddedHttpServer), R]): R =
-    withLocalWorksIndex { indexV2 =>
-      withServer(Index("index-v1"), indexV2) { server =>
-        testWith((getApiPrefix(ApiVersions.v2), indexV2, server))
       }
     }
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
@@ -1,14 +1,8 @@
 package uk.ac.wellcome.platform.api.works.v1
 
-import com.sksamuel.elastic4s.Index
-import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.platform.api.works.ApiErrorsTestBase
-import uk.ac.wellcome.test.fixtures.TestWith
 
 class ApiV1ErrorsTest extends ApiV1WorksTestBase with ApiErrorsTestBase {
-  def withApi[R]: TestWith[(String, Index, Index, EmbeddedHttpServer), R] => R =
-    withV1Api[R]
-
   describe("returns a 400 Bad Request for errors in the ?includes parameter") {
     it("a single invalid include") {
       assertIsBadRequest(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
@@ -6,8 +6,9 @@ import uk.ac.wellcome.test.fixtures.TestWith
 
 class ApiV1ErrorsTest extends ApiV1WorksTestBase with ApiErrorsTestBase {
   def withServer[R](testWith: TestWith[EmbeddedHttpServer, R]): R =
-    withV1Api { case (_, server: EmbeddedHttpServer) =>
-      testWith(server)
+    withV1Api {
+      case (_, server: EmbeddedHttpServer) =>
+        testWith(server)
     }
 
   describe("returns a 400 Bad Request for errors in the ?includes parameter") {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
@@ -1,8 +1,15 @@
 package uk.ac.wellcome.platform.api.works.v1
 
+import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.platform.api.works.ApiErrorsTestBase
+import uk.ac.wellcome.test.fixtures.TestWith
 
 class ApiV1ErrorsTest extends ApiV1WorksTestBase with ApiErrorsTestBase {
+  def withServer[R](testWith: TestWith[EmbeddedHttpServer, R]): R =
+    withV1Api { case (_, _, server: EmbeddedHttpServer) =>
+      testWith(server)
+    }
+
   describe("returns a 400 Bad Request for errors in the ?includes parameter") {
     it("a single invalid include") {
       assertIsBadRequest(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1ErrorsTest.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.test.fixtures.TestWith
 
 class ApiV1ErrorsTest extends ApiV1WorksTestBase with ApiErrorsTestBase {
   def withServer[R](testWith: TestWith[EmbeddedHttpServer, R]): R =
-    withV1Api { case (_, _, server: EmbeddedHttpServer) =>
+    withV1Api { case (_, server: EmbeddedHttpServer) =>
       testWith(server)
     }
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
@@ -7,7 +7,7 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
   it("returns a 302 Redirect if looking up a redirected work") {
     val redirectedWork = createIdentifiedRedirectedWork
 
-    withV1ApiFixtures {
+    withV1Api {
       case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         insertIntoElasticsearch(indexV1, redirectedWork)
         server.httpGet(
@@ -23,7 +23,7 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
   it("preserves query parameters on a 302 Redirect") {
     val redirectedWork = createIdentifiedRedirectedWork
 
-    withV1ApiFixtures {
+    withV1Api {
       case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         insertIntoElasticsearch(indexV1, redirectedWork)
         server.httpGet(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
@@ -8,7 +8,7 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
     val redirectedWork = createIdentifiedRedirectedWork
 
     withV1Api {
-      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
+      case (indexV1, server: EmbeddedHttpServer) =>
         insertIntoElasticsearch(indexV1, redirectedWork)
         server.httpGet(
           path = s"/$apiPrefix/works/${redirectedWork.canonicalId}",
@@ -24,7 +24,7 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
     val redirectedWork = createIdentifiedRedirectedWork
 
     withV1Api {
-      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
+      case (indexV1, server: EmbeddedHttpServer) =>
         insertIntoElasticsearch(indexV1, redirectedWork)
         server.httpGet(
           path =

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
@@ -7,8 +7,8 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
   it("returns a 302 Redirect if looking up a redirected work") {
     val redirectedWork = createIdentifiedRedirectedWork
 
-    withV1Api {
-      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+    withV1ApiFixtures {
+      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         insertIntoElasticsearch(indexV1, redirectedWork)
         server.httpGet(
           path = s"/$apiPrefix/works/${redirectedWork.canonicalId}",
@@ -23,8 +23,8 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
   it("preserves query parameters on a 302 Redirect") {
     val redirectedWork = createIdentifiedRedirectedWork
 
-    withV1Api {
-      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+    withV1ApiFixtures {
+      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         insertIntoElasticsearch(indexV1, redirectedWork)
         server.httpGet(
           path =

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.models.work.internal._
 class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("returns a list of works") {
-    withV1ApiFixtures {
+    withV1Api {
       case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
@@ -61,7 +61,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("returns a single work when requested with id") {
-    withV1ApiFixtures {
+    withV1Api {
       case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWork
 
@@ -90,7 +90,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("renders the items if the items include is present") {
-    withV1ApiFixtures {
+    withV1Api {
       case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           itemsV1 = createIdentifiedItems(count = 1)
@@ -123,7 +123,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it(
     "returns the requested page of results when requested with page & pageSize") {
-    withV1ApiFixtures {
+    withV1Api {
       case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
@@ -230,7 +230,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("returns matching results if doing a full-text search") {
-    withV1ApiFixtures {
+    withV1Api {
       case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "A drawing of a dodo"
@@ -275,7 +275,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it(
     "includes a list of identifiers on a list endpoint if we pass ?includes=identifiers") {
-    withV1ApiFixtures {
+    withV1Api {
       case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
@@ -329,7 +329,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it(
     "includes a list of identifiers on a single work endpoint if we pass ?includes=identifiers") {
-    withV1ApiFixtures {
+    withV1Api {
       case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val otherIdentifier = createSourceIdentifier
         val work = createIdentifiedWorkWith(
@@ -362,7 +362,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("searches different indices with the ?_index query parameter") {
-    withV1ApiFixtures {
+    withV1Api {
       case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         withLocalWorksIndex { altIndex =>
           val work = createIdentifiedWork
@@ -416,7 +416,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("looks up works in different indices with the ?_index query parameter") {
-    withV1ApiFixtures {
+    withV1Api {
       case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         withLocalWorksIndex { altIndex =>
           val work = createIdentifiedWorkWith(
@@ -482,7 +482,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it(
     "includes the thumbnail field if available and we use the thumbnail include") {
-    withV1ApiFixtures {
+    withV1Api {
       case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           thumbnail = Some(
@@ -523,7 +523,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("only returns works from the v1 index") {
-    withApiFixtures(ApiVersions.v1) {
+    withApi(ApiVersions.v1) {
       case (apiPrefix, indexV1, indexV2, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "One orange ocelot"

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -219,13 +219,12 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("ignores parameters that are unused when making an API request") {
-    withHttpServer(ApiVersions.v1) {
-      case (apiPrefix, server: EmbeddedHttpServer) =>
-        server.httpGet(
-          path = s"/$apiPrefix/works?foo=bar",
-          andExpect = Status.Ok,
-          withJsonBody = emptyJsonResult(apiPrefix)
-        )
+    withHttpServer { server: EmbeddedHttpServer =>
+      server.httpGet(
+        path = s"/$apiPrefix/works?foo=bar",
+        andExpect = Status.Ok,
+        withJsonBody = emptyJsonResult(apiPrefix)
+      )
     }
   }
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -219,12 +219,13 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("ignores parameters that are unused when making an API request") {
-    withHttpServer { server: EmbeddedHttpServer =>
-      server.httpGet(
-        path = s"/$apiPrefix/works?foo=bar",
-        andExpect = Status.Ok,
-        withJsonBody = emptyJsonResult(apiPrefix)
-      )
+    withV1Api {
+      case (_, _, server: EmbeddedHttpServer) =>
+        server.httpGet(
+          path = s"/$apiPrefix/works?foo=bar",
+          andExpect = Status.Ok,
+          withJsonBody = emptyJsonResult(apiPrefix)
+        )
     }
   }
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -9,7 +9,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("returns a list of works") {
     withV1Api {
-      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
+      case (indexV1, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
         insertIntoElasticsearch(indexV1, works: _*)
@@ -62,7 +62,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("returns a single work when requested with id") {
     withV1Api {
-      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
+      case (indexV1, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWork
 
         insertIntoElasticsearch(indexV1, work)
@@ -91,7 +91,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("renders the items if the items include is present") {
     withV1Api {
-      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
+      case (indexV1, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           itemsV1 = createIdentifiedItems(count = 1)
         )
@@ -124,7 +124,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it(
     "returns the requested page of results when requested with page & pageSize") {
     withV1Api {
-      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
+      case (indexV1, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
         insertIntoElasticsearch(indexV1, works: _*)
@@ -220,7 +220,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("ignores parameters that are unused when making an API request") {
     withV1Api {
-      case (_, _, server: EmbeddedHttpServer) =>
+      case (_, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?foo=bar",
           andExpect = Status.Ok,
@@ -231,7 +231,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("returns matching results if doing a full-text search") {
     withV1Api {
-      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
+      case (indexV1, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "A drawing of a dodo"
         )
@@ -276,7 +276,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it(
     "includes a list of identifiers on a list endpoint if we pass ?includes=identifiers") {
     withV1Api {
-      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
+      case (indexV1, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val identifier0 = createSourceIdentifier
@@ -330,7 +330,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it(
     "includes a list of identifiers on a single work endpoint if we pass ?includes=identifiers") {
     withV1Api {
-      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
+      case (indexV1, server: EmbeddedHttpServer) =>
         val otherIdentifier = createSourceIdentifier
         val work = createIdentifiedWorkWith(
           otherIdentifiers = List(otherIdentifier)
@@ -363,7 +363,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("searches different indices with the ?_index query parameter") {
     withV1Api {
-      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
+      case (indexV1, server: EmbeddedHttpServer) =>
         withLocalWorksIndex { altIndex =>
           val work = createIdentifiedWork
           insertIntoElasticsearch(indexV1, work)
@@ -417,7 +417,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("looks up works in different indices with the ?_index query parameter") {
     withV1Api {
-      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
+      case (indexV1, server: EmbeddedHttpServer) =>
         withLocalWorksIndex { altIndex =>
           val work = createIdentifiedWorkWith(
             title = "Wombles of Wimbledon"
@@ -483,7 +483,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   it(
     "includes the thumbnail field if available and we use the thumbnail include") {
     withV1Api {
-      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
+      case (indexV1, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           thumbnail = Some(
             DigitalLocation(
@@ -523,8 +523,8 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("only returns works from the v1 index") {
-    withApi(ApiVersions.v1) {
-      case (apiPrefix, indexV1, indexV2, server: EmbeddedHttpServer) =>
+    withApi {
+      case (indexV1, indexV2, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "One orange ocelot"
         )
@@ -535,7 +535,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
         eventually {
           server.httpGet(
-            path = s"/$apiPrefix/works?query=ocelot",
+            path = s"/${getApiPrefix(ApiVersions.v1)}/works?query=ocelot",
             andExpect = Status.Ok,
             withJsonBody = s"""
                  |{

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -2,13 +2,14 @@ package uk.ac.wellcome.platform.api.works.v1
 
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
+import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.models.work.internal._
 
 class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it("returns a list of works") {
-    withV1Api {
-      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+    withV1ApiFixtures {
+      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
         insertIntoElasticsearch(indexV1, works: _*)
@@ -60,8 +61,8 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("returns a single work when requested with id") {
-    withV1Api {
-      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+    withV1ApiFixtures {
+      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWork
 
         insertIntoElasticsearch(indexV1, work)
@@ -89,8 +90,8 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("renders the items if the items include is present") {
-    withV1Api {
-      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+    withV1ApiFixtures {
+      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           itemsV1 = createIdentifiedItems(count = 1)
         )
@@ -122,8 +123,8 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it(
     "returns the requested page of results when requested with page & pageSize") {
-    withV1Api {
-      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+    withV1ApiFixtures {
+      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
         insertIntoElasticsearch(indexV1, works: _*)
@@ -218,8 +219,8 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("ignores parameters that are unused when making an API request") {
-    withV1Api {
-      case (apiPrefix, _, _, server: EmbeddedHttpServer) =>
+    withHttpServer(ApiVersions.v1) {
+      case (apiPrefix, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?foo=bar",
           andExpect = Status.Ok,
@@ -229,8 +230,8 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("returns matching results if doing a full-text search") {
-    withV1Api {
-      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+    withV1ApiFixtures {
+      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "A drawing of a dodo"
         )
@@ -274,8 +275,8 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it(
     "includes a list of identifiers on a list endpoint if we pass ?includes=identifiers") {
-    withV1Api {
-      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+    withV1ApiFixtures {
+      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val identifier0 = createSourceIdentifier
@@ -328,8 +329,8 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it(
     "includes a list of identifiers on a single work endpoint if we pass ?includes=identifiers") {
-    withV1Api {
-      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+    withV1ApiFixtures {
+      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val otherIdentifier = createSourceIdentifier
         val work = createIdentifiedWorkWith(
           otherIdentifiers = List(otherIdentifier)
@@ -361,8 +362,8 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("searches different indices with the ?_index query parameter") {
-    withV1Api {
-      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+    withV1ApiFixtures {
+      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         withLocalWorksIndex { altIndex =>
           val work = createIdentifiedWork
           insertIntoElasticsearch(indexV1, work)
@@ -415,8 +416,8 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("looks up works in different indices with the ?_index query parameter") {
-    withV1Api {
-      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+    withV1ApiFixtures {
+      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         withLocalWorksIndex { altIndex =>
           val work = createIdentifiedWorkWith(
             title = "Wombles of Wimbledon"
@@ -481,8 +482,8 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
 
   it(
     "includes the thumbnail field if available and we use the thumbnail include") {
-    withV1Api {
-      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+    withV1ApiFixtures {
+      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           thumbnail = Some(
             DigitalLocation(
@@ -522,7 +523,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
   }
 
   it("only returns works from the v1 index") {
-    withV1Api {
+    withApiFixtures(ApiVersions.v1) {
       case (apiPrefix, indexV1, indexV2, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "One orange ocelot"

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestBase.scala
@@ -1,11 +1,21 @@
 package uk.ac.wellcome.platform.api.works.v1
 
+import com.sksamuel.elastic4s.Index
+import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.models.v1.DisplayV1SerialisationTestBase
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
+import uk.ac.wellcome.test.fixtures.TestWith
 
 trait ApiV1WorksTestBase
     extends ApiWorksTestBase
     with DisplayV1SerialisationTestBase {
   val apiPrefix: String = getApiPrefix(ApiVersions.v1)
+
+  def withV1Api[R](testWith: TestWith[(Index, EmbeddedHttpServer), R]): R =
+    withLocalWorksIndex { indexV1 =>
+      withServer(indexV1, Index("index-v2")) { server =>
+        testWith((indexV1, server))
+      }
+    }
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestBase.scala
@@ -7,5 +7,5 @@ import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 trait ApiV1WorksTestBase
     extends ApiWorksTestBase
     with DisplayV1SerialisationTestBase {
-  val apiVersion: ApiVersions.Value = ApiVersions.v1
+  val apiPrefix: String = getApiPrefix(ApiVersions.v1)
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestBase.scala
@@ -7,5 +7,5 @@ import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 trait ApiV1WorksTestBase
     extends ApiWorksTestBase
     with DisplayV1SerialisationTestBase {
-  def withV1Api[R] = withApiFixtures[R](ApiVersions.v1)(_)
+  val apiVersion: ApiVersions.Value = ApiVersions.v1
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
 
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
-    withV1ApiFixtures {
+    withV1Api {
       case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val work = createIdentifiedInvisibleWork
 
@@ -24,7 +24,7 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
   }
 
   it("excludes works with visible=false from list results") {
-    withV1ApiFixtures {
+    withV1Api {
       case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val deletedWork = createIdentifiedInvisibleWork
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
@@ -69,7 +69,7 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
   }
 
   it("excludes works with visible=false from search results") {
-    withV1ApiFixtures {
+    withV1Api {
       case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           title = "An upside-down umbrella"

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
@@ -7,8 +7,8 @@ import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
 
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
-    withV1Api {
-      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+    withV1ApiFixtures {
+      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val work = createIdentifiedInvisibleWork
 
         insertIntoElasticsearch(indexV1, work)
@@ -24,8 +24,8 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
   }
 
   it("excludes works with visible=false from list results") {
-    withV1Api {
-      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+    withV1ApiFixtures {
+      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val deletedWork = createIdentifiedInvisibleWork
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
@@ -69,8 +69,8 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
   }
 
   it("excludes works with visible=false from search results") {
-    withV1Api {
-      case (apiPrefix, indexV1, _, server: EmbeddedHttpServer) =>
+    withV1ApiFixtures {
+      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           title = "An upside-down umbrella"
         )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTestInvisible.scala
@@ -8,7 +8,7 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
 
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
     withV1Api {
-      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
+      case (indexV1, server: EmbeddedHttpServer) =>
         val work = createIdentifiedInvisibleWork
 
         insertIntoElasticsearch(indexV1, work)
@@ -25,7 +25,7 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
 
   it("excludes works with visible=false from list results") {
     withV1Api {
-      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
+      case (indexV1, server: EmbeddedHttpServer) =>
         val deletedWork = createIdentifiedInvisibleWork
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
@@ -70,7 +70,7 @@ class ApiV1WorksTestInvisible extends ApiV1WorksTestBase {
 
   it("excludes works with visible=false from search results") {
     withV1Api {
-      case (apiPrefix, indexV1, server: EmbeddedHttpServer) =>
+      case (indexV1, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           title = "An upside-down umbrella"
         )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
@@ -6,8 +6,9 @@ import uk.ac.wellcome.test.fixtures.TestWith
 
 class ApiV2ErrorsTest extends ApiV2WorksTestBase with ApiErrorsTestBase {
   def withServer[R](testWith: TestWith[EmbeddedHttpServer, R]): R =
-    withV2Api { case (_, server: EmbeddedHttpServer) =>
-      testWith(server)
+    withV2Api {
+      case (_, server: EmbeddedHttpServer) =>
+        testWith(server)
     }
 
   describe("returns a 400 Bad Request for errors in the ?include parameter") {

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.test.fixtures.TestWith
 
 class ApiV2ErrorsTest extends ApiV2WorksTestBase with ApiErrorsTestBase {
   def withServer[R](testWith: TestWith[EmbeddedHttpServer, R]): R =
-    withV2Api { case (_, _, server: EmbeddedHttpServer) =>
+    withV2Api { case (_, server: EmbeddedHttpServer) =>
       testWith(server)
     }
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
@@ -1,8 +1,15 @@
 package uk.ac.wellcome.platform.api.works.v2
 
+import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.platform.api.works.ApiErrorsTestBase
+import uk.ac.wellcome.test.fixtures.TestWith
 
 class ApiV2ErrorsTest extends ApiV2WorksTestBase with ApiErrorsTestBase {
+  def withServer[R](testWith: TestWith[EmbeddedHttpServer, R]): R =
+    withV2Api { case (_, _, server: EmbeddedHttpServer) =>
+      testWith(server)
+    }
+
   describe("returns a 400 Bad Request for errors in the ?include parameter") {
     it("a single invalid include") {
       assertIsBadRequest(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
@@ -1,14 +1,8 @@
 package uk.ac.wellcome.platform.api.works.v2
 
-import com.sksamuel.elastic4s.Index
-import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.platform.api.works.ApiErrorsTestBase
-import uk.ac.wellcome.test.fixtures.TestWith
 
 class ApiV2ErrorsTest extends ApiV2WorksTestBase with ApiErrorsTestBase {
-  def withApi[R]: TestWith[(String, Index, Index, EmbeddedHttpServer), R] => R =
-    withV2Api[R]
-
   describe("returns a 400 Bad Request for errors in the ?include parameter") {
     it("a single invalid include") {
       assertIsBadRequest(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
@@ -10,7 +10,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
   describe("listing works") {
     it("ignores works with no workType") {
-      withV2ApiFixtures {
+      withV2Api {
         case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
           val noWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(workType = None)
@@ -44,7 +44,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
     }
 
     it("filters out works with a different workType") {
-      withV2ApiFixtures {
+      withV2Api {
         case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
@@ -79,7 +79,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
     }
 
     it("can filter by multiple workTypes") {
-      withV2ApiFixtures {
+      withV2Api {
         case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
@@ -126,7 +126,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
     }
 
     it("filters by item LocationType") {
-      withV2ApiFixtures {
+      withV2Api {
         case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
           val noItemWorks = createIdentifiedWorks(count = 3)
           val matchingWork1 = createIdentifiedWorkWith(
@@ -183,7 +183,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
   describe("searching works") {
     it("ignores works with no workType") {
-      withV2ApiFixtures {
+      withV2Api {
         case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
           val noWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
@@ -220,7 +220,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
     }
 
     it("filters out works with a different workType") {
-      withV2ApiFixtures {
+      withV2Api {
         case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
@@ -257,7 +257,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
     }
 
     it("can filter by multiple workTypes") {
-      withV2ApiFixtures {
+      withV2Api {
         case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
@@ -307,7 +307,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
     }
 
     it("filters by item LocationType") {
-      withV2ApiFixtures {
+      withV2Api {
         case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
           val noItemWorks = createIdentifiedWorks(count = 3)
           val matchingWork1 = createIdentifiedWorkWith(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
@@ -10,8 +10,8 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
   describe("listing works") {
     it("ignores works with no workType") {
-      withV2Api {
-        case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+      withV2ApiFixtures {
+        case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
           val noWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(workType = None)
           }
@@ -44,8 +44,8 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
     }
 
     it("filters out works with a different workType") {
-      withV2Api {
-        case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+      withV2ApiFixtures {
+        case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               workType = Some(WorkType(id = "m", label = "Manuscripts")))
@@ -79,8 +79,8 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
     }
 
     it("can filter by multiple workTypes") {
-      withV2Api {
-        case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+      withV2ApiFixtures {
+        case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               workType = Some(WorkType(id = "m", label = "Manuscripts")))
@@ -126,8 +126,8 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
     }
 
     it("filters by item LocationType") {
-      withV2Api {
-        case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+      withV2ApiFixtures {
+        case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
           val noItemWorks = createIdentifiedWorks(count = 3)
           val matchingWork1 = createIdentifiedWorkWith(
             canonicalId = "001",
@@ -183,8 +183,8 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
   describe("searching works") {
     it("ignores works with no workType") {
-      withV2Api {
-        case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+      withV2ApiFixtures {
+        case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
           val noWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               title = "Amazing aubergines",
@@ -220,8 +220,8 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
     }
 
     it("filters out works with a different workType") {
-      withV2Api {
-        case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+      withV2ApiFixtures {
+        case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               title = "Bouncing bananas",
@@ -257,8 +257,8 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
     }
 
     it("can filter by multiple workTypes") {
-      withV2Api {
-        case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+      withV2ApiFixtures {
+        case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               title = "Bouncing bananas",
@@ -307,8 +307,8 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
     }
 
     it("filters by item LocationType") {
-      withV2Api {
-        case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+      withV2ApiFixtures {
+        case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
           val noItemWorks = createIdentifiedWorks(count = 3)
           val matchingWork1 = createIdentifiedWorkWith(
             canonicalId = "001",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
@@ -11,7 +11,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
   describe("listing works") {
     it("ignores works with no workType") {
       withV2Api {
-        case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+        case (indexV2, server: EmbeddedHttpServer) =>
           val noWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(workType = None)
           }
@@ -45,7 +45,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("filters out works with a different workType") {
       withV2Api {
-        case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+        case (indexV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               workType = Some(WorkType(id = "m", label = "Manuscripts")))
@@ -80,7 +80,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("can filter by multiple workTypes") {
       withV2Api {
-        case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+        case (indexV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               workType = Some(WorkType(id = "m", label = "Manuscripts")))
@@ -127,7 +127,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("filters by item LocationType") {
       withV2Api {
-        case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+        case (indexV2, server: EmbeddedHttpServer) =>
           val noItemWorks = createIdentifiedWorks(count = 3)
           val matchingWork1 = createIdentifiedWorkWith(
             canonicalId = "001",
@@ -184,7 +184,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
   describe("searching works") {
     it("ignores works with no workType") {
       withV2Api {
-        case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+        case (indexV2, server: EmbeddedHttpServer) =>
           val noWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               title = "Amazing aubergines",
@@ -221,7 +221,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("filters out works with a different workType") {
       withV2Api {
-        case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+        case (indexV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               title = "Bouncing bananas",
@@ -258,7 +258,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("can filter by multiple workTypes") {
       withV2Api {
-        case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+        case (indexV2, server: EmbeddedHttpServer) =>
           val wrongWorkTypeWorks = (1 to 3).map { _ =>
             createIdentifiedWorkWith(
               title = "Bouncing bananas",
@@ -308,7 +308,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
 
     it("filters by item LocationType") {
       withV2Api {
-        case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+        case (indexV2, server: EmbeddedHttpServer) =>
           val noItemWorks = createIdentifiedWorks(count = 3)
           val matchingWork1 = createIdentifiedWorkWith(
             canonicalId = "001",

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
@@ -8,7 +8,7 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
     val redirectedWork = createIdentifiedRedirectedWork
 
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         insertIntoElasticsearch(indexV2, redirectedWork)
         server.httpGet(
           path = s"/$apiPrefix/works/${redirectedWork.canonicalId}",
@@ -24,7 +24,7 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
     val redirectedWork = createIdentifiedRedirectedWork
 
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         insertIntoElasticsearch(indexV2, redirectedWork)
         server.httpGet(
           path =

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
@@ -7,7 +7,7 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
   it("returns a TemporaryRedirect if looking up a redirected work") {
     val redirectedWork = createIdentifiedRedirectedWork
 
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         insertIntoElasticsearch(indexV2, redirectedWork)
         server.httpGet(
@@ -23,7 +23,7 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
   it("preserves query parameters on a 302 Redirect") {
     val redirectedWork = createIdentifiedRedirectedWork
 
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         insertIntoElasticsearch(indexV2, redirectedWork)
         server.httpGet(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
@@ -7,8 +7,8 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
   it("returns a TemporaryRedirect if looking up a redirected work") {
     val redirectedWork = createIdentifiedRedirectedWork
 
-    withV2Api {
-      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+    withV2ApiFixtures {
+      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         insertIntoElasticsearch(indexV2, redirectedWork)
         server.httpGet(
           path = s"/$apiPrefix/works/${redirectedWork.canonicalId}",
@@ -23,8 +23,8 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
   it("preserves query parameters on a 302 Redirect") {
     val redirectedWork = createIdentifiedRedirectedWork
 
-    withV2Api {
-      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+    withV2ApiFixtures {
+      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         insertIntoElasticsearch(indexV2, redirectedWork)
         server.httpGet(
           path =

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
@@ -15,7 +15,7 @@ class ApiV2WorksIncludesTest
   it(
     "includes a list of identifiers on a list endpoint if we pass ?include=identifiers") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val identifier0 = createSourceIdentifier
@@ -60,7 +60,7 @@ class ApiV2WorksIncludesTest
   it(
     "includes a list of identifiers on a single work endpoint if we pass ?include=identifiers") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val otherIdentifier = createSourceIdentifier
         val work = createIdentifiedWorkWith(
           otherIdentifiers = List(otherIdentifier)
@@ -89,7 +89,7 @@ class ApiV2WorksIncludesTest
 
   it("renders the items if the items include is present") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           items = createIdentifiedItems(count = 1) :+ createUnidentifiableItemWith()
         )
@@ -117,7 +117,7 @@ class ApiV2WorksIncludesTest
   it(
     "includes a list of subjects on a list endpoint if we pass ?include=subjects") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val subjects1 = List(createSubject)
@@ -158,7 +158,7 @@ class ApiV2WorksIncludesTest
   it(
     "includes a list of subjects on a single work endpoint if we pass ?include=subjects") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val subject = List(createSubject)
         val work = createIdentifiedWork.copy(subjects = subject)
 
@@ -184,7 +184,7 @@ class ApiV2WorksIncludesTest
 
   it("includes a list of genres on a list endpoint if we pass ?include=genres") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val genres1 = List(
@@ -227,7 +227,7 @@ class ApiV2WorksIncludesTest
   it(
     "includes a list of genres on a single work endpoint if we pass ?include=genres") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val genre = List(
           Genre("ornithology", List(Unidentifiable(Concept("ornithology")))))
         val work = createIdentifiedWork.copy(genres = genre)
@@ -255,7 +255,7 @@ class ApiV2WorksIncludesTest
   it(
     "includes a list of contributors on a list endpoint if we pass ?include=contributors") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val contributors1 =
@@ -298,7 +298,7 @@ class ApiV2WorksIncludesTest
   it(
     "includes a list of contributors on a single work endpoint if we pass ?include=contributors") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val contributor =
           List(Contributor(Unidentifiable(Person("Ginger Rogers"))))
         val work = createIdentifiedWork.copy(contributors = contributor)
@@ -326,7 +326,7 @@ class ApiV2WorksIncludesTest
   it(
     "includes a list of production events on a list endpoint if we pass ?include=production") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val productionEvents1 = createProductionEventList(count = 1)
@@ -367,7 +367,7 @@ class ApiV2WorksIncludesTest
   it(
     "includes a list of production on a single work endpoint if we pass ?include=production") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val productionEventList = createProductionEventList()
         val work = createIdentifiedWorkWith(
           production = productionEventList

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
@@ -14,7 +14,7 @@ class ApiV2WorksIncludesTest
     with SubjectGenerators {
   it(
     "includes a list of identifiers on a list endpoint if we pass ?include=identifiers") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
@@ -59,7 +59,7 @@ class ApiV2WorksIncludesTest
 
   it(
     "includes a list of identifiers on a single work endpoint if we pass ?include=identifiers") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val otherIdentifier = createSourceIdentifier
         val work = createIdentifiedWorkWith(
@@ -88,7 +88,7 @@ class ApiV2WorksIncludesTest
   }
 
   it("renders the items if the items include is present") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           items = createIdentifiedItems(count = 1) :+ createUnidentifiableItemWith()
@@ -116,7 +116,7 @@ class ApiV2WorksIncludesTest
 
   it(
     "includes a list of subjects on a list endpoint if we pass ?include=subjects") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
@@ -157,7 +157,7 @@ class ApiV2WorksIncludesTest
 
   it(
     "includes a list of subjects on a single work endpoint if we pass ?include=subjects") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val subject = List(createSubject)
         val work = createIdentifiedWork.copy(subjects = subject)
@@ -183,7 +183,7 @@ class ApiV2WorksIncludesTest
   }
 
   it("includes a list of genres on a list endpoint if we pass ?include=genres") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
@@ -226,7 +226,7 @@ class ApiV2WorksIncludesTest
 
   it(
     "includes a list of genres on a single work endpoint if we pass ?include=genres") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val genre = List(
           Genre("ornithology", List(Unidentifiable(Concept("ornithology")))))
@@ -254,7 +254,7 @@ class ApiV2WorksIncludesTest
 
   it(
     "includes a list of contributors on a list endpoint if we pass ?include=contributors") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
@@ -297,7 +297,7 @@ class ApiV2WorksIncludesTest
 
   it(
     "includes a list of contributors on a single work endpoint if we pass ?include=contributors") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val contributor =
           List(Contributor(Unidentifiable(Person("Ginger Rogers"))))
@@ -325,7 +325,7 @@ class ApiV2WorksIncludesTest
 
   it(
     "includes a list of production events on a list endpoint if we pass ?include=production") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
@@ -366,7 +366,7 @@ class ApiV2WorksIncludesTest
 
   it(
     "includes a list of production on a single work endpoint if we pass ?include=production") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val productionEventList = createProductionEventList()
         val work = createIdentifiedWorkWith(

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
@@ -14,8 +14,8 @@ class ApiV2WorksIncludesTest
     with SubjectGenerators {
   it(
     "includes a list of identifiers on a list endpoint if we pass ?include=identifiers") {
-    withV2Api {
-      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+    withV2ApiFixtures {
+      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val identifier0 = createSourceIdentifier
@@ -59,8 +59,8 @@ class ApiV2WorksIncludesTest
 
   it(
     "includes a list of identifiers on a single work endpoint if we pass ?include=identifiers") {
-    withV2Api {
-      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+    withV2ApiFixtures {
+      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val otherIdentifier = createSourceIdentifier
         val work = createIdentifiedWorkWith(
           otherIdentifiers = List(otherIdentifier)
@@ -88,8 +88,8 @@ class ApiV2WorksIncludesTest
   }
 
   it("renders the items if the items include is present") {
-    withV2Api {
-      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+    withV2ApiFixtures {
+      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           items = createIdentifiedItems(count = 1) :+ createUnidentifiableItemWith()
         )
@@ -116,8 +116,8 @@ class ApiV2WorksIncludesTest
 
   it(
     "includes a list of subjects on a list endpoint if we pass ?include=subjects") {
-    withV2Api {
-      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+    withV2ApiFixtures {
+      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val subjects1 = List(createSubject)
@@ -157,8 +157,8 @@ class ApiV2WorksIncludesTest
 
   it(
     "includes a list of subjects on a single work endpoint if we pass ?include=subjects") {
-    withV2Api {
-      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+    withV2ApiFixtures {
+      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val subject = List(createSubject)
         val work = createIdentifiedWork.copy(subjects = subject)
 
@@ -183,8 +183,8 @@ class ApiV2WorksIncludesTest
   }
 
   it("includes a list of genres on a list endpoint if we pass ?include=genres") {
-    withV2Api {
-      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+    withV2ApiFixtures {
+      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val genres1 = List(
@@ -226,8 +226,8 @@ class ApiV2WorksIncludesTest
 
   it(
     "includes a list of genres on a single work endpoint if we pass ?include=genres") {
-    withV2Api {
-      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+    withV2ApiFixtures {
+      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val genre = List(
           Genre("ornithology", List(Unidentifiable(Concept("ornithology")))))
         val work = createIdentifiedWork.copy(genres = genre)
@@ -254,8 +254,8 @@ class ApiV2WorksIncludesTest
 
   it(
     "includes a list of contributors on a list endpoint if we pass ?include=contributors") {
-    withV2Api {
-      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+    withV2ApiFixtures {
+      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val contributors1 =
@@ -297,8 +297,8 @@ class ApiV2WorksIncludesTest
 
   it(
     "includes a list of contributors on a single work endpoint if we pass ?include=contributors") {
-    withV2Api {
-      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+    withV2ApiFixtures {
+      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val contributor =
           List(Contributor(Unidentifiable(Person("Ginger Rogers"))))
         val work = createIdentifiedWork.copy(contributors = contributor)
@@ -325,8 +325,8 @@ class ApiV2WorksIncludesTest
 
   it(
     "includes a list of production events on a list endpoint if we pass ?include=production") {
-    withV2Api {
-      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+    withV2ApiFixtures {
+      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
         val productionEvents1 = createProductionEventList(count = 1)
@@ -366,8 +366,8 @@ class ApiV2WorksIncludesTest
 
   it(
     "includes a list of production on a single work endpoint if we pass ?include=production") {
-    withV2Api {
-      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+    withV2ApiFixtures {
+      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val productionEventList = createProductionEventList()
         val work = createIdentifiedWorkWith(
           production = productionEventList
@@ -392,5 +392,4 @@ class ApiV2WorksIncludesTest
         }
     }
   }
-
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.models.work.internal._
 class ApiV2WorksTest extends ApiV2WorksTestBase {
   it("returns a list of works") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
         insertIntoElasticsearch(indexV2, works: _*)
@@ -46,7 +46,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("returns a single work when requested with id") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWork
 
         insertIntoElasticsearch(indexV2, work)
@@ -71,7 +71,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   it(
     "returns the requested page of results when requested with page & pageSize") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
         insertIntoElasticsearch(indexV2, works: _*)
@@ -152,7 +152,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("ignores parameters that are unused when making an API request") {
     withV2Api {
-      case (_, _, server: EmbeddedHttpServer) =>
+      case (_, server: EmbeddedHttpServer) =>
         server.httpGet(
           path = s"/$apiPrefix/works?foo=bar",
           andExpect = Status.Ok,
@@ -163,7 +163,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("returns matching results if doing a full-text search") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "A drawing of a dodo"
         )
@@ -202,7 +202,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("searches different indices with the ?_index query parameter") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         withLocalWorksIndex { altIndex =>
           val work = createIdentifiedWork
           insertIntoElasticsearch(indexV2, work)
@@ -246,7 +246,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("looks up works in different indices with the ?_index query parameter") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         withLocalWorksIndex { altIndex =>
           val work = createIdentifiedWorkWith(
             title = "Playing with pangolins"
@@ -302,7 +302,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("shows the thumbnail field if available") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           thumbnail = Some(
             DigitalLocation(
@@ -337,8 +337,8 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   }
 
   it("only returns works from the v2 index") {
-    withApi(ApiVersions.v2) {
-      case (apiPrefix, indexV1, indexV2, server: EmbeddedHttpServer) =>
+    withApi {
+      case (indexV1, indexV2, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "Working with wombats"
         )
@@ -351,7 +351,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
         eventually {
           server.httpGet(
-            path = s"/$apiPrefix/works?query=wombats",
+            path = s"/${getApiPrefix(ApiVersions.v2)}/works?query=wombats",
             andExpect = Status.Ok,
             withJsonBody = s"""
                  |{

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.models.work.internal._
 
 class ApiV2WorksTest extends ApiV2WorksTestBase {
   it("returns a list of works") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
@@ -45,7 +45,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   }
 
   it("returns a single work when requested with id") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWork
 
@@ -70,7 +70,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it(
     "returns the requested page of results when requested with page & pageSize") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
@@ -161,7 +161,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   }
 
   it("returns matching results if doing a full-text search") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "A drawing of a dodo"
@@ -200,7 +200,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   }
 
   it("searches different indices with the ?_index query parameter") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         withLocalWorksIndex { altIndex =>
           val work = createIdentifiedWork
@@ -244,7 +244,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   }
 
   it("looks up works in different indices with the ?_index query parameter") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         withLocalWorksIndex { altIndex =>
           val work = createIdentifiedWorkWith(
@@ -300,7 +300,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   }
 
   it("shows the thumbnail field if available") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           thumbnail = Some(
@@ -336,7 +336,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   }
 
   it("only returns works from the v2 index") {
-    withApiFixtures(ApiVersions.v2) {
+    withApi(ApiVersions.v2) {
       case (apiPrefix, indexV1, indexV2, server: EmbeddedHttpServer) =>
         val work1 = createIdentifiedWorkWith(
           title = "Working with wombats"

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -151,7 +151,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   }
 
   it("ignores parameters that are unused when making an API request") {
-    withHttpServer(ApiVersions.v2) { case (apiPrefix, server: EmbeddedHttpServer) =>
+    withHttpServer { server: EmbeddedHttpServer =>
       server.httpGet(
         path = s"/$apiPrefix/works?foo=bar",
         andExpect = Status.Ok,

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -151,12 +151,13 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   }
 
   it("ignores parameters that are unused when making an API request") {
-    withHttpServer { server: EmbeddedHttpServer =>
-      server.httpGet(
-        path = s"/$apiPrefix/works?foo=bar",
-        andExpect = Status.Ok,
-        withJsonBody = emptyJsonResult(apiPrefix)
-      )
+    withV2Api {
+      case (_, _, server: EmbeddedHttpServer) =>
+        server.httpGet(
+          path = s"/$apiPrefix/works?foo=bar",
+          andExpect = Status.Ok,
+          withJsonBody = emptyJsonResult(apiPrefix)
+        )
     }
   }
 

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestBase.scala
@@ -7,5 +7,5 @@ import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 trait ApiV2WorksTestBase
     extends ApiWorksTestBase
     with DisplayV2SerialisationTestBase {
-  val apiVersion: ApiVersions.Value = ApiVersions.v2
+  val apiPrefix: String = getApiPrefix(ApiVersions.v2)
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestBase.scala
@@ -7,5 +7,5 @@ import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 trait ApiV2WorksTestBase
     extends ApiWorksTestBase
     with DisplayV2SerialisationTestBase {
-  def withV2Api[R] = withApiFixtures[R](ApiVersions.v2)(_)
+  val apiVersion: ApiVersions.Value = ApiVersions.v2
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestBase.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestBase.scala
@@ -1,11 +1,21 @@
 package uk.ac.wellcome.platform.api.works.v2
 
+import com.sksamuel.elastic4s.Index
+import com.twitter.finatra.http.EmbeddedHttpServer
 import uk.ac.wellcome.display.models.ApiVersions
 import uk.ac.wellcome.display.models.v2.DisplayV2SerialisationTestBase
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
+import uk.ac.wellcome.test.fixtures.TestWith
 
 trait ApiV2WorksTestBase
     extends ApiWorksTestBase
     with DisplayV2SerialisationTestBase {
   val apiPrefix: String = getApiPrefix(ApiVersions.v2)
+
+  def withV2Api[R](testWith: TestWith[(Index, EmbeddedHttpServer), R]): R =
+    withLocalWorksIndex { indexV2 =>
+      withServer(Index("index-v1"), indexV2) { server =>
+        testWith((indexV2, server))
+      }
+    }
 }

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 
 class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedInvisibleWork
 
@@ -23,7 +23,7 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
   }
 
   it("excludes works with visible=false from list results") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val deletedWork = createIdentifiedInvisibleWork
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
@@ -58,7 +58,7 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
   }
 
   it("excludes works with visible=false from search results") {
-    withV2ApiFixtures {
+    withV2Api {
       case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           title = "This shouldn't be deleted!"

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedInvisibleWork
 
         insertIntoElasticsearch(indexV2, work)
@@ -24,7 +24,7 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
 
   it("excludes works with visible=false from list results") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val deletedWork = createIdentifiedInvisibleWork
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
@@ -59,7 +59,7 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
 
   it("excludes works with visible=false from search results") {
     withV2Api {
-      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
+      case (indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           title = "This shouldn't be deleted!"
         )

--- a/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
+++ b/catalogue_api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
@@ -6,8 +6,8 @@ import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 
 class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
-    withV2Api {
-      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+    withV2ApiFixtures {
+      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedInvisibleWork
 
         insertIntoElasticsearch(indexV2, work)
@@ -23,8 +23,8 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
   }
 
   it("excludes works with visible=false from list results") {
-    withV2Api {
-      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+    withV2ApiFixtures {
+      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val deletedWork = createIdentifiedInvisibleWork
         val works = createIdentifiedWorks(count = 2).sortBy { _.canonicalId }
 
@@ -58,8 +58,8 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
   }
 
   it("excludes works with visible=false from search results") {
-    withV2Api {
-      case (apiPrefix, _, indexV2, server: EmbeddedHttpServer) =>
+    withV2ApiFixtures {
+      case (apiPrefix, indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
           title = "This shouldn't be deleted!"
         )


### PR DESCRIPTION
Part of #3415. Merging #3412 is blocked because the API tests are hitting a memory limit and crashing out midway through. We need to do less work in the tests!

This patch refactors the API tests to only create the Elasticsearch indexes if we're actually going to use them – currently we apply a bunch of mappings/make delete calls that are irrelevant. This should make the tests a bit more efficient, or at least faster.

I’ve also decoupled the creation of the “API prefix” string from starting a server, which means we have to start slightly fewer servers. Again, should be a small efficiency gain.