### PR TITLE
Add a script for deleting ECR images older than N days

### DIFF
--- a/scripts/tidy_ecr_repo.py
+++ b/scripts/tidy_ecr_repo.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8
+
+import datetime as dt
+import getpass
+
+import boto3
+import click
+
+
+def role_arn_to_session(**kwargs):
+    client = boto3.client("sts")
+    response = client.assume_role(**kwargs)
+    return boto3.Session(
+        aws_access_key_id=response["Credentials"]["AccessKeyId"],
+        aws_secret_access_key=response["Credentials"]["SecretAccessKey"],
+        aws_session_token=response["Credentials"]["SessionToken"]
+    )
+
+
+def describe_images(ecr_client, repo_name):
+    paginator = ecr_client.get_paginator("describe_images")
+    for page in paginator.paginate(repositoryName=repo_name):
+        yield from page["imageDetails"]
+
+
+@click.command()
+@click.argument("repo_name")
+@click.option("--account_id", default="760097843905")
+@click.option("--older_than", default=500, type=int)
+def main(repo_name, account_id, older_than):
+    sess = role_arn_to_session(
+        RoleArn="arn:aws:iam::%s:role/admin" % account_id,
+        RoleSessionName="%s--%s" % (getpass.getuser(), __file__)
+    )
+    ecr_client = sess.client("ecr")
+
+    images_to_delete = []
+
+    full_repo_name = "uk.ac.wellcome/%s" % repo_name
+    for image in describe_images(ecr_client, repo_name=full_repo_name):
+        when_pushed = dt.datetime.now(dt.timezone.utc) - image["imagePushedAt"]
+        if when_pushed.days > 500:
+            images_to_delete.append({"imageDigest": image["imageDigest"]})
+
+    confirm = click.confirm("About to delete %d images" % len(images_to_delete))
+
+    ecr_client.batch_delete_image(
+        repositoryName=full_repo_name,
+        imageIds=images_to_delete
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tidy_ecr_repo.py
+++ b/scripts/tidy_ecr_repo.py
@@ -41,7 +41,7 @@ def main(repo_name, account_id, older_than):
     full_repo_name = "uk.ac.wellcome/%s" % repo_name
     for image in describe_images(ecr_client, repo_name=full_repo_name):
         when_pushed = dt.datetime.now(dt.timezone.utc) - image["imagePushedAt"]
-        if when_pushed.days > 500:
+        if when_pushed.days > older_than:
             images_to_delete.append({"imageDigest": image["imageDigest"]})
 
     click.confirm("About to delete %d images" % len(images_to_delete))


### PR DESCRIPTION
Closes #3473. Implicitly assumes we don't have any long-running images in an active task definition, but I don't expect us to use this very often!