### PR TITLE
Catalogue VPC

### DIFF
--- a/infrastructure/terraform/shared/outputs.tf
+++ b/infrastructure/terraform/shared/outputs.tf
@@ -187,6 +187,20 @@ output "datascience_vpc_id" {
   value = "${module.datascience_vpc.vpc_id}"
 }
 
+# Catalogue VPC
+
+output "catalogue_vpc_private_subnets" {
+  value = ["${module.catalogue_vpc.private_subnets}"]
+}
+
+output "catalogue_vpc_public_subnets" {
+  value = ["${module.catalogue_vpc.public_subnets}"]
+}
+
+output "catalogue_vpc_id" {
+  value = "${module.catalogue_vpc.vpc_id}"
+}
+
 # Endpoint Services
 
 output "service-pl-winslow" {

--- a/infrastructure/terraform/shared/terraform.tf
+++ b/infrastructure/terraform/shared/terraform.tf
@@ -33,6 +33,17 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias   = "catalogue"
+  region  = "${local.aws_region}"
+  version = "1.10.0"
+
+  assume_role {
+    role_arn = "arn:aws:iam::975596993436:role/catalogue-developer"
+  }
+}
+
+
+provider "aws" {
   alias   = "datascience"
   region  = "${local.aws_region}"
   version = "1.10.0"

--- a/infrastructure/terraform/shared/vpcs.tf
+++ b/infrastructure/terraform/shared/vpcs.tf
@@ -32,6 +32,10 @@ locals {
   datascience_cidr_block_vpc     = "172.17.0.0/16"
   datascience_cidr_block_public  = "172.17.0.0/17"
   datascience_cidr_block_private = "172.17.128.0/17"
+
+  catalogue_cidr_block_vpc     = "172.18.0.0/16"
+  catalogue_cidr_block_public  = "172.18.0.0/17"
+  catalogue_cidr_block_private = "172.18.128.0/17"
 }
 
 module "storage_vpc" {
@@ -115,5 +119,29 @@ module "datascience_vpc" {
 
   providers = {
     aws = "aws.datascience"
+  }
+}
+
+# Used by:
+# - Item requesting service
+# TODO: Move all catalogue services into this VPC
+
+module "catalogue_vpc" {
+  source = "github.com/wellcometrust/terraform//network/prebuilt/vpc/public-private-igw?ref=v19.5.3"
+
+  name = "catalogue-172-18-0-0-16"
+
+  cidr_block_vpc = "${local.catalogue_cidr_block_vpc}"
+
+  public_az_count           = "3"
+  cidr_block_public         = "${local.catalogue_cidr_block_public}"
+  cidrsubnet_newbits_public = "2"
+
+  private_az_count           = "3"
+  cidr_block_private         = "${local.catalogue_cidr_block_private}"
+  cidrsubnet_newbits_private = "2"
+
+  providers = {
+    aws = "aws.catalogue"
   }
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

Create a dedicated catalogue VPC to run services in (currently catalogue infra is running legacy style in the platform account.

### Who is this change for?

Folk who want properly partitioned & secure network / AWS resources.

For https://github.com/wellcomecollection/item-requests-service/issues/16