### PR TITLE
add and store cloudfront logs in s3 bucket

### DIFF
--- a/infrastructure/terraform/critical/api.wellcomecollection.org/cloudfront.tf
+++ b/infrastructure/terraform/critical/api.wellcomecollection.org/cloudfront.tf
@@ -184,4 +184,9 @@ resource "aws_cloudfront_distribution" "api_root" {
       restriction_type = "none"
     }
   }
+  logging_config {
+    include_cookies = false
+    bucket          = "${var.cf_logging_bucket}"
+    prefix          = "api_root"
+  }
 }

--- a/infrastructure/terraform/critical/api.wellcomecollection.org/variables.tf
+++ b/infrastructure/terraform/critical/api.wellcomecollection.org/variables.tf
@@ -9,3 +9,5 @@ variable "cert_domain" {
 variable "public_api_bucket_domain_name" {}
 
 variable "description" {}
+
+variable "cf_logging_bucket" {}

--- a/infrastructure/terraform/critical/main.tf
+++ b/infrastructure/terraform/critical/main.tf
@@ -7,6 +7,8 @@ module "api-stage" {
   public_api_bucket_domain_name = "${aws_s3_bucket.public_api.bucket_domain_name}"
 
   description = "Collection APIs staging"
+
+  cf_logging_bucket = "${aws_s3_bucket.api_root_cf_logs.bucket_domain_name}"
 }
 
 module "api" {
@@ -18,6 +20,8 @@ module "api" {
   public_api_bucket_domain_name = "${aws_s3_bucket.public_api.bucket_domain_name}"
 
   description = "Collection APIs production"
+
+  cf_logging_bucket = "${aws_s3_bucket.api_root_cf_logs.bucket_domain_name}"
 }
 
 // S3 origin for redirect to developers.wellcomecollection.org

--- a/infrastructure/terraform/critical/s3.tf
+++ b/infrastructure/terraform/critical/s3.tf
@@ -1,0 +1,14 @@
+resource "aws_s3_bucket" "api_root_cf_logs" {
+  bucket = "weco-cloudfront-logs"
+  acl    = "private"
+
+  lifecycle_rule {
+    id      = "cf-logs"
+    prefix  = ""
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
+}


### PR DESCRIPTION
### What is this PR trying to achieve?
Adds logging to the Cloudfront distribution with a data retention period of objects being 30 days.

If we need larger time frames we should stream off this data and store it elsewhere as Cloudfront logs store things such as IPs etc.


